### PR TITLE
docs: allow build core_reference/children example

### DIFF
--- a/examples/core_reference/children.rs
+++ b/examples/core_reference/children.rs
@@ -32,11 +32,11 @@ fn Example(cx: Scope) -> Element {
 }
 
 #[derive(Props)]
-struct BannerProps {
+struct BannerProps<'a> {
     children: Element<'a>,
 }
 
-fn Banner(cx: Scope) -> Element {
+fn Banner<'a>(cx: Scope<'a, BannerProps<'a>>) -> Element<'a> {
     cx.render(rsx! {
         div {
             h1 { "This is a great banner!" }


### PR DESCRIPTION
It needs lifetime parameters If you want to build it so I have added lifetime parameters.