### PR TITLE
fix: diff_lazynodes bug adding children

### DIFF
--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -423,8 +423,8 @@ impl<'b> DiffState<'b> {
         match (old.children.len(), new.children.len()) {
             (0, 0) => {}
             (0, _) => {
-                let created = self.create_children(new.children);
                 self.mutations.push_root(root);
+                let created = self.create_children(new.children);
                 self.mutations.append_children(created as u32);
             }
             (_, _) => self.diff_children(old.children, new.children),

--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -424,6 +424,7 @@ impl<'b> DiffState<'b> {
             (0, 0) => {}
             (0, _) => {
                 let created = self.create_children(new.children);
+                self.mutations.push_root(root);
                 self.mutations.append_children(created as u32);
             }
             (_, _) => self.diff_children(old.children, new.children),

--- a/tests/diffing.rs
+++ b/tests/diffing.rs
@@ -730,3 +730,28 @@ fn remove_list_nokeyed() {
         ]
     );
 }
+
+#[test]
+fn add_nested_elements() {
+    let vdom = new_dom();
+
+    let (_create, change) = vdom.diff_lazynodes(
+        rsx! {
+            div{}
+        },
+        rsx! {
+            div{
+                div{}
+            }
+        },
+    );
+
+    assert_eq!(
+        change.edits,
+        [
+            CreateElement { root: 2, tag: "div" },
+            PushRoot { root: 1 },
+            AppendChildren { many: 1 },
+        ]
+    );
+}

--- a/tests/diffing.rs
+++ b/tests/diffing.rs
@@ -749,8 +749,8 @@ fn add_nested_elements() {
     assert_eq!(
         change.edits,
         [
-            CreateElement { root: 2, tag: "div" },
             PushRoot { root: 1 },
+            CreateElement { root: 2, tag: "div" },
             AppendChildren { many: 1 },
         ]
     );


### PR DESCRIPTION
Fixes  #332
When adding children to a element which previously had none, the mutations did not add the PushRoot instruction before adding children.
This PR adds the instruction.