### PR TITLE
fix: use typeid of atoms for their unique ID to prevent down casting panics

### DIFF
--- a/packages/fermi/src/atoms/atom.rs
+++ b/packages/fermi/src/atoms/atom.rs
@@ -3,7 +3,7 @@ use crate::{AtomId, AtomRoot, Readable, Writable};
 pub type Atom<T> = fn(AtomBuilder) -> T;
 pub struct AtomBuilder;
 
-impl<V> Readable<V> for Atom<V> {
+impl<V: 'static> Readable<V> for Atom<V> {
     fn read(&self, _root: AtomRoot) -> Option<V> {
         todo!()
     }
@@ -11,11 +11,14 @@ impl<V> Readable<V> for Atom<V> {
         (*self)(AtomBuilder)
     }
     fn unique_id(&self) -> AtomId {
-        *self as *const ()
+        AtomId {
+            ptr: *self as *const (),
+            type_id: std::any::TypeId::of::<V>(),
+        }
     }
 }
 
-impl<V> Writable<V> for Atom<V> {
+impl<V: 'static> Writable<V> for Atom<V> {
     fn write(&self, _root: AtomRoot, _value: V) {
         todo!()
     }

--- a/packages/fermi/src/atoms/atomfamily.rs
+++ b/packages/fermi/src/atoms/atomfamily.rs
@@ -4,7 +4,7 @@ use im_rc::HashMap as ImMap;
 pub struct AtomFamilyBuilder;
 pub type AtomFamily<K, V> = fn(AtomFamilyBuilder) -> ImMap<K, V>;
 
-impl<K, V> Readable<ImMap<K, V>> for AtomFamily<K, V> {
+impl<K, V: 'static> Readable<ImMap<K, V>> for AtomFamily<K, V> {
     fn read(&self, _root: AtomRoot) -> Option<ImMap<K, V>> {
         todo!()
     }
@@ -14,11 +14,14 @@ impl<K, V> Readable<ImMap<K, V>> for AtomFamily<K, V> {
     }
 
     fn unique_id(&self) -> AtomId {
-        *self as *const ()
+        AtomId {
+            ptr: *self as *const (),
+            type_id: std::any::TypeId::of::<V>(),
+        }
     }
 }
 
-impl<K, V> Writable<ImMap<K, V>> for AtomFamily<K, V> {
+impl<K, V: 'static> Writable<ImMap<K, V>> for AtomFamily<K, V> {
     fn write(&self, _root: AtomRoot, _value: ImMap<K, V>) {
         todo!()
     }

--- a/packages/fermi/src/atoms/atomref.rs
+++ b/packages/fermi/src/atoms/atomref.rs
@@ -4,7 +4,7 @@ use std::cell::RefCell;
 pub struct AtomRefBuilder;
 pub type AtomRef<T> = fn(AtomRefBuilder) -> T;
 
-impl<V> Readable<RefCell<V>> for AtomRef<V> {
+impl<V: 'static> Readable<RefCell<V>> for AtomRef<V> {
     fn read(&self, _root: AtomRoot) -> Option<RefCell<V>> {
         todo!()
     }
@@ -14,7 +14,10 @@ impl<V> Readable<RefCell<V>> for AtomRef<V> {
     }
 
     fn unique_id(&self) -> AtomId {
-        *self as *const ()
+        AtomId {
+            ptr: *self as *const (),
+            type_id: std::any::TypeId::of::<V>(),
+        }
     }
 }
 


### PR DESCRIPTION
The previous implementation of AtomIds for Fermi could lead to downcast errors if Rust merged two statics together.

Now, we only downcast a type if the TypeId is verified to match by adding its TypeId into its AtomId.

This prevents the particular issue but doesn't help with Rust merging statics together.

In apps that actually use their atoms, this won't be an issue (hopefully).

Fixes #536 