### PR TITLE
Fix closure signature for use_ref example in interactivity docs

### DIFF
--- a/docs/guide/src/interactivity/hooks.md
+++ b/docs/guide/src/interactivity/hooks.md
@@ -140,7 +140,7 @@ fn Child(cx: Scope, name: String) -> Element {
 
 // ✅ Or, use a hashmap with use_ref
 ```rust
-let ages = use_ref(&cx, |_| HashMap::new());
+let ages = use_ref(&cx, || HashMap::new());
 
 names.iter().map(|name| {
     let age = ages.get(name).unwrap();


### PR DESCRIPTION
The example showed the closure accepting a single argument, but it accepts none.