### PR TITLE
replace fxhash crate with rustc-hash

### DIFF
--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["dom", "ui", "gui", "react", "wasm"]
 bumpalo = { version = "3.6", features = ["collections", "boxed"] }
 
 # faster hashmaps
-fxhash = "0.2"
+rustc-hash = "1.1.0"
 
 # Used in diffing
 longest-increasing-subsequence = "0.1.0"

--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -104,7 +104,7 @@ use crate::{
     Attribute, TemplateAttributeValue,
 };
 use bumpalo::Bump;
-use fxhash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{smallvec, SmallVec};
 
 pub(crate) struct DiffState<'bump> {
@@ -886,7 +886,7 @@ impl<'b> DiffState<'b> {
     // The stack is empty upon entry.
     fn diff_keyed_children(&mut self, old: &'b [VNode<'b>], new: &'b [VNode<'b>]) {
         if cfg!(debug_assertions) {
-            let mut keys = fxhash::FxHashSet::default();
+            let mut keys = rustc_hash::FxHashSet::default();
             let mut assert_unique_keys = |children: &'b [VNode<'b>]| {
                 keys.clear();
                 for child in children {

--- a/packages/core/src/mutations.rs
+++ b/packages/core/src/mutations.rs
@@ -276,7 +276,7 @@ pub enum DomEdit<'bump> {
     },
 }
 
-use fxhash::FxHashSet;
+use rustc_hash::FxHashSet;
 use DomEdit::*;
 
 impl<'a> Mutations<'a> {

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use bumpalo::Bump;
 use futures_channel::mpsc::UnboundedSender;
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use slab::Slab;
 use std::{
     any::{Any, TypeId},

--- a/packages/core/src/template.rs
+++ b/packages/core/src/template.rs
@@ -60,7 +60,7 @@
 /// The maxiumum integer in JS
 pub const JS_MAX_INT: u64 = 9007199254740991;
 
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use std::{cell::Cell, hash::Hash, marker::PhantomData, ops::Index};
 
 use bumpalo::Bump;

--- a/packages/core/src/util.rs
+++ b/packages/core/src/util.rs
@@ -90,8 +90,8 @@ impl<'a> Iterator for ElementIdIterator<'a> {
 mod leaky {
     use std::sync::Mutex;
 
-    use fxhash::FxHashSet;
     use once_cell::sync::Lazy;
+    use rustc_hash::FxHashSet;
     static STATIC_CACHE: Lazy<Mutex<FxHashSet<&'static str>>> =
         Lazy::new(|| Mutex::new(FxHashSet::default()));
 

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -6,8 +6,8 @@ use crate::diff::DiffState;
 use crate::innerlude::*;
 use futures_channel::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures_util::{future::poll_fn, StreamExt};
-use fxhash::FxHashSet;
 use indexmap::IndexSet;
+use rustc_hash::FxHashSet;
 use std::{collections::VecDeque, iter::FromIterator, task::Poll};
 
 /// A virtual node system that progresses user events and diffs UI trees.

--- a/packages/native-core-macro/Cargo.toml
+++ b/packages/native-core-macro/Cargo.toml
@@ -23,5 +23,5 @@ dioxus-native-core = { path = "../native-core", version = "^0.2.0" }
 dioxus = { path = "../dioxus" }
 
 smallvec = "1.6"
-fxhash = "0.2"
+rustc-hash = "1.1.0"
 anymap = "0.12.1"

--- a/packages/native-core-macro/src/lib.rs
+++ b/packages/native-core-macro/src/lib.rs
@@ -169,7 +169,7 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
                         state_tree: &'a mut T,
                         rdom: &'a T2,
                         ctx: &anymap::AnyMap,
-                    ) -> fxhash::FxHashSet<dioxus_core::GlobalNodeId>{
+                    ) -> rustc_hash::FxHashSet<dioxus_core::GlobalNodeId>{
                         #[derive(Eq, PartialEq)]
                         struct HeightOrdering {
                             height: u16,
@@ -236,9 +236,9 @@ fn impl_derive_macro(ast: &syn::DeriveInput) -> TokenStream {
                             }
                         }
 
-                        let mut dirty_elements = fxhash::FxHashSet::default();
+                        let mut dirty_elements = rustc_hash::FxHashSet::default();
                         // the states of any elements that are dirty
-                        let mut states: fxhash::FxHashMap<dioxus_core::GlobalNodeId, MembersDirty> = fxhash::FxHashMap::default();
+                        let mut states: rustc_hash::FxHashMap<dioxus_core::GlobalNodeId, MembersDirty> = rustc_hash::FxHashMap::default();
 
                         for (id, mask) in dirty {
                             let members_dirty = MembersDirty {

--- a/packages/native-core-macro/tests/update_state.rs
+++ b/packages/native-core-macro/tests/update_state.rs
@@ -318,7 +318,7 @@ fn state_reduce_parent_called_minimally_on_update() {
             value: AttributeValue::Text("99%"),
             ns: Some("style"),
         }],
-        dirty_scopes: fxhash::FxHashSet::default(),
+        dirty_scopes: rustc_hash::FxHashSet::default(),
         refs: Vec::new(),
     }]);
     let _to_rerender = dom.update_state(nodes_updated, AnyMap::new());
@@ -387,7 +387,7 @@ fn state_reduce_child_called_minimally_on_update() {
             value: AttributeValue::Text("99%"),
             ns: Some("style"),
         }],
-        dirty_scopes: fxhash::FxHashSet::default(),
+        dirty_scopes: rustc_hash::FxHashSet::default(),
         refs: Vec::new(),
     }]);
     let _to_rerender = dom.update_state(nodes_updated, AnyMap::new());

