### PR TITLE
feat: `disabled` attribute support

### DIFF
--- a/packages/desktop/src/index.js
+++ b/packages/desktop/src/index.js
@@ -368,6 +368,12 @@ class Interpreter {
         case "dangerous_inner_html":
           node.innerHTML = value;
           break;
+        case "disabled":
+          console.log("SB: " + value);
+          if (value != "") {
+            node.disabled = "true";
+          }
+          break;
         default:
           node.setAttribute(name, value);
       }

--- a/packages/desktop/src/index.js
+++ b/packages/desktop/src/index.js
@@ -372,6 +372,8 @@ class Interpreter {
           console.log("SB: " + value);
           if (value != "") {
             node.disabled = "true";
+          } else {
+            node.setAttribute(name, value);
           }
           break;
         default:
@@ -379,6 +381,7 @@ class Interpreter {
       }
     }
   }
+
   RemoveAttribute(edit) {
     const name = edit.field;
     const node = this.nodes[edit.root];

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -66,6 +66,7 @@ features = [
     "SvgElement",
     "SvgAnimatedString",
     "HtmlOptionElement",
+    "HtmlButtonElement",
     "IdleDeadline",
 ]
 

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -13,7 +13,7 @@ use std::{any::Any, fmt::Debug, rc::Rc, sync::Arc};
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::{
     CssStyleDeclaration, Document, Element, Event, HtmlElement, HtmlInputElement,
-    HtmlOptionElement, HtmlTextAreaElement, Node, HtmlButtonElement,
+    HtmlOptionElement, HtmlTextAreaElement, Node, HtmlButtonElement
 };
 
 use crate::{nodeslab::NodeSlab, WebConfig};
@@ -349,6 +349,10 @@ impl WebsysDom {
                 }
                 "disabled" => {
                     if let Some(node) = node.dyn_ref::<HtmlButtonElement>() {
+                        node.set_disabled(value != "");
+                    } else if let Some(node) = node.dyn_ref::<HtmlInputElement>() {
+                        node.set_disabled(value != "");
+                    } else if let Some(node) = node.dyn_ref::<HtmlTextAreaElement>() {
                         node.set_disabled(value != "");
                     } else {
                         fallback();

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -13,7 +13,7 @@ use std::{any::Any, fmt::Debug, rc::Rc, sync::Arc};
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::{
     CssStyleDeclaration, Document, Element, Event, HtmlElement, HtmlInputElement,
-    HtmlOptionElement, HtmlTextAreaElement, Node,
+    HtmlOptionElement, HtmlTextAreaElement, Node, HtmlButtonElement,
 };
 
 use crate::{nodeslab::NodeSlab, WebConfig};
@@ -343,6 +343,13 @@ impl WebsysDom {
                 "selected" => {
                     if let Some(node) = node.dyn_ref::<HtmlOptionElement>() {
                         node.set_selected(true);
+                    } else {
+                        fallback();
+                    }
+                }
+                "disabled" => {
+                    if let Some(node) = node.dyn_ref::<HtmlButtonElement>() {
+                        node.set_disabled(value != "");
                     } else {
                         fallback();
                     }

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -12,8 +12,8 @@ use fxhash::FxHashMap;
 use std::{any::Any, fmt::Debug, rc::Rc, sync::Arc};
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::{
-    CssStyleDeclaration, Document, Element, Event, HtmlElement, HtmlInputElement,
-    HtmlOptionElement, HtmlTextAreaElement, Node, HtmlButtonElement
+    CssStyleDeclaration, Document, Element, Event, HtmlButtonElement, HtmlElement,
+    HtmlInputElement, HtmlOptionElement, HtmlTextAreaElement, Node,
 };
 
 use crate::{nodeslab::NodeSlab, WebConfig};


### PR DESCRIPTION
#97 is not a good solution for this problem: #96

I change the code can be use like:

```
button {
    disabled: "",
    "Test"
}
```

if the `disabled` is a empty str, `disabled=false` else `disabled=true`

update[feat]: `dioxus-web` && `dioxus-desktop`