### PR TITLE
Make all packages which require futures-channel ask for the same version

### DIFF
--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -32,7 +32,7 @@ smallvec = "1.6"
 
 slab = "0.4"
 
-futures-channel = "0.3"
+futures-channel = "0.3.21"
 
 # used for noderefs
 once_cell = "1.8"


### PR DESCRIPTION
If they aren't the same then Cargo cannot resolve a working version for some reason.