### PR TITLE
Make render marco bypass lazynodes

### DIFF
--- a/packages/core-macro/src/lib.rs
+++ b/packages/core-macro/src/lib.rs
@@ -65,8 +65,15 @@ pub fn rsx_without_templates(s: TokenStream) -> TokenStream {
 pub fn render(s: TokenStream) -> TokenStream {
     match syn::parse::<rsx::CallBody>(s) {
         Err(err) => err.to_compile_error().into(),
-        Ok(body) => quote::quote! {
-            cx.render(#body)
+        Ok(body) => {
+            let mut inner = proc_macro2::TokenStream::new();
+            body.to_tokens_without_lazynodes(&mut inner);
+            quote::quote! {
+                {
+                    let __cx = NodeFactory::new(&cx.scope);
+                    Some(#inner)
+                }
+            }
         }
         .into_token_stream()
         .into(),


### PR DESCRIPTION
The render macro doesn't need lazy nodes. It can use the node factory directly without the overhead of calling LazyNodes::new or LazyNodes::call