### PR TITLE
allow the last attribute in a component to contain formatting

### DIFF
--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -234,13 +234,15 @@ impl Parse for ComponentField {
             let content = ContentField::ManExpr(input.parse()?);
             return Ok(Self { name, content });
         }
-
-        if input.peek(LitStr) && input.peek2(Token![,]) {
-            let t: LitStr = input.fork().parse()?;
-
-            if is_literal_foramtted(&t) {
-                let content = ContentField::Formatted(input.parse()?);
-                return Ok(Self { name, content });
+        if input.peek(LitStr) {
+            let forked = input.fork();
+            let t: LitStr = forked.parse()?;
+            // the string literal must either be the end of the input or a followed by a comma
+            if forked.is_empty() || forked.peek(Token![,]) {
+                if is_literal_foramtted(&t) {
+                    let content = ContentField::Formatted(input.parse()?);
+                    return Ok(Self { name, content });
+                }
             }
         }
 


### PR DESCRIPTION
fixes #502 
The current method of parsing components checks if the attribute has a trailing comma before checking for formatting. This PR allows the last attribute to not have a trailing comma, but still contain formatted segments.