### PR TITLE
Feat: file drag and drop working properly on desktop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
 rust-version = "1.60.0"
 
-
 [dev-dependencies]
 dioxus = { path = "./packages/dioxus" }
 dioxus-desktop = { path = "./packages/desktop" }

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -6,16 +6,20 @@ This calculator version uses React-style state management. All state is held as 
 use dioxus::events::*;
 use dioxus::html::input_data::keyboard_types::Key;
 use dioxus::prelude::*;
+use dioxus_desktop::{DesktopConfig, WindowBuilder};
 
 fn main() {
     use dioxus_desktop::tao::dpi::LogicalSize;
-    dioxus_desktop::launch_cfg(app, |cfg| {
-        cfg.with_window(|w| {
-            w.with_title("Calculator Demo")
+
+    dioxus_desktop::launch_cfg(
+        app,
+        DesktopConfig::new().with_window(
+            WindowBuilder::new()
+                .with_title("Calculator Demo")
                 .with_resizable(false)
-                .with_inner_size(LogicalSize::new(320.0, 530.0))
-        })
-    });
+                .with_inner_size(LogicalSize::new(320.0, 530.0)),
+        ),
+    );
 }
 
 fn app(cx: Scope) -> Element {

--- a/examples/custom_html.rs
+++ b/examples/custom_html.rs
@@ -2,14 +2,18 @@
 //! to add things like stylesheets, scripts, and third-party JS libraries.
 
 use dioxus::prelude::*;
+use dioxus_desktop::DesktopConfig;
 
 fn main() {
-    dioxus_desktop::launch_cfg(app, |c| {
-        c.with_custom_head("<style>body { background-color: red; }</style>".into())
-    });
+    dioxus_desktop::launch_cfg(
+        app,
+        DesktopConfig::new()
+            .with_custom_head("<style>body { background-color: red; }</style>".into()),
+    );
 
-    dioxus_desktop::launch_cfg(app, |c| {
-        c.with_custom_index(
+    dioxus_desktop::launch_cfg(
+        app,
+        DesktopConfig::new().with_custom_index(
             r#"
 <!DOCTYPE html>
 <html>
@@ -23,9 +27,9 @@ fn main() {
   </body>
 </html>
         "#
-            .into(),
-        )
-    });
+            .to_string(),
+        ),
+    );
 }
 
 fn app(cx: Scope) -> Element {

--- a/examples/file_explorer.rs
+++ b/examples/file_explorer.rs
@@ -9,9 +9,13 @@
 //! we dont need to clutter our code with `read` commands.
 
 use dioxus::prelude::*;
+use dioxus_desktop::{DesktopConfig, WindowBuilder};
 
 fn main() {
-    dioxus_desktop::launch_cfg(app, |c| c.with_window(|w| w.with_resizable(true)));
+    dioxus_desktop::launch_cfg(
+        app,
+        DesktopConfig::default().with_window(WindowBuilder::new().with_resizable(true)),
+    );
 }
 
 fn app(cx: Scope) -> Element {

--- a/examples/filedragdrop.rs
+++ b/examples/filedragdrop.rs
@@ -11,15 +11,30 @@ fn app(cx: Scope) -> Element {
         div {
             h1 { "drag a file here and check your console" }
             div {
+                height: "250px",
+                width: "250px",
+                background: "green",
+                draggable: "true",
+            }
+            div {
+                id: "dropzone",
                 height: "500px",
                 width: "500px",
                 background: "red",
+                // prevent_default: "ondragover",
+                // prevent_default: "ondragleave",
+                // prevent_default: "ondragenter",
+                // "ondragover": "return false;",
+                ondragover: move |evt| {},
                 ondragenter: move |evt: DragEvent| {
                     println!("drag enter {:?}", evt.files());
                 },
                 ondragleave: move |_| {
                     println!("drag leave");
-                }
+                },
+                ondrop: move |evt| {
+                    println!("drop {:?}", evt.files());
+                },
             }
         }
     ))

--- a/examples/filedragdrop.rs
+++ b/examples/filedragdrop.rs
@@ -1,6 +1,5 @@
 use dioxus::events::DragEvent;
 use dioxus::prelude::*;
-use dioxus_desktop::DesktopConfig;
 
 fn main() {
     dioxus_desktop::launch(app);
@@ -16,15 +15,16 @@ fn app(cx: Scope) -> Element {
                 background: "green",
                 draggable: "true",
             }
+            input {
+                "type": "file",
+                multiple: "true",
+                oninput: move |evt| println!("input event: {:?}", evt),
+            }
             div {
                 id: "dropzone",
                 height: "500px",
                 width: "500px",
                 background: "red",
-                // prevent_default: "ondragover",
-                // prevent_default: "ondragleave",
-                // prevent_default: "ondragenter",
-                // "ondragover": "return false;",
                 ondragover: move |evt| {},
                 ondragenter: move |evt: DragEvent| {
                     println!("drag enter {:?}", evt.files());

--- a/examples/filedragdrop.rs
+++ b/examples/filedragdrop.rs
@@ -1,18 +1,26 @@
+use dioxus::events::DragEvent;
 use dioxus::prelude::*;
+use dioxus_desktop::DesktopConfig;
 
 fn main() {
-    dioxus_desktop::launch_with_props(app, (), |c| {
-        c.with_file_drop_handler(|_w, e| {
-            println!("{:?}", e);
-            true
-        })
-    });
+    dioxus_desktop::launch(app);
 }
 
 fn app(cx: Scope) -> Element {
     cx.render(rsx!(
         div {
             h1 { "drag a file here and check your console" }
+            div {
+                height: "500px",
+                width: "500px",
+                background: "red",
+                ondragenter: move |evt: DragEvent| {
+                    println!("drag enter {:?}", evt.files());
+                },
+                ondragleave: move |_| {
+                    println!("drag leave");
+                }
+            }
         }
     ))
 }

--- a/examples/flat_router.rs
+++ b/examples/flat_router.rs
@@ -1,17 +1,19 @@
 use dioxus::prelude::*;
-use dioxus_desktop::tao::dpi::LogicalSize;
+use dioxus_desktop::{tao::dpi::LogicalSize, DesktopConfig, WindowBuilder};
 use dioxus_router::{Link, Route, Router};
 
 fn main() {
     env_logger::init();
 
-    dioxus_desktop::launch_cfg(app, |c| {
-        c.with_window(|c| {
-            c.with_title("Spinsense Client")
+    dioxus_desktop::launch_cfg(
+        app,
+        DesktopConfig::new().with_window(
+            WindowBuilder::new()
+                .with_title("Spinsense Client")
                 .with_inner_size(LogicalSize::new(600, 1000))
-                .with_resizable(false)
-        })
-    })
+                .with_resizable(false),
+        ),
+    )
 }
 
 fn app(cx: Scope) -> Element {

--- a/examples/hydration.rs
+++ b/examples/hydration.rs
@@ -10,12 +10,14 @@
 //! proof-of-concept for the hydration feature, but you'll probably only want to use hydration for the web.
 
 use dioxus::prelude::*;
+use dioxus_desktop::DesktopConfig;
 
 fn main() {
     let vdom = VirtualDom::new(app);
+
     let content = dioxus_ssr::render_vdom_cfg(&vdom, |f| f.pre_render(true));
 
-    dioxus_desktop::launch_cfg(app, |c| c.with_prerendered(content));
+    dioxus_desktop::launch_cfg(app, DesktopConfig::new().with_prerendered(content));
 }
 
 fn app(cx: Scope) -> Element {

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -34,6 +34,7 @@ mime_guess = "2.0.3"
 dunce = "1.0.2"
 
 interprocess = { version = "1.1.1", optional = true }
+nfd = "0.0.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9.3"

--- a/packages/desktop/src/cfg.rs
+++ b/packages/desktop/src/cfg.rs
@@ -48,57 +48,49 @@ impl DesktopConfig {
     }
 
     /// set the directory from which assets will be searched in release mode
-    pub fn with_resource_directory(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+    pub fn with_resource_directory(mut self, path: impl Into<PathBuf>) -> Self {
         self.resource_dir = Some(path.into());
         self
     }
 
     /// Set whether or not the right-click context menu should be disabled.
-    pub fn with_disable_context_menu(&mut self, disable: bool) -> &mut Self {
+    pub fn with_disable_context_menu(mut self, disable: bool) -> Self {
         self.disable_context_menu = disable;
         self
     }
 
     /// Set the pre-rendered HTML content
-    pub fn with_prerendered(&mut self, content: String) -> &mut Self {
+    pub fn with_prerendered(mut self, content: String) -> Self {
         self.pre_rendered = Some(content);
         self
     }
 
     /// Set the configuration for the window.
-    pub fn with_window(
-        &mut self,
-        configure: impl FnOnce(WindowBuilder) -> WindowBuilder,
-    ) -> &mut Self {
-        // gots to do a swap because the window builder only takes itself as muy self
-        // I wish more people knew about returning &mut Self
-        let mut builder = WindowBuilder::default().with_title("Dioxus App");
-        std::mem::swap(&mut self.window, &mut builder);
-        builder = configure(builder);
-        std::mem::swap(&mut self.window, &mut builder);
+    pub fn with_window(mut self, window_builder: WindowBuilder) -> Self {
+        self.window = window_builder;
         self
     }
 
     // /// Set a custom event handler
     // pub fn with_event_handler(
-    //     &mut self,
+    //     mut self,
     //     handler: impl Fn(&mut EventLoop<()>, &mut WebView) + 'static,
-    // ) -> &mut Self {
+    // ) -> Self {
     //     self.event_handler = Some(Box::new(handler));
     //     self
     // }
 
     /// Set a file drop handler
     pub fn with_file_drop_handler(
-        &mut self,
+        mut self,
         handler: impl Fn(&Window, FileDropEvent) -> bool + 'static,
-    ) -> &mut Self {
+    ) -> Self {
         self.file_drop_handler = Some(Box::new(handler));
         self
     }
 
     /// Set a custom protocol
-    pub fn with_custom_protocol<F>(&mut self, name: String, handler: F) -> &mut Self
+    pub fn with_custom_protocol<F>(mut self, name: String, handler: F) -> Self
     where
         F: Fn(&HttpRequest) -> WryResult<HttpResponse> + 'static,
     {
@@ -107,7 +99,7 @@ impl DesktopConfig {
     }
 
     /// Set a custom icon for this application
-    pub fn with_icon(&mut self, icon: Icon) -> &mut Self {
+    pub fn with_icon(mut self, icon: Icon) -> Self {
         self.window.window.window_icon = Some(icon);
         self
     }
@@ -115,7 +107,7 @@ impl DesktopConfig {
     /// Inject additional content into the document's HEAD.
     ///
     /// This is useful for loading CSS libraries, JS libraries, etc.
-    pub fn with_custom_head(&mut self, head: String) -> &mut Self {
+    pub fn with_custom_head(mut self, head: String) -> Self {
         self.custom_head = Some(head);
         self
     }
@@ -126,7 +118,7 @@ impl DesktopConfig {
     ///
     /// Dioxus injects some loader code into the closing body tag. Your document
     /// must include a body element!
-    pub fn with_custom_index(&mut self, index: String) -> &mut Self {
+    pub fn with_custom_index(mut self, index: String) -> Self {
         self.custom_index = Some(index);
         self
     }

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -234,5 +234,3 @@ pub fn use_eval<S: std::string::ToString>(cx: &ScopeState) -> &dyn Fn(S) {
 
     cx.use_hook(|| move |script| desktop.eval(script))
 }
-
-

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -234,3 +234,5 @@ pub fn use_eval<S: std::string::ToString>(cx: &ScopeState) -> &dyn Fn(S) {
 
     cx.use_hook(|| move |script| desktop.eval(script))
 }
+
+

--- a/packages/desktop/src/index.html
+++ b/packages/desktop/src/index.html
@@ -9,4 +9,10 @@
     <div id="main"></div>
     <!-- MODULE LOADER -->
   </body>
+  <script>
+    // Prevent the default behavior of the browser when the user drops a file
+    // This prevents the browser from navigating to the file
+    window.ondragover = function(e) { e.preventDefault(); return false };
+    window.ondrop = function(e) { e.preventDefault(); return false };
+  </script>
 </html>

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -11,6 +11,7 @@ mod events;
 #[cfg(feature = "hot-reload")]
 mod hot_reload;
 mod protocol;
+mod topic;
 
 use std::{cell::RefCell, rc::Rc};
 
@@ -149,6 +150,24 @@ pub fn launch_with_props<P: 'static + Send>(root: Component<P>, props: P, mut cf
                                     is_ready.store(true, std::sync::atomic::Ordering::Relaxed);
                                     let _ = proxy.send_event(UserWindowEvent::Update);
                                 }
+                                // "file_input" => {
+                                //     match nfd::open_file_multiple_dialog(None, None) {
+                                //         Ok(f) => match f {
+                                //             nfd::Response::Okay(f) => {
+                                //                 dbg!("Okay", f);
+                                //             }
+                                //             nfd::Response::OkayMultiple(f) => {
+                                //                 dbg!("OkayMultiple", f);
+                                //             }
+                                //             nfd::Response::Cancel => {
+                                //                 dbg!("Cancel");
+                                //             }
+                                //         },
+                                //         Err(f) => {
+                                //             dbg!(f);
+                                //         }
+                                //     };
+                                // }
                                 "browser_open" => {
                                     let data = message.params();
                                     log::trace!("Open browser: {:?}", data);

--- a/packages/html/src/events.rs
+++ b/packages/html/src/events.rs
@@ -2,9 +2,14 @@ use bumpalo::boxed::Box as BumpBox;
 use dioxus_core::exports::bumpalo;
 use dioxus_core::*;
 
+pub mod event_data {
+    pub mod drag;
+    pub mod mouse;
+}
+
 pub mod on {
     //! Input events and associated data
-
+    pub use crate::event_data::drag::*;
     use crate::geometry::{
         ClientPoint, Coordinates, ElementPoint, LinesVector, PagePoint, PagesVector, PixelsVector,
         ScreenPoint, WheelDelta,
@@ -211,30 +216,6 @@ pub mod on {
             /// ondoubleclick
             ondblclick
 
-            /// ondrag
-            ondrag
-
-            /// ondragend
-            ondragend
-
-            /// ondragenter
-            ondragenter
-
-            /// ondragexit
-            ondragexit
-
-            /// ondragleave
-            ondragleave
-
-            /// ondragover
-            ondragover
-
-            /// ondragstart
-            ondragstart
-
-            /// ondrop
-            ondrop
-
             /// onmousedown
             onmousedown
 
@@ -260,6 +241,32 @@ pub mod on {
 
             /// onmouseup
             onmouseup
+        ];
+
+        DragEvent(DragData): [
+            /// ondrag
+            ondrag
+
+            /// ondragend
+            ondragend
+
+            /// ondragenter
+            ondragenter
+
+            /// ondragexit
+            ondragexit
+
+            /// ondragleave
+            ondragleave
+
+            /// ondragover
+            ondragover
+
+            /// ondragstart
+            ondragstart
+
+            /// ondrop
+            ondrop
         ];
 
         PointerEvent(PointerData): [
@@ -771,7 +778,7 @@ pub mod on {
             f.debug_struct("MouseData")
                 .field("coordinates", &self.coordinates())
                 .field("modifiers", &self.modifiers())
-                .field("held_buttons", &self.held_buttons())
+                .field("held_buttons", &self.held_buttons() as &dyn Debug)
                 .field("trigger_button", &self.trigger_button())
                 .finish()
         }

--- a/packages/html/src/events/event_data/drag.rs
+++ b/packages/html/src/events/event_data/drag.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use super::super::*;
+use on::*;
+
+pub type DragEvent = UiEvent<DragData>;
+
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone)]
+pub struct DragData {
+    pub transfer: DataTransfer,
+    pub mouse_data: MouseData,
+}
+
+impl DragData {
+    pub fn files(&self) -> &[PathBuf] {
+        &self.transfer.files
+    }
+}
+
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Clone)]
+pub struct DataTransfer {
+    pub files: Vec<PathBuf>,
+}
+
+impl std::ops::Deref for DragData {
+    type Target = MouseData;
+    fn deref(&self) -> &Self::Target {
+        &self.mouse_data
+    }
+}

--- a/packages/html/src/events/event_data/mouse.rs
+++ b/packages/html/src/events/event_data/mouse.rs
@@ -1,0 +1,1 @@
+pub struct MouseEvent {}

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -25,8 +25,7 @@ class ListenerMap {
       } else {
         this.global[event_name].active++;
       }
-    }
-    else {
+    } else {
       const id = element.getAttribute("data-dioxus-id");
       if (!this.local[id]) {
         this.local[id] = {};
@@ -40,11 +39,13 @@ class ListenerMap {
     if (bubbles) {
       this.global[event_name].active--;
       if (this.global[event_name].active === 0) {
-        this.root.removeEventListener(event_name, this.global[event_name].callback);
+        this.root.removeEventListener(
+          event_name,
+          this.global[event_name].callback
+        );
         delete this.global[event_name];
       }
-    }
-    else {
+    } else {
       const id = element.getAttribute("data-dioxus-id");
       delete this.local[id][event_name];
       if (this.local[id].length === 0) {
@@ -251,7 +252,6 @@ export class Interpreter {
         // this handler is only provided on desktop implementations since this
         // method is not used by the web implementation
         let handler = (event) => {
-
           let target = event.target;
           if (target != null) {
             let realId = target.getAttribute(`data-dioxus-id`);
@@ -327,9 +327,14 @@ export class Interpreter {
               }
             }
 
+            // handle ondrag events
+            if (event.type == "drag") {
+            }
+
             if (realId === null) {
               return;
             }
+
             window.ipc.postMessage(
               serializeIpcMessage("user_event", {
                 event: edit.event_name,
@@ -339,7 +344,12 @@ export class Interpreter {
             );
           }
         };
-        this.NewEventListener(edit.event_name, edit.root, handler, event_bubbles(edit.event_name));
+        this.NewEventListener(
+          edit.event_name,
+          edit.root,
+          handler,
+          event_bubbles(edit.event_name)
+        );
 
         break;
       case "SetText":
@@ -433,10 +443,7 @@ export function serialize_event(event) {
         values: {},
       };
     }
-    case "click":
-    case "contextmenu":
-    case "doubleclick":
-    case "dblclick":
+
     case "drag":
     case "dragend":
     case "dragenter":
@@ -445,6 +452,59 @@ export function serialize_event(event) {
     case "dragover":
     case "dragstart":
     case "drop":
+      const {
+        altKey,
+        button,
+        buttons,
+        clientX,
+        clientY,
+        ctrlKey,
+        metaKey,
+        offsetX,
+        offsetY,
+        pageX,
+        pageY,
+        screenX,
+        screenY,
+        shiftKey,
+      } = event;
+
+      let files = [];
+
+      // on the web, we want to keep the files around
+      // on the desktop, we want to let the OS handle the files
+
+      // let event = event as DragEvent;
+      // if (event.dataTransfer) {
+      //   for (let file in event.dataTransfer.files) {
+      //   }
+      // }
+
+      return {
+        transfer: {
+          files: files,
+        },
+        mouse_data: {
+          alt_key: altKey,
+          button: button,
+          buttons: buttons,
+          client_x: clientX,
+          client_y: clientY,
+          ctrl_key: ctrlKey,
+          meta_key: metaKey,
+          offset_x: offsetX,
+          offset_y: offsetY,
+          page_x: pageX,
+          page_y: pageY,
+          screen_x: screenX,
+          screen_y: screenY,
+          shift_key: shiftKey,
+        },
+      };
+    case "click":
+    case "contextmenu":
+    case "doubleclick":
+    case "dblclick":
     case "mousedown":
     case "mouseenter":
     case "mouseleave":

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -2,9 +2,31 @@ export function main() {
   let root = window.document.getElementById("main");
   if (root != null) {
     window.interpreter = new Interpreter(root);
+
+    // // Catch all file input clicks
+    // root.addEventListener("click", function (event) {
+    //   let target = event.target;
+
+    //   if (target !== null) {
+    //     if (target.tagName === "INPUT" && target.type === "file") {
+    //       let realId = target.getAttribute(`data-dioxus-id`);
+    //       if (realId !== null) {
+    //         event.preventDefault();
+    //         let contents = serialize_event(event);
+    //         window.ipc.postMessage(serializeIpcMessage("file_input", {
+    //           mounted_dom_id: parseInt(realId),
+    //           contents,
+    //         }));
+    //       }
+    //     }
+    //   }
+    // });
+
     window.ipc.postMessage(serializeIpcMessage("initialize"));
   }
 }
+
+
 
 class ListenerMap {
   constructor(root) {
@@ -296,7 +318,6 @@ export class Interpreter {
               `dioxus-prevent-default`
             );
 
-            // event.preventDefault();
 
             let contents = serialize_event(event);
 
@@ -304,11 +325,10 @@ export class Interpreter {
               event.preventDefault();
             }
 
+            // Handle drag
             if (event.type == "dragenter" || event.type == "dragover" || event.type == "dragleave" || event.type == "drop") {
-              console.log("canceled dragover/dragenter");
               event.dataTransfer.dropEffect = "copy";
               event.preventDefault();
-              console.log(event);
             }
 
             if (event.type === "submit") {

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -16,12 +16,14 @@ class ListenerMap {
   }
 
   create(event_name, element, handler, bubbles) {
+    console.log("create", event_name, element, handler, bubbles);
     if (bubbles) {
       if (this.global[event_name] === undefined) {
         this.global[event_name] = {};
         this.global[event_name].active = 1;
         this.global[event_name].callback = handler;
-        this.root.addEventListener(event_name, handler);
+        element.addEventListener(event_name, handler);
+        // this.root.addEventListener(event_name, handler);
       } else {
         this.global[event_name].active++;
       }
@@ -253,6 +255,7 @@ export class Interpreter {
         // method is not used by the web implementation
         let handler = (event) => {
           let target = event.target;
+          console.log(event);
           if (target != null) {
             let realId = target.getAttribute(`data-dioxus-id`);
             let shouldPreventDefault = target.getAttribute(
@@ -293,10 +296,19 @@ export class Interpreter {
               `dioxus-prevent-default`
             );
 
+            // event.preventDefault();
+
             let contents = serialize_event(event);
 
             if (shouldPreventDefault === `on${event.type}`) {
               event.preventDefault();
+            }
+
+            if (event.type == "dragenter" || event.type == "dragover" || event.type == "dragleave" || event.type == "drop") {
+              console.log("canceled dragover/dragenter");
+              event.dataTransfer.dropEffect = "copy";
+              event.preventDefault();
+              console.log(event);
             }
 
             if (event.type === "submit") {

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -44,8 +44,7 @@ class ListenerMap {
         this.global[event_name] = {};
         this.global[event_name].active = 1;
         this.global[event_name].callback = handler;
-        element.addEventListener(event_name, handler);
-        // this.root.addEventListener(event_name, handler);
+        this.root.addEventListener(event_name, handler);
       } else {
         this.global[event_name].active++;
       }
@@ -277,7 +276,6 @@ export class Interpreter {
         // method is not used by the web implementation
         let handler = (event) => {
           let target = event.target;
-          console.log(event);
           if (target != null) {
             let realId = target.getAttribute(`data-dioxus-id`);
             let shouldPreventDefault = target.getAttribute(
@@ -357,10 +355,6 @@ export class Interpreter {
                   }
                 }
               }
-            }
-
-            // handle ondrag events
-            if (event.type == "drag") {
             }
 
             if (realId === null) {


### PR DESCRIPTION
This PR gets rid of the custom file drag and drop handler from config in favor of a new DragEvent that returns a true list of Files.

There isn't a good cross-platform approach here unfortunately, so we'll have to settle for some wrapper structs with different methods depending on the platform.

https://user-images.githubusercontent.com/10237910/189492691-904e2d76-f3a2-475c-a204-0b1bf3c15684.mov


