### PR TITLE
fix: unmarking component as dirty in silent write

### DIFF
--- a/packages/fermi/src/hooks/atom_ref.rs
+++ b/packages/fermi/src/hooks/atom_ref.rs
@@ -76,7 +76,6 @@ impl<T: 'static> UseAtomRef<T> {
     }
 
     pub fn write_silent(&self) -> RefMut<T> {
-        self.root.force_update(self.ptr);
         self.value.borrow_mut()
     }
 


### PR DESCRIPTION
Quick fix for Fermi crate to avoid re-render in silent write.