### PR TITLE
fix scroll data

### DIFF
--- a/packages/desktop/src/events.rs
+++ b/packages/desktop/src/events.rs
@@ -105,7 +105,7 @@ fn make_synthetic_event(name: &str, val: serde_json::Value) -> Arc<dyn Any + Sen
             Arc::new(serde_json::from_value::<TouchData>(val).unwrap())
         }
 
-        "scroll" => Arc::new(()),
+        "scroll" => Arc::new(ScrollData {}),
 
         "wheel" => Arc::new(serde_json::from_value::<WheelData>(val).unwrap()),
 

--- a/packages/html/src/events.rs
+++ b/packages/html/src/events.rs
@@ -250,9 +250,6 @@ pub mod on {
             /// onmouseout
             onmouseout
 
-            ///
-            onscroll
-
             /// onmouseover
             ///
             /// Triggered when the users's mouse hovers over an element.
@@ -260,6 +257,11 @@ pub mod on {
 
             /// onmouseup
             onmouseup
+        ];
+
+        ScrollEvent(ScrollData): [
+            ///
+            onscroll
         ];
 
         PointerEvent(PointerData): [
@@ -896,6 +898,11 @@ pub mod on {
                 .finish()
         }
     }
+
+    pub type ScrollEvent = UiEvent<ScrollData>;
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+    #[derive(Debug, Clone)]
+    pub struct ScrollData {}
 
     pub type MediaEvent = UiEvent<MediaData>;
     #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
fixes #566

This adds a event data type for the onscroll event, instead of using the mouse data type. The onscoll event does not contain any data about the pointer on the web platform: https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll_event#event_type