### PR TITLE
Flatten optional prop attributes

### DIFF
--- a/examples/optional_props.rs
+++ b/examples/optional_props.rs
@@ -28,7 +28,7 @@ struct ButtonProps {
     #[props(default)]
     c: Option<String>,
 
-    #[props(default)]
+    #[props(default, strip_option)]
     d: Option<String>,
 }
 

--- a/examples/optional_props.rs
+++ b/examples/optional_props.rs
@@ -1,0 +1,37 @@
+//! Example: README.md showcase
+//!
+//! The example from the README.md.
+
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::desktop::launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    cx.render(rsx! {
+        Button {
+            a: "asd".to_string(),
+            c: Some("asd".to_string()),
+            d: "asd".to_string(),
+        }
+    })
+}
+
+#[derive(Props, PartialEq)]
+struct ButtonProps {
+    a: String,
+
+    #[props(default)]
+    b: Option<String>,
+
+    #[props(default)]
+    c: Option<String>,
+
+    #[props(default)]
+    d: Option<String>,
+}
+
+fn Button(cx: Scope<ButtonProps>) -> Element {
+    todo!()
+}

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -22,13 +22,13 @@ pub struct LinkProps<'a> {
     /// Link { to: Route::Home, href: Route::as_url }
     ///
     /// ```
-    #[props(default, setter(strip_option))]
+    #[props(default, strip_option)]
     href: Option<&'a str>,
 
-    #[props(default, setter(strip_option))]
+    #[props(default, strip_option)]
     class: Option<&'a str>,
 
-    #[props(default, setter(strip_option))]
+    #[props(default, strip_option)]
     id: Option<&'a str>,
 
     children: Element<'a>,

--- a/packages/router/src/components/router.rs
+++ b/packages/router/src/components/router.rs
@@ -11,7 +11,7 @@ use crate::RouterService;
 pub struct RouterProps<'a> {
     children: Element<'a>,
 
-    #[props(default, setter(strip_option))]
+    #[props(default, strip_option)]
     onchange: Option<&'a Fn(&'a str)>,
 }
 


### PR DESCRIPTION
This PR flattens the attributes provided to us by https://github.com/idanarye/rust-typed-builder

So instead of `#[props(setter(strip_option)]`, it would just be `#[props(strip_option)]`.

cc @autarch 