### PR TITLE
Add pretty printer for RSX (autoformatting)

### DIFF
--- a/packages/rsx/Cargo.toml
+++ b/packages/rsx/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro-error = "1.0.4"
 proc-macro2 = { version = "1.0.6" }
 quote = "1.0"
 syn = { version = "1.0.11", features = ["full", "extra-traits"] }
+prettyplease = {git = "https://github.com/jkelleyrtp/prettyplease.git", branch = "jk/expr"}

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -19,7 +19,7 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     ext::IdentExt,
     parse::{Parse, ParseBuffer, ParseStream},
-    token, Expr, Ident, LitStr, Result, Token,
+    token, Attribute, Expr, Ident, LitStr, Result, Token,
 };
 
 pub struct Component {
@@ -150,14 +150,15 @@ impl ToTokens for Component {
 
 // the struct's fields info
 pub struct ComponentField {
-    name: Ident,
-    content: ContentField,
+    pub name: Ident,
+    pub content: ContentField,
 }
 
-enum ContentField {
+pub enum ContentField {
     ManExpr(Expr),
     Formatted(LitStr),
     OnHandlerRaw(Expr),
+    Meta(Attribute),
 }
 
 impl ToTokens for ContentField {
@@ -170,6 +171,7 @@ impl ToTokens for ContentField {
             ContentField::OnHandlerRaw(e) => tokens.append_all(quote! {
                 __cx.event_handler(#e)
             }),
+            ContentField::Meta(_) => {}
         }
     }
 }

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseBuffer, ParseStream},
-    Expr, Ident, LitStr, Result, Token,
+    Attribute, Expr, Ident, LitStr, Result, Token,
 };
 
 // =======================================
@@ -235,6 +235,9 @@ pub enum ElementAttr {
     // EventClosure { name: Ident, closure: ExprClosure },
     /// onclick: {}
     EventTokens { name: Ident, tokens: Expr },
+
+    /// Comments/attributes
+    Meta(Attribute),
 }
 
 pub struct ElementAttrNamed {
@@ -276,6 +279,9 @@ impl ToTokens for ElementAttrNamed {
                 quote! {
                     dioxus_elements::on::#name(__cx, #tokens)
                 }
+            }
+            ElementAttr::Meta(_) => {
+                return;
             }
         });
     }

--- a/packages/rsx/src/pretty.rs
+++ b/packages/rsx/src/pretty.rs
@@ -1,1 +1,176 @@
 //! pretty printer for rsx!
+use syn::{Attribute, Meta};
+
+use crate::*;
+use std::fmt::{self, Write};
+
+fn fmt_block(block: &str) -> Option<String> {
+    let parsed: CallBody = syn::parse_str(block).ok()?;
+
+    let mut buf = String::new();
+
+    for node in parsed.roots.iter() {
+        write_ident(&mut buf, node, 0).ok()?;
+    }
+
+    Some(buf)
+}
+
+fn write_ident(buf: &mut dyn Write, node: &BodyNode, indent: usize) -> fmt::Result {
+    match node {
+        BodyNode::Element(el) => {
+            let Element {
+                name,
+                key,
+                attributes,
+                children,
+                _is_static,
+            } = el;
+
+            write_tabs(buf, indent)?;
+            writeln!(buf, "{name} {{")?;
+
+            if let Some(key) = key {
+                let key = key.value();
+                write_tabs(buf, indent + 1)?;
+                write!(buf, "key: \"{key}\"")?;
+                if !attributes.is_empty() {
+                    writeln!(buf, ",")?;
+                }
+            }
+
+            for attr in attributes {
+                write_tabs(buf, indent + 1)?;
+                match &attr.attr {
+                    ElementAttr::AttrText { name, value } => {
+                        writeln!(buf, "{name}: \"{value}\",", value = value.value())?;
+                    }
+                    ElementAttr::AttrExpression { name, value } => {
+                        let out = prettyplease::unparse_expr(value);
+                        writeln!(buf, "{}: {},", name, out)?;
+                    }
+
+                    ElementAttr::CustomAttrText { name, value } => todo!(),
+                    ElementAttr::CustomAttrExpression { name, value } => todo!(),
+
+                    ElementAttr::EventTokens { name, tokens } => {
+                        let out = prettyplease::unparse_expr(tokens);
+
+                        let mut lines = out.split('\n').peekable();
+                        let first = lines.next().unwrap();
+                        writeln!(buf, "{}: {}", name, first)?;
+
+                        while let Some(line) = lines.next() {
+                            write_tabs(buf, indent + 1)?;
+                            write!(buf, "{}", line)?;
+                            // writeln!(buf, "{}", line)?;
+                            if lines.peek().is_none() {
+                                writeln!(buf, ",")?;
+                            } else {
+                                writeln!(buf)?;
+                            }
+                        }
+                    }
+                    ElementAttr::Meta(_) => {}
+                }
+            }
+
+            for child in children {
+                write_ident(buf, child, indent + 1)?;
+            }
+
+            write_tabs(buf, indent)?;
+            writeln!(buf, "}}")?;
+        }
+        BodyNode::Component(_) => {
+            //
+            // write!(buf, "{}", " ".repeat(ident))
+        }
+        BodyNode::Text(t) => {
+            //
+            // write!(buf, "{}", " ".repeat(ident))
+            write_tabs(buf, indent)?;
+            writeln!(buf, "\"{}\"", t.value())?;
+        }
+        BodyNode::RawExpr(_) => {
+            //
+            // write!(buf, "{}", " ".repeat(ident))
+        }
+        BodyNode::Meta(att) => {
+            //
+            // if att.path.segments.last().unwrap().ident == "doc" {
+            let val = att.tokens.to_string();
+            write_tabs(buf, indent)?;
+            writeln!(buf, "{}", val)?;
+            // }
+            // match att {}
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
+fn formats_block() {
+    let block = r#"
+        div {
+                                    div {
+                                    class: "asd",
+                                    class: "asd",class: "asd",class: "asd",class: "asd",class: "asd",
+                                    key: "ddd",
+                                    onclick: move |_| {
+                                        let blah = 120;
+                                                    true
+                                    },
+                                    blah: 123,
+                                    onclick: move |_| {
+                                        let blah = 120;
+                                                    true
+                                    },
+                                    onclick: move |_| {
+                                        let blah = 120;
+                                                    true
+                                    },
+                                    onclick: move |_| {
+                                        let blah = 120;
+                                                    true
+                                    },
+
+                                    div {
+                                        div {
+                                            "hi"
+                                        }
+                                        h2 {
+                            class: "asd",
+                                        }
+                                    }
+            }
+        }
+    "#;
+
+    let formatted = fmt_block(block).unwrap();
+
+    print!("{formatted}");
+}
+
+fn write_tabs(f: &mut dyn Write, num: usize) -> std::fmt::Result {
+    for _ in 0..num {
+        write!(f, "    ")?
+    }
+    Ok(())
+}
+
+#[test]
+fn parse_comment() {
+    let block = r#"
+    div {
+        adsasd: "asd", // this is a comment
+    }
+        "#;
+
+    // let parsed: CallBody = syn::parse_str(block).ok()?;
+
+    let parsed: TokenStream2 = syn::parse_str(block).unwrap();
+
+    dbg!(parsed);
+}


### PR DESCRIPTION
This PR adds a pretty printer for the RSX AST. Unfortunately, regular comments are not preserved in the parsing of rust code into a TokenStream. I'm not sure if we can get those.

edit: aha! we can https://github.com/dtolnay/syn/issues/946#issuecomment-809026437