### PR TITLE
Clean up desktop's index.html

### DIFF
--- a/packages/desktop/src/index.html
+++ b/packages/desktop/src/index.html
@@ -1,22 +1,15 @@
 <!DOCTYPE html>
 <html>
-
-<html>
-
-<head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" charset="utf-8" />
-</head>
-
-
-<body>
-    <div id="main">
-    </div>
-</body>
-
-<script>
-    import("./index.js").then(function (module) {
-        module.main();
-    });
-</script>
-
+    <head>
+        <title>Dioxus app</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    </head>
+    <body>
+        <div id="main"></div>
+        <script>
+            import("./index.js").then(function (module) {
+                module.main();
+            });
+        </script>
+    </body>
 </html>


### PR DESCRIPTION
Initially I wanted to delete only the duplicated `<html>` opening tag, but then decided to make it a fully valid HTML document.

Passes https://validator.w3.org/nu/#textarea check.