### PR TITLE
Fix: AttributeValue bug; tests; CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
       - run: sudo apt-get update
-      - run: sudo apt install libwebkit2gtk-4.0-dev libappindicator3-dev libgtk-3-dev
+      - run: sudo apt install libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -56,7 +56,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
       - run: sudo apt-get update
-      - run: sudo apt install libwebkit2gtk-4.0-dev libappindicator3-dev libgtk-3-dev
+      - run: sudo apt install libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev
       - uses: davidB/rust-cargo-make@v1
       - uses: browser-actions/setup-firefox@latest
       - uses: jetli/wasm-pack-action@v0.3.0
@@ -96,7 +96,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
       - run: sudo apt-get update
-      - run: sudo apt install libwebkit2gtk-4.0-dev libappindicator3-dev libgtk-3-dev
+      - run: sudo apt install libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
@@ -117,7 +117,7 @@ jobs:
   #       run: |
   #         apt-get update &&\
   #         apt-get install build-essential &&\
-  #         apt install libwebkit2gtk-4.0-dev libappindicator3-dev libgtk-3-dev -y &&\
+  #         apt install libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev -y &&\
   #         cargo +nightly tarpaulin --verbose --all-features --workspace --timeout 120 --out Xml
   #     - name: Upload to codecov.io
   #       uses: codecov/codecov-action@v2

--- a/packages/core/src/arbitrary_value.rs
+++ b/packages/core/src/arbitrary_value.rs
@@ -2,6 +2,7 @@ use std::fmt::Formatter;
 
 // trying to keep values at 3 bytes
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serialize", serde(untagged))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum AttributeValue<'a> {
     Text(&'a str),

--- a/packages/core/src/arbitrary_value.rs
+++ b/packages/core/src/arbitrary_value.rs
@@ -1,9 +1,11 @@
 use std::fmt::Formatter;
 
+/// Possible values for an attribute
 // trying to keep values at 3 bytes
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serialize", serde(untagged))]
 #[derive(Clone, Debug, PartialEq)]
+#[allow(missing_docs)]
 pub enum AttributeValue<'a> {
     Text(&'a str),
     Float32(f32),
@@ -26,6 +28,8 @@ pub enum AttributeValue<'a> {
     Any(ArbitraryAttributeValue<'a>),
 }
 
+// todo
+#[allow(missing_docs)]
 impl<'a> AttributeValue<'a> {
     pub fn is_truthy(&self) -> bool {
         match self {
@@ -113,6 +117,8 @@ impl<'de, 'a> serde::Deserialize<'de> for ArbitraryAttributeValue<'a> {
     }
 }
 
+// todo
+#[allow(missing_docs)]
 impl<'a> AttributeValue<'a> {
     pub fn as_text(&self) -> Option<&'a str> {
         match self {

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -73,10 +73,10 @@ pub(crate) mod innerlude {
 }
 
 pub use crate::innerlude::{
-    AnyEvent, Attribute, Component, DioxusElement, DomEdit, Element, ElementId, ElementIdIterator,
-    EventHandler, EventPriority, IntoVNode, LazyNodes, Listener, Mutations, NodeFactory,
-    Properties, SchedulerMsg, Scope, ScopeId, ScopeState, TaskId, UiEvent, UserEvent, VComponent,
-    VElement, VFragment, VNode, VPlaceholder, VText, VirtualDom,
+    AnyEvent, Attribute, AttributeValue, Component, DioxusElement, DomEdit, Element, ElementId,
+    ElementIdIterator, EventHandler, EventPriority, IntoVNode, LazyNodes, Listener, Mutations,
+    NodeFactory, Properties, SchedulerMsg, Scope, ScopeId, ScopeState, TaskId, UiEvent, UserEvent,
+    VComponent, VElement, VFragment, VNode, VPlaceholder, VText, VirtualDom,
 };
 
 /// The purpose of this module is to alleviate imports of many common types

--- a/packages/native-core-macro/tests/update_state.rs
+++ b/packages/native-core-macro/tests/update_state.rs
@@ -1,4 +1,5 @@
 use anymap::AnyMap;
+use dioxus_core::AttributeValue;
 use dioxus_core::VNode;
 use dioxus_core::*;
 use dioxus_core_macro::*;
@@ -347,7 +348,7 @@ fn state_reduce_parent_called_minimally_on_update() {
         edits: vec![DomEdit::SetAttribute {
             root: 1,
             field: "width",
-            value: "99%",
+            value: AttributeValue::Text("99%"),
             ns: Some("style"),
         }],
         dirty_scopes: fxhash::FxHashSet::default(),
@@ -416,7 +417,7 @@ fn state_reduce_child_called_minimally_on_update() {
         edits: vec![DomEdit::SetAttribute {
             root: 4,
             field: "width",
-            value: "99%",
+            value: AttributeValue::Text("99%"),
             ns: Some("style"),
         }],
         dirty_scopes: fxhash::FxHashSet::default(),


### PR DESCRIPTION
Fixes:
- String attributes incorrectly rendered as `[Object object]`
- Couple of failing tests
- Missing dependency in Github CI

With the new `AttributeValue`, attributes were serialized with values like `{Text: "value"}`, resulting in `[Object object]` when the interpreter applied them.

This simple fix restores the original behavior at least for Text values, by serializing them without the tag (just `"value"`).

I am not sure if this is a correct/complete approach, and I don't even know what the expected behavior would be for more complex variants such as `Vec3Float`. But at least the simple Text case is working again now.