--- a/packages/native-core/Cargo.toml
+++ b/packages/native-core/Cargo.toml
@@ -17,7 +17,7 @@ dioxus-core-macro = { path = "../core-macro", version = "^0.2.1" }
 
 taffy = "0.1.0"
 smallvec = "1.6"
-fxhash = "0.2"
+rustc-hash = "1.1.0"
 anymap = "0.12.1"
 
 [dev-dependencies]

--- a/packages/native-core/src/real_dom.rs
+++ b/packages/native-core/src/real_dom.rs
@@ -1,5 +1,5 @@
 use anymap::AnyMap;
-use fxhash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::ops::{Index, IndexMut};
 
 use dioxus_core::{

--- a/packages/native-core/src/state.rs
+++ b/packages/native-core/src/state.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, fmt::Debug};
 
 use anymap::AnyMap;
 use dioxus_core::GlobalNodeId;
-use fxhash::FxHashSet;
+use rustc_hash::FxHashSet;
 
 use crate::node_ref::{NodeMask, NodeView};
 use crate::real_dom::NodeData;

--- a/packages/tui/Cargo.toml
+++ b/packages/tui/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.15.0", features = ["full"] }
 futures = "0.3.19"
 taffy = "0.1.0"
 smallvec = "1.6"
-fxhash = "0.2"
+rustc-hash = "1.1.0"
 anymap = "0.12.1"
 
 [dev-dependencies]

--- a/packages/tui/src/hooks.rs
+++ b/packages/tui/src/hooks.rs
@@ -2,7 +2,7 @@ use crossterm::event::{
     Event as TermEvent, KeyCode as TermKeyCode, KeyModifiers, MouseButton, MouseEventKind,
 };
 use dioxus_core::*;
-use fxhash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use dioxus_html::geometry::euclid::{Point2D, Rect, Size2D};
 use dioxus_html::geometry::{

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -133,7 +133,7 @@ fn render_vdom(
                 terminal.clear().unwrap();
             }
 
-            let mut to_rerender: fxhash::FxHashSet<GlobalNodeId> =
+            let mut to_rerender: rustc_hash::FxHashSet<GlobalNodeId> =
                 vec![GlobalNodeId::VNodeId(ElementId(0))]
                     .into_iter()
                     .collect();

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -21,7 +21,7 @@ js-sys = "0.3.56"
 wasm-bindgen = { version = "0.2.79", features = ["enable-interning"] }
 wasm-bindgen-futures = "0.4.29"
 log = { version = "0.4.14" }
-fxhash = "0.2.1"
+rustc-hash = "1.1.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 once_cell = "1.9.0"
 anyhow = "1.0.53"

--- a/packages/web/src/olddom.rs
+++ b/packages/web/src/olddom.rs
@@ -8,7 +8,7 @@
 //! - Partial delegation?>
 
 use dioxus_core::{DomEdit, ElementId, SchedulerMsg, ScopeId, UserEvent};
-use fxhash::FxHashMap;
+use rustc_hash::FxHashMap;
 use std::{any::Any, fmt::Debug, rc::Rc, sync::Arc};
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::{


### PR DESCRIPTION
The rust performance book recommends using rustc-hash instead of fxhash for maintenance reasons - https://nnethercote.github.io/perf-book/hashing.html

"[rustc-hash](https://crates.io/crates/rustc-hash) provides FxHashSet and FxHashMap types that are drop-in replacements for HashSet and HashMap. Its hashing algorithm is low-quality but very fast, especially for integer keys, and has been found to out-perform all other hash algorithms within rustc. ([fxhash](https://crates.io/crates/fxhash) is an older, less well maintained implementation of the same algorithm and types.)"

Do you see any reasons against this? Let me know what you think!