### PR TITLE
feat: add "optional" flag for props

### DIFF
--- a/examples/optional_props.rs
+++ b/examples/optional_props.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 //! Example: README.md showcase
 //!
 //! The example from the README.md.
@@ -14,6 +16,7 @@ fn app(cx: Scope) -> Element {
             a: "asd".to_string(),
             c: Some("asd".to_string()),
             d: "asd".to_string(),
+            e: "asd".to_string(),
         }
     })
 }
@@ -30,8 +33,19 @@ struct ButtonProps {
 
     #[props(default, strip_option)]
     d: Option<String>,
+
+    #[props(optional)]
+    e: Option<String>,
 }
 
 fn Button(cx: Scope<ButtonProps>) -> Element {
-    todo!()
+    cx.render(rsx! {
+        button {
+            "{cx.props.a}"
+            "{cx.props.b:?}"
+            "{cx.props.c:?}"
+            "{cx.props.d:?}"
+            "{cx.props.e:?}"
+        }
+    })
 }

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -364,6 +364,14 @@ mod field_info {
                                 Some(syn::parse(quote!(Default::default()).into()).unwrap());
                             Ok(())
                         }
+
+                        "optional" => {
+                            self.default =
+                                Some(syn::parse(quote!(Default::default()).into()).unwrap());
+                            self.strip_option = true;
+                            Ok(())
+                        }
+
                         _ => {
                             macro_rules! handle_fields {
                                 ( $( $flag:expr, $field:ident, $already:expr; )* ) => {


### PR DESCRIPTION
Adds the flag "optional" to props that combines default and strip_option