### PR TITLE
panic on errors in hot-reload if no error handler socket is connected

### DIFF
--- a/packages/desktop/src/controller.rs
+++ b/packages/desktop/src/controller.rs
@@ -86,6 +86,8 @@ impl DesktopController {
                                         (serde_json::to_string(&err).unwrap() + "\n").as_bytes(),
                                     )
                                     .unwrap();
+                            } else {
+                                panic!("{}", err);
                             }
                         }
                     }

--- a/packages/rsx_interpreter/src/captuered_context.rs
+++ b/packages/rsx_interpreter/src/captuered_context.rs
@@ -113,9 +113,9 @@ impl ToTokens for CapturedContextBuilder {
                     let expr = segment.to_token_stream();
                     let as_string = expr.to_string();
                     let format_expr = if format_args.is_empty() {
-                        "{".to_string() + format_args + "}"
+                        "{".to_string() + &format_args + "}"
                     } else {
-                        "{".to_string() + ":" + format_args + "}"
+                        "{".to_string() + ":" + &format_args + "}"
                     };
                     Some(quote! {
                         FormattedArg{

--- a/packages/rsx_interpreter/src/error.rs
+++ b/packages/rsx_interpreter/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
 
 use crate::CodeLocation;
@@ -35,5 +37,20 @@ impl ParseError {
         }
         location.column += 1;
         ParseError { message, location }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::ParseError(error) => write!(
+                f,
+                "parse error:\n--> at {}:{}:{}\n\t{:?}\n",
+                error.location.file_path, error.location.line, error.location.column, error.message
+            ),
+            Error::RecompileRequiredError(reason) => {
+                write!(f, "recompile required: {:?}\n", reason)
+            }
+        }
     }
 }

--- a/packages/rsx_interpreter/src/interperter.rs
+++ b/packages/rsx_interpreter/src/interperter.rs
@@ -39,7 +39,7 @@ fn resolve_ifmt(ifmt: &IfmtInput, captured: &IfmtArgs) -> Result<String, Error> 
                     }
                 }
             }
-            Segment::Literal(lit) => result.push_str(lit),
+            Segment::Literal(lit) => result.push_str(&lit),
         }
     }
     Ok(result)
@@ -117,12 +117,12 @@ fn build_node<'a>(
 
                     ElementAttr::AttrExpression { .. }
                     | ElementAttr::CustomAttrExpression { .. } => {
-                        let (name, value) = match &attr.attr {
+                        let (name, value, span) = match &attr.attr {
                             ElementAttr::AttrExpression { name, value } => {
-                                (name.to_string(), value)
+                                (name.to_string(), value, name.span())
                             }
                             ElementAttr::CustomAttrExpression { name, value } => {
-                                (name.value(), value)
+                                (name.value(), value, name.span())
                             }
                             _ => unreachable!(),
                         };
@@ -140,6 +140,11 @@ fn build_node<'a>(
                                     is_volatile: false,
                                     namespace,
                                 });
+                            } else {
+                                return Err(Error::ParseError(ParseError::new(
+                                    syn::Error::new(span, format!("unknown attribute: {}", name)),
+                                    ctx.location.clone(),
+                                )));
                             }
                         } else {
                             return Err(Error::RecompileRequiredError(

--- a/packages/rsx_interpreter/src/lib.rs
+++ b/packages/rsx_interpreter/src/lib.rs
@@ -150,6 +150,8 @@ impl RsxContext {
     fn report_error(&self, error: Error) {
         if let Some(handler) = &self.data.write().unwrap().error_handler {
             handler.handle_error(error)
+        } else {
+            panic!("no error handler set for this platform...\n{}", error);
         }
     }
 


### PR DESCRIPTION
Issue: If a application has the hot-reload feature enabled, but did not run through dioxus serve, the application will silently fail on errors.

Solution: When an error is produced warn the user the websocket was not connected and note that they should use hot reloading through dioxus serve --hot-reload, and panic with the error message.