### PR TITLE
Fix cfg conditions for wasm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@ pub mod hooks {
     #[cfg(feature = "hooks")]
     pub use dioxus_hooks::*;
 
-    #[cfg(all(target = "wasm", feature = "web"))]
+    #[cfg(all(target_arch = "wasm32", feature = "web"))]
     pub use dioxus_web::use_eval;
 
-    #[cfg(all(not(target = "wasm"), feature = "desktop"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "desktop"))]
     pub use dioxus_desktop::use_eval;
 }
 


### PR DESCRIPTION
In the src/lib.rs file, there were `cfg` conditional compilation flags around the imports of `use_eval` which were written as

```rs
    #[cfg(all(target = "wasm", feature = "web"))]
```
which were meant to only enable the following code on the wasm target, but these were setup incorrect. The correct way to check if on wasm is the following:
```rs
    #[cfg(all(target_arch = "wasm32", feature = "web"))]
```