### PR TITLE
Fix query parsing

### DIFF
--- a/packages/router/src/hooks/use_route.rs
+++ b/packages/router/src/hooks/use_route.rs
@@ -51,7 +51,7 @@ impl UseRoute {
     #[cfg(feature = "query")]
     pub fn query<T: serde::de::DeserializeOwned>(&self) -> Option<T> {
         let query = self.url().query()?;
-        serde_urlencoded::from_str(query.strip_prefix('?').unwrap_or("")).ok()
+        serde_urlencoded::from_str(query).ok()
     }
 
     /// Get the first query parameter given the parameter name.


### PR DESCRIPTION
The router was silently throwing away queries not prefixed with an extra `?`.

The documentation for `url::Url::query` indicates that it will not include the `?` delimiter ahead of the URL-encoded form string, and `strip_prefix` returns `None` if the prefix doesn't match.