### PR TITLE
Transparent window means transparent WebView

### DIFF
--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -177,6 +177,7 @@ pub fn launch_with_props<P: 'static + Send>(
 
                 let mut webview = WebViewBuilder::new(window)
                     .unwrap()
+                    .with_transparent(cfg.window.window.transparent)
                     .with_url("dioxus://index.html/")
                     .unwrap()
                     .with_rpc_handler(move |_window: &Window, req: RpcRequest| {


### PR DESCRIPTION
Hi,

Small contribution here. When creating a transparent Window, shouldn't it also set the `WevView` to be transparent automatically ? This is what this PR is about.

Unfortunately, I am wondering if someone somewhere would need the window to be transparent, but not the `WevView`. If that's the case, then this solution won't do...but really, why would someone need that kind of feature ?

Have a nice day!