### PR TITLE
Removed alerts when right click is disabled.

### DIFF
--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -189,12 +189,10 @@ pub fn launch_with_props<P: 'static + Send>(
                         r#"
                         if (document.addEventListener) {
                         document.addEventListener('contextmenu', function(e) {
-                            alert("You've tried to open context menu");
                             e.preventDefault();
                         }, false);
                         } else {
                         document.attachEvent('oncontextmenu', function() {
-                            alert("You've tried to open context menu");
                             window.event.returnValue = false;
                         });
                         }


### PR DESCRIPTION
This PR removes the JavaScript alerts shown when the user makes a right click but they are disabled (by default, they are disabled on release).

Is the `alert` on purpose or was it just forgotten ? Since alerts are *kinda* considered bad practice, I think they should be removed. Feel free to close this PR if I'm mistaken.