### PR TITLE
tui bugfixes and text modifier elements

### DIFF
--- a/packages/tui/Cargo.toml
+++ b/packages/tui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dioxus-tui"
 version = "0.2.0"
 authors = ["Jonathan Kelley, @dementhos"]
-edition = "2018"
+edition = "2021"
 description = "TUI-based renderer for Dioxus"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
@@ -19,10 +19,7 @@ dioxus-html = { path = "../html", version = "^0.2.0" }
 tui = "0.17.0"
 crossterm = "0.23.0"
 anyhow = "1.0.42"
-thiserror = "1.0.24"
-ctrlc = "3.2.1"
-bumpalo = { version = "3.8.0", features = ["boxed"] }
 tokio = { version = "1.15.0", features = ["full"] }
 futures = "0.3.19"
-stretch2 = "0.4.0"
+stretch2 = "0.4.1"
 

--- a/packages/tui/src/layout.rs
+++ b/packages/tui/src/layout.rs
@@ -55,6 +55,25 @@ pub fn collect_layout<'a>(
                 tui_modifier: TuiModifier::default(),
             };
 
+            // handle text modifier elements
+            if el.namespace.is_none() {
+                match el.tag {
+                    "b" => apply_attributes("font-weight", "bold", &mut modifier),
+                    "strong" => apply_attributes("font-weight", "bold", &mut modifier),
+                    "u" => apply_attributes("text-decoration", "underline", &mut modifier),
+                    "ins" => apply_attributes("text-decoration", "underline", &mut modifier),
+                    "del" => apply_attributes("text-decoration", "line-through", &mut modifier),
+                    "i" => apply_attributes("font-style", "italic", &mut modifier),
+                    "em" => apply_attributes("font-style", "italic", &mut modifier),
+                    "mark" => apply_attributes(
+                        "background-color",
+                        "rgba(241, 231, 64, 50%)",
+                        &mut modifier,
+                    ),
+                    _ => (),
+                }
+            }
+
             for &Attribute { name, value, .. } in el.attributes {
                 apply_attributes(name, value, &mut modifier);
             }

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -172,7 +172,7 @@ pub fn render_vdom(
                             match evt.as_ref().unwrap() {
                                 InputEvent::UserInput(event) => match event {
                                     TermEvent::Key(key) => {
-                                        if matches!(key.code, KeyCode::Char('c'))
+                                        if matches!(key.code, KeyCode::Char('C' | 'c'))
                                             && key.modifiers.contains(KeyModifiers::CONTROL)
                                         {
                                             break;


### PR DESCRIPTION
- Fix ctrl c not quitting (new crossterm version interprets ctrl + key as ctrl + capital key)
- adds margin for borders
- adds all keys
- add text property elements: b, strong, u, ins, del, i, em, and mark