### PR TITLE
to_owned!: allow optional comma at the end

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -134,7 +134,7 @@ pub(crate) mod unsafe_utils {
 /// }
 /// ```
 macro_rules! to_owned {
-    ($($es:ident),+) => {$(
+    ($($es:ident),+$(,)?) => {$(
         #[allow(unused_mut)]
         let mut $es = $es.to_owned();
     )*}


### PR DESCRIPTION
Allow an optional comma at the end of to_owned!
```
#[test]
fn it_works() {
    let a = 1;
    let b = true;
    to_owned![a, b,];
}
```
I would prefer it this way. Let me know what you think.