### PR TITLE
fix tui benchmark

### DIFF
--- a/packages/tui/benches/update.rs
+++ b/packages/tui/benches/update.rs
@@ -65,7 +65,7 @@ fn Grid(cx: Scope<GridProps>) -> Element {
     let count = use_state(cx, || 0);
     let counts = use_ref(cx, || vec![0; size * size]);
 
-    let ctx: &TuiContext = cx.consume_context().unwrap();
+    let ctx: TuiContext = cx.consume_context().unwrap();
     if *count.get() + 1 >= (size * size) {
         ctx.quit();
     } else {


### PR DESCRIPTION
Changes the tui benchmark to consume TuiContext instead of &TuiConext because consume context now returns owned values instead of references