### PR TITLE
Boolattrs limit type

### DIFF
--- a/examples/disabled.rs
+++ b/examples/disabled.rs
@@ -18,6 +18,11 @@ fn app(cx: Scope) -> Element {
                 disabled: "{disabled}",
                 "lower button"
             }
+
+            input {
+                value: "false",
+            }
+
         }
     })
 }

--- a/packages/desktop/src/index.js
+++ b/packages/desktop/src/index.js
@@ -369,8 +369,38 @@ class Interpreter {
           node.innerHTML = value;
           break;
         default:
+
+          const bool_attrs = [
+            "allowfullscreen",
+            "allowpaymentrequest",
+            "async",
+            "autofocus",
+            "autoplay",
+            "checked",
+            "controls",
+            "default",
+            "defer",
+            "disabled",
+            "formnovalidate",
+            "hidden",
+            "ismap",
+            "itemscope",
+            "loop",
+            "multiple",
+            "muted",
+            "nomodule",
+            "novalidate",
+            "open",
+            "playsinline",
+            "readonly",
+            "required",
+            "reversed",
+            "selected",
+            "truespeed",
+          ]
+
           // https://github.com/facebook/react/blob/8b88ac2592c5f555f315f9440cbb665dd1e7457a/packages/react-dom/src/shared/DOMProperty.js#L352-L364
-          if (value == "false" && name != "capture" && name != "download") {
+          if (value == "false" && bool_attrs.indexOf(name)) {
             node.removeAttribute(name);
           } else {
             node.setAttribute(name, value);

--- a/packages/desktop/src/index.js
+++ b/packages/desktop/src/index.js
@@ -1,3 +1,32 @@
+const bool_attrs = [
+  "allowfullscreen",
+  "allowpaymentrequest",
+  "async",
+  "autofocus",
+  "autoplay",
+  "checked",
+  "controls",
+  "default",
+  "defer",
+  "disabled",
+  "formnovalidate",
+  "hidden",
+  "ismap",
+  "itemscope",
+  "loop",
+  "multiple",
+  "muted",
+  "nomodule",
+  "novalidate",
+  "open",
+  "playsinline",
+  "readonly",
+  "required",
+  "reversed",
+  "selected",
+  "truespeed",
+]
+
 function serialize_event(event) {
   switch (event.type) {
     case "copy":
@@ -369,36 +398,6 @@ class Interpreter {
           node.innerHTML = value;
           break;
         default:
-
-          const bool_attrs = [
-            "allowfullscreen",
-            "allowpaymentrequest",
-            "async",
-            "autofocus",
-            "autoplay",
-            "checked",
-            "controls",
-            "default",
-            "defer",
-            "disabled",
-            "formnovalidate",
-            "hidden",
-            "ismap",
-            "itemscope",
-            "loop",
-            "multiple",
-            "muted",
-            "nomodule",
-            "novalidate",
-            "open",
-            "playsinline",
-            "readonly",
-            "required",
-            "reversed",
-            "selected",
-            "truespeed",
-          ]
-
           // https://github.com/facebook/react/blob/8b88ac2592c5f555f315f9440cbb665dd1e7457a/packages/react-dom/src/shared/DOMProperty.js#L352-L364
           if (value == "false" && bool_attrs.indexOf(name)) {
             node.removeAttribute(name);

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -348,40 +348,42 @@ impl WebsysDom {
                     }
                 }
                 _ => {
-
-                    let bool_attrs = vec![
-                        "allowfullscreen",
-                        "allowpaymentrequest",
-                        "async",
-                        "autofocus",
-                        "autoplay",
-                        "checked",
-                        "controls",
-                        "default",
-                        "defer",
-                        "disabled",
-                        "formnovalidate",
-                        "hidden",
-                        "ismap",
-                        "itemscope",
-                        "loop",
-                        "multiple",
-                        "muted",
-                        "nomodule",
-                        "novalidate",
-                        "open",
-                        "playsinline",
-                        "readonly",
-                        "required",
-                        "reversed",
-                        "selected",
-                        "truespeed",
-                    ];
-
                     // https://github.com/facebook/react/blob/8b88ac2592c5f555f315f9440cbb665dd1e7457a/packages/react-dom/src/shared/DOMProperty.js#L352-L364
-                    if value == "false" && bool_attrs.contains(&name) {
+                    if value == "false" {
                         if let Some(el) = node.dyn_ref::<Element>() {
-                            let _ = el.remove_attribute(name);
+                            match name {
+                                "allowfullscreen"
+                                | "allowpaymentrequest"
+                                | "async"
+                                | "autofocus"
+                                | "autoplay"
+                                | "checked"
+                                | "controls"
+                                | "default"
+                                | "defer"
+                                | "disabled"
+                                | "formnovalidate"
+                                | "hidden"
+                                | "ismap"
+                                | "itemscope"
+                                | "loop"
+                                | "multiple"
+                                | "muted"
+                                | "nomodule"
+                                | "novalidate"
+                                | "open"
+                                | "playsinline"
+                                | "readonly"
+                                | "required"
+                                | "reversed"
+                                | "selected"
+                                | "truespeed" => {
+                                    let _ = el.remove_attribute(name);
+                                }
+                                _ => {
+                                    let _ = el.set_attribute(name, value);
+                                }
+                            };
                         }
                     } else {
                         fallback();

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -348,8 +348,38 @@ impl WebsysDom {
                     }
                 }
                 _ => {
+
+                    let bool_attrs = vec![
+                        "allowfullscreen",
+                        "allowpaymentrequest",
+                        "async",
+                        "autofocus",
+                        "autoplay",
+                        "checked",
+                        "controls",
+                        "default",
+                        "defer",
+                        "disabled",
+                        "formnovalidate",
+                        "hidden",
+                        "ismap",
+                        "itemscope",
+                        "loop",
+                        "multiple",
+                        "muted",
+                        "nomodule",
+                        "novalidate",
+                        "open",
+                        "playsinline",
+                        "readonly",
+                        "required",
+                        "reversed",
+                        "selected",
+                        "truespeed",
+                    ];
+
                     // https://github.com/facebook/react/blob/8b88ac2592c5f555f315f9440cbb665dd1e7457a/packages/react-dom/src/shared/DOMProperty.js#L352-L364
-                    if value == "false" && ((name != "capture") && (name != "download")) {
+                    if value == "false" && bool_attrs.contains(&name) {
                         if let Some(el) = node.dyn_ref::<Element>() {
                             let _ = el.remove_attribute(name);
                         }


### PR DESCRIPTION
I have add all `bool_attrs` into white_list, if the attr is a bool attr, then will check `true` and `false`, else normal set attribute.

```
"allowfullscreen",
"allowpaymentrequest",
"async",
"autofocus",
"autoplay",
"checked",
"controls",
"default",
"defer",
"disabled",
"formnovalidate",
"hidden",
"ismap",
"itemscope",
"loop",
"multiple",
"muted",
"nomodule",
"novalidate",
"open",
"playsinline",
"readonly",
"required",
"reversed",
"selected",
"truespeed",
```