### PR TITLE
allow duplicate variables in format_args_f

### DIFF
--- a/packages/core-macro/tests/ifmt.rs
+++ b/packages/core-macro/tests/ifmt.rs
@@ -23,4 +23,10 @@ fn formatting_compiles() {
         format_args_f!("{x.borrow():?}").to_string(),
         format!("{:?}", x.borrow())
     );
+
+    // allows duplicate format args
+    assert_eq!(
+        format_args_f!("{x:?} {x:?}").to_string(),
+        format!("{:?} {:?}", x, x)
+    );
 }


### PR DESCRIPTION
currently this fails to compile:
```rust
let x = 0;
rsx!{
  "{x} {x}"
}
```
This is because the format_args_f macro transforms it into
...
format_args!("{x} {x}", x = x x = x)
...
which contains duplicates that are not allowed in format_args.
This PR deduplicates the assignments.