### PR TITLE
Login Form Example

### DIFF
--- a/examples/login_form.rs
+++ b/examples/login_form.rs
@@ -1,0 +1,89 @@
+//! This example demonstrates the following:
+//! Futures in a callback, Router, and Forms
+
+use dioxus::events::*;
+use dioxus::prelude::*;
+use dioxus::router::{Link, Router, Route, RouterService};
+
+fn main() {
+    dioxus::desktop::launch(APP);
+}
+
+static APP: Component = |cx| {
+    cx.render(rsx!{
+        Router {
+            Route { to: "/", home() }
+            Route { to: "/login", login() }
+        }
+    })
+};
+
+fn home(cx: Scope) -> Element {
+    cx.render(rsx! {
+        h1 { "Welcome Home" }
+        Link { to: "/login", "Login" }
+    })
+}
+
+
+fn login(cx: Scope) -> Element {
+    let username = use_state(&cx, String::new);
+    let password = use_state(&cx, String::new);
+
+    let service = cx.consume_context::<RouterService>()?;
+
+    let onsubmit = move |_| {
+        cx.push_future({
+            let (username, password) = (username.get().clone(), password.get().clone());
+            let service = service.clone();
+
+            async move {
+                let params = [
+                    ("username", username.to_string()),
+                    ("password", password.to_string())
+                ];
+
+                let resp = reqwest::Client::new()
+                    .post("http://localhost/login")
+                    .form(&params)
+                    .send()
+                    .await;
+
+                match resp {
+                    Ok(data) => {
+                        // Parse data from here, such as storing a response token
+                        service.push_route("/");
+                    }
+                    Err(err) => {} //Handle any errors from the fetch here
+                }
+            }
+        });
+    };
+
+    cx.render(rsx!{
+        h1 { "Login" }
+        form {
+            onsubmit: onsubmit,
+            // Prevent the default behavior of <form> to post
+            prevent_default: "onsubmit",
+            input {
+                oninput: move |evt| username.set(evt.value.clone())
+            }
+            label {
+                "Username"
+            }
+            br {}
+            input {
+                oninput: move |evt| password.set(evt.value.clone()),
+                r#type: "password"
+            }
+            label {
+                "Password"
+            }
+            br {}
+            button {
+                "Login"
+            }
+        }
+    })
+}

--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1047,7 +1047,7 @@ impl input {
     /// - `text`
     /// - `time`
     /// - `url`
-    /// - `week`    
+    /// - `week`
     pub fn r#type<'a>(&self, cx: NodeFactory<'a>, val: Arguments) -> Attribute<'a> {
         cx.attr("type", val, None, false)
     }
@@ -1101,6 +1101,12 @@ impl label {
     }
 }
 impl a {
+    pub fn prevent_default<'a>(&self, cx: NodeFactory<'a>, val: Arguments) -> Attribute<'a> {
+        cx.attr("dioxus-prevent-default", val, None, false)
+    }
+}
+
+impl form {
     pub fn prevent_default<'a>(&self, cx: NodeFactory<'a>, val: Arguments) -> Attribute<'a> {
         cx.attr("dioxus-prevent-default", val, None, false)
     }


### PR DESCRIPTION
Creating a login form example to demonstrate a common example using a form to login and make an async call to an external api.


A couple of caveats:
Only works on web, but to keep it consistent as router changes are added in left it as dioxus::desktop.
This works on the current version of the router on web, but is bound to change as the router is updated.

I can add something quick to the guide as well, it looks like a lots changed in there. Any suggestions on where to add it?