### PR TITLE
Feat: move to dyn Scope for arena

### DIFF
--- a/packages/core/examples/step.rs
+++ b/packages/core/examples/step.rs
@@ -1,33 +1,18 @@
-//! An example that shows how to:
-//!     create a scope,
-//!     render a component,
-//!     change some data
-//!     render it again
-//!     consume the diffs and write that to a renderer
-
 use dioxus_core::prelude::*;
 
 fn main() -> Result<(), ()> {
     let p1 = Props { name: "bob".into() };
 
-    let _vdom = VirtualDom::new_with_props(Example, p1);
-    // vdom.progress()?;
+    let mut vdom = VirtualDom::new_with_props(Example, p1);
+    vdom.update_props(|p: &mut Props| {});
 
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 struct Props {
     name: String,
 }
-
-// impl Properties for Props {
-//     fn call(&self, ptr: *const ()) {}
-
-//     // fn new() -> Self {
-//     //     todo!()
-//     // }
-// }
 
 static Example: FC<Props> = |ctx, _props| {
     ctx.render(html! {

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -296,10 +296,12 @@ mod vtext {
 /// Virtual Components for custom user-defined components
 /// Only supports the functional syntax
 mod vcomponent {
-    use crate::innerlude::{Context, FC};
-    use std::{any::TypeId, marker::PhantomData};
+    use crate::innerlude::{Context, ScopeIdx, FC};
+    use std::{any::TypeId, cell::RefCell, marker::PhantomData, rc::Rc};
 
     use super::DomTree;
+
+    pub type StableScopeAddres = Rc<RefCell<Option<ScopeIdx>>>;
 
     #[derive(Debug)]
     pub struct VComponent<'src> {
@@ -308,6 +310,11 @@ mod vcomponent {
         pub(crate) props_type: TypeId,
         pub(crate) comp: *const (),
         pub(crate) caller: Caller,
+
+        // once a component gets mounted, its parent gets a stable address.
+        // this way we can carry the scope index from between renders
+        // genius, really!
+        pub assigned_scope: StableScopeAddres,
     }
 
     pub struct Caller(Box<dyn Fn(Context) -> DomTree>);
@@ -323,10 +330,10 @@ mod vcomponent {
         // - perform comparisons when diffing (memoization)
         // -
         pub fn new<P>(comp: FC<P>, props: P) -> Self {
-            let caller = move |ctx: Context| {
-                let t = comp(ctx, &props);
-                t
-            };
+            // let caller = move |ctx: Context| {
+            //     let t = comp(ctx, &props);
+            //     t
+            // };
             // let _caller = comp as *const ();
             // let _props = Box::new(props);
 

--- a/packages/core/src/patch.rs
+++ b/packages/core/src/patch.rs
@@ -126,6 +126,7 @@ pub struct EditMachine<'src> {
     pub traversal: Traversal,
     next_temporary: u32,
     forcing_new_listeners: bool,
+
     pub emitter: EditList<'src>,
 }
 
@@ -214,10 +215,6 @@ impl<'a> EditMachine<'a> {
         debug_assert!(self.traversal_is_committed());
         debug_assert!(start < end);
         let temp_base = self.next_temporary;
-        // debug!(
-        //     "emit: save_children_to_temporaries({}, {}, {})",
-        //     temp_base, start, end
-        // );
         self.next_temporary = temp_base + (end - start) as u32;
         self.emitter.push(Edit::SaveChildrenToTemporaries {
             temp: temp_base,
@@ -365,6 +362,11 @@ impl<'a> EditMachine<'a> {
         debug_assert!(self.traversal_is_committed());
         self.emitter.push(Edit::RemoveListener { event });
         // debug!("emit: remove_event_listener({:?})", event);
+    }
+
+    pub fn save_known_root(&mut self, id: ScopeIdx) {
+        log::debug!("emit: save_known_root({:?})", id);
+        self.emitter.push(Edit::MakeKnown { node: id })
     }
 
     // pub fn save_template(&mut self, id: CacheId) {


### PR DESCRIPTION
This PR adds a type parameter to Scope and adds a new trait `Scoped` which lets us create a generic Scope based on props. This makes the code easier to write, but is probably slightly less performant.

One day we'll make a 

generational bumped typed arena.

something like for each type T, we reserve a cache line and then reuse those slots with a generational counter