### PR TITLE
fixing build warnings in hello world example

### DIFF
--- a/docs/guide/src/hello_world.md
+++ b/docs/guide/src/hello_world.md
@@ -63,7 +63,7 @@ $ cat Cargo.toml
 [package]
 name = "hello-dioxus"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -92,10 +92,10 @@ use dioxus::prelude::*;
 
 
 fn main() {
-    dioxus::desktop::launch(App);
+    dioxus::desktop::launch(app);
 }
 
-fn App(cx: Scope) -> Element {
+fn app(cx: Scope) -> Element {
     cx.render(rsx! (
         div { "Hello, world!" }
     ))
@@ -118,14 +118,14 @@ This initialization code launches a Tokio runtime on a helper thread where your 
 
 ```rust
 fn main() {
-    dioxus::desktop::launch(App);
+    dioxus::desktop::launch(app);
 }
 ```
 
 Finally, our app. Every component in Dioxus is a function that takes in `Context` and `Props` and returns an `Element`.
 
 ```rust
-fn App(cx: Scope) -> Element {
+fn app(cx: Scope) -> Element {
     cx.render(rsx! {
         div { "Hello, world!" }
     })


### PR DESCRIPTION
Fixing this warning when I try to compile

warning: function `App` should have a snake case name
 --> src/main.rs:7:4
  |
7 | fn App(cx: Scope) -> Element {
  |    ^^^ help: convert the identifier to snake case: `app`
  |
  = note: `#[warn(non_snake_case)]` on by default

Also changing edition from 2018 to 2021