### PR TITLE
fix unnecessary div

### DIFF
--- a/packages/router/src/components/router.rs
+++ b/packages/router/src/components/router.rs
@@ -33,6 +33,6 @@ pub fn Router<'a>(cx: Scope<'a, RouterProps<'a>>) -> Element {
     }
 
     cx.render(rsx!(
-        div { &cx.props.children }
+        &cx.props.children
     ))
 }

--- a/packages/router/src/components/router.rs
+++ b/packages/router/src/components/router.rs
@@ -32,7 +32,5 @@ pub fn Router<'a>(cx: Scope<'a, RouterProps<'a>>) -> Element {
         cx.props.onchange.call(path.to_string());
     }
 
-    cx.render(rsx!(
-        &cx.props.children
-    ))
+    cx.render(rsx!(&cx.props.children))
 }


### PR DESCRIPTION
This PR removes the `div` element that was wrapped around children of the router. This could confuse people and throw css styles off.