### PR TITLE
Nested Routes do not work [#432]

### DIFF
--- a/packages/router/src/components/redirect.rs
+++ b/packages/router/src/components/redirect.rs
@@ -36,14 +36,14 @@ pub fn Redirect<'a>(cx: Scope<'a, RedirectProps<'a>>) -> Element {
 
     let immediate_redirect = cx.use_hook(|| {
         if let Some(from) = cx.props.from {
-            router.register_total_route(from.to_string(), cx.scope_id());
+            router.register_total_route(from.to_string(), None, cx.scope_id());
             false
         } else {
             true
         }
     });
 
-    if *immediate_redirect || router.should_render(cx.scope_id()) {
+    if *immediate_redirect || router.should_render(cx.scope_id(), None) {
         router.replace_route(cx.props.to, None, None);
     }
 

--- a/packages/router/src/components/route.rs
+++ b/packages/router/src/components/route.rs
@@ -27,14 +27,57 @@ pub struct RouteProps<'a> {
 /// )
 /// ```
 pub fn Route<'a>(cx: Scope<'a, RouteProps<'a>>) -> Element {
+    // Initialize route with first render true. It will be changed to false on the first render.
+    // This is done to make sure we get every sibling route registered before we choose one to render.
+    // If we don't do this, we need to have routes in a specific order to avoid flickering.
+    //
+    // For example, the following woud flicker when navigating to /blog/1, rendering /blog first,
+    // then registering /blog/:id, and re rendering /blog to hide it.
+    //
+    //```rust, ignore
+    // rsx!(
+    //     Router {
+    //         Route { to: "/blog", Blog {} }
+    //         Route { to: "/blog/:id", BlogItem {} }
+    //     }
+    // )
+    //```
+    //
+    // Flickering would not happen if we have the more specific route registered first.
+    // For example, the following would not flicker even if we remove this first render restriction:
+    //
+    //```rust, ignore
+    // rsx!(
+    //     Router {
+    //         Route { to: "/blog/:id", BlogItem {} }
+    //         Route { to: "/blog", Blog {} }
+    //     }
+    // )
+    //```
+    let first_render = use_state(&cx, || true);
+
     let router_root = cx
         .use_hook(|| cx.consume_context::<Arc<RouterCore>>())
         .as_ref()?;
 
+    let parent_context = cx.use_hook(|| cx.consume_context::<RouteContext>());
+
+    let parent_scope_id = match parent_context {
+        Some(context) => Some(context.scope_id),
+        None => None,
+    };
+
     cx.use_hook(|| {
         // create a bigger, better, longer route if one above us exists
-        let total_route = match cx.consume_context::<RouteContext>() {
-            Some(ctx) => ctx.total_route,
+        let total_route = match parent_context {
+            Some(ctx) => {
+                // concat parent route, making sure we have a single slash in between
+                format!(
+                    "{}/{}",
+                    ctx.total_route.trim_end_matches("/"),
+                    cx.props.to.trim_start_matches("/")
+                )
+            }
             None => cx.props.to.to_string(),
         };
 
@@ -42,19 +85,45 @@ pub fn Route<'a>(cx: Scope<'a, RouteProps<'a>>) -> Element {
         let route_context = cx.provide_context(RouteContext {
             declared_route: cx.props.to.to_string(),
             total_route,
+            scope_id: cx.scope_id(),
         });
 
         // submit our rout
-        router_root.register_total_route(route_context.total_route, cx.scope_id());
+        router_root.register_total_route(route_context.total_route, parent_scope_id, cx.scope_id());
+    });
+
+    let _ = cx.use_hook(|| RouteUnmountListener {
+        scope_id: cx.scope_id(),
+        router: router_root.clone(),
+        parent_scope_id: parent_scope_id,
     });
 
     log::trace!("Checking Route: {:?}", cx.props.to);
 
-    if router_root.should_render(cx.scope_id()) {
+    if *first_render.get() {
+        first_render.set(false);
+        log::trace!("First render of Route: {:?}", cx.scope_id());
+        None
+    } else if router_root.should_render(cx.scope_id(), parent_scope_id) {
         log::trace!("Route should render: {:?}", cx.scope_id());
         cx.render(rsx!(&cx.props.children))
     } else {
         log::trace!("Route should *not* render: {:?}", cx.scope_id());
         None
+    }
+}
+
+// This struct is used to know when the component is unmounted,
+// so we can remove it from the router on drop.
+struct RouteUnmountListener {
+    scope_id: ScopeId,
+    parent_scope_id: Option<ScopeId>,
+    router: Arc<RouterCore>,
+}
+
+impl Drop for RouteUnmountListener {
+    fn drop(&mut self) {
+        self.router
+            .unregister_total_route(self.scope_id, self.parent_scope_id);
     }
 }

--- a/packages/router/src/components/router.rs
+++ b/packages/router/src/components/router.rs
@@ -48,7 +48,7 @@ pub fn Router<'a>(cx: Scope<'a, RouterProps<'a>>) -> Element {
     });
 
     // next time we run the rout_found will be filled
-    if svc.route_found.get().is_none() {
+    if svc.route_found.borrow().is_empty() {
         cx.props.onchange.call(svc.clone());
     }
 

--- a/packages/router/src/routecontext.rs
+++ b/packages/router/src/routecontext.rs
@@ -1,3 +1,4 @@
+use dioxus::prelude::*;
 /// A `RouteContext` is a context that is provided by [`Route`](fn.Route.html) components.
 ///
 /// This signals to all child [`Route`] and [`Link`] components that they are
@@ -21,4 +22,7 @@ pub struct RouteContext {
     /// "/level0/level1/:id"
     /// ```
     pub total_route: String,
+
+    /// The `scope_id` is used to identify this route as parent for nested routes.
+    pub(crate) scope_id: ScopeId,
 }


### PR DESCRIPTION
(fixes DioxusLabs/dioxus#432)

This makes nested routes work by checking routes one level (closest shared parent `Route` or `Router`) at a time and in relevance (naive) order. So for example:
```
- /blog/1 <--- level: 0, check order: 2
- /blog/ <--- level: 0, check order: 3
    |- /laraira <--- level: 1, check order: 1
    |- /:id <--- level: 1, check order: 2
- /blog/10 <--- level: 0, check order: 1
- / <--- level: 0, check order: 4
```
On each level there can be a single match at a time, so the first one to be found will be used and we no longer check the rest, and if the one found has nested routes, they will be checked when rendered only against same level siblings, and so on.

There's a few issues mentioned in comments I'd like to iterate with you guys, so please leave some comments :)