### PR TITLE
feature: allow futures and streams to be passed directly into rsx

### DIFF
--- a/examples/suspense.rs
+++ b/examples/suspense.rs
@@ -15,6 +15,7 @@
 
 use dioxus::prelude::*;
 use dioxus_desktop::{Config, LogicalSize, WindowBuilder};
+use futures_util::FutureExt;
 
 fn main() {
     let cfg = Config::new().with_window(
@@ -77,5 +78,25 @@ fn Doggo(cx: Scope) -> Element {
         },
         Some(Err(_)) => rsx! { div { "loading dogs failed" } },
         None => rsx! { div { "loading dogs..." } },
+    })
+}
+
+fn sus2(cx: Scope) -> Element {
+    let value1 = use_future(&cx, (), |_| async { 123 });
+    let value2 = use_future(&cx, (), |_| async { 123 });
+
+    cx.render(rsx! {
+        div {
+            async move {
+                let a = value1.await;
+                let b = value2.await;
+                render!("{a} {b}")
+            }
+
+            async move {
+                let a = value1.await;
+                render!("{a}")
+            }
+        }
     })
 }

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -900,7 +900,7 @@ impl Debug for NodeFactory<'_> {
 ///
 /// As such, all node creation must go through the factory, which is only available in the component context.
 /// These strict requirements make it possible to manage lifetimes and state.
-pub trait IntoVNode<'a, I = (), J = ()> {
+pub trait IntoVNode<'a, I = (), J = (), K = ()> {
     /// Convert this into a [`VNode`], using the [`NodeFactory`] as a source of allocation
     fn into_vnode(self, cx: NodeFactory<'a>) -> VNode<'a>;
 }
@@ -994,3 +994,37 @@ where
         }
     }
 }
+
+pub struct FutureToSuspense;
+impl<'a, T> IntoVNode<'a, FutureToSuspense, T> for T
+where
+    T: futures_util::Future<Output = Element<'a>> + 'a,
+    // I: IntoVNode<'a> + 'a,
+{
+    fn into_vnode(self, cx: NodeFactory<'a>) -> VNode<'a> {
+        let future = cx.bump.alloc(self);
+        todo!()
+        // VNode::Suspense(cx.bump.alloc(VSuspense {
+        //     future,
+        //     id: empty_cell(),
+        //     key: None,
+        // }))
+    }
+}
+
+// pub struct StreamToSuspense;
+// impl<'a, T, I> IntoVNode<'a, StreamToSuspense, T> for T
+// where
+//     T: futures_util::Stream<Item = I>,
+//     I: IntoVNode<'a>,
+// {
+//     fn into_vnode(self, cx: NodeFactory<'a>) -> VNode<'a> {
+//         let future = cx.bump.alloc(self);
+//         todo!()
+//         // VNode::Suspense(cx.bump.alloc(VSuspense {
+//         //     future,
+//         //     id: empty_cell(),
+//         //     key: None,
+//         // }))
+//     }
+// }

--- a/packages/hooks/src/usefuture.rs
+++ b/packages/hooks/src/usefuture.rs
@@ -146,6 +146,17 @@ impl<T> UseFuture<T> {
     }
 }
 
+impl<'a, T> Future for &'a UseFuture<T> {
+    type Output = &'a T;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        todo!()
+    }
+}
+
 pub trait UseFutureDep: Sized + Clone {
     type Out;
     fn out(&self) -> Self::Out;

--- a/packages/rsx/src/node.rs
+++ b/packages/rsx/src/node.rs
@@ -55,13 +55,14 @@ impl Parse for BodyNode {
             // example:
             // div {}
             if let Some(ident) = path.get_ident() {
+                let ident_name = ident.to_string();
+
+                if ident_name == "async" {
+                    return Ok(BodyNode::RawExpr(stream.parse()?));
+                }
+
                 if body_stream.peek(token::Brace)
-                    && ident
-                        .to_string()
-                        .chars()
-                        .next()
-                        .unwrap()
-                        .is_ascii_lowercase()
+                    && ident_name.chars().next().unwrap().is_ascii_lowercase()
                 {
                     return Ok(BodyNode::Element(stream.parse::<Element>()?));
                 }


### PR DESCRIPTION
This PR essentially implements suspense and partial rendering :)

The best improvement we get with this is support in SSR for knowing when an app has finished loading data before passing out the edits.

It also means the VirtualDom can implement streaming edits - a very significant feature for React.

However, we lack a proper React-equivalent scheduler with swim lanes (priority lanes), so there's no concept of "hot and cold" DOM zones.