### PR TITLE
feat: use infer instead of outdated mime-guess, bump wry

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -21,7 +21,7 @@ serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 log = "0.4.14"
-wry = { version = "0.19.0" }
+wry = { version = "0.20.2" }
 futures-channel = "0.3.21"
 tokio = { version = "1.16.1", features = [
     "sync",
@@ -30,7 +30,7 @@ tokio = { version = "1.16.1", features = [
     "time",
 ], optional = true, default-features = false }
 webbrowser = "0.7.1"
-mime_guess = "2.0.3"
+infer = "0.9.0"
 dunce = "1.0.2"
 
 interprocess = { version = "1.1.1", optional = true }

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -10,6 +10,7 @@ mod escape;
 mod events;
 #[cfg(feature = "hot-reload")]
 mod hot_reload;
+mod mime;
 mod protocol;
 
 use desktop_context::UserWindowEvent;

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -10,7 +10,6 @@ mod escape;
 mod events;
 #[cfg(feature = "hot-reload")]
 mod hot_reload;
-mod mime;
 mod protocol;
 
 use desktop_context::UserWindowEvent;


### PR DESCRIPTION
Infer is more robust that mime-guess for loading assets from the file system. 