### PR TITLE
Feat: add console_error_panic_hook by default for wasm

### DIFF
--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -20,7 +20,7 @@ wasm-bindgen-futures = "0.4.20"
 log = { version = "0.4.14", features = ["release_max_level_off"] }
 fxhash = "0.2.1"
 wasm-logger = "0.2.0"
-console_error_panic_hook = "0.1.6"
+console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen-test = "0.3.21"
 once_cell = "1.8"
 async-channel = "1.6.1"
@@ -69,22 +69,11 @@ features = [
     "IdleDeadline",
 ]
 
-
-# [lib]
-# crate-type = ["cdylib", "rlib"]
+[features]
+default = ["panic_hook"]
+panic_hook = ["console_error_panic_hook"]
 
 [dev-dependencies]
 dioxus-core-macro = { path = "../core-macro" }
 wasm-bindgen-test = "0.3.28"
 dioxus-ssr = { path = "../ssr" }
-# im-rc = "15.0.0"
-# separator = "0.4.1"
-# uuid = { version = "0.8.2", features = ["v4", "wasm-bindgen"] }
-# serde = { version = "1.0.126", features = ["derive"] }
-# reqwest = { version = "0.11", features = ["json"] }
-# dioxus-hooks = { path = "../hooks" }
-# rand = { version = "0.8.4", features = ["small_rng"] }
-
-# [dev-dependencies.getrandom]
-# version = "0.2"
-# features = ["js"]

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -120,6 +120,10 @@ pub fn launch_with_props<T, F>(
     T: Send + 'static,
     F: FnOnce(WebConfig) -> WebConfig,
 {
+    if cfg!(feature = "panic_hook") {
+        console_error_panic_hook::set_once();
+    }
+
     let config = configuration_builder(WebConfig::default());
     wasm_bindgen_futures::spawn_local(run_with_props(root_component, root_properties, config));
 }


### PR DESCRIPTION
Most users who want to build a Dioxus app *also* want stacktraces on panics. This PR just adds that by default, improving the onboarding DX for users so they can actually see *why* their app panicked.