### PR TITLE
Fix weird docs typo/copy-paste error

### DIFF
--- a/packages/fermi/src/hooks/state.rs
+++ b/packages/fermi/src/hooks/state.rs
@@ -92,8 +92,8 @@ impl<T: 'static> AtomState<T> {
     ///
     /// This is useful for passing the setter function to other components.
     ///
-    /// However, for most cases, calling `to_owned` o`AtomState`te is the
-    /// preferred way to get "anoth`set_state`tate handle.
+    /// However, for most cases, calling `to_owned` on the state is the
+    /// preferred way to get "another" state handle.
     ///
     ///
     /// # Examples

--- a/packages/hooks/src/usestate.rs
+++ b/packages/hooks/src/usestate.rs
@@ -110,8 +110,8 @@ impl<T: 'static> UseState<T> {
     ///
     /// This is useful for passing the setter function to other components.
     ///
-    /// However, for most cases, calling `to_owned` o`UseState`te is the
-    /// preferred way to get "anoth`set_state`tate handle.
+    /// However, for most cases, calling `to_owned` on the state is the
+    /// preferred way to get "another" state handle.
     ///
     ///
     /// # Examples


### PR DESCRIPTION
Introduced in a8952a9ee8d8831fa911cef4e7035293c3a9f88b and 4518b6bc8cfbe246d0844b2a32f11f437115d00d by @jkelleyrtp  
Spotted while reading the docs. I don't know how this happened (twice!), perhaps some find-and-replace or editor macro trickery. I was pretty easy to deduce correct text though.