### PR TITLE
feat: canoncialize assets for macOS, Windows, and Linux

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -29,6 +29,11 @@ dioxus-html = { path = "../html", features = ["serialize"], version = "^0.1.6" }
 webbrowser = "0.5.5"
 mime_guess = "2.0.3"
 dioxus-interpreter-js = { path = "../interpreter", version = "^0.0.0" }
+dunce = "1.0.2"
+
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.9.3"
 
 
 [features]

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -30,11 +30,8 @@ webbrowser = "0.5.5"
 mime_guess = "2.0.3"
 dioxus-interpreter-js = { path = "../interpreter", version = "^0.0.0" }
 dunce = "1.0.2"
-
-
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.3"
-
 
 [features]
 default = ["tokio_runtime"]

--- a/packages/desktop/src/cfg.rs
+++ b/packages/desktop/src/cfg.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use wry::application::window::Icon;
 use wry::{
     application::{
@@ -18,6 +20,7 @@ pub struct DesktopConfig {
     pub(crate) pre_rendered: Option<String>,
     pub(crate) event_handler: Option<Box<DynEventHandlerFn>>,
     pub(crate) disable_context_menu: bool,
+    pub(crate) resource_dir: Option<PathBuf>,
 }
 
 pub(crate) type WryProtocol = (
@@ -38,14 +41,23 @@ impl DesktopConfig {
             file_drop_handler: None,
             pre_rendered: None,
             disable_context_menu: !cfg!(debug_assertions),
+            resource_dir: None,
         }
     }
 
+    /// set the directory from which assets will be searched in release mode
+    pub fn with_resource_directory(mut self, path: impl Into<PathBuf>) -> Self {
+        self.resource_dir = Some(path.into());
+        self
+    }
+
+    /// Set whether or not the right-click context menu should be disabled.
     pub fn with_disable_context_menu(&mut self, disable: bool) -> &mut Self {
         self.disable_context_menu = disable;
         self
     }
 
+    /// With pre-rendered HTML content
     pub fn with_prerendered(&mut self, content: String) -> &mut Self {
         self.pre_rendered = Some(content);
         self

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -122,7 +122,10 @@ pub fn launch_with_props<P: 'static + Send>(
                 let (is_ready, sender) = (desktop.is_ready.clone(), desktop.sender.clone());
 
                 let proxy = proxy.clone();
+
                 let file_handler = cfg.file_drop_handler.take();
+
+                let resource_dir = cfg.resource_dir.clone();
 
                 let mut webview = WebViewBuilder::new(window)
                     .unwrap()
@@ -160,7 +163,9 @@ pub fn launch_with_props<P: 'static + Send>(
                                 log::warn!("invalid IPC message received");
                             });
                     })
-                    .with_custom_protocol(String::from("dioxus"), protocol::desktop_handler)
+                    .with_custom_protocol(String::from("dioxus"), move |r| {
+                        protocol::desktop_handler(r, resource_dir.clone())
+                    })
                     .with_file_drop_handler(move |window, evet| {
                         file_handler
                             .as_ref()

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -4,7 +4,7 @@ use wry::{
     Result,
 };
 
-pub(super) fn desktop_handler(request: &Request) -> Result<Response> {
+pub(super) fn desktop_handler(request: &Request, asset_root: Option<PathBuf>) -> Result<Response> {
     // Any content that uses the `dioxus://` scheme will be shuttled through this handler as a "special case".
     // For now, we only serve two pieces of content which get included as bytes into the final binary.
     let path = request.uri().replace("dioxus://", "");
@@ -21,7 +21,9 @@ pub(super) fn desktop_handler(request: &Request) -> Result<Response> {
             .mimetype("text/javascript")
             .body(dioxus_interpreter_js::INTERPRETER_JS.as_bytes().to_vec())
     } else {
-        let asset_root = get_asset_root().unwrap_or_else(|| Path::new(".").to_path_buf());
+        let asset_root = asset_root
+            .unwrap_or_else(|| get_asset_root().unwrap_or_else(|| Path::new(".").to_path_buf()));
+
         let asset = asset_root.join(trimmed).canonicalize()?;
 
         if !asset.starts_with(asset_root) {


### PR DESCRIPTION
This PR adds the right relative pathing for assets when bundled through cargo-bundle.

It's never been this easy to include an image in your Rust `.app`! :)

I don't have any other machine than a mac box so I can't test alternate implementations.

https://crates.io/crates/directories

- [x] macOS

These targets do not provide a straightforward way of bundling assets. I've opted to make it the asset dir configurable instead.
- [ ] windows
- [ ] linux (rpm)
- [ ] linux (deb)