### PR TITLE
fix: Remove a Node listeners when it is removed

### DIFF
--- a/packages/native-core/src/real_dom.rs
+++ b/packages/native-core/src/real_dom.rs
@@ -644,6 +644,9 @@ impl<S: State> RealDom<S> {
     fn remove(&mut self, id: GlobalNodeId) -> Option<TemplateRefOrNode<S>> {
         // We do not need to remove the node from the parent's children list for children.
         fn inner<S: State>(dom: &mut RealDom<S>, id: GlobalNodeId) -> Option<TemplateRefOrNode<S>> {
+            for nodes_listeners in dom.nodes_listening.values_mut() {
+                nodes_listeners.remove(&id);
+            }
             let mut either = match id {
                 GlobalNodeId::VNodeId(id) => *dom.nodes[id.0].take()?,
                 GlobalNodeId::TemplateId {
@@ -686,6 +689,9 @@ impl<S: State> RealDom<S> {
                 }
             }
         };
+        for nodes_listeners in self.nodes_listening.values_mut() {
+            nodes_listeners.remove(&id);
+        }
         if let Some(parent) = node.parent() {
             let parent = &mut self[parent];
             parent.remove_child(id);


### PR DESCRIPTION
This will clean up all the listeners of a Node when it's removed.

I noticed while using `get_listening_sorted()` it would sometimes panic because it was unable to find a removed Node that previously had a listener. With this fix, the listeners and the node list should be on sync, so whenever you try to retrieve all the node listeners it should only get Nodes that actually exist.

Note: I haven't actually tested these changes with the new changes from https://github.com/DioxusLabs/dioxus/commit/047ed1e5536d266785240fb3db475ac2fc77b785