### PR TITLE
Fix/Feat: Don't force the &dyn Fn syntax for passing through event handlers

### DIFF
--- a/examples/framework_benchmark.rs
+++ b/examples/framework_benchmark.rs
@@ -91,7 +91,7 @@ fn app(cx: Scope) -> Element {
 struct ActionButtonProps<'a> {
     name: &'a str,
     id: &'a str,
-    onclick: EventHandler<'a, ()>,
+    onclick: EventHandler<'a>,
 }
 
 fn ActionButton<'a>(cx: Scope<'a, ActionButtonProps<'a>>) -> Element {

--- a/examples/framework_benchmark.rs
+++ b/examples/framework_benchmark.rs
@@ -41,22 +41,22 @@ fn app(cx: Scope) -> Element {
                     div { class: "col-md-6",
                         div { class: "row",
                             ActionButton { name: "Create 1,000 rows", id: "run",
-                                onclick: move || items.set(Label::new_list(1_000)),
+                                onclick: move |_| items.set(Label::new_list(1_000)),
                             }
                             ActionButton { name: "Create 10,000 rows", id: "runlots",
-                                onclick: move || items.set(Label::new_list(10_000)),
+                                onclick: move |_| items.set(Label::new_list(10_000)),
                             }
                             ActionButton { name: "Append 1,000 rows", id: "add",
-                                onclick: move || items.write().extend(Label::new_list(1_000)),
+                                onclick: move |_| items.write().extend(Label::new_list(1_000)),
                             }
                             ActionButton { name: "Update every 10th row", id: "update",
-                                onclick: move || items.write().iter_mut().step_by(10).for_each(|item| item.labels[2] = "!!!"),
+                                onclick: move |_| items.write().iter_mut().step_by(10).for_each(|item| item.labels[2] = "!!!"),
                             }
                             ActionButton { name: "Clear", id: "clear",
-                                onclick: move || items.write().clear(),
+                                onclick: move |_| items.write().clear(),
                             }
                             ActionButton { name: "Swap rows", id: "swaprows",
-                                onclick: move || items.write().swap(0, 998),
+                                onclick: move |_| items.write().swap(0, 998),
                             }
                         }
                     }
@@ -91,7 +91,7 @@ fn app(cx: Scope) -> Element {
 struct ActionButtonProps<'a> {
     name: &'a str,
     id: &'a str,
-    onclick: &'a dyn Fn(),
+    onclick: EventHandler<'a, ()>,
 }
 
 fn ActionButton<'a>(cx: Scope<'a, ActionButtonProps<'a>>) -> Element {
@@ -102,7 +102,7 @@ fn ActionButton<'a>(cx: Scope<'a, ActionButtonProps<'a>>) -> Element {
                 class:"btn btn-primary btn-block",
                 r#type: "button",
                 id: "{cx.props.id}",
-                onclick: move |_| (cx.props.onclick)(),
+                onclick: move |_| cx.props.onclick.call(()),
 
                 "{cx.props.name}"
             }

--- a/examples/pattern_model.rs
+++ b/examples/pattern_model.rs
@@ -15,8 +15,6 @@
 //! the RefCell will panic and crash. You can use `try_get_mut` or `.modify` to avoid this problem, or just not hold two
 //! RefMuts at the same time.
 
-use std::sync::Arc;
-
 use dioxus::desktop::wry::application::dpi::LogicalSize;
 use dioxus::events::*;
 use dioxus::prelude::*;
@@ -117,7 +115,7 @@ fn app(cx: Scope) -> Element {
 #[derive(Props)]
 struct CalculatorKeyProps<'a> {
     name: &'a str,
-    onclick: &'a dyn Fn(MouseEvent),
+    onclick: EventHandler<'a, MouseEvent>,
     children: Element<'a>,
 }
 
@@ -125,7 +123,7 @@ fn CalculatorKey<'a>(cx: Scope<'a, CalculatorKeyProps<'a>>) -> Element {
     cx.render(rsx! {
         button {
             class: "calculator-key {cx.props.name}",
-            onclick: move |e| (cx.props.onclick)(e),
+            onclick: move |e| cx.props.onclick.call(e),
             &cx.props.children
         }
     })

--- a/packages/core-macro/src/rsx/component.rs
+++ b/packages/core-macro/src/rsx/component.rs
@@ -165,7 +165,7 @@ impl ToTokens for ContentField {
                 __cx.raw_text(format_args_f!(#s)).0
             }),
             ContentField::OnHandlerRaw(e) => tokens.append_all(quote! {
-                __cx.bump().alloc(#e)
+                __cx.event_handler(#e)
             }),
         }
     }

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -212,7 +212,7 @@ impl ScopeArena {
             items
                 .listeners
                 .drain(..)
-                .for_each(|listener| drop(listener.callback.callback.borrow_mut().take()));
+                .for_each(|listener| drop(listener.callback.borrow_mut().take()));
         }
     }
 
@@ -300,7 +300,7 @@ impl ScopeArena {
                                 break;
                             }
 
-                            let mut cb = listener.callback.callback.borrow_mut();
+                            let mut cb = listener.callback.borrow_mut();
                             if let Some(cb) = cb.as_mut() {
                                 // todo: arcs are pretty heavy to clone
                                 // we really want to convert arc to rc

--- a/packages/hooks/src/useref.rs
+++ b/packages/hooks/src/useref.rs
@@ -1,5 +1,5 @@
 use std::{
-    cell::{Cell, Ref, RefCell, RefMut},
+    cell::{Ref, RefCell, RefMut},
     rc::Rc,
 };
 

--- a/packages/html/src/events.rs
+++ b/packages/html/src/events.rs
@@ -43,10 +43,7 @@ pub mod on {
                         // ie copy
                         let shortname: &'static str = &event_name[2..];
 
-                        let handler = EventHandler {
-                            callback: bump.alloc(std::cell::RefCell::new(Some(callback))),
-                        };
-
+                        let handler = bump.alloc(std::cell::RefCell::new(Some(callback)));
                         factory.listener(shortname, handler)
                     }
                 )*


### PR DESCRIPTION
Fixes #77 #88

The docs were "ahead of the times" and were describing a feature that did not yet exist!

This has been remedied in this PR.