### PR TITLE
Some fixes for wayland and ios.

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -28,7 +28,7 @@ tokio = { version = "1.16.1", features = [
     "rt",
     "time",
 ], optional = true, default-features = false }
-webbrowser = "0.7.1"
+webbrowser = "0.8.0"
 infer = "0.9.0"
 dunce = "1.0.2"
 

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -173,7 +173,13 @@ pub(super) fn handler(
 ) {
     // currently dioxus-desktop supports a single window only,
     // so we can grab the only webview from the map;
-    let webview = desktop.webviews.values().next().unwrap();
+    // on wayland it is possible that a user event is emitted
+    // before the webview is initialized. ignore the event.
+    let webview = if let Some(webview) = desktop.webviews.values().next() {
+        webview
+    } else {
+        return;
+    };
     let window = webview.window();
 
     match user_event {


### PR DESCRIPTION
Updating to webbrowser 0.8.0 fixes compiling for ios, while not crashing if the webview isn't initialized yet fixes an issue encountered on sway/wayland/linux.