### PR TITLE
Capture correct radio button value in a form input event

### DIFF
--- a/examples/form.rs
+++ b/examples/form.rs
@@ -20,6 +20,8 @@ fn app(cx: Scope) -> Element {
                     input { r#type: "text", name: "username" }
                     input { r#type: "text", name: "full-name" }
                     input { r#type: "password", name: "password" }
+                    input { r#type: "radio", name: "color", value: "red" }
+                    input { r#type: "radio", name: "color", value: "blue" }
                     button { r#type: "submit", value: "Submit", "Submit the form" }
                 }
             }


### PR DESCRIPTION
Solution implemented is to return an optional value from the target element, which for all cases except radio buttons is a Some.  For radios, only the checked element will return a Some.  This prevents the last radio in the group from always overwriting the group value.