### PR TITLE
examples: simplfy running them by enabling features automatically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,4 @@ serde_json = "1.0.73"
 rand = { version = "0.8.4", features = ["small_rng"] }
 tokio = { version = "1.14.0", features = ["full"] }
 reqwest = { version = "0.11.8", features = ["json"] }
+dioxus = { path = ".", features = ["desktop", "ssr", "router"] }

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ If you know React, then you already know Dioxus.
 
 ### Examples
 
-All examples in this repo are desktop apps. To run an example, simply clone this repo and use cargo with the `desktop` feature enabled. For SSR examples, you might need to enable SSR instead.
+All examples in this repo are desktop apps. To run an example, simply clone this repo and use `cargo run --example XYZ`
 
 ```
-cargo run --features desktop --example EXAMPLE
+cargo run --example EXAMPLE
 ```
 
 ## Get Started with...


### PR DESCRIPTION
cc #55 

This turns on the desktop, router, and ssr features by default for examples.

  @nilsmartel can you make sure this functions the way you expect it to?

```
git pull
git checkout jk/simplify-example-run
cargo run --example readme
```