### PR TITLE
feat: enable multiwindow support for desktop apps

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -32,6 +32,8 @@ dioxus-html = { path = "../html", features = ["serialize"], version = "^0.1.6" }
 webbrowser = "0.5.5"
 mime_guess = "2.0.3"
 dioxus-interpreter-js = { path = "../interpreter", version = "^0.0.0" }
+futures = "0.3.21"
+futures-util = "0.3.21"
 
 
 [features]

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -1,9 +1,9 @@
 use std::rc::Rc;
 
-use dioxus_core::ScopeState;
+use dioxus_core::{Component, ScopeState};
 use wry::application::event_loop::EventLoopProxy;
 
-use crate::UserWindowEvent;
+use crate::{cfg::DesktopConfig, UserWindowEvent};
 
 type ProxyType = EventLoopProxy<UserWindowEvent>;
 
@@ -104,6 +104,15 @@ impl DesktopContext {
         let _ = self
             .proxy
             .send_event(UserWindowEvent::SetDecorations(decoration));
+    }
+
+    /// change window to borderless
+    pub fn create_window<P: 'static>(
+        &self,
+        root: Component<P>,
+        props: P,
+        builder: impl FnOnce(&mut DesktopConfig) -> &mut DesktopConfig,
+    ) {
     }
 }
 


### PR DESCRIPTION
This PR uses the work done by @mrxiaozhuox to enable multiwindow desktop apps through the window context API. To achieve this, we send along props and a root component to launch a new window with. This means windows cannot accept new children, but they *can* accept `'static` props. I'd like to add non-static prop support at some point but core itself doesn't support this.

In the future, we can support multiwindow more natively with subtrees, but for now, we can only do VirtualDom linking.

I'm not entirely sure how cross-app contexts will work in this architecture since most contexts believe they are the only context in an app.

Anyways, this will be an awesome feature to support through components or hooks.
