### PR TITLE
Remove lower case components that use the paran syntax

### DIFF
--- a/examples/rsx_usage.rs
+++ b/examples/rsx_usage.rs
@@ -196,6 +196,9 @@ fn app(cx: Scope) -> Element {
             Label { text: "hello geneirc world!" }
             Label { text: 99.9 }
 
+            // Lowercase components work too, as long as they are access using a path
+            baller::lowercase_component {}
+
             // helper functions
             // Single values must be wrapped in braces or `Some` to satisfy `IntoIterator`
             [helper(&cx, "hello world!")]
@@ -218,6 +221,10 @@ mod baller {
     /// This component totally balls
     pub fn Baller(_: Scope<BallerProps>) -> Element {
         todo!()
+    }
+
+    pub fn lowercase_component(cx: Scope) -> Element {
+        cx.render(rsx! { "look ma, no uppercase" })
     }
 }
 

--- a/examples/rsx_usage.rs
+++ b/examples/rsx_usage.rs
@@ -184,11 +184,8 @@ fn app(cx: Scope) -> Element {
             // Can take children too!
             Taller { a: "asd", div {"hello world!"} }
 
-            // Components can be used with the `call` syntax
             // This component's props are defined *inline* with the `inline_props` macro
-            with_inline(
-                text: "using functionc all syntax"
-            )
+            WithInline { text: "using functionc all syntax" }
 
             // Components can be geneirc too
             // This component takes i32 type to give you typed input
@@ -196,8 +193,8 @@ fn app(cx: Scope) -> Element {
             // Type inference can be used too
             TypedInput { initial: 10.0 }
             // geneircs with the `inline_props` macro
-            label(text: "hello geneirc world!")
-            label(text: 99.9)
+            Label { text: "hello geneirc world!" }
+            Label { text: 99.9 }
 
             // helper functions
             // Single values must be wrapped in braces or `Some` to satisfy `IntoIterator`
@@ -255,7 +252,7 @@ where
 }
 
 #[inline_props]
-fn with_inline<'a>(cx: Scope<'a>, text: &'a str) -> Element {
+fn WithInline<'a>(cx: Scope<'a>, text: &'a str) -> Element {
     cx.render(rsx! {
         p { "{text}" }
     })
@@ -263,7 +260,7 @@ fn with_inline<'a>(cx: Scope<'a>, text: &'a str) -> Element {
 
 // generic component with inline_props too
 #[inline_props]
-fn label<T>(cx: Scope, text: T) -> Element
+fn Label<T>(cx: Scope, text: T) -> Element
 where
     T: Display,
 {

--- a/examples/rsx_usage.rs
+++ b/examples/rsx_usage.rs
@@ -199,6 +199,9 @@ fn app(cx: Scope) -> Element {
             // Lowercase components work too, as long as they are access using a path
             baller::lowercase_component {}
 
+            // For in-scope lowercase components, use the `self` keyword
+            self::lowercase_helper {}
+
             // helper functions
             // Single values must be wrapped in braces or `Some` to satisfy `IntoIterator`
             [helper(&cx, "hello world!")]
@@ -209,6 +212,12 @@ fn app(cx: Scope) -> Element {
 fn helper<'a>(cx: &'a ScopeState, text: &str) -> Element<'a> {
     cx.render(rsx! {
         p { "{text}" }
+    })
+}
+
+fn lowercase_helper(cx: Scope) -> Element {
+    cx.render(rsx! {
+        "asd"
     })
 }
 

--- a/examples/todomvc.rs
+++ b/examples/todomvc.rs
@@ -73,7 +73,7 @@ pub fn app(cx: Scope<()>) -> Element {
                     }
                 }
                 ul { class: "todo-list",
-                    filtered_todos.iter().map(|id| rsx!(todo_entry( key: "{id}", id: *id, todos: todos  )))
+                    filtered_todos.iter().map(|id| rsx!(TodoEntry { key: "{id}", id: *id, todos: todos }))
                 }
                 (!todos.is_empty()).then(|| rsx!(
                     footer { class: "footer",
@@ -111,7 +111,7 @@ pub struct TodoEntryProps<'a> {
     id: u32,
 }
 
-pub fn todo_entry<'a>(cx: Scope<'a, TodoEntryProps<'a>>) -> Element {
+pub fn TodoEntry<'a>(cx: Scope<'a, TodoEntryProps<'a>>) -> Element {
     let is_editing = use_state(&cx, || false);
 
     let todos = cx.props.todos.get();

--- a/packages/dioxus/tests/miri_stress.rs
+++ b/packages/dioxus/tests/miri_stress.rs
@@ -34,17 +34,17 @@ fn test_memory_leak() {
 
         cx.render(rsx!(
             div { "Hello, world!" }
-            child()
-            child()
-            child()
-            child()
-            child()
-            child()
-            borrowed_child(na: name)
-            borrowed_child(na: name)
-            borrowed_child(na: name)
-            borrowed_child(na: name)
-            borrowed_child(na: name)
+            Child {}
+            Child {}
+            Child {}
+            Child {}
+            Child {}
+            Child {}
+            BorrowedChild { na: name }
+            BorrowedChild { na: name }
+            BorrowedChild { na: name }
+            BorrowedChild { na: name }
+            BorrowedChild { na: name }
         ))
     }
 
@@ -53,15 +53,15 @@ fn test_memory_leak() {
         na: &'a str,
     }
 
-    fn borrowed_child<'a>(cx: Scope<'a, BorrowedProps<'a>>) -> Element {
+    fn BorrowedChild<'a>(cx: Scope<'a, BorrowedProps<'a>>) -> Element {
         rsx!(cx, div {
             "goodbye {cx.props.na}"
-            child()
-            child()
+            Child {}
+            Child {}
         })
     }
 
-    fn child(cx: Scope) -> Element {
+    fn Child(cx: Scope) -> Element {
         rsx!(cx, div { "goodbye world" })
     }
 
@@ -91,7 +91,7 @@ fn memo_works_properly() {
 
         cx.render(rsx!(
             div { "Hello, world! {name}" }
-            child(na: "asdfg".to_string() )
+            Child { na: "asdfg".to_string() }
         ))
     }
 
@@ -100,7 +100,7 @@ fn memo_works_properly() {
         na: String,
     }
 
-    fn child(cx: Scope<ChildProps>) -> Element {
+    fn Child(cx: Scope<ChildProps>) -> Element {
         rsx!(cx, div { "goodbye world" })
     }
 
@@ -120,10 +120,10 @@ fn memo_works_properly() {
 fn free_works_on_root_props() {
     fn app(cx: Scope<Custom>) -> Element {
         cx.render(rsx! {
-            child(a: "alpha")
-            child(a: "beta")
-            child(a: "gamma")
-            child(a: "delta")
+            Child { a: "alpha"}
+            Child { a: "beta"}
+            Child { a: "gamma"}
+            Child { a: "delta"}
         })
     }
 
@@ -132,7 +132,7 @@ fn free_works_on_root_props() {
         a: &'static str,
     }
 
-    fn child(cx: Scope<ChildProps>) -> Element {
+    fn Child(cx: Scope<ChildProps>) -> Element {
         rsx!(cx, "child {cx.props.a}")
     }
 
@@ -154,7 +154,7 @@ fn free_works_on_root_props() {
 fn free_works_on_borrowed() {
     fn app(cx: Scope) -> Element {
         cx.render(rsx! {
-            child(a: "alpha", b: "asd".to_string())
+            Child { a: "alpha", b: "asd".to_string() }
         })
     }
     #[derive(Props)]
@@ -163,7 +163,7 @@ fn free_works_on_borrowed() {
         b: String,
     }
 
-    fn child<'a>(cx: Scope<'a, ChildProps<'a>>) -> Element {
+    fn Child<'a>(cx: Scope<'a, ChildProps<'a>>) -> Element {
         dbg!("rendering child");
         rsx!(cx, "child {cx.props.a}, {cx.props.b}")
     }
@@ -208,9 +208,9 @@ fn old_props_arent_stale() {
         *cnt += 1;
 
         if *cnt == 1 {
-            rsx!(cx, div { child(a: "abcdef".to_string()) })
+            rsx!(cx, div { Child { a: "abcdef".to_string() } })
         } else {
-            rsx!(cx, div { child(a: "abcdef".to_string()) })
+            rsx!(cx, div { Child { a: "abcdef".to_string() } })
         }
     }
 
@@ -218,7 +218,7 @@ fn old_props_arent_stale() {
     struct ChildProps {
         a: String,
     }
-    fn child(cx: Scope<ChildProps>) -> Element {
+    fn Child(cx: Scope<ChildProps>) -> Element {
         dbg!("rendering child", &cx.props.a);
         rsx!(cx, div { "child {cx.props.a}" })
     }
@@ -251,7 +251,7 @@ fn old_props_arent_stale() {
 fn basic() {
     fn app(cx: Scope) -> Element {
         rsx!(cx, div {
-            child(a: "abcdef".to_string())
+            Child { a: "abcdef".to_string() }
         })
     }
 
@@ -260,7 +260,7 @@ fn basic() {
         a: String,
     }
 
-    fn child(cx: Scope<ChildProps>) -> Element {
+    fn Child(cx: Scope<ChildProps>) -> Element {
         dbg!("rendering child", &cx.props.a);
         rsx!(cx, div { "child {cx.props.a}" })
     }

--- a/packages/rsx/src/node.rs
+++ b/packages/rsx/src/node.rs
@@ -74,17 +74,14 @@ impl Parse for BodyNode {
             //
             // example
             // Div {}
-            // Div ()
             // ::Div {}
             // crate::Div {}
-            // component()
+            // component {} <-- already handled by elements
             // ::component {}
-            // ::component ()
             // crate::component{}
-            // crate::component()
             // Input::<InputProps<'_, i32> {}
             // crate::Input::<InputProps<'_, i32> {}
-            if body_stream.peek(token::Brace) || body_stream.peek(token::Paren) {
+            if body_stream.peek(token::Brace) {
                 Component::validate_component_path(&path)?;
 
                 return Ok(BodyNode::Component(stream.parse()?));

--- a/packages/web/examples/hydrate.rs
+++ b/packages/web/examples/hydrate.rs
@@ -13,7 +13,7 @@ fn app(cx: Scope) -> Element {
             h2 { "thing 2"}
             "asd"
             "asd"
-            bapp()
+            Bapp {}
         }
         (0..10).map(|f| rsx!{
             div {
@@ -23,7 +23,7 @@ fn app(cx: Scope) -> Element {
     })
 }
 
-fn bapp(cx: Scope) -> Element {
+fn Bapp(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             h1 { "thing 1" }


### PR DESCRIPTION
This implementation had the unfortunate side-effect of colliding with regular function calls leading to a sore point. This gets rid of that implementation and only allows lowercase components if they use the path syntax.

This is implemented to make room for #550 and regular helper functions being more common.