### PR TITLE
fix: actually remove nodes in keyed_diff_middle

### DIFF
--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -813,6 +813,15 @@ impl<'b> DiffState<'b> {
             return;
         }
 
+        // remove any old children that are not shared
+        // todo: make this an iterator
+        for child in old {
+            let key = child.key().unwrap();
+            if !shared_keys.contains(&key) {
+                self.remove_nodes([child], true);
+            }
+        }
+
         // 4. Compute the LIS of this list
         let mut lis_sequence = Vec::default();
         lis_sequence.reserve(new_index_to_old_index.len());

--- a/packages/core/tests/diffing.rs
+++ b/packages/core/tests/diffing.rs
@@ -623,16 +623,17 @@ fn controlled_keyed_diffing_out_of_order() {
     assert_eq!(
         changes.edits,
         [
+            Remove { root: 4 },
             // move 4 to after 6
             PushRoot { root: 1 },
             InsertAfter { n: 1, root: 3 },
             // remove 7
 
             // create 9 and insert before 6
-            CreateElement { root: 5, tag: "div" },
+            CreateElement { root: 4, tag: "div" },
             InsertBefore { n: 1, root: 3 },
             // create 0 and insert before 5
-            CreateElement { root: 6, tag: "div" },
+            CreateElement { root: 5, tag: "div" },
             InsertBefore { n: 1, root: 2 },
         ]
     );
@@ -659,7 +660,8 @@ fn controlled_keyed_diffing_out_of_order_max_test() {
     assert_eq!(
         changes.edits,
         [
-            CreateElement { root: 6, tag: "div" },
+            Remove { root: 5 },
+            CreateElement { root: 5, tag: "div" },
             InsertBefore { n: 1, root: 3 },
             PushRoot { root: 4 },
             InsertBefore { n: 1, root: 1 },


### PR DESCRIPTION
I guess this bit of code got lost in the refactor from iterative to recursive. 😅

Derp derp derp