### PR TITLE
feat: use serde-wasm-bindgen crate for speedup

### DIFF
--- a/packages/interpreter/src/bindings.rs
+++ b/packages/interpreter/src/bindings.rs
@@ -31,7 +31,7 @@ extern "C" {
     pub fn Remove(this: &Interpreter, root: u64);
 
     #[wasm_bindgen(method)]
-    pub fn CreateTextNode(this: &Interpreter, text: &str, root: u64);
+    pub fn CreateTextNode(this: &Interpreter, text: JsValue, root: u64);
 
     #[wasm_bindgen(method)]
     pub fn CreateElement(this: &Interpreter, tag: &str, root: u64);
@@ -49,10 +49,16 @@ extern "C" {
     pub fn RemoveEventListener(this: &Interpreter, root: u64, name: &str);
 
     #[wasm_bindgen(method)]
-    pub fn SetText(this: &Interpreter, root: u64, text: &str);
+    pub fn SetText(this: &Interpreter, root: u64, text: JsValue);
 
     #[wasm_bindgen(method)]
-    pub fn SetAttribute(this: &Interpreter, root: u64, field: &str, value: &str, ns: Option<&str>);
+    pub fn SetAttribute(
+        this: &Interpreter,
+        root: u64,
+        field: &str,
+        value: JsValue,
+        ns: Option<&str>,
+    );
 
     #[wasm_bindgen(method)]
     pub fn RemoveAttribute(this: &Interpreter, root: u64, field: &str);

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -29,6 +29,7 @@ gloo-timers = { version = "0.2.3", features = ["futures"] }
 futures-util = "0.3.19"
 smallstr = "0.2.0"
 dioxus-interpreter-js = { path = "../interpreter", version = "^0.0.0", features = ["web"] }
+serde-wasm-bindgen = "0.4.2"
 
 [dependencies.web-sys]
 version = "0.3.56"

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -105,9 +105,7 @@ impl WebsysDom {
                 DomEdit::InsertAfter { root, n } => self.interpreter.InsertAfter(root, n),
                 DomEdit::InsertBefore { root, n } => self.interpreter.InsertBefore(root, n),
                 DomEdit::Remove { root } => self.interpreter.Remove(root),
-                DomEdit::CreateTextNode { text, root } => {
-                    self.interpreter.CreateTextNode(text, root)
-                }
+
                 DomEdit::CreateElement { tag, root } => self.interpreter.CreateElement(tag, root),
                 DomEdit::CreateElementNs { tag, root, ns } => {
                     self.interpreter.CreateElementNs(tag, root, ns)
@@ -123,15 +121,27 @@ impl WebsysDom {
                 DomEdit::RemoveEventListener { root, event } => {
                     self.interpreter.RemoveEventListener(root, event)
                 }
-                DomEdit::SetText { root, text } => self.interpreter.SetText(root, text),
+
+                DomEdit::RemoveAttribute { root, name } => {
+                    self.interpreter.RemoveAttribute(root, name)
+                }
+
+                DomEdit::CreateTextNode { text, root } => {
+                    let text = serde_wasm_bindgen::to_value(text).unwrap();
+                    self.interpreter.CreateTextNode(text, root)
+                }
+                DomEdit::SetText { root, text } => {
+                    let text = serde_wasm_bindgen::to_value(text).unwrap();
+                    self.interpreter.SetText(root, text)
+                }
                 DomEdit::SetAttribute {
                     root,
                     field,
                     value,
                     ns,
-                } => self.interpreter.SetAttribute(root, field, value, ns),
-                DomEdit::RemoveAttribute { root, name } => {
-                    self.interpreter.RemoveAttribute(root, name)
+                } => {
+                    let value = serde_wasm_bindgen::to_value(value).unwrap();
+                    self.interpreter.SetAttribute(root, field, value, ns)
                 }
             }
         }


### PR DESCRIPTION
This PR uses the crate suggested by @t1m0t to use a different flavor of converting strings to JsValues. On my machine, this results in a performance improvement of about 20% and a size reduction of 10%.