### PR TITLE
chore: rollback to option instead of anyhow

### DIFF
--- a/docs/guide/examples/component_children_inspect.rs
+++ b/docs/guide/examples/component_children_inspect.rs
@@ -26,7 +26,7 @@ struct ClickableProps<'a> {
 // ANCHOR: Clickable
 fn Clickable<'a>(cx: Scope<'a, ClickableProps<'a>>) -> Element {
     match cx.props.children {
-        Ok(VNode { dynamic_nodes, .. }) => {
+        Some(VNode { dynamic_nodes, .. }) => {
             todo!("render some stuff")
         }
         _ => {

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -194,7 +194,7 @@ mod field_info {
                 // children field is automatically defaulted to None
                 if name == "children" {
                     builder_attr.default =
-                        Some(syn::parse(quote!(::dioxus::core::VNode::empty()).into()).unwrap());
+                        Some(syn::parse(quote!(Default::default()).into()).unwrap());
                 }
 
                 // auto detect optional

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -31,12 +31,11 @@ futures-channel = "0.3.21"
 
 indexmap = "1.7"
 
-# Serialize the Edits for use in Webview/Liveview instances
-serde = { version = "1", features = ["derive"], optional = true }
-anyhow = "1.0.66"
-
 smallbox = "0.8.1"
 log = "0.4.17"
+
+# Serialize the Edits for use in Webview/Liveview instances
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "*", features = ["full"] }

--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -81,12 +81,12 @@ impl VirtualDom {
         self.ensure_drop_safety(id);
 
         if let Some(root) = self.scopes[id.0].as_ref().try_root_node() {
-            if let RenderReturn::Sync(Ok(node)) = unsafe { root.extend_lifetime_ref() } {
+            if let RenderReturn::Sync(Some(node)) = unsafe { root.extend_lifetime_ref() } {
                 self.drop_scope_inner(node)
             }
         }
         if let Some(root) = unsafe { self.scopes[id.0].as_ref().previous_frame().try_load_node() } {
-            if let RenderReturn::Sync(Ok(node)) = unsafe { root.extend_lifetime_ref() } {
+            if let RenderReturn::Sync(Some(node)) = unsafe { root.extend_lifetime_ref() } {
                 self.drop_scope_inner(node)
             }
         }

--- a/packages/core/src/create.rs
+++ b/packages/core/src/create.rs
@@ -354,8 +354,8 @@ impl<'b> VirtualDom {
         use RenderReturn::*;
 
         match return_nodes {
-            Sync(Ok(t)) => self.mount_component(scope, template, t, idx),
-            Sync(Err(_e)) => todo!("Propogate error upwards"),
+            Sync(Some(t)) => self.mount_component(scope, template, t, idx),
+            Sync(None) => todo!("Propogate error upwards"),
             Async(_) => self.mount_component_placeholder(template, idx, scope),
         }
     }

--- a/packages/core/src/error_boundary.rs
+++ b/packages/core/src/error_boundary.rs
@@ -5,7 +5,7 @@ use crate::ScopeId;
 /// A boundary that will capture any errors from child components
 #[allow(dead_code)]
 pub struct ErrorBoundary {
-    error: RefCell<Option<(anyhow::Error, ScopeId)>>,
+    error: RefCell<Option<ScopeId>>,
     id: ScopeId,
 }
 

--- a/packages/core/src/fragment.rs
+++ b/packages/core/src/fragment.rs
@@ -27,8 +27,8 @@ use crate::innerlude::*;
 /// You want to use this free-function when your fragment needs a key and simply returning multiple nodes from rsx! won't cut it.
 #[allow(non_upper_case_globals, non_snake_case)]
 pub fn Fragment<'a>(cx: Scope<'a, FragmentProps<'a>>) -> Element {
-    let children = cx.props.0.as_ref().map_err(|e| anyhow::anyhow!("{}", e))?;
-    Ok(VNode {
+    let children = cx.props.0.as_ref()?;
+    Some(VNode {
         key: children.key,
         parent: children.parent,
         template: children.template,
@@ -95,7 +95,7 @@ impl<'a> Properties for FragmentProps<'a> {
     type Builder = FragmentBuilder<'a, false>;
     const IS_STATIC: bool = false;
     fn builder() -> Self::Builder {
-        FragmentBuilder(VNode::empty())
+        FragmentBuilder(None)
     }
     unsafe fn memoize(&self, _other: &Self) -> bool {
         false

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -34,10 +34,10 @@ pub(crate) mod innerlude {
     pub use crate::scopes::*;
     pub use crate::virtual_dom::*;
 
-    /// An [`Element`] is a possibly-errored [`VNode`] created by calling `render` on [`Scope`] or [`ScopeState`].
+    /// An [`Element`] is a possibly-none [`VNode`] created by calling `render` on [`Scope`] or [`ScopeState`].
     ///
     /// An Errored [`Element`] will propagate the error to the nearest error boundary.
-    pub type Element<'a> = Result<VNode<'a>, anyhow::Error>;
+    pub type Element<'a> = Option<VNode<'a>>;
 
     /// A [`Component`] is a function that takes a [`Scope`] and returns an [`Element`].
     ///

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -58,7 +58,7 @@ pub struct VNode<'a> {
 impl<'a> VNode<'a> {
     /// Create a template with no nodes that will be skipped over during diffing
     pub fn empty() -> Element<'a> {
-        Ok(VNode {
+        Some(VNode {
             key: None,
             parent: None,
             root_ids: &[],
@@ -466,16 +466,6 @@ impl<'a> IntoDynNode<'a> for DynamicNode<'a> {
     }
 }
 
-// An element that's an error is currently lost into the ether
-impl<'a> IntoDynNode<'a> for Element<'a> {
-    fn into_vnode(self, _cx: &'a ScopeState) -> DynamicNode<'a> {
-        match self {
-            Ok(val) => val.into_vnode(_cx),
-            _ => DynamicNode::default(),
-        }
-    }
-}
-
 impl<'a, T: IntoDynNode<'a>> IntoDynNode<'a> for Option<T> {
     fn into_vnode(self, _cx: &'a ScopeState) -> DynamicNode<'a> {
         match self {
@@ -488,7 +478,7 @@ impl<'a, T: IntoDynNode<'a>> IntoDynNode<'a> for Option<T> {
 impl<'a> IntoDynNode<'a> for &Element<'a> {
     fn into_vnode(self, _cx: &'a ScopeState) -> DynamicNode<'a> {
         match self.as_ref() {
-            Ok(val) => val.clone().into_vnode(_cx),
+            Some(val) => val.clone().into_vnode(_cx),
             _ => DynamicNode::default(),
         }
     }
@@ -542,7 +532,7 @@ impl<'a> IntoTemplate<'a> for VNode<'a> {
 impl<'a> IntoTemplate<'a> for Element<'a> {
     fn into_template(self, _cx: &'a ScopeState) -> VNode<'a> {
         match self {
-            Ok(val) => val.into_template(_cx),
+            Some(val) => val.into_template(_cx),
             _ => VNode::empty().unwrap(),
         }
     }

--- a/packages/core/src/scheduler/wait.rs
+++ b/packages/core/src/scheduler/wait.rs
@@ -78,7 +78,7 @@ impl VirtualDom {
 
             fiber.waiting_on.borrow_mut().remove(&id);
 
-            if let RenderReturn::Sync(Ok(template)) = ret {
+            if let RenderReturn::Sync(Some(template)) = ret {
                 let mutations_ref = &mut fiber.mutations.borrow_mut();
                 let mutations = &mut **mutations_ref;
                 let template: &VNode = unsafe { std::mem::transmute(template) };

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -390,7 +390,7 @@ impl<'src> ScopeState {
             }
         }
 
-        Ok(element)
+        Some(element)
     }
 
     /// Create a dynamic text node using [`Arguments`] and the [`ScopeState`]'s internal [`Bump`] allocator

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -477,7 +477,7 @@ impl VirtualDom {
     pub fn rebuild(&mut self) -> Mutations {
         match unsafe { self.run_scope(ScopeId(0)).extend_lifetime_ref() } {
             // Rebuilding implies we append the created elements to the root
-            RenderReturn::Sync(Ok(node)) => {
+            RenderReturn::Sync(Some(node)) => {
                 let m = self.create_scope(ScopeId(0), node);
                 self.mutations.edits.push(Mutation::AppendChildren {
                     id: ElementId(0),
@@ -485,7 +485,7 @@ impl VirtualDom {
                 });
             }
             // If an error occurs, we should try to render the default error component and context where the error occured
-            RenderReturn::Sync(Err(e)) => panic!("Cannot catch errors during rebuild {:?}", e),
+            RenderReturn::Sync(None) => panic!("Cannot catch errors during rebuild"),
             RenderReturn::Async(_) => unreachable!("Root scope cannot be an async component"),
         }
 

--- a/packages/core/tests/bubble_error.rs
+++ b/packages/core/tests/bubble_error.rs
@@ -9,7 +9,7 @@ fn app(cx: Scope) -> Element {
         _ => unreachable!(),
     };
 
-    let value = raw.parse::<f32>().unwrap();
+    let value = raw.parse::<f32>().unwrap_or(123.123);
 
     cx.render(rsx! {
         div { "hello {value}" }

--- a/packages/core/tests/bubble_error.rs
+++ b/packages/core/tests/bubble_error.rs
@@ -9,7 +9,7 @@ fn app(cx: Scope) -> Element {
         _ => unreachable!(),
     };
 
-    let value = raw.parse::<f32>()?;
+    let value = raw.parse::<f32>().unwrap();
 
     cx.render(rsx! {
         div { "hello {value}" }

--- a/packages/router/src/components/redirect.rs
+++ b/packages/router/src/components/redirect.rs
@@ -47,5 +47,5 @@ pub fn Redirect<'a>(cx: Scope<'a, RedirectProps<'a>>) -> Element {
         router.replace_route(cx.props.to, None, None);
     }
 
-    cx.render(rsx!(()))
+    None
 }

--- a/packages/router/src/components/route.rs
+++ b/packages/router/src/components/route.rs
@@ -52,6 +52,6 @@ pub fn Route<'a>(cx: Scope<'a, RouteProps<'a>>) -> Element {
         cx.render(rsx!(&cx.props.children))
     } else {
         log::debug!("Route should *not* render: {:?}", cx.scope_id());
-        cx.render(rsx!(()))
+        None
     }
 }

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -171,7 +171,7 @@ impl ToTokens for Component {
 
                     toks.append_all(quote! {
                         .children(
-                            Ok({ #renderer })
+                            Some({ #renderer })
                         )
                     });
                 }

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -70,7 +70,7 @@ impl ToTokens for CallBody {
 
         if self.inline_cx {
             out_tokens.append_all(quote! {
-                Ok({
+                Some({
                     let __cx = cx;
                     #body
                 })

--- a/packages/ssr/src/lib.rs
+++ b/packages/ssr/src/lib.rs
@@ -23,7 +23,7 @@ pub fn render_lazy(f: LazyNodes<'_, '_>) -> String {
     fn lazy_app<'a>(cx: Scope<'a, RootProps<'static, 'static>>) -> Element<'a> {
         let lazy = cx.props.caller.take().unwrap();
         let lazy: LazyNodes = unsafe { std::mem::transmute(lazy) };
-        Ok(lazy.call(cx))
+        Some(lazy.call(cx))
     }
 
     let props: RootProps = unsafe {

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -51,7 +51,7 @@ impl Renderer {
     ) -> std::fmt::Result {
         // We should never ever run into async or errored nodes in SSR
         // Error boundaries and suspense boundaries will convert these to sync
-        if let RenderReturn::Sync(Ok(node)) = dom.get_scope(scope).unwrap().root_node() {
+        if let RenderReturn::Sync(Some(node)) = dom.get_scope(scope).unwrap().root_node() {
             self.render_template(buf, dom, node)?
         };
 
@@ -89,7 +89,7 @@ impl Renderer {
                             let scope = dom.get_scope(id).unwrap();
                             let node = scope.root_node();
                             match node {
-                                RenderReturn::Sync(Ok(node)) => {
+                                RenderReturn::Sync(Some(node)) => {
                                     self.render_template(buf, dom, node)?
                                 }
                                 _ => todo!(

--- a/packages/tui/examples/tui_colorpicker.rs
+++ b/packages/tui/examples/tui_colorpicker.rs
@@ -17,7 +17,7 @@ fn app(cx: Scope) -> Element {
             width: "100%",
             background_color: "hsl({hue}, 70%, {brightness}%)",
             onmousemove: move |evt| {
-                if let RenderReturn::Sync(Ok(node)) = cx.root_node() {
+                if let RenderReturn::Sync(Some(node)) = cx.root_node() {
                     if let Some(id) = node.root_ids[0].get() {
                         let node = tui_query.get(id);
                         let Size{width, height} = node.size().unwrap();

--- a/packages/tui/src/widgets/mod.rs
+++ b/packages/tui/src/widgets/mod.rs
@@ -10,7 +10,7 @@ use dioxus_core::{ElementId, RenderReturn, Scope};
 pub use input::*;
 
 pub(crate) fn get_root_id<T>(cx: Scope<T>) -> Option<ElementId> {
-    if let RenderReturn::Sync(Ok(sync)) = cx.root_node() {
+    if let RenderReturn::Sync(Some(sync)) = cx.root_node() {
         sync.root_ids.get(0).and_then(|id| id.get())
     } else {
         None


### PR DESCRIPTION
After trying to use the error handling with anyhow, I don't really think it's worth the breaking change.

Error boundaries are best paired with exceptions. Currently, we don't protect the render tree from panics which is what error boundaries would be good for anyway.

The idea here is to pull back the Result changes are just stick with Option<Vnode>. If you want to throw an error, you can use the throw trait or panic.

The throw trait and panic will be implemented in a future PR.