### PR TITLE
fix desktop dependency `wry`

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -20,7 +20,7 @@ serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.30"
 log = "0.4.14"
-wry = { version = "0.22.0", git = "https://github.com/tauri-apps/wry", branch = "release" }
+wry = { version = "0.22.0" }
 futures-channel = "0.3.21"
 tokio = { version = "1.16.1", features = [
     "sync",


### PR DESCRIPTION
`dioxus-desktop` currently depends on `wry` via git.

This is an issue because:
1. The specified branch (`release`) doesn't seem to exist within the [wry repository](https://github.com/tauri-apps/wry).
2. IIRC crates.io doesn't allow git dependencies.
3. The specified version is already available via crates.io

This PR fixes all of the above by changing the dependency back to crates.io.