### PR TITLE
fix: class attributes don't adhere to es6 spec

### DIFF
--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -6,12 +6,6 @@ export function main() {
   }
 }
 export class Interpreter {
-  root;
-  stack;
-  listeners;
-  handlers;
-  lastNodeWasText;
-  nodes;
   constructor(root) {
     this.root = root;
     this.stack = [root];


### PR DESCRIPTION
Fixes #215 .

TSC was generating too modern of code that carried over into the current version. This PR removes class attributes to adhere to es6 (the latest spec we adhere to).