### PR TITLE
Disable reload context menu in production

### DIFF
--- a/packages/desktop/src/index.html
+++ b/packages/desktop/src/index.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Dioxus app</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    </head>
-    <body>
-        <div id="main"></div>
-        <script>
-            import("./index.js").then(function (module) {
-                module.main();
-            });
-        </script>
-    </body>
+  <head>
+    <title>Dioxus app</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <div id="main"></div>
+    <script>
+      import("./index.js").then(function (module) {
+        module.main();
+      });
+    </script>
+  </body>
 </html>

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -174,7 +174,25 @@ pub fn launch_with_props<P: 'static + Send>(
                 }
 
                 if cfg!(debug_assertions) {
+                    // in debug, we are okay with the reload menu showing and dev tool
                     webview = webview.with_dev_tool(true);
+                } else {
+                    // in release mode, we don't want to show the dev tool or reload menus
+                    webview = webview.with_initialization_script(
+                        r#"
+                        if (document.addEventListener) {
+                        document.addEventListener('contextmenu', function(e) {
+                            alert("You've tried to open context menu");
+                            e.preventDefault();
+                        }, false);
+                        } else {
+                        document.attachEvent('oncontextmenu', function() {
+                            alert("You've tried to open context menu");
+                            window.event.returnValue = false;
+                        });
+                        }
+                    "#,
+                    )
                 }
 
                 desktop.webviews.insert(window_id, webview.build().unwrap());


### PR DESCRIPTION
Webview will never get custom context menus (the thing when you right click), so it's up to app authors to implement their own context menus. A library for making that easier will be very helpful to the Dioxus ecosystem.

Anyways, this PR adds an initialization script in release mode that disables the context menu altogether, since having a right click menu that *just* shows reload is probably not super helpful to most users.