### PR TITLE
Feat: arbitrary custom attribute names with formatting

### DIFF
--- a/examples/custom_attributes.rs
+++ b/examples/custom_attributes.rs
@@ -1,0 +1,27 @@
+//! Use custom formatting in attributes to set attributes
+
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::desktop::launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    let disabled = use_state(&cx, || false);
+
+    // let button_disabled = if *disabled { "disabled" } else { "nnn" };
+
+    cx.render(rsx! {
+        div {
+            button {
+                onclick: move |_| disabled.set(!disabled.get()),
+                "click to " [if *disabled {"enable"} else {"disable"} ] " the lower button"
+            }
+
+            button {
+                "disabled": "{disabled}",
+                "lower button"
+            }
+        }
+    })
+}

--- a/examples/custom_attributes.rs
+++ b/examples/custom_attributes.rs
@@ -9,7 +9,7 @@ fn main() {
 fn app(cx: Scope) -> Element {
     let disabled = use_state(&cx, || false);
 
-    // let button_disabled = if *disabled { "disabled" } else { "nnn" };
+    let button_disabled = if *disabled { "disabled" } else { "nnn" };
 
     cx.render(rsx! {
         div {
@@ -19,7 +19,7 @@ fn app(cx: Scope) -> Element {
             }
 
             button {
-                "disabled": "{disabled}",
+                "{button_disabled}": "true",
                 "lower button"
             }
         }

--- a/examples/manual_edits.rs
+++ b/examples/manual_edits.rs
@@ -32,8 +32,4 @@ fn main() {
         // append the container to the default render element ("dioxusroot" if used with default config)
         AppendChildren { many: 1 },
     ];
-
-    let app: Component = |cx| cx.render(rsx!(div { "some app" }));
-
-    dioxus_desktop::launch_with_props(app, (), |c| c.with_edits(edits));
 }

--- a/packages/core-macro/src/rsx/component.rs
+++ b/packages/core-macro/src/rsx/component.rs
@@ -221,7 +221,7 @@ fn is_literal_foramtted(lit: &LitStr) -> bool {
     while let Some(next) = chars.next() {
         if next == '{' {
             let nen = chars.next();
-            if nen == Some('{') {
+            if nen != Some('{') {
                 return true;
             }
         }

--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -563,6 +563,9 @@ impl<'bump> DiffState<'bump> {
             for (old_attr, new_attr) in old.attributes.iter().zip(new.attributes.iter()) {
                 if old_attr.value != new_attr.value || new_attr.is_volatile {
                     self.mutations.set_attribute(new_attr, root.as_u64());
+                } else if old_attr.name != new_attr.name {
+                    self.mutations.remove_attribute(old_attr, root.as_u64());
+                    self.mutations.set_attribute(new_attr, root.as_u64());
                 }
             }
         } else {

--- a/packages/core/src/mutations.rs
+++ b/packages/core/src/mutations.rs
@@ -100,13 +100,13 @@ pub enum DomEdit<'bump> {
     },
     SetAttribute {
         root: u64,
-        field: &'static str,
+        field: &'bump str,
         value: &'bump str,
         ns: Option<&'bump str>,
     },
     RemoveAttribute {
         root: u64,
-        name: &'static str,
+        name: &'bump str,
     },
 }
 
@@ -213,7 +213,7 @@ impl<'a> Mutations<'a> {
         });
     }
 
-    pub(crate) fn remove_attribute(&mut self, attribute: &Attribute, root: u64) {
+    pub(crate) fn remove_attribute(&mut self, attribute: &'a Attribute<'a>, root: u64) {
         let name = attribute.name;
         self.edits.push(RemoveAttribute { name, root });
     }

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -290,7 +290,7 @@ pub trait DioxusElement {
 /// `href="https://example.com"`.
 #[derive(Clone, Debug)]
 pub struct Attribute<'a> {
-    pub name: &'static str,
+    pub name: &'a str,
 
     pub value: &'a str,
 
@@ -534,6 +534,24 @@ impl<'a> NodeFactory<'a> {
         is_volatile: bool,
     ) -> Attribute<'a> {
         let (value, is_static) = self.raw_text(val);
+        Attribute {
+            name,
+            value,
+            is_static,
+            namespace,
+            is_volatile,
+        }
+    }
+
+    pub fn custom_attr(
+        &self,
+        name: Arguments,
+        val: Arguments,
+        namespace: Option<&'static str>,
+        is_volatile: bool,
+    ) -> Attribute<'a> {
+        let (value, is_static) = self.raw_text(val);
+        let (name, _) = self.raw_text(name);
         Attribute {
             name,
             value,

--- a/packages/desktop/src/index.js
+++ b/packages/desktop/src/index.js
@@ -344,7 +344,7 @@ class Interpreter {
   }
 
   SetAttribute(edit) {
-    // console.log("setting attr", edit);
+    console.log("setting attr", edit);
     const name = edit.field;
     const value = edit.value;
     const ns = edit.ns;
@@ -368,17 +368,13 @@ class Interpreter {
         case "dangerous_inner_html":
           node.innerHTML = value;
           break;
-        case "disabled":
-          node.disabled = value === "true";
-          break;
-
         default:
           node.setAttribute(name, value);
       }
     }
   }
   RemoveAttribute(edit) {
-    const name = edit.field;
+    const name = edit.name;
     const node = this.nodes[edit.root];
     node.removeAttribute(name);
 

--- a/packages/desktop/src/index.js
+++ b/packages/desktop/src/index.js
@@ -368,6 +368,10 @@ class Interpreter {
         case "dangerous_inner_html":
           node.innerHTML = value;
           break;
+        case "disabled":
+          node.disabled = value === "true";
+          break;
+
         default:
           node.setAttribute(name, value);
       }


### PR DESCRIPTION
This lets you implement boolean attributes with your own custom logic.

cc #97 #96 

The "disabled" example is a great showcase of when this ability is useful:

```rust
fn app(cx: Scope) -> Element {
    let disabled = use_state(&cx, || false);

    let button_disabled = if *disabled { "disabled" } else { "nnn" };

    cx.render(rsx! {
        div {
            button {
                onclick: move |_| disabled.set(!disabled.get()),
                "click to " [if *disabled {"enable"} else {"disable"} ] " the lower button"
            }

            button {
                "{button_disabled}": "true",
                "lower button"
            }
        }
    })
```