### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/guide/src/setup.md
+++ b/docs/guide/src/setup.md
@@ -38,7 +38,7 @@ For windows users: download the [bootstrapper for Webview2 from Microsoft](https
 
 For linux users, we need the development libraries for libgtk.
 
-````
+```
 sudo apt install libwebkit2gtk-4.0-dev libgtk-3-dev libappindicator3-dev
 ```
 


### PR DESCRIPTION
This breaks the page currently; https://dioxuslabs.com/guide/setup.html