### PR TITLE
Lowercase components, nodebuilder, and merging of "components" and "elements" in macros.

### DIFF
--- a/packages/core/src/properties.rs
+++ b/packages/core/src/properties.rs
@@ -56,7 +56,7 @@ impl<'a, const A: bool> FragmentBuilder<'a, A> {
 impl<'a> Properties for FragmentProps<'a> {
     type Builder = FragmentBuilder<'a, false>;
     const IS_STATIC: bool = false;
-    fn builder() -> Self::Builder {
+    fn builder(cx: &ScopeState) -> Self::Builder {
         FragmentBuilder(None)
     }
     unsafe fn memoize(&self, _other: &Self) -> bool {
@@ -136,7 +136,7 @@ pub trait Properties: Sized {
     const IS_STATIC: bool;
 
     /// Create a builder for this component.
-    fn builder() -> Self::Builder;
+    fn builder(cx: &ScopeState) -> Self::Builder;
 
     /// Memoization can only happen if the props are valid for the 'static lifetime
     ///
@@ -149,7 +149,7 @@ pub trait Properties: Sized {
 impl Properties for () {
     type Builder = EmptyBuilder;
     const IS_STATIC: bool = true;
-    fn builder() -> Self::Builder {
+    fn builder(cx: &ScopeState) -> Self::Builder {
         EmptyBuilder {}
     }
     unsafe fn memoize(&self, _other: &Self) -> bool {
@@ -165,6 +165,9 @@ impl EmptyBuilder {
 
 /// This utility function launches the builder method so rsx! and html! macros can use the typed-builder pattern
 /// to initialize a component's props.
-pub fn fc_to_builder<'a, T: Properties + 'a>(_: fn(Scope<'a, T>) -> Element) -> T::Builder {
-    T::builder()
+pub fn fc_to_builder<'a, T: Properties + 'a>(
+    cx: &'a ScopeState,
+    _: fn(Scope<'a, T>) -> Element,
+) -> T::Builder {
+    T::builder(cx)
 }

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -430,6 +430,12 @@ impl<'a, P> std::ops::Deref for Scope<'a, P> {
     }
 }
 
+impl<'a, P> From<Scope<'a, P>> for &'a ScopeState {
+    fn from(val: Scope<'a, P>) -> Self {
+        val.scope
+    }
+}
+
 /// A component's unique identifier.
 ///
 /// `ScopeId` is a `usize` that is unique across the entire [`VirtualDom`] and across time. [`ScopeID`]s will never be reused
@@ -931,7 +937,32 @@ impl ScopeState {
         // Finally, clear the hook arena
         self.hook_arena.reset();
     }
+
+    // /// Get the builder for this element or component
+    // pub fn builder<'a, P, O, I>(&self, _f: fn(I) -> O) -> P::Builder
+    // where
+    //     P: Properties,
+    //     I: IntoScopeState<'a, P>,
+    // {
+    //     P::builder(self)
+    // }
 }
+
+// pub trait IntoScopeState<'a, P> {
+//     fn inner(self) -> &'a ScopeState;
+// }
+
+// impl<'a, P> IntoScopeState<'a, P> for Scope<'a, P> {
+//     fn inner(self) -> &'a ScopeState {
+//         self.scope
+//     }
+// }
+
+// impl<'a> IntoScopeState<'a, ()> for &'a ScopeState {
+//     fn inner(self) -> &'a ScopeState {
+//         self
+//     }
+// }
 
 pub(crate) struct BumpFrame {
     pub bump: Bump,

--- a/packages/html/tests/static.rs
+++ b/packages/html/tests/static.rs
@@ -1,0 +1,61 @@
+use std::{any::Any, ops::Deref, ptr::addr_of};
+//
+use dioxus_core::prelude::*;
+
+struct NodeBuilder<'a, P> {
+    inner: Scope<'a>,
+    parent: P,
+}
+impl NodeBuilder<'_, ()> {
+    fn class(self, f: &str) -> Self {
+        todo!()
+    }
+
+    fn build(self) {}
+}
+
+struct Base<'a> {
+    inner: &'a ScopeState,
+}
+
+trait MyThing<T> {}
+
+trait Buildable<P, O> {
+    type Builder;
+}
+
+impl<'a, F, I> Buildable<(), NodeBuilder<'a, I>> for F
+where
+    F: Fn(&ScopeState) -> NodeBuilder<I>,
+{
+    type Builder = NodeBuilder<'static, I>;
+}
+
+impl<F, P> Buildable<P, Element<'static>> for F
+where
+    F: Fn(Scope<P>) -> Element,
+    P: Properties,
+{
+    type Builder = P::Builder;
+}
+
+fn buildit<P: Properties, O, C: Buildable<P, O>>(f: C) -> C::Builder {
+    todo!()
+}
+
+fn base(cx: &ScopeState) -> NodeBuilder<()> {
+    todo!()
+}
+
+fn my_component(cx: Scope) -> Element {
+    todo!()
+}
+
+fn dis_ambiguate(cx: Scope) {
+    // Used by builder
+    let builder = base(&cx);
+
+    // Used by the macro
+    let r = buildit(base).class("asda").build();
+    let r = buildit(my_component).build();
+}


### PR DESCRIPTION
This PR adds lowercase components, the nodebuilder, and refactors rsx to couple together components and elements as "blocks" in the eye of the macro.

It'll also have to adjust the hotreload system to optimistically update attributes and be force a reload if the template cannot be found (since it probably refers to a component).