### PR TITLE
fix: ping window after virtualdom is ready

### DIFF
--- a/examples/heavy_compute.rs
+++ b/examples/heavy_compute.rs
@@ -1,0 +1,28 @@
+//! This example shows that you can place heavy work on the main thread, and then
+//!
+//! You *should* be using `tokio::spawn_blocking` instead.
+//!
+//! Your app runs in an async runtime (Tokio), so you should avoid blocking
+//! the rendering of the VirtualDom.
+//!
+//!
+
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::desktop::launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    // This is discouraged
+    std::thread::sleep(std::time::Duration::from_millis(2_000));
+
+    // This is suggested
+    tokio::task::spawn_blocking(move || {
+        std::thread::sleep(std::time::Duration::from_millis(2_000));
+    });
+
+    cx.render(rsx! {
+        div { "Hello, world!" }
+    })
+}

--- a/packages/desktop/src/controller.rs
+++ b/packages/desktop/src/controller.rs
@@ -57,6 +57,9 @@ impl DesktopController {
                     .unwrap()
                     .push_front(serde_json::to_string(&edits.edits).unwrap());
 
+                // Make sure the window is ready for any new updates
+                proxy.send_event(UserWindowEvent::Update).unwrap();
+
                 loop {
                     dom.wait_for_work().await;
                     let mut muts = dom.work_with_deadline(|| false);

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -143,7 +143,6 @@ pub fn launch_with_props<P: 'static + Send>(
                                         .send_event(user_window_events::UserWindowEvent::Update);
                                 }
                                 "browser_open" => {
-                                    println!("browser_open");
                                     let data = message.params();
                                     log::trace!("Open browser: {:?}", data);
                                     if let Some(temp) = data.as_object() {

--- a/packages/desktop/src/user_window_events.rs
+++ b/packages/desktop/src/user_window_events.rs
@@ -3,6 +3,7 @@ use wry::application::window::Fullscreen as WryFullscreen;
 
 use crate::controller::DesktopController;
 
+#[derive(Debug)]
 pub(crate) enum UserWindowEvent {
     Update,
 


### PR DESCRIPTION
Fix #266 

We weren't pinging the window to wake up after the initial rebuild - which we do after every *new* edit is generated.