### PR TITLE
Make log message in Link component trace level, not debug

### DIFF
--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -41,7 +41,7 @@ pub struct LinkProps<'a> {
 }
 
 pub fn Link<'a>(cx: Scope<'a, LinkProps<'a>>) -> Element {
-    log::debug!("render Link to {}", cx.props.to);
+    log::trace!("render Link to {}", cx.props.to);
     if let Some(service) = cx.consume_context::<RouterService>() {
         return cx.render(rsx! {
             a {


### PR DESCRIPTION
All the other routing-related messages are at the trace level. Leaving this at
debug was an oversight on my part.