### PR TITLE
fix path separator for hot reloading

### DIFF
--- a/packages/rsx_interpreter/src/lib.rs
+++ b/packages/rsx_interpreter/src/lib.rs
@@ -24,7 +24,8 @@ lazy_static! {
 // the location of the code relative to the current crate based on [std::panic::Location]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodeLocation {
-    pub file: String,
+    pub crate_path: String,
+    pub file_path: String,
     pub line: u32,
     pub column: u32,
 }
@@ -83,14 +84,12 @@ macro_rules! get_line_num {
     () => {{
         let line = line!();
         let column = column!();
-        let file = file!();
+        let file_path = file!().to_string();
+        let mut crate_path = env!("CARGO_MANIFEST_DIR").to_string();
 
-        #[cfg(windows)]
-        let file = env!("CARGO_MANIFEST_DIR").to_string() + "\\" + file!();
-        #[cfg(unix)]
-        let file = env!("CARGO_MANIFEST_DIR").to_string() + "/" + file!();
         CodeLocation {
-            file: file.to_string(),
+            crate_path,
+            file_path,
             line: line,
             column: column,
         }

--- a/packages/rsx_interpreter/src/lib.rs
+++ b/packages/rsx_interpreter/src/lib.rs
@@ -85,7 +85,7 @@ macro_rules! get_line_num {
         let line = line!();
         let column = column!();
         let file_path = file!().to_string();
-        let mut crate_path = env!("CARGO_MANIFEST_DIR").to_string();
+        let crate_path = env!("CARGO_MANIFEST_DIR").to_string();
 
         CodeLocation {
             crate_path,

--- a/packages/rsx_interpreter/tests/render.rs
+++ b/packages/rsx_interpreter/tests/render.rs
@@ -16,7 +16,8 @@ fn render_basic() {
     let dom = VirtualDom::new(Base);
     let static_vnodes = rsx!(div{"hello world"});
     let location = CodeLocation {
-        file: String::new(),
+        file_path: String::new(),
+        crate_path: String::new(),
         line: 0,
         column: 0,
     };
@@ -61,7 +62,8 @@ fn render_nested() {
         }
     };
     let location = CodeLocation {
-        file: String::new(),
+        file_path: String::new(),
+        crate_path: String::new(),
         line: 1,
         column: 0,
     };
@@ -112,7 +114,8 @@ fn render_component() {
         }
     };
     let location = CodeLocation {
-        file: String::new(),
+        file_path: String::new(),
+        crate_path: String::new(),
         line: 2,
         column: 0,
     };
@@ -163,7 +166,8 @@ fn render_iterator() {
         }
     };
     let location = CodeLocation {
-        file: String::new(),
+        file_path: String::new(),
+        crate_path: String::new(),
         line: 3,
         column: 0,
     };
@@ -216,7 +220,8 @@ fn render_captured_variable() {
         }
     };
     let location = CodeLocation {
-        file: String::new(),
+        file_path: String::new(),
+        crate_path: String::new(),
         line: 4,
         column: 0,
     };
@@ -267,7 +272,8 @@ fn render_listener() {
         }
     };
     let location = CodeLocation {
-        file: String::new(),
+        file_path: String::new(),
+        crate_path: String::new(),
         line: 5,
         column: 0,
     };


### PR DESCRIPTION
The path to the file in hot reloading currently produces a different result on unix and windows because they have different path separators, but when building for wasm it fails to detect the os.
Solution: Keep the crate and file path separate