### PR TITLE
Remove argument from `use_hook` closure

### DIFF
--- a/examples/borrowed.rs
+++ b/examples/borrowed.rs
@@ -23,7 +23,7 @@ fn main() {
 }
 
 fn app(cx: Scope) -> Element {
-    let text = cx.use_hook(|_| vec![String::from("abc=def")]);
+    let text = cx.use_hook(|| vec![String::from("abc=def")]);
 
     let first = text.get_mut(0).unwrap();
 

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -10,7 +10,7 @@ pub type ProxyType = EventLoopProxy<UserWindowEvent>;
 
 /// Get an imperative handle to the current window
 pub fn use_window(cx: &ScopeState) -> &DesktopContext {
-    cx.use_hook(|_| cx.consume_context::<DesktopContext>())
+    cx.use_hook(|| cx.consume_context::<DesktopContext>())
         .as_ref()
         .unwrap()
 }
@@ -232,5 +232,5 @@ pub(super) fn handler(
 pub fn use_eval<S: std::string::ToString>(cx: &ScopeState) -> &dyn Fn(S) {
     let desktop = use_window(cx).clone();
 
-    cx.use_hook(|_| move |script| desktop.eval(script))
+    cx.use_hook(|| move |script| desktop.eval(script))
 }

--- a/packages/dioxus/tests/borrowedstate.rs
+++ b/packages/dioxus/tests/borrowedstate.rs
@@ -8,7 +8,7 @@ fn test_borrowed_state() {
 }
 
 fn Parent(cx: Scope) -> Element {
-    let value = cx.use_hook(|_| String::new());
+    let value = cx.use_hook(|| String::new());
 
     cx.render(rsx! {
         div {

--- a/packages/dioxus/tests/earlyabort.rs
+++ b/packages/dioxus/tests/earlyabort.rs
@@ -20,7 +20,7 @@ fn new_dom<P: 'static + Send>(app: Component<P>, props: P) -> VirtualDom {
 #[test]
 fn test_early_abort() {
     const app: Component = |cx| {
-        let val = cx.use_hook(|_| 0);
+        let val = cx.use_hook(|| 0);
 
         *val += 1;
 

--- a/packages/dioxus/tests/lifecycle.rs
+++ b/packages/dioxus/tests/lifecycle.rs
@@ -34,7 +34,7 @@ fn manual_diffing() {
 #[test]
 fn events_generate() {
     fn app(cx: Scope) -> Element {
-        let count = cx.use_hook(|_| 0);
+        let count = cx.use_hook(|| 0);
 
         let inner = match *count {
             0 => {
@@ -77,7 +77,7 @@ fn events_generate() {
 #[test]
 fn components_generate() {
     fn app(cx: Scope) -> Element {
-        let render_phase = cx.use_hook(|_| 0);
+        let render_phase = cx.use_hook(|| 0);
         *render_phase += 1;
 
         cx.render(match *render_phase {
@@ -171,7 +171,7 @@ fn components_generate() {
 #[test]
 fn component_swap() {
     fn app(cx: Scope) -> Element {
-        let render_phase = cx.use_hook(|_| 0);
+        let render_phase = cx.use_hook(|| 0);
         *render_phase += 1;
 
         cx.render(match *render_phase {

--- a/packages/dioxus/tests/miri_stress.rs
+++ b/packages/dioxus/tests/miri_stress.rs
@@ -22,7 +22,7 @@ fn new_dom<P: 'static + Send>(app: Component<P>, props: P) -> VirtualDom {
 #[test]
 fn test_memory_leak() {
     fn app(cx: Scope) -> Element {
-        let val = cx.use_hook(|_| 0);
+        let val = cx.use_hook(|| 0);
 
         *val += 1;
 
@@ -30,7 +30,7 @@ fn test_memory_leak() {
             return None;
         }
 
-        let name = cx.use_hook(|_| String::from("asd"));
+        let name = cx.use_hook(|| String::from("asd"));
 
         cx.render(rsx!(
             div { "Hello, world!" }
@@ -79,7 +79,7 @@ fn test_memory_leak() {
 #[test]
 fn memo_works_properly() {
     fn app(cx: Scope) -> Element {
-        let val = cx.use_hook(|_| 0);
+        let val = cx.use_hook(|| 0);
 
         *val += 1;
 
@@ -87,7 +87,7 @@ fn memo_works_properly() {
             return None;
         }
 
-        let name = cx.use_hook(|_| String::from("asd"));
+        let name = cx.use_hook(|| String::from("asd"));
 
         cx.render(rsx!(
             div { "Hello, world! {name}" }
@@ -192,7 +192,7 @@ fn free_works_on_root_hooks() {
     }
 
     fn app(cx: Scope) -> Element {
-        let name = cx.use_hook(|_| Droppable(String::from("asd")));
+        let name = cx.use_hook(|| Droppable(String::from("asd")));
         rsx!(cx, div { "{name.0}" })
     }
 
@@ -204,7 +204,7 @@ fn free_works_on_root_hooks() {
 fn old_props_arent_stale() {
     fn app(cx: Scope) -> Element {
         dbg!("rendering parent");
-        let cnt = cx.use_hook(|_| 0);
+        let cnt = cx.use_hook(|| 0);
         *cnt += 1;
 
         if *cnt == 1 {

--- a/packages/dioxus/tests/sharedstate.rs
+++ b/packages/dioxus/tests/sharedstate.rs
@@ -36,7 +36,7 @@ fn swap_test() {
     struct MySharedState(&'static str);
 
     fn app(cx: Scope) -> Element {
-        let val = cx.use_hook(|_| 0);
+        let val = cx.use_hook(|| 0);
         *val += 1;
 
         cx.provide_context(Rc::new(MySharedState("world!")));

--- a/packages/fermi/src/hooks/atom_ref.rs
+++ b/packages/fermi/src/hooks/atom_ref.rs
@@ -16,7 +16,7 @@ use std::{
 pub fn use_atom_ref<T: 'static>(cx: &ScopeState, atom: AtomRef<T>) -> &UseAtomRef<T> {
     let root = use_atom_root(cx);
 
-    &cx.use_hook(|_| {
+    &cx.use_hook(|| {
         root.initialize(atom);
         (
             UseAtomRef {

--- a/packages/fermi/src/hooks/atom_root.rs
+++ b/packages/fermi/src/hooks/atom_root.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 // Returns the atom root, initiaizing it at the root of the app if it does not exist.
 pub fn use_atom_root(cx: &ScopeState) -> &Rc<AtomRoot> {
-    cx.use_hook(|_| match cx.consume_context::<Rc<AtomRoot>>() {
+    cx.use_hook(|| match cx.consume_context::<Rc<AtomRoot>>() {
         Some(root) => root,
         None => cx.provide_root_context(Rc::new(AtomRoot::new(cx.schedule_update_any()))),
     })

--- a/packages/fermi/src/hooks/init_atom_root.rs
+++ b/packages/fermi/src/hooks/init_atom_root.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 // Initializes the atom root and retuns it;
 pub fn use_init_atom_root(cx: &ScopeState) -> &Rc<AtomRoot> {
-    cx.use_hook(|_| match cx.consume_context::<Rc<AtomRoot>>() {
+    cx.use_hook(|| match cx.consume_context::<Rc<AtomRoot>>() {
         Some(ctx) => ctx,
         None => cx.provide_context(Rc::new(AtomRoot::new(cx.schedule_update_any()))),
     })

--- a/packages/fermi/src/hooks/read.rs
+++ b/packages/fermi/src/hooks/read.rs
@@ -22,7 +22,7 @@ pub fn use_read_rc<V: 'static>(cx: &ScopeState, f: impl Readable<V>) -> &Rc<V> {
         }
     }
 
-    let inner = cx.use_hook(|_| UseReadInner {
+    let inner = cx.use_hook(|| UseReadInner {
         value: None,
         root: root.clone(),
         scope_id: cx.scope_id(),

--- a/packages/fermi/src/hooks/set.rs
+++ b/packages/fermi/src/hooks/set.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 pub fn use_set<T: 'static>(cx: &ScopeState, f: impl Writable<T>) -> &Rc<dyn Fn(T)> {
     let root = use_atom_root(cx);
-    cx.use_hook(|_| {
+    cx.use_hook(|| {
         let id = f.unique_id();
         let root = root.clone();
         root.initialize(f);

--- a/packages/fermi/src/hooks/state.rs
+++ b/packages/fermi/src/hooks/state.rs
@@ -33,7 +33,7 @@ use std::{
 pub fn use_atom_state<T: 'static>(cx: &ScopeState, f: impl Writable<T>) -> &AtomState<T> {
     let root = crate::use_atom_root(cx);
 
-    let inner = cx.use_hook(|_| AtomState {
+    let inner = cx.use_hook(|| AtomState {
         value: None,
         root: root.clone(),
         scope_id: cx.scope_id(),

--- a/packages/hooks/src/use_shared_state.rs
+++ b/packages/hooks/src/use_shared_state.rs
@@ -61,7 +61,7 @@ impl<T> ProvidedStateInner<T> {
 ///
 ///
 pub fn use_context<T: 'static>(cx: &ScopeState) -> Option<UseSharedState<T>> {
-    let state = cx.use_hook(|_| {
+    let state = cx.use_hook(|| {
         let scope_id = cx.scope_id();
         let root = cx.consume_context::<ProvidedState<T>>();
 
@@ -173,7 +173,7 @@ where
 ///
 ///
 pub fn use_context_provider<T: 'static>(cx: &ScopeState, f: impl FnOnce() -> T) {
-    cx.use_hook(|_| {
+    cx.use_hook(|| {
         let state: ProvidedState<T> = Rc::new(RefCell::new(ProvidedStateInner {
             value: Rc::new(RefCell::new(f())),
             notify_any: cx.schedule_update_any(),

--- a/packages/hooks/src/usecoroutine.rs
+++ b/packages/hooks/src/usecoroutine.rs
@@ -65,7 +65,7 @@ where
     G: FnOnce(UnboundedReceiver<M>) -> F,
     F: Future<Output = ()> + 'static,
 {
-    cx.use_hook(|_| {
+    cx.use_hook(|| {
         let (tx, rx) = futures_channel::mpsc::unbounded();
         let task = cx.push_future(init(rx));
         cx.provide_context(CoroutineHandle { tx, task })
@@ -76,7 +76,7 @@ where
 ///
 /// See the docs for [`use_coroutine`] for more details.
 pub fn use_coroutine_handle<M: 'static>(cx: &ScopeState) -> Option<&CoroutineHandle<M>> {
-    cx.use_hook(|_| cx.consume_context::<CoroutineHandle<M>>())
+    cx.use_hook(|| cx.consume_context::<CoroutineHandle<M>>())
         .as_ref()
 }
 

--- a/packages/hooks/src/useeffect.rs
+++ b/packages/hooks/src/useeffect.rs
@@ -34,7 +34,7 @@ where
         dependencies: Vec<Box<dyn Any>>,
     }
 
-    let state = cx.use_hook(move |_| UseEffect {
+    let state = cx.use_hook(move || UseEffect {
         needs_regen: true,
         task: Cell::new(None),
         dependencies: Vec::new(),

--- a/packages/hooks/src/usefuture.rs
+++ b/packages/hooks/src/usefuture.rs
@@ -25,7 +25,7 @@ where
     F: Future<Output = T> + 'static,
     D: UseFutureDep,
 {
-    let state = cx.use_hook(move |_| UseFuture {
+    let state = cx.use_hook(move || UseFuture {
         update: cx.schedule_update(),
         needs_regen: Cell::new(true),
         slot: Rc::new(Cell::new(None)),

--- a/packages/hooks/src/usemodel.rs
+++ b/packages/hooks/src/usemodel.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 pub fn use_model<'a, T: 'static>(cx: &'a ScopeState, f: impl FnOnce() -> T) -> UseModel<'a, T> {
-    let inner = cx.use_hook(|_| UseModelInner {
+    let inner = cx.use_hook(|| UseModelInner {
         update_scheduled: Cell::new(false),
         update_callback: cx.schedule_update(),
         value: RefCell::new(f()),
@@ -78,7 +78,7 @@ pub fn use_model_coroutine<'a, T, F: Future<Output = ()> + 'static>(
     _model: UseModel<T>,
     _f: impl FnOnce(AppModels) -> F,
 ) -> UseModelCoroutine {
-    cx.use_hook(|_| UseModelTaskInner {
+    cx.use_hook(|| UseModelTaskInner {
         task: Default::default(),
     });
     todo!()

--- a/packages/hooks/src/useref.rs
+++ b/packages/hooks/src/useref.rs
@@ -111,7 +111,7 @@ use std::{
 /// })
 /// ```
 pub fn use_ref<T: 'static>(cx: &ScopeState, initialize_refcell: impl FnOnce() -> T) -> &UseRef<T> {
-    let hook = cx.use_hook(|_| UseRef {
+    let hook = cx.use_hook(|| UseRef {
         update: cx.schedule_update(),
         value: Rc::new(RefCell::new(initialize_refcell())),
         dirty: Rc::new(Cell::new(false)),

--- a/packages/hooks/src/usestate.rs
+++ b/packages/hooks/src/usestate.rs
@@ -34,7 +34,7 @@ pub fn use_state<T: 'static>(
     cx: &ScopeState,
     initial_state_fn: impl FnOnce() -> T,
 ) -> &UseState<T> {
-    let hook = cx.use_hook(move |_| {
+    let hook = cx.use_hook(move || {
         let current_val = Rc::new(initial_state_fn());
         let update_callback = cx.schedule_update();
         let slot = Rc::new(RefCell::new(current_val.clone()));

--- a/packages/hooks/src/usesuspense.rs
+++ b/packages/hooks/src/usesuspense.rs
@@ -7,7 +7,7 @@ pub fn use_suspense<R: 'static, F: Future<Output = R> + 'static>(
     create_future: impl FnOnce() -> F,
     render: impl FnOnce(&R) -> Element,
 ) -> Element {
-    let sus = cx.use_hook(|_| {
+    let sus = cx.use_hook(|| {
         let fut = create_future();
 
         let wip_value: Rc<Cell<Option<R>>> = Default::default();

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -77,7 +77,7 @@ pub struct LinkProps<'a> {
 /// }
 /// ```
 pub fn Link<'a>(cx: Scope<'a, LinkProps<'a>>) -> Element {
-    let svc = cx.use_hook(|_| cx.consume_context::<Arc<RouterCore>>());
+    let svc = cx.use_hook(|| cx.consume_context::<Arc<RouterCore>>());
 
     let LinkProps {
         to,

--- a/packages/router/src/components/redirect.rs
+++ b/packages/router/src/components/redirect.rs
@@ -34,7 +34,7 @@ pub struct RedirectProps<'a> {
 pub fn Redirect<'a>(cx: Scope<'a, RedirectProps<'a>>) -> Element {
     let router = use_router(&cx);
 
-    let immediate_redirect = cx.use_hook(|_| {
+    let immediate_redirect = cx.use_hook(|| {
         if let Some(from) = cx.props.from {
             router.register_total_route(from.to_string(), cx.scope_id());
             false

--- a/packages/router/src/components/route.rs
+++ b/packages/router/src/components/route.rs
@@ -28,10 +28,10 @@ pub struct RouteProps<'a> {
 /// ```
 pub fn Route<'a>(cx: Scope<'a, RouteProps<'a>>) -> Element {
     let router_root = cx
-        .use_hook(|_| cx.consume_context::<Arc<RouterCore>>())
+        .use_hook(|| cx.consume_context::<Arc<RouterCore>>())
         .as_ref()?;
 
-    cx.use_hook(|_| {
+    cx.use_hook(|| {
         // create a bigger, better, longer route if one above us exists
         let total_route = match cx.consume_context::<RouteContext>() {
             Some(ctx) => ctx.total_route,

--- a/packages/router/src/components/router.rs
+++ b/packages/router/src/components/router.rs
@@ -37,7 +37,7 @@ pub struct RouterProps<'a> {
 /// Will fallback to HashRouter is BrowserRouter is not available, or through configuration.
 #[allow(non_snake_case)]
 pub fn Router<'a>(cx: Scope<'a, RouterProps<'a>>) -> Element {
-    let svc = cx.use_hook(|_| {
+    let svc = cx.use_hook(|| {
         cx.provide_context(RouterCore::new(
             &cx,
             RouterCfg {

--- a/packages/router/src/hooks/use_route.rs
+++ b/packages/router/src/hooks/use_route.rs
@@ -7,7 +7,7 @@ use url::Url;
 /// context of a [`Router`]. If this function is called outside of a `Router`
 /// component it will panic.
 pub fn use_route(cx: &ScopeState) -> &UseRoute {
-    let handle = cx.use_hook(|_| {
+    let handle = cx.use_hook(|| {
         let router = cx
             .consume_context::<RouterService>()
             .expect("Cannot call use_route outside the scope of a Router component");

--- a/packages/router/src/hooks/use_router.rs
+++ b/packages/router/src/hooks/use_router.rs
@@ -3,7 +3,7 @@ use dioxus::core::ScopeState;
 
 /// This hook provides access to the `RouterService` for the app.
 pub fn use_router(cx: &ScopeState) -> &RouterService {
-    cx.use_hook(|_| {
+    cx.use_hook(|| {
         cx.consume_context::<RouterService>()
             .expect("Cannot call use_route outside the scope of a Router component")
     })

--- a/packages/web/src/util.rs
+++ b/packages/web/src/util.rs
@@ -16,7 +16,7 @@ use dioxus_core::*;
 /// The closure will panic if the provided script is not valid JavaScript code
 /// or if it returns an uncaught error.
 pub fn use_eval<S: std::string::ToString>(cx: &ScopeState) -> &dyn Fn(S) {
-    cx.use_hook(|_| {
+    cx.use_hook(|| {
         |script: S| {
             js_sys::Function::new_no_args(&script.to_string())
                 .call0(&wasm_bindgen::JsValue::NULL)


### PR DESCRIPTION
This is a breaking change.

---

Alternative: we *could* make `use_hook` take a trait `impl UseHookFn`, and implement it for both `()->T` and `(usize)->T`, and deprecate the latter, but breaking it seems better:

- There is no valid use case for the argument
- It's an easy change (find + replace)
- Neat function signature -> docs quick to understand
- There wouldn't be a good mechanism to make this deprecation show up as a warning