### PR TITLE
Yet another builder API (and other bikeshedding)

### DIFF
--- a/benches/jsframework.rs
+++ b/benches/jsframework.rs
@@ -23,7 +23,7 @@ criterion_group!(mbenches, create_rows);
 criterion_main!(mbenches);
 
 fn create_rows(c: &mut Criterion) {
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         let mut rng = SmallRng::from_entropy();
 
         rsx!(cx, table {

--- a/examples/components_and_slots.rs
+++ b/examples/components_and_slots.rs
@@ -1,0 +1,129 @@
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::desktop::launch(App.renderer());
+}
+
+#[component]
+fn App(cx: Scope) -> Element {
+    fn simple_name(cx: Scope<NameRenderProps>) -> Element {
+        cx.render(dom(|h| {
+            [h.element("div")
+                .children([h.text("simple name: "), h.text(&cx.props.name)])
+                .finish()]
+        }))
+    }
+
+    let clicked = use_state(&cx, || 0);
+    let component_num = *clicked.get() % 3;
+
+    cx.render(dom(move |h| {
+        [
+            h.element("div")
+                .children([h.component(
+                    Wrapper,
+                    WrapperProps {
+                        name: "Joe".into(),
+                        slot: match component_num {
+                            0 => Slot::from_renderer("my name renderer", simple_name),
+                            1 => Slot::from_component(FancyNameRenderer),
+                            _ => Slot::empty(),
+                        },
+                    },
+                )])
+                .finish(),
+            h.element("button")
+                .on_any("click", |_| clicked.set(*clicked.get() + 1))
+                .children([match component_num {
+                    0 => h.text("switch to fancy"),
+                    1 => h.text("switch to empty"),
+                    _ => h.text("switch to simple"),
+                }])
+                .finish(),
+        ]
+    }))
+}
+
+#[derive(PartialEq, Props)]
+struct WrapperProps {
+    name: String,
+    slot: Slot<NameRenderProps>,
+}
+
+/// Renders a given name with a given component.
+#[component]
+fn Wrapper(cx: Scope<WrapperProps>) -> Element {
+    cx.render(dom(|h| {
+        [h.element("div")
+            .children([
+                h.element("div")
+                    .children([h.text("the div content below is rendered by another component:")]),
+                h.element("div").children([h.component(
+                    cx.props.slot,
+                    NameRenderProps {
+                        name: cx.props.name.clone(),
+                    },
+                )]),
+            ])
+            .finish()]
+    }))
+}
+
+#[derive(PartialEq, Props)]
+struct NameRenderProps {
+    name: String,
+}
+
+/// Renders the given name in in a formatted way.
+#[component]
+fn FancyNameRenderer(cx: Scope<NameRenderProps>) -> Element {
+    cx.render(dom(|h| {
+        [h.element("div")
+            .style([
+                ("background-color", "#FDECF9"),
+                ("border-radius", "5px"),
+                ("margin-top", "2px"),
+                ("padding", "2px"),
+            ])
+            .children([
+                h.text("fancy name: "),
+                h.element("span")
+                    .style([("font-style", "italic")])
+                    .children([h.text(&cx.props.name)])
+                    .finish(),
+            ])
+            .finish()]
+    }))
+}
+
+/// An example way of extending the builder with additional functionality.
+trait ElementStyleExt: Sized {
+    /// Accepts CSS style pairs and sets the `style` attribute for a given element.
+    ///
+    /// E.g.:
+    ///
+    /// ```
+    /// h.element("div").style([("padding", "1px"), ("background-color", "red")]);
+    /// ```
+    fn style<I, S>(self, style: I) -> Self
+    where
+        I: IntoIterator<Item = (S, S)>,
+        S: AsRef<str>;
+}
+
+impl ElementStyleExt for ElementBuilder<'_> {
+    fn style<I, S>(self, style: I) -> Self
+    where
+        I: IntoIterator<Item = (S, S)>,
+        S: AsRef<str>,
+    {
+        self.attr(
+            "style",
+            &style
+                .into_iter()
+                .map(|(k, v)| format!("{}: {}", k.as_ref(), v.as_ref()))
+                .collect::<Vec<_>>()
+                .join("; "),
+        )
+    }
+}

--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -1,0 +1,77 @@
+use proc_macro2::Ident;
+use quote::{format_ident, quote, ToTokens};
+use syn::{parse::Parse, ItemFn, Signature, Type, Visibility};
+
+pub struct ComponentFn {
+    vis: Visibility,
+    name: Ident,
+    render_fn: ItemFn,
+    props_ty: Type,
+}
+
+fn parse_props_type(sig: &Signature) -> Type {
+    for input in &sig.inputs {
+        match input {
+            syn::FnArg::Receiver(_) => {}
+            syn::FnArg::Typed(ty) => {
+                if let syn::Type::Path(p) = &*ty.ty {
+                    for segment in &p.path.segments {
+                        if segment.ident == "Scope" {
+                            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                                for arg in &args.args {
+                                    if let syn::GenericArgument::Type(ty) = arg {
+                                        return ty.clone();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    syn::parse_quote!(())
+}
+
+impl Parse for ComponentFn {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut render_fn: ItemFn = input.parse()?;
+
+        let name = render_fn.sig.ident;
+        render_fn.sig.ident = format_ident!("render");
+
+        let vis = render_fn.vis;
+        render_fn.vis = Visibility::Inherited;
+
+        Ok(Self {
+            vis,
+            props_ty: parse_props_type(&render_fn.sig),
+            render_fn,
+            name,
+        })
+    }
+}
+
+impl ToTokens for ComponentFn {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let name = &self.name;
+        let vis = &self.vis;
+        let props_ty = &self.props_ty;
+        let render_fn = &self.render_fn;
+
+        tokens.extend(quote! {
+            #vis struct #name;
+
+            impl dioxus::prelude::Component for #name {
+                type Props = #props_ty;
+
+                fn renderer(&self) -> fn(dioxus::prelude::Scope<Self::Props>) -> dioxus::prelude::Element {
+                    #render_fn
+                    render
+                }
+
+            }
+        });
+    }
+}

--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -60,7 +60,17 @@ impl ToTokens for ComponentFn {
         let props_ty = &self.props_ty;
         let render_fn = &self.render_fn;
 
+        let docs = render_fn
+            .attrs
+            .iter()
+            .filter(|attr| attr.path.is_ident("doc"))
+            .fold(quote! {}, |mut ts, attr| {
+                attr.to_tokens(&mut ts);
+                ts
+            });
+
         tokens.extend(quote! {
+            #docs
             #vis struct #name;
 
             impl dioxus::prelude::Component for #name {

--- a/packages/core-macro/src/lib.rs
+++ b/packages/core-macro/src/lib.rs
@@ -2,6 +2,7 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::parse_macro_input;
 
+mod component;
 mod inlineprops;
 mod props;
 
@@ -101,6 +102,14 @@ pub fn rsx(s: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn inline_props(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
     match syn::parse::<inlineprops::InlinePropsBody>(s) {
+        Err(e) => e.to_compile_error().into(),
+        Ok(s) => s.to_token_stream().into(),
+    }
+}
+
+#[proc_macro_attribute]
+pub fn component(_args: proc_macro::TokenStream, s: TokenStream) -> TokenStream {
+    match syn::parse::<component::ComponentFn>(s) {
         Err(e) => e.to_compile_error().into(),
         Ok(s) => s.to_token_stream().into(),
     }

--- a/packages/core/src/component.rs
+++ b/packages/core/src/component.rs
@@ -50,14 +50,25 @@ impl<P: Properties> PartialEq for Slot<P> {
 }
 
 impl<P: Properties> Slot<P> {
-    pub fn new<C: Component<Props = P>>(component: C) -> Self {
+    pub fn from_component<C: Component<Props = P>>(component: C) -> Self {
         Self {
             name: component.name(),
             renderer: component.renderer(),
         }
     }
 
-    pub fn lazy(&self, props: P) -> LazyNodes {
-        LazyNodes::new(move |h| h.component(self.renderer, props, None, self.name))
+    pub fn from_renderer(name: &'static str, renderer: fn(Scope<P>) -> Element) -> Self {
+        Self { name, renderer }
+    }
+
+    pub fn empty() -> Self {
+        fn _f<P2>(_cx: Scope<P2>) -> Element {
+            None
+        }
+
+        Self {
+            name: "empty slot",
+            renderer: _f::<P>,
+        }
     }
 }

--- a/packages/core/src/component.rs
+++ b/packages/core/src/component.rs
@@ -1,0 +1,63 @@
+#![allow(missing_docs)]
+use crate::{Element, LazyNodes, Properties, Scope};
+use std::any::type_name;
+
+pub trait Component {
+    type Props: Properties;
+
+    fn name(&self) -> &'static str {
+        type_name::<Self>()
+    }
+
+    fn renderer(&self) -> fn(scope: Scope<Self::Props>) -> Element;
+
+    #[inline]
+    fn lazy(&self, props: Self::Props) -> LazyNodes {
+        LazyNodes::new(move |h| h.component(self.renderer(), props, None, self.name()))
+    }
+}
+
+pub struct Slot<P: Properties> {
+    name: &'static str,
+    renderer: fn(scope: Scope<P>) -> Element,
+}
+
+impl<P: Properties> Clone for Slot<P> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name,
+            renderer: self.renderer,
+        }
+    }
+}
+
+impl<P: Properties> Copy for Slot<P> {}
+
+impl<P: Properties> Component for Slot<P> {
+    type Props = P;
+
+    fn renderer(&self) -> fn(scope: Scope<Self::Props>) -> Element {
+        self.renderer
+    }
+}
+
+impl<P: Properties> PartialEq for Slot<P> {
+    fn eq(&self, other: &Self) -> bool {
+        // FIXME: function equality is not that well-defined,
+        // should we just ignore it and compare the name only?
+        self.name == other.name && (self.renderer as usize) == (other.renderer as usize)
+    }
+}
+
+impl<P: Properties> Slot<P> {
+    pub fn new<C: Component<Props = P>>(component: C) -> Self {
+        Self {
+            name: component.name(),
+            renderer: component.renderer(),
+        }
+    }
+
+    pub fn lazy(&self, props: P) -> LazyNodes {
+        LazyNodes::new(move |h| h.component(self.renderer, props, None, self.name))
+    }
+}

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(missing_docs)]
 
 pub(crate) mod arbitrary_value;
+pub(crate) mod component;
 pub(crate) mod diff;
 pub(crate) mod events;
 pub(crate) mod lazynodes;
@@ -15,6 +16,7 @@ pub(crate) mod virtual_dom;
 
 pub(crate) mod innerlude {
     pub use crate::arbitrary_value::*;
+    pub use crate::component::*;
     pub use crate::events::*;
     pub use crate::lazynodes::*;
     pub use crate::mutations::*;
@@ -29,7 +31,7 @@ pub(crate) mod innerlude {
     /// Any [`None`] [`Element`] will automatically be coerced into a placeholder [`VNode`] with the [`VNode::Placeholder`] variant.
     pub type Element<'a> = Option<VNode<'a>>;
 
-    /// A [`Component`] is a function that takes a [`Scope`] and returns an [`Element`].
+    /// A [`RenderFn`] is a function that takes a [`Scope`] and returns an [`Element`].
     ///
     /// Components can be used in other components with two syntax options:
     /// - lowercase as a function call with named arguments (rust style)
@@ -65,7 +67,7 @@ pub(crate) mod innerlude {
     ///     // ...
     /// };
     /// ```
-    pub type Component<P = ()> = fn(Scope<P>) -> Element;
+    pub type RenderFn<P = ()> = fn(Scope<P>) -> Element;
 
     /// A list of attributes
     ///
@@ -73,10 +75,11 @@ pub(crate) mod innerlude {
 }
 
 pub use crate::innerlude::{
-    AnyEvent, Attribute, AttributeValue, Component, DioxusElement, DomEdit, Element, ElementId,
-    ElementIdIterator, EventHandler, EventPriority, IntoVNode, LazyNodes, Listener, Mutations,
-    NodeFactory, Properties, SchedulerMsg, Scope, ScopeId, ScopeState, TaskId, UiEvent, UserEvent,
-    VComponent, VElement, VFragment, VNode, VPlaceholder, VText, VirtualDom,
+    dom, AnyEvent, Attribute, AttributeValue, DioxusElement, DomBuilder, DomEdit, Element,
+    ElementBuilder, ElementId, ElementIdIterator, EventHandler, EventPriority, IntoVNode,
+    LazyNodes, Listener, Mutations, NodeFactory, Properties, RenderFn, SchedulerMsg, Scope,
+    ScopeId, ScopeState, TaskId, UiEvent, UserEvent, VComponent, VElement, VFragment, VNode,
+    VPlaceholder, VText, VirtualDom,
 };
 
 /// The purpose of this module is to alleviate imports of many common types
@@ -84,8 +87,9 @@ pub use crate::innerlude::{
 /// This includes types like [`Scope`], [`Element`], and [`Component`].
 pub mod prelude {
     pub use crate::innerlude::{
-        fc_to_builder, Attributes, Component, DioxusElement, Element, EventHandler, Fragment,
-        LazyNodes, NodeFactory, Properties, Scope, ScopeId, ScopeState, VNode, VirtualDom,
+        dom, fc_to_builder, Attributes, Component, DioxusElement, DomBuilder, Element,
+        ElementBuilder, EventHandler, Fragment, LazyNodes, NodeFactory, Properties, RenderFn,
+        Scope, ScopeId, ScopeState, Slot, VNode, VirtualDom,
     };
 }
 

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -6,7 +6,7 @@
 use crate::{
     innerlude::{AttributeValue, ComponentPtr, Element, Properties, Scope, ScopeId, ScopeState},
     lazynodes::LazyNodes,
-    AnyEvent, Component,
+    AnyEvent, RenderFn,
 };
 use bumpalo::{boxed::Box as BumpBox, Bump};
 use std::{
@@ -213,7 +213,7 @@ impl ElementId {
     }
 }
 
-fn empty_cell() -> Cell<Option<ElementId>> {
+pub(crate) fn empty_cell() -> Cell<Option<ElementId>> {
     Cell::new(None)
 }
 
@@ -457,7 +457,7 @@ pub struct VComponent<'src> {
 }
 
 pub(crate) struct VComponentProps<P> {
-    pub render_fn: Component<P>,
+    pub render_fn: RenderFn<P>,
     pub memo: unsafe fn(&P, &P) -> bool,
     pub props: P,
 }
@@ -592,7 +592,7 @@ impl<'a> NodeFactory<'a> {
         VNode::Element(self.bump.alloc(VElement {
             tag: tag_name,
             key,
-            namespace,
+            namespace: namespace.map(Into::into),
             listeners,
             attributes,
             children,

--- a/packages/core/src/util.rs
+++ b/packages/core/src/util.rs
@@ -81,3 +81,7 @@ impl<'a> Iterator for ElementIdIterator<'a> {
         returned_node
     }
 }
+
+pub(crate) type BString<'b> = bumpalo::collections::String<'b>;
+pub(crate) type BVec<'b, T> = bumpalo::collections::Vec<'b, T>;
+pub(crate) type BBox<'b, T> = bumpalo::boxed::Box<'b, T>;

--- a/packages/core/src/virtual_dom/builder.rs
+++ b/packages/core/src/virtual_dom/builder.rs
@@ -1,0 +1,266 @@
+#![allow(missing_docs)]
+use bumpalo::Bump;
+
+use crate::{
+    innerlude::{empty_cell, BBox, BString, BVec, Component},
+    AnyEvent, Attribute, AttributeValue, IntoVNode, LazyNodes, Listener, NodeFactory, UiEvent,
+    VElement, VNode, VText,
+};
+
+pub fn dom<'a, 'b, T>(f: impl FnOnce(DomBuilder<'a>) -> T + 'a + 'b) -> LazyNodes<'a, 'b>
+where
+    T: IntoVNode<'a>,
+{
+    LazyNodes::new(|factory| f(DomBuilder { factory }).into_vnode(factory))
+}
+
+#[derive(Clone, Copy)]
+pub struct DomBuilder<'a> {
+    factory: NodeFactory<'a>,
+}
+
+impl<'a> DomBuilder<'a> {
+    #[inline]
+    pub fn element(&self, tag: &'static str) -> ElementBuilder<'a> {
+        ElementBuilder::new(*self, tag)
+    }
+
+    #[inline]
+    pub fn component<C>(&self, component: C) -> ComponentBuilder<'a, C>
+    where
+        C: Component,
+        C::Props: Default + 'a,
+    {
+        ComponentBuilder::new(*self, component, Default::default())
+    }
+
+    #[inline]
+    pub fn component_with<C>(&self, component: C, props: C::Props) -> ComponentBuilder<'a, C>
+    where
+        C: Component,
+        C::Props: 'a,
+    {
+        ComponentBuilder::new(*self, component, props)
+    }
+
+    #[inline]
+    pub fn text(&self, text: &str) -> VNode<'a> {
+        VNode::Text(self.bump().alloc(VText {
+            id: empty_cell(),
+            text: BString::from_str_in(text, self.factory.bump()).into_bump_str(),
+            is_static: false,
+        }))
+    }
+
+    #[inline]
+    pub fn text_static(&self, text: &'static str) -> VNode<'a> {
+        VNode::Text(self.bump().alloc(VText {
+            id: empty_cell(),
+            text,
+            is_static: false,
+        }))
+    }
+
+    #[inline]
+    fn bump(&self) -> &'a Bump {
+        self.factory.bump()
+    }
+}
+
+pub struct ComponentBuilder<'a, C>
+where
+    C: Component,
+{
+    builder: DomBuilder<'a>,
+    props: C::Props,
+    component: C,
+    key: Option<&'a str>,
+}
+
+impl<'a, C> ComponentBuilder<'a, C>
+where
+    C: Component,
+    C::Props: 'a,
+{
+    #[inline]
+    fn new(builder: DomBuilder<'a>, component: C, props: C::Props) -> Self {
+        Self {
+            builder,
+            component,
+            props,
+            key: None,
+        }
+    }
+
+    #[inline]
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(BString::from_str_in(key, self.builder.factory.bump()).into_bump_str());
+        self
+    }
+
+    #[inline]
+    pub fn key_static(mut self, key: &'static str) -> Self {
+        self.key = Some(key);
+        self
+    }
+
+    pub fn build(self) -> VNode<'a> {
+        self.into()
+    }
+}
+
+impl<'a, C: Component> From<ComponentBuilder<'a, C>> for VNode<'a>
+where
+    C::Props: 'a,
+{
+    fn from(c: ComponentBuilder<'a, C>) -> Self {
+        c.builder
+            .factory
+            .component(c.component.renderer(), c.props, None, c.component.name())
+    }
+}
+
+pub struct ElementBuilder<'a> {
+    builder: DomBuilder<'a>,
+    namespace: Option<&'static str>,
+    listeners: BVec<'a, Listener<'a>>,
+    attributes: BVec<'a, Attribute<'a>>,
+    children: BVec<'a, VNode<'a>>,
+    key: Option<&'a str>,
+    tag: &'static str,
+}
+
+impl<'a> ElementBuilder<'a> {
+    #[inline]
+    fn new(builder: DomBuilder<'a>, tag: &'static str) -> Self {
+        Self {
+            builder,
+            namespace: None,
+            listeners: BVec::new_in(builder.bump()),
+            attributes: BVec::new_in(builder.bump()),
+            children: BVec::new_in(builder.bump()),
+            key: None,
+            tag,
+        }
+    }
+
+    #[inline]
+    pub fn namespace(mut self, ns: &'static str) -> Self {
+        self.namespace = Some(ns);
+        self
+    }
+
+    #[inline]
+    pub fn attr(mut self, name: &'static str, value: &str) -> Self {
+        self.attributes.push(Attribute {
+            name,
+            value: AttributeValue::Text(
+                BString::from_str_in(value, self.builder.bump()).into_bump_str(),
+            ),
+            is_static: true,
+            is_volatile: false,
+            namespace: None,
+        });
+        self
+    }
+
+    #[inline]
+    pub fn children<I, T>(mut self, children: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<VNode<'a>>,
+    {
+        self.children.extend(children.into_iter().map(Into::into));
+        self
+    }
+
+    #[inline]
+    pub fn key(mut self, key: &str) -> Self {
+        self.key = Some(BString::from_str_in(key, self.builder.factory.bump()).into_bump_str());
+        self
+    }
+
+    #[inline]
+    pub fn key_static(mut self, key: &'static str) -> Self {
+        self.key = Some(key);
+        self
+    }
+
+    #[inline]
+    pub fn on<E, F>(self, event: &'static str, callback: F) -> Self
+    where
+        F: Fn(UiEvent<E>) + 'a,
+        E: Send + Sync + 'static,
+    {
+        self.on_any::<E, _>(event, move |evt: AnyEvent| {
+            let event = evt.downcast::<E>().unwrap();
+            callback(event)
+        })
+    }
+
+    #[inline]
+    pub fn on_any<E, F>(mut self, event: &'static str, callback: F) -> Self
+    where
+        F: Fn(AnyEvent) + 'a,
+    {
+        let bump = self.builder.bump();
+
+        // we can't allocate unsized in bumpalo's box, so we need to craft the box manually
+        // safety: this is essentially the same as calling Box::new() but manually
+        // The box is attached to the lifetime of the bumpalo allocator
+        let cb: &mut dyn FnMut(AnyEvent) = bump.alloc(callback);
+
+        let callback: BBox<dyn FnMut(AnyEvent) + 'a> = unsafe { BBox::from_raw(cb) };
+
+        let handler = bump.alloc(std::cell::RefCell::new(Some(callback)));
+
+        self.listeners
+            .push(self.builder.factory.listener(event, handler));
+        self
+    }
+
+    #[inline]
+    pub fn build(self) -> VNode<'a> {
+        self.into()
+    }
+}
+
+impl<'a> From<ElementBuilder<'a>> for VNode<'a> {
+    fn from(el: ElementBuilder<'a>) -> Self {
+        let mut items = el.builder.factory.scope.items.borrow_mut();
+        let listeners = el.listeners.into_bump_slice();
+
+        for listener in listeners {
+            let long_listener = unsafe { std::mem::transmute(listener) };
+            items.listeners.push(long_listener);
+        }
+
+        VNode::Element(el.builder.bump().alloc(VElement {
+            tag: el.tag,
+            key: el.key,
+            namespace: el.namespace,
+            listeners,
+            attributes: el.attributes.into_bump_slice(),
+            children: el.children.into_bump_slice(),
+            id: empty_cell(),
+            parent: empty_cell(),
+        }))
+    }
+}
+
+impl<'a> IntoVNode<'a> for ElementBuilder<'a> {
+    fn into_vnode(self, _cx: NodeFactory<'a>) -> VNode<'a> {
+        self.into()
+    }
+}
+
+// This *could* be more generic, but the main purpose of this
+// blanket impl is to allow conveniently turning arrays into fragments, including
+// empty ones.
+//
+// If this was more generic, people would need type annotations for empty arrays.
+impl<'a, const N: usize> IntoVNode<'a> for [VNode<'a>; N] {
+    fn into_vnode(self, cx: NodeFactory<'a>) -> VNode<'a> {
+        cx.fragment_from_iter(IntoIterator::into_iter(self))
+    }
+}

--- a/packages/core/src/virtual_dom/builder.rs
+++ b/packages/core/src/virtual_dom/builder.rs
@@ -26,16 +26,7 @@ impl<'a> DomBuilder<'a> {
     }
 
     #[inline]
-    pub fn component<C>(&self, component: C) -> ComponentBuilder<'a, C>
-    where
-        C: Component,
-        C::Props: Default + 'a,
-    {
-        ComponentBuilder::new(*self, component, Default::default())
-    }
-
-    #[inline]
-    pub fn component_with<C>(&self, component: C, props: C::Props) -> ComponentBuilder<'a, C>
+    pub fn component<C>(&self, component: C, props: C::Props) -> ComponentBuilder<'a, C>
     where
         C: Component,
         C::Props: 'a,
@@ -62,7 +53,7 @@ impl<'a> DomBuilder<'a> {
     }
 
     #[inline]
-    fn bump(&self) -> &'a Bump {
+    pub fn bump(&self) -> &'a Bump {
         self.factory.bump()
     }
 }
@@ -104,8 +95,12 @@ where
         self
     }
 
-    pub fn build(self) -> VNode<'a> {
+    pub fn finish(self) -> VNode<'a> {
         self.into()
+    }
+
+    pub fn bump(&self) -> &'a Bump {
+        self.builder.bump()
     }
 }
 
@@ -192,14 +187,14 @@ impl<'a> ElementBuilder<'a> {
         F: Fn(UiEvent<E>) + 'a,
         E: Send + Sync + 'static,
     {
-        self.on_any::<E, _>(event, move |evt: AnyEvent| {
+        self.on_any(event, move |evt: AnyEvent| {
             let event = evt.downcast::<E>().unwrap();
             callback(event)
         })
     }
 
     #[inline]
-    pub fn on_any<E, F>(mut self, event: &'static str, callback: F) -> Self
+    pub fn on_any<F>(mut self, event: &'static str, callback: F) -> Self
     where
         F: Fn(AnyEvent) + 'a,
     {
@@ -220,8 +215,12 @@ impl<'a> ElementBuilder<'a> {
     }
 
     #[inline]
-    pub fn build(self) -> VNode<'a> {
+    pub fn finish(self) -> VNode<'a> {
         self.into()
+    }
+
+    pub fn bump(&self) -> &'a Bump {
+        self.builder.bump()
     }
 }
 

--- a/packages/core/src/virtual_dom/mod.rs
+++ b/packages/core/src/virtual_dom/mod.rs
@@ -10,6 +10,9 @@ use fxhash::FxHashSet;
 use indexmap::IndexSet;
 use std::{collections::VecDeque, iter::FromIterator, task::Poll};
 
+pub(crate) mod builder;
+pub use builder::{dom, DomBuilder, ElementBuilder};
+
 /// A virtual node system that progresses user events and diffs UI trees.
 ///
 ///
@@ -154,7 +157,7 @@ impl VirtualDom {
     /// ```
     ///
     /// Note: the VirtualDom is not progressed, you must either "run_with_deadline" or use "rebuild" to progress it.
-    pub fn new(root: Component) -> Self {
+    pub fn new(root: RenderFn) -> Self {
         Self::new_with_props(root, ())
     }
 
@@ -188,7 +191,7 @@ impl VirtualDom {
     /// let mut dom = VirtualDom::new_with_props(Example, SomeProps { name: "jane" });
     /// let mutations = dom.rebuild();
     /// ```
-    pub fn new_with_props<P>(root: Component<P>, root_props: P) -> Self
+    pub fn new_with_props<P>(root: RenderFn<P>, root_props: P) -> Self
     where
         P: 'static,
     {
@@ -209,7 +212,7 @@ impl VirtualDom {
     /// let dom = VirtualDom::new_with_scheduler(Example, (), channel);
     /// ```
     pub fn new_with_props_and_scheduler<P: 'static>(
-        root: Component<P>,
+        root: RenderFn<P>,
         root_props: P,
         channel: (
             UnboundedSender<SchedulerMsg>,

--- a/packages/desktop/src/controller.rs
+++ b/packages/desktop/src/controller.rs
@@ -24,7 +24,7 @@ impl DesktopController {
     // Launch the virtualdom on its own thread managed by tokio
     // returns the desktop state
     pub(super) fn new_on_tokio<P: Send + 'static>(
-        root: Component<P>,
+        root: RenderFn<P>,
         props: P,
         proxy: EventLoopProxy<UserWindowEvent>,
     ) -> Self {

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -44,7 +44,7 @@ use wry::webview::WebViewBuilder;
 ///     })
 /// }
 /// ```
-pub fn launch(root: Component) {
+pub fn launch(root: RenderFn) {
     launch_with_props(root, (), |c| c)
 }
 
@@ -68,7 +68,7 @@ pub fn launch(root: Component) {
 /// }
 /// ```
 pub fn launch_cfg(
-    root: Component,
+    root: RenderFn,
     config_builder: impl FnOnce(&mut DesktopConfig) -> &mut DesktopConfig,
 ) {
     launch_with_props(root, (), config_builder)
@@ -98,7 +98,7 @@ pub fn launch_cfg(
 /// }
 /// ```
 pub fn launch_with_props<P: 'static + Send>(
-    root: Component<P>,
+    root: RenderFn<P>,
     props: P,
     builder: impl FnOnce(&mut DesktopConfig) -> &mut DesktopConfig,
 ) {

--- a/packages/ssr/tests/renders.rs
+++ b/packages/ssr/tests/renders.rs
@@ -3,13 +3,13 @@ use dioxus_core_macro::*;
 use dioxus_html as dioxus_elements;
 use dioxus_ssr::{render_lazy, render_vdom, render_vdom_cfg, SsrConfig, SsrRenderer, TextRenderer};
 
-static SIMPLE_APP: Component = |cx| {
+static SIMPLE_APP: RenderFn = |cx| {
     cx.render(rsx!(div {
         "hello world!"
     }))
 };
 
-static SLIGHTLY_MORE_COMPLEX: Component = |cx| {
+static SLIGHTLY_MORE_COMPLEX: RenderFn = |cx| {
     cx.render(rsx! {
         div { title: "About W3Schools",
             (0..20).map(|f| rsx!{
@@ -27,14 +27,14 @@ static SLIGHTLY_MORE_COMPLEX: Component = |cx| {
     })
 };
 
-static NESTED_APP: Component = |cx| {
+static NESTED_APP: RenderFn = |cx| {
     cx.render(rsx!(
         div {
             SIMPLE_APP {}
         }
     ))
 };
-static FRAGMENT_APP: Component = |cx| {
+static FRAGMENT_APP: RenderFn = |cx| {
     cx.render(rsx!(
         div { "f1" }
         div { "f2" }
@@ -90,7 +90,7 @@ fn write_to_file() {
 
 #[test]
 fn styles() {
-    static STLYE_APP: Component = |cx| {
+    static STLYE_APP: RenderFn = |cx| {
         cx.render(rsx! {
             div { color: "blue", font_size: "46px"  }
         })

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -49,11 +49,11 @@ impl TuiContext {
     }
 }
 
-pub fn launch(app: Component<()>) {
+pub fn launch(app: RenderFn<()>) {
     launch_cfg(app, Config::default())
 }
 
-pub fn launch_cfg(app: Component<()>, cfg: Config) {
+pub fn launch_cfg(app: RenderFn<()>, cfg: Config) {
     let mut dom = VirtualDom::new(app);
 
     let (handler, state, register_event) = RinkInputHandler::new();

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::util::use_eval;
 use dioxus::SchedulerMsg;
 use dioxus::VirtualDom;
 pub use dioxus_core as dioxus;
-use dioxus_core::prelude::Component;
+use dioxus_core::prelude::RenderFn;
 use futures_util::FutureExt;
 
 mod cache;
@@ -91,7 +91,7 @@ mod util;
 ///     rsx!(cx, div {"hello world"})
 /// }
 /// ```
-pub fn launch(root_component: Component) {
+pub fn launch(root_component: RenderFn) {
     launch_with_props(root_component, (), |c| c);
 }
 
@@ -114,7 +114,7 @@ pub fn launch(root_component: Component) {
 ///     })
 /// }
 /// ```
-pub fn launch_cfg(root: Component, config_builder: impl FnOnce(&mut WebConfig) -> &mut WebConfig) {
+pub fn launch_cfg(root: RenderFn, config_builder: impl FnOnce(&mut WebConfig) -> &mut WebConfig) {
     launch_with_props(root, (), config_builder)
 }
 
@@ -143,7 +143,7 @@ pub fn launch_cfg(root: Component, config_builder: impl FnOnce(&mut WebConfig) -
 /// }
 /// ```
 pub fn launch_with_props<T>(
-    root_component: Component<T>,
+    root_component: RenderFn<T>,
     root_properties: T,
     configuration_builder: impl FnOnce(&mut WebConfig) -> &mut WebConfig,
 ) where
@@ -170,7 +170,7 @@ pub fn launch_with_props<T>(
 ///     wasm_bindgen_futures::spawn_local(app_fut);
 /// }
 /// ```
-pub async fn run_with_props<T: 'static + Send>(root: Component<T>, root_props: T, cfg: WebConfig) {
+pub async fn run_with_props<T: 'static + Send>(root: RenderFn<T>, root_props: T, cfg: WebConfig) {
     let mut dom = VirtualDom::new_with_props(root, root_props);
 
     for s in crate::cache::BUILTIN_INTERNED_STRINGS {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub use dioxus_rsx_interpreter as rsx_interpreter;
 pub mod prelude {
     pub use crate::hooks::*;
     pub use dioxus_core::prelude::*;
-    pub use dioxus_core_macro::{format_args_f, inline_props, rsx, Props};
+    pub use dioxus_core_macro::{component, format_args_f, inline_props, rsx, Props};
     pub use dioxus_elements::{GlobalAttributes, SvgAttributes};
     pub use dioxus_html as dioxus_elements;
 

--- a/tests/create_dom.rs
+++ b/tests/create_dom.rs
@@ -10,7 +10,7 @@ use dioxus::prelude::*;
 mod test_logging;
 use dioxus_core::DomEdit::*;
 
-fn new_dom<P: 'static + Send>(app: Component<P>, props: P) -> VirtualDom {
+fn new_dom<P: 'static + Send>(app: RenderFn<P>, props: P) -> VirtualDom {
     const IS_LOGGING_ENABLED: bool = false;
     test_logging::set_up_logging(IS_LOGGING_ENABLED);
     VirtualDom::new_with_props(app, props)
@@ -18,7 +18,7 @@ fn new_dom<P: 'static + Send>(app: Component<P>, props: P) -> VirtualDom {
 
 #[test]
 fn test_original_diff() {
-    static APP: Component = |cx| {
+    static APP: RenderFn = |cx| {
         cx.render(rsx! {
             div {
                 div {
@@ -45,7 +45,7 @@ fn test_original_diff() {
 
 #[test]
 fn create() {
-    static APP: Component = |cx| {
+    static APP: RenderFn = |cx| {
         cx.render(rsx! {
             div {
                 div {
@@ -87,7 +87,7 @@ fn create() {
 
 #[test]
 fn create_list() {
-    static APP: Component = |cx| {
+    static APP: RenderFn = |cx| {
         cx.render(rsx! {
             {(0..3).map(|f| rsx!{ div {
                 "hello"
@@ -118,7 +118,7 @@ fn create_list() {
 
 #[test]
 fn create_simple() {
-    static APP: Component = |cx| {
+    static APP: RenderFn = |cx| {
         cx.render(rsx! {
             div {}
             div {}
@@ -144,7 +144,7 @@ fn create_simple() {
 }
 #[test]
 fn create_components() {
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         cx.render(rsx! {
             Child { "abc1" }
             Child { "abc2" }
@@ -192,7 +192,7 @@ fn create_components() {
 }
 #[test]
 fn anchors() {
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         cx.render(rsx! {
             {true.then(|| rsx!{ div { "hello" } })}
             {false.then(|| rsx!{ div { "goodbye" } })}

--- a/tests/earlyabort.rs
+++ b/tests/earlyabort.rs
@@ -12,7 +12,7 @@ use dioxus_core::{DomEdit::*, ScopeId};
 
 const IS_LOGGING_ENABLED: bool = false;
 
-fn new_dom<P: 'static + Send>(app: Component<P>, props: P) -> VirtualDom {
+fn new_dom<P: 'static + Send>(app: RenderFn<P>, props: P) -> VirtualDom {
     test_logging::set_up_logging(IS_LOGGING_ENABLED);
     VirtualDom::new_with_props(app, props)
 }
@@ -21,7 +21,7 @@ fn new_dom<P: 'static + Send>(app: Component<P>, props: P) -> VirtualDom {
 /// In debug, this should also toss a warning.
 #[test]
 fn test_early_abort() {
-    const app: Component = |cx| {
+    const app: RenderFn = |cx| {
         let val = cx.use_hook(|_| 0);
 
         *val += 1;

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -17,7 +17,7 @@ fn manual_diffing() {
         value: Shared<&'static str>,
     }
 
-    static App: Component<AppProps> = |cx| {
+    static App: RenderFn<AppProps> = |cx| {
         let val = cx.props.value.lock().unwrap();
         cx.render(rsx! { div { "{val}" } })
     };
@@ -212,7 +212,7 @@ fn component_swap() {
         })
     };
 
-    static NavBar: Component = |cx| {
+    static NavBar: RenderFn = |cx| {
         println!("running navbar");
         cx.render(rsx! {
             h1 {
@@ -222,7 +222,7 @@ fn component_swap() {
         })
     };
 
-    static NavLink: Component = |cx| {
+    static NavLink: RenderFn = |cx| {
         println!("running navlink");
         cx.render(rsx! {
             h1 {
@@ -231,7 +231,7 @@ fn component_swap() {
         })
     };
 
-    static Dashboard: Component = |cx| {
+    static Dashboard: RenderFn = |cx| {
         println!("running dashboard");
         cx.render(rsx! {
             div {
@@ -240,7 +240,7 @@ fn component_swap() {
         })
     };
 
-    static Results: Component = |cx| {
+    static Results: RenderFn = |cx| {
         println!("running results");
         cx.render(rsx! {
             div {

--- a/tests/miri_stress.rs
+++ b/tests/miri_stress.rs
@@ -17,7 +17,7 @@ mod test_logging;
 
 const IS_LOGGING_ENABLED: bool = false;
 
-fn new_dom<P: 'static + Send>(app: Component<P>, props: P) -> VirtualDom {
+fn new_dom<P: 'static + Send>(app: RenderFn<P>, props: P) -> VirtualDom {
     test_logging::set_up_logging(IS_LOGGING_ENABLED);
     VirtualDom::new_with_props(app, props)
 }

--- a/tests/sharedstate.rs
+++ b/tests/sharedstate.rs
@@ -11,12 +11,12 @@ mod test_logging;
 fn shared_state_test() {
     struct MySharedState(&'static str);
 
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         cx.provide_context(Rc::new(MySharedState("world!")));
         cx.render(rsx!(Child {}))
     };
 
-    static Child: Component = |cx| {
+    static Child: RenderFn = |cx| {
         let shared = cx.consume_context::<Rc<MySharedState>>()?;
         cx.render(rsx!("Hello, {shared.0}"))
     };

--- a/tests/vdom_rebuild.rs
+++ b/tests/vdom_rebuild.rs
@@ -15,7 +15,7 @@ use dioxus_core::DomEdit::*;
 
 #[test]
 fn app_runs() {
-    static App: Component = |cx| rsx!(cx, div{"hello"} );
+    static App: RenderFn = |cx| rsx!(cx, div{"hello"} );
 
     let mut vdom = VirtualDom::new(App);
     let edits = vdom.rebuild();
@@ -23,7 +23,7 @@ fn app_runs() {
 
 #[test]
 fn fragments_work() {
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         cx.render(rsx!(
             div{"hello"}
             div{"goodbye"}
@@ -37,7 +37,7 @@ fn fragments_work() {
 
 #[test]
 fn lists_work() {
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         cx.render(rsx!(
             h1 {"hello"}
             (0..6).map(|f| rsx!(span{ "{f}" }))
@@ -50,7 +50,7 @@ fn lists_work() {
 
 #[test]
 fn conditional_rendering() {
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         cx.render(rsx!(
             h1 {"hello"}
             {true.then(|| rsx!(span{ "a" }))}
@@ -77,13 +77,13 @@ fn conditional_rendering() {
 
 #[test]
 fn child_components() {
-    static App: Component = |cx| {
+    static App: RenderFn = |cx| {
         cx.render(rsx!(
             {true.then(|| rsx!(Child { }))}
             {false.then(|| rsx!(Child { }))}
         ))
     };
-    static Child: Component = |cx| {
+    static Child: RenderFn = |cx| {
         cx.render(rsx!(
             h1 {"hello"}
             h1 {"goodbye"}


### PR DESCRIPTION
Hi, I'm not a huge fan of DSL macros in Rust so I've been experimenting building the DOM with builders as well.

I've just noticed that work is being done in #257 as I'm writing this, but it's reassuring that both of us went in very similar directions.

The key differences I've noticed or I've additionally done in this PR:

- I renamed the existing `Component` type to `RenderFn` and introduced a `Component` trait, as there are some issues with simply treating functions as components:
  - there's no way to attach metadata (like name) to them
  - Rust complains about the naming convention violation, it's possible to bypass this obviously but it's still annoying
- I intentionally kept my `ElementBuilder` simple and generic, and would rather create wrapper components (e.g. `Div`) over them with more detailed APIs.
- Blanket impl over arrays of `VNode`s that turn into a fragment.

As I was poking around the codebase I've also noticed that tag names/attributes are currently required to be `'static`, which means it's impossible to create these dynamically without hacks, was this done deliberately as a design decision?

I don't intend to get this merged in any shape or form, I've just done this for the sake of experiments and bikeshedding.