### PR TITLE
change with_ctrl_c_quit to without_ctrl_c_quit for tui config

### DIFF
--- a/docs/reference/src/platforms/tui.md
+++ b/docs/reference/src/platforms/tui.md
@@ -53,7 +53,6 @@ $ cargo run
 Press "ctrl-c" to close the app. To switch from "ctrl-c" to  just "q" to quit you can launch the app with a configuration to disable the default quit and use the root TuiContext to quit on your own.
 
 ```rust
-//  main
 use dioxus::events::{KeyCode, KeyboardEvent};
 use dioxus::prelude::*;
 use dioxus::tui::TuiContext;
@@ -61,11 +60,10 @@ use dioxus::tui::TuiContext;
 fn main() {
     dioxus::tui::launch_cfg(
         app,
-        dioxus::tui::Config {
-            ctrl_c_quit: false,
+        dioxus::tui::Config::new()
+            .without_ctrl_c_quit()
             // Some older terminals only support 16 colors or ANSI colors if your terminal is one of these change this to BaseColors or ANSI
-            rendering_mode: dioxus::tui::RenderingMode::Rgb,
-        },
+            .with_rendering_mode(dioxus::tui::RenderingMode::Rgb),
     );
 }
 

--- a/packages/tui/src/config.rs
+++ b/packages/tui/src/config.rs
@@ -21,9 +21,9 @@ impl Config {
         }
     }
 
-    pub fn with_ctrl_c_quit(self) -> Self {
+    pub fn without_ctrl_c_quit(self) -> Self {
         Self {
-            ctrl_c_quit: true,
+            ctrl_c_quit: false,
             ..self
         }
     }


### PR DESCRIPTION
The default config has ctrl_c_quit enabled, but the method with_ctrl_c_quit sets it to enabled again. It should disable it instead.