### PR TITLE
Ergonomic custom elements

### DIFF
--- a/examples/custom_element.rs
+++ b/examples/custom_element.rs
@@ -15,16 +15,17 @@ fn main() {
     println!("{}", output);
 }
 
+custom_elements! {
+    my_element("my-element", name);
+    your_element("your-element", foo, bar);
+    other_element("other-element",);
+}
+
 fn app(cx: Scope) -> Element {
-    let nf = NodeFactory::new(&cx);
-
-    let mut attrs = dioxus::core::exports::bumpalo::collections::Vec::new_in(nf.bump());
-
-    attrs.push(nf.attr("client-id", format_args!("abc123"), None, false));
-
-    attrs.push(nf.attr("name", format_args!("bob"), None, false));
-
-    attrs.push(nf.attr("age", format_args!("47"), None, false));
-
-    Some(nf.raw_element("my-element", None, &[], attrs.into_bump_slice(), &[], None))
+    render! {
+        div { "built-in element" },
+        my_element { name: "bob", title: "global attribute works", "custom element" }
+        your_element { foo: "foo", bar: "bar" }
+        other_element { "other element" }
+    }
 }

--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -32,5 +32,5 @@ pub mod prelude {
     pub use dioxus_html as dioxus_elements;
 
     #[cfg(feature = "html")]
-    pub use dioxus_elements::{GlobalAttributes, SvgAttributes};
+    pub use dioxus_elements::{custom_elements, GlobalAttributes, SvgAttributes};
 }

--- a/packages/html/src/lib.rs
+++ b/packages/html/src/lib.rs
@@ -24,3 +24,27 @@ mod web_sys_bind;
 pub use elements::*;
 pub use events::*;
 pub use global_attributes::*;
+
+#[macro_export]
+macro_rules! custom_elements {
+    (
+        $( $ele:ident( $tag:expr, $( $attr:ident ),* ); )+
+    ) => {$(
+        #[allow(non_camel_case_types)]
+        pub struct $ele;
+
+        impl DioxusElement for $ele {
+            const TAG_NAME: &'static str = $tag;
+            const NAME_SPACE: Option<&'static str> = None;
+        }
+        impl GlobalAttributes for $ele {}
+        impl $ele {$(
+            #[allow(non_upper_case_globals)]
+            pub const $attr: AttributeDiscription = AttributeDiscription {
+                name: stringify!($attr),
+                namespace: None,
+                volatile: false,
+            };
+        )*}
+    )+}
+}

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -178,15 +178,16 @@ impl ToTokens for Element {
             .iter()
             .filter(|f| !matches!(f.attr, ElementAttr::EventTokens { .. }));
 
-        tokens.append_all(quote! {
+        tokens.append_all(quote! {{
+            use dioxus_elements::*;
             __cx.element(
-                dioxus_elements::#name,
+                #name,
                 __cx.bump().alloc([ #(#listeners),* ]),
                 __cx.bump().alloc([ #(#attr),* ]),
                 __cx.bump().alloc([ #(#children),* ]),
                 #key,
             )
-        });
+        }});
     }
 }
 
@@ -243,14 +244,16 @@ impl ToTokens for ElementAttrNamed {
 
         tokens.append_all(match attr {
             ElementAttr::AttrText { name, value } => {
-                quote! {
-                    __cx.attr_disciption( dioxus_elements::#el_name::#name, #value)
-                }
+                quote! {{
+                    use dioxus_elements::*;
+                    __cx.attr_disciption( #el_name::#name, #value)
+                }}
             }
             ElementAttr::AttrExpression { name, value } => {
-                quote! {
-                    __cx.attr_disciption( dioxus_elements::#el_name::#name, #value)
-                }
+                quote! {{
+                    use dioxus_elements::*;
+                    __cx.attr_disciption( #el_name::#name, #value)
+                }}
             }
             ElementAttr::CustomAttrText { name, value } => {
                 quote! {

--- a/packages/rsx/src/template.rs
+++ b/packages/rsx/src/template.rs
@@ -119,16 +119,17 @@ impl ToTokens for TemplateElementBuilder {
             }
             None => quote! {None},
         };
-        tokens.append_all(quote! {
+        tokens.append_all(quote! {{
+            use dioxus_elements::*;
             TemplateElement::new(
-                dioxus_elements::#tag::TAG_NAME,
-                dioxus_elements::#tag::NAME_SPACE,
+                #tag::TAG_NAME,
+                #tag::NAME_SPACE,
                 &[#(#attributes),*],
                 &[#(#children),*],
                 &[#(#listeners),*],
                 #parent,
             )
-        })
+        }})
     }
 }
 
@@ -223,12 +224,13 @@ impl ToTokens for TemplateAttributeBuilder {
             TemplateAttributeValue::Dynamic(idx) => quote! {TemplateAttributeValue::Dynamic(#idx)},
         };
         match name {
-            AttributeName::Ident(name) => tokens.append_all(quote! {
+            AttributeName::Ident(name) => tokens.append_all(quote! {{
+                use dioxus_elements::*;
                 TemplateAttribute{
-                    attribute: dioxus_elements::#element_tag::#name,
+                    attribute: #element_tag::#name,
                     value: #value,
                 }
-            }),
+            }}),
             AttributeName::Str(lit) => tokens.append_all(quote! {
                 TemplateAttribute{
                     attribute: dioxus::prelude::AttributeDiscription{


### PR DESCRIPTION
With this PR I propose that all lowercase identifiers followed by braces are treated as elements instead of components,  currently only single identifiers that are in `diouxus_html` are treated as such. Allowing identifiers with a path is the most ergonomic and simple way I found to express custom elements, this paired with the `custom_elements` macro that generates the `DioxusElement` definition inside a sun-module and uses the module and struct name to define the element tag results in a decent way to declare this kind of elements.  

```rust
rsx!(
  div { "normal element" },
  some::element { "also an element" }, // <some-element>
)
```

This change would probably break code that uses lowercase components but since the docs and general convention seems to be to declare components starting with uppercase I thought this is acceptable.