### PR TITLE
fix: render_lazy can't handle components

### DIFF
--- a/examples/ssr.rs
+++ b/examples/ssr.rs
@@ -22,6 +22,16 @@ fn main() {
         })
     );
 
+    // render_lazy can also take components - but it won't be able to process futures
+    println!(
+        "{}",
+        dioxus::ssr::render_lazy(rsx! {
+            div {
+                Child {}
+            }
+        })
+    );
+
     // We can configure the SSR rendering to add ids for rehydration
     println!(
         "{}",
@@ -44,4 +54,9 @@ fn app(cx: Scope) -> Element {
             p { "Body" }
         }
     ))
+}
+
+#[allow(non_snake_case)]
+fn Child(_cx: Scope) -> Element {
+    None
 }

--- a/packages/ssr/src/lib.rs
+++ b/packages/ssr/src/lib.rs
@@ -42,19 +42,22 @@ impl SsrRenderer {
 pub fn render_lazy<'a>(f: LazyNodes<'a, '_>) -> String {
     let vdom = VirtualDom::new(app);
 
-    // Safety
-    //
-    // The lifetimes bounds on LazyNodes are really complicated - they need to support the nesting restrictions in
-    // regular component usage. The <'a> lifetime is used to enforce that all calls of IntoVnode use the same allocator.
-    //
-    // When LazyNodes are provided, they are FnOnce, but do not come with a allocator selected to borrow from. The <'a>
-    // lifetime is therefore longer than the lifetime of the allocator which doesn't exist... yet.
-    //
-    // Therefore, we cast our local bump allocator to the right lifetime. This is okay because our usage of the bump
-    // arena is *definitely* shorter than the <'a> lifetime, and we return *owned* data - not borrowed data.
-    let new_f = unsafe { std::mem::transmute(f) };
-    let _ = vdom.create_vnodes(new_f);
-    let root = vdom.base_scope().root_node();
+    let f = unsafe { std::mem::transmute(f) };
+    let root = vdom.render_vnodes(f);
+
+    // // Safety
+    // //
+    // // The lifetimes bounds on LazyNodes are really complicated - they need to support the nesting restrictions in
+    // // regular component usage. The <'a> lifetime is used to enforce that all calls of IntoVnode use the same allocator.
+    // //
+    // // When LazyNodes are provided, they are FnOnce, but do not come with a allocator selected to borrow from. The <'a>
+    // // lifetime is therefore longer than the lifetime of the allocator which doesn't exist... yet.
+    // //
+    // // Therefore, we cast our local bump allocator to the right lifetime. This is okay because our usage of the bump
+    // // arena is *definitely* shorter than the <'a> lifetime, and we return *owned* data - not borrowed data.
+    // let new_f = unsafe { std::mem::transmute(f) };
+    // let _ = vdom.create_vnodes(new_f);
+    // let root = vdom.base_scope().root_node();
 
     format!(
         "{:}",

--- a/packages/ssr/tests/renders.rs
+++ b/packages/ssr/tests/renders.rs
@@ -116,6 +116,19 @@ fn lazy() {
 }
 
 #[test]
+fn lazy_with_child() {
+    fn Child(cx: Scope) -> Element {
+        None
+    }
+
+    let p = render_lazy(rsx! {
+        div { Child {} }
+    });
+
+    assert_eq!(p, "<div></div>");
+}
+
+#[test]
 fn big_lazy() {
     let s = render_lazy(rsx! {
         div {


### PR DESCRIPTION
This PR changes render_lazy to use the virtual dom's create_nodes method which progress component lifecycles. This is important for render_lazy to be able to handle components.

Be warned though - there's no concept of "suspense" with Dioxus-core, so all futures will end up as empty nodes in render_lazy.

Fixes #355 