### PR TITLE
feat: Support Bytes type in AttributeValue

### DIFF
--- a/packages/core/src/arbitrary_value.rs
+++ b/packages/core/src/arbitrary_value.rs
@@ -65,7 +65,7 @@ impl<'a> std::fmt::Display for AttributeValue<'a> {
             AttributeValue::Vec4Float(_, _, _, _) => todo!(),
             AttributeValue::Vec4Int(_, _, _, _) => todo!(),
             AttributeValue::Vec4Uint(_, _, _, _) => todo!(),
-            AttributeValue::Bytes(_) => todo!(),
+            AttributeValue::Bytes(a) => write!(f, "{:?}", a),
             AttributeValue::Any(_) => todo!(),
         }
     }


### PR DESCRIPTION
I am not yet familiarized with the core codebase so I am not sure why this is needed, but looks like I need it, otherwise it would just panic.

Context: I am working on my own renderer and I am implementing an image element with an attribute that receives the content of the image in form of bytes.

I tried it with these changes and it worked :)
