### PR TITLE
Improve test speed in the CI

### DIFF
--- a/.docker/Dockerfile_pre_test
+++ b/.docker/Dockerfile_pre_test
@@ -1,9 +1,20 @@
 FROM rust:1.58-buster
 
 RUN apt update
-RUN apt install -y libglib2.0-dev libgtk-3-dev libsoup2.4-dev libappindicator3-dev libwebkit2gtk-4.0-dev firefox-esr
+RUN apt install -y \
+    libglib2.0-dev \
+    libgtk-3-dev \
+    libsoup2.4-dev \
+    libappindicator3-dev \
+    libwebkit2gtk-4.0-dev \
+    firefox-esr
+# for kcov and Tarpaulin
+#liblzma-dev binutils-dev libcurl4-openssl-dev libdw-dev libelf-dev
 
 RUN cargo install cargo-make --debug
+# for test coverage
+#RUN cargo install cargo-tarpaulin
+# clean up a bit
 RUN cargo install cargo-cache && cargo cache -a
 
-CMD ["echo","\"base image built\""]
+CMD ["exit"]

--- a/.docker/run_local_tests.sh
+++ b/.docker/run_local_tests.sh
@@ -25,14 +25,13 @@ function run_script {
         then
         docker image rm dioxus-base-test-image
         docker image rm dioxus-test-image
-        docker system prune -af
         fi
     fi
 }
 
 run_script || echo "Error occured.. cleaning a bit." && \
-    docker system prune -af;
+    docker system prune -f;
 
-docker system prune -af
+docker system prune -f
 
 echo "Script finished to execute"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,9 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - run: sudo apt-get update
       - run: sudo apt install libwebkit2gtk-4.0-dev libappindicator3-dev libgtk-3-dev
-      - name: Install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+      - uses: davidB/rust-cargo-make@v1
       - uses: browser-actions/setup-firefox@latest
+      - uses: jetli/wasm-pack-action@v0.3.0
       - uses: actions-rs/cargo@v1
         with:
           command: make

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,13 +10,6 @@ CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 namespace = "core"
 private = true
 
-[tasks.tests]
-category = "Testing"
-dependencies = ["tests-setup"]
-description = "Run all tests"
-env = {CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*", "**/packages/changelog"]}
-run_task = {name = ["test-flow"], fork = true}
-
 [tasks.tests-setup]
 private = true
 script = [
@@ -31,12 +24,28 @@ script = [
 ]
 script_runner = "@duckscript"
 
+[tasks.tests]
+category = "Testing"
+dependencies = ["tests-setup"]
+description = "Run all tests"
+env = {CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*"]}
+run_task = {name = ["test-flow", "test-with-browser"], fork = true}
+
+[tasks.build]
+command = "cargo"
+args = ["build"]
+
 [tasks.test-flow]
 dependencies = ["test"]
 private = true
-workspace = true
 
 [tasks.test]
-args = ["test", "--all-targets", "--workspace", "--exclude", "dioxus-mobile"]
+dependencies = ["build"]
 command = "cargo"
+args = ["test", "--all-targets", "--workspace", "--exclude", "dioxus-router"]
 private = true
+
+[tasks.test-with-browser]
+env = { CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS = ["**/packages/router"] }
+private = true
+workspace = true

--- a/packages/router/Makefile.toml
+++ b/packages/router/Makefile.toml
@@ -1,4 +1,4 @@
-[tasks.test]
+[tasks.test-with-browser]
 extend = "core::wasm-pack-base"
 command = "wasm-pack"
 args = [


### PR DESCRIPTION
I modified the Makefile a bit so that it doesn't compile on every crate. Instead, it builds first then runs the tests (eventually build what is required for the tests). With this in place, tests in CI take much less time to proceed.
Added also a separate test in the Makefile will test with proper configuration for runtime tests.