### PR TITLE
Exclude benchmarks from testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
       - .github/**
       - lib.rs
       - Cargo.toml
+      - Makefile.toml
 
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -42,7 +42,7 @@ private = true
 [tasks.test]
 dependencies = ["build"]
 command = "cargo"
-args = ["test", "--all-targets", "--workspace", "--exclude", "dioxus-router"]
+args = ["test", "--lib", "--bins", "--tests", "--examples", "--workspace", "--exclude", "dioxus-router"]
 private = true
 
 [tasks.test-with-browser]


### PR DESCRIPTION
I looked a bit into why our CI test are taking so long (~30m in some cases) and it appears that the benchmarks are at fault. The `tui_update` benchmark in particular is taking very long (18 minutes on my machine).

I propose removing the benchmarks from the tests we perform in CI. This will make it faster to check that a PR doesn't break anything, improving the workflow.

I don't think they add much value to PR testing anyway – it's not like anyone is checking them for performance regressions during PRs. We *could* have a separate CI thingy that benchmarks `master` every time it updates and makes the HTML reports show up somewhere. That would be cool, but also probably more trouble than its worth.

```
$ time cargo test --bench tui_update
    Finished test [unoptimized + debuginfo] target(s) in 0.18s
     Running benches/tui_update.rs (target/debug/deps/tui_update-449d66af8971ddbe)
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

Gnuplot not found, using plotters backend
Testing Update boxes/size/9
Success
Testing Update boxes/size/36
Success
Testing Update boxes/size/81
Success
Testing Update boxes/size/144
Success
Testing Update boxes/size/225
Success
Testing Update boxes/size/324
Success
Testing Update boxes/size/441
Success
Testing Update boxes/size/576
Success


real	18m24,196s
user	18m19,504s
sys	0m1,090s
```