### PR TITLE
fix: instantly resolving futures should not use popping

### DIFF
--- a/examples/order.rs
+++ b/examples/order.rs
@@ -1,0 +1,28 @@
+#![allow(non_snake_case)]
+
+//! This example proves that instantly resolving futures don't cause issues
+
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::desktop::launch(App);
+}
+
+fn App(cx: Scope) -> Element {
+    cx.render(rsx!(Demo {}))
+}
+
+fn Demo(cx: Scope) -> Element {
+    let fut1 = use_future(&cx, (), |_| async move {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        10
+    });
+
+    cx.render(match fut1.value() {
+        Some(value) => {
+            let content = format!("content : {:?}", value);
+            rsx!(div{ "{content}" })
+        }
+        None => rsx!(div{"computing!"}),
+    })
+}

--- a/packages/desktop/src/controller.rs
+++ b/packages/desktop/src/controller.rs
@@ -61,9 +61,10 @@ impl DesktopController {
 
                 loop {
                     dom.wait_for_work().await;
-                    let mut muts = dom.work_with_deadline(|| false);
 
-                    while let Some(edit) = muts.pop() {
+                    let muts = dom.work_with_deadline(|| false);
+
+                    for edit in muts {
                         edit_queue
                             .lock()
                             .unwrap()
@@ -97,7 +98,7 @@ impl DesktopController {
             let mut queue = self.pending_edits.lock().unwrap();
             let (_id, view) = self.webviews.iter_mut().next().unwrap();
 
-            while let Some(edit) = queue.pop() {
+            for edit in queue.drain(..) {
                 view.evaluate_script(&format!("window.interpreter.handleEdits({})", edit))
                     .unwrap();
             }


### PR DESCRIPTION
This fixes #306 .

Instead of implementing a VecDeque as shown in #326 , we just use a regular push/drain approach which fixes all the ordering bugs.