### PR TITLE
Use futures-channel instead of async-channel in rIC/rAF code

### DIFF
--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -23,13 +23,13 @@ wasm-logger = "0.2.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 wasm-bindgen-test = "0.3.29"
 once_cell = "1.9.0"
-async-channel = "1.6.1"
 anyhow = "1.0.53"
 gloo-timers = { version = "0.2.3", features = ["futures"] }
 futures-util = "0.3.19"
 smallstr = "0.2.0"
 dioxus-interpreter-js = { path = "../interpreter", version = "^0.0.0", features = ["web"] }
 serde-wasm-bindgen = "0.4.2"
+futures-channel = "0.3.21"
 
 [dependencies.web-sys]
 version = "0.3.56"

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -87,14 +87,11 @@ impl WebsysDom {
             }
         });
 
+        // a match here in order to avoid some error during runtime browser test
         let document = load_document();
         let root = match document.get_element_by_id(&cfg.rootname) {
             Some(root) => root,
-            // a match here in order to avoid some error during runtime browser test
-            None => {
-                let body = document.create_element("body").ok().unwrap();
-                body
-            }
+            None => document.create_element("body").ok().unwrap(),
         };
 
         Self {

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -211,7 +211,7 @@ pub async fn run_with_props<T: 'static + Send>(root: Component<T>, root_props: T
         websys_dom.apply_edits(edits.edits);
     }
 
-    let work_loop = ric_raf::RafLoop::new();
+    let mut work_loop = ric_raf::RafLoop::new();
 
     loop {
         log::trace!("waiting for work");


### PR DESCRIPTION
This PR re-uses the dioxus-core futures-channel dependency instead of pulling in the async-channel dependency.