### PR TITLE
fix: always prevent default on `A` tags in desktop

### DIFF
--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -217,6 +217,11 @@ export class Interpreter {
                   }
                 }
               }
+
+              // also prevent buttons from submitting
+              if (target.tagName == "BUTTON") {
+                event.preventDefault();
+              }
             }
             // walk the tree to find the real element
             while (realId == null) {

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -210,6 +210,7 @@ export class Interpreter {
               // todo call prevent default if it's the right type of event
               if (shouldPreventDefault !== `onclick`) {
                 if (target.tagName == "A") {
+                  event.preventDefault();
                   const href = target.getAttribute("href");
                   if (href !== "" && href !== null && href !== undefined) {
                     window.rpc.call("browser_open", { href });


### PR DESCRIPTION
We had a regression in a recent commit that removed prevent default in all desktop cases.

This PR fixes that, re-enabling out-linking.