### PR TITLE
feat: simple signals implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "packages/native-core",
     "packages/native-core-macro",
     "packages/rsx-rosetta",
+    "packages/signals",
     "docs/guide",
 ]
 
@@ -43,6 +44,7 @@ dioxus = { path = "./packages/dioxus" }
 dioxus-desktop = { path = "./packages/desktop", features = ["transparent"] }
 dioxus-ssr = { path = "./packages/ssr" }
 dioxus-router = { path = "./packages/router" }
+dioxus-signals = { path = "./packages/signals" }
 fermi = { path = "./packages/fermi" }
 futures-util = "0.3.21"
 log = "0.4.14"

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -1,0 +1,41 @@
+//! Example: README.md showcase
+//!
+//! The example from the README.md.
+
+use dioxus::prelude::*;
+use dioxus_signals::{use_init_signal_rt, use_signal};
+use std::time::Duration;
+
+fn main() {
+    dioxus_desktop::launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    use_init_signal_rt(cx);
+
+    let mut count = use_signal(cx, || 0);
+    let mut running = use_signal(cx, || false);
+
+    use_coroutine(cx, |_: UnboundedReceiver<()>| async move {
+        loop {
+            if running.get() {
+                count += 1;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    cx.render(rsx! {
+        h1 { "High-Five counter: {count}" }
+
+        button { onclick: move |_| count += 1, "Up high!" }
+        button { onclick: move |_| count -= 1, "Down low!" }
+
+        button { onclick: move |_| running.set(!running.get()), "Start counting" }
+
+
+        if count.get() > 3 {
+            rsx! ( h2 { "Nice!" } )
+        }
+    })
+}

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -14,7 +14,7 @@ fn app(cx: Scope) -> Element {
     use_future!(cx, || async move {
         loop {
             count += 1;
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(400)).await;
         }
     });
 
@@ -22,5 +22,9 @@ fn app(cx: Scope) -> Element {
         h1 { "High-Five counter: {count}" }
         button { onclick: move |_| count += 1, "Up high!" }
         button { onclick: move |_| count -= 1, "Down low!" }
+
+        if count() > 5 {
+            rsx!{ h2 { "High five!" } }
+        }
     })
 }

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -1,7 +1,3 @@
-//! Example: README.md showcase
-//!
-//! The example from the README.md.
-
 use dioxus::prelude::*;
 use dioxus_signals::{use_init_signal_rt, use_signal};
 use std::time::Duration;
@@ -15,7 +11,7 @@ fn app(cx: Scope) -> Element {
 
     let mut count = use_signal(cx, || 0);
 
-    use_coroutine(cx, |_: UnboundedReceiver<()>| async move {
+    use_future!(cx, || async move {
         loop {
             count += 1;
             tokio::time::sleep(Duration::from_millis(100)).await;

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -14,28 +14,17 @@ fn app(cx: Scope) -> Element {
     use_init_signal_rt(cx);
 
     let mut count = use_signal(cx, || 0);
-    let mut running = use_signal(cx, || false);
 
     use_coroutine(cx, |_: UnboundedReceiver<()>| async move {
         loop {
-            if running.get() {
-                count += 1;
-            }
+            count += 1;
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     });
 
     cx.render(rsx! {
         h1 { "High-Five counter: {count}" }
-
         button { onclick: move |_| count += 1, "Up high!" }
         button { onclick: move |_| count -= 1, "Down low!" }
-
-        button { onclick: move |_| running.set(!running.get()), "Start counting" }
-
-
-        if count.get() > 3 {
-            rsx! ( h2 { "Nice!" } )
-        }
     })
 }

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dioxus-signals"
+version = "0.0.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dioxus-core = { path = "../core" }
+slab = "0.4.7"

--- a/packages/signals/src/lib.rs
+++ b/packages/signals/src/lib.rs
@@ -1,0 +1,131 @@
+use std::{
+    fmt::Display,
+    marker::PhantomData,
+    ops::{Add, Div, Mul, Sub},
+};
+
+mod rt;
+
+use dioxus_core::ScopeState;
+pub use rt::*;
+
+pub fn use_init_signal_rt(cx: &ScopeState) {
+    cx.use_hook(|| {
+        let rt = crate::rt::claim_rt(cx.schedule_update_any());
+        cx.provide_context(rt);
+    });
+}
+
+pub fn use_signal<T: 'static>(cx: &ScopeState, f: impl FnOnce() -> T) -> Signal<T> {
+    *cx.use_hook(|| {
+        let rt: &'static SignalRt = cx.consume_context().unwrap();
+        let id = rt.init(f());
+        rt.subscribe(id, cx.scope_id());
+
+        Signal {
+            rt,
+            id,
+            t: PhantomData,
+        }
+    })
+}
+
+pub struct Signal<T> {
+    id: usize,
+    rt: &'static SignalRt,
+    t: PhantomData<T>,
+}
+
+impl<T: 'static> Signal<T> {
+    pub fn set(&mut self, value: T) {
+        self.rt.set(self.id, value);
+    }
+
+    pub fn map<U>(&self, _f: impl FnOnce(T) -> U) -> Signal<U> {
+        todo!()
+    }
+
+    pub fn update<O>(&self, _f: impl FnOnce(&mut T) -> O) {
+        todo!()
+    }
+}
+
+impl<T: Clone + 'static> Signal<T> {
+    pub fn get(&self) -> T {
+        self.rt.get(self.id)
+    }
+}
+
+// impl<T> std::ops::Deref for Signal<T> {
+//     type Target = dyn Fn() -> T;
+
+//     fn deref(&self) -> &Self::Target {
+//         todo!()
+//     }
+// }
+
+impl<T> std::clone::Clone for Signal<T> {
+    fn clone(&self) -> Self {
+        Self {
+            t: PhantomData,
+            id: self.id,
+            rt: self.rt,
+        }
+    }
+}
+
+impl<T> Copy for Signal<T> {}
+
+impl<T: Display + 'static> Display for Signal<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.rt.with::<T, _>(self.id, |v| T::fmt(v, f))
+    }
+}
+
+impl<T: Add<Output = T> + Copy + 'static> std::ops::AddAssign<T> for Signal<T> {
+    fn add_assign(&mut self, rhs: T) {
+        self.set(self.get() + rhs);
+    }
+}
+
+impl<T: Sub<Output = T> + Copy + 'static> std::ops::SubAssign<T> for Signal<T> {
+    fn sub_assign(&mut self, rhs: T) {
+        self.set(self.get() - rhs);
+    }
+}
+
+impl<T: Mul<Output = T> + Copy + 'static> std::ops::MulAssign<T> for Signal<T> {
+    fn mul_assign(&mut self, rhs: T) {
+        self.set(self.get() * rhs);
+    }
+}
+
+impl<T: Div<Output = T> + Copy + 'static> std::ops::DivAssign<T> for Signal<T> {
+    fn div_assign(&mut self, rhs: T) {
+        self.set(self.get() / rhs);
+    }
+}
+
+// impl<T: Add<Output = T> + Copy> std::ops::AddAssign<T> for Signal<T> {
+//     fn add_assign(&mut self, rhs: T) {
+//         self.set((*self.current()) + rhs);
+//     }
+// }
+
+// impl<T: Sub<Output = T> + Copy> std::ops::SubAssign<T> for Signal<T> {
+//     fn sub_assign(&mut self, rhs: T) {
+//         self.set((*self.current()) - rhs);
+//     }
+// }
+
+// impl<T: Mul<Output = T> + Copy> std::ops::MulAssign<T> for Signal<T> {
+//     fn mul_assign(&mut self, rhs: T) {
+//         self.set((*self.current()) * rhs);
+//     }
+// }
+
+// impl<T: Div<Output = T> + Copy> std::ops::DivAssign<T> for Signal<T> {
+//     fn div_assign(&mut self, rhs: T) {
+//         self.set((*self.current()) / rhs);
+//     }
+// }

--- a/packages/signals/src/rt.rs
+++ b/packages/signals/src/rt.rs
@@ -59,11 +59,29 @@ impl SignalRt {
         }
     }
 
+    pub fn remove(&self, id: usize) {
+        self.signals.borrow_mut().remove(id);
+    }
+
     pub fn with<T: 'static, O>(&self, id: usize, f: impl FnOnce(&T) -> O) -> O {
         let signals = self.signals.borrow();
         let inner = &signals[id];
         let inner = inner.value.downcast_ref::<T>().unwrap();
         f(&*inner)
+    }
+
+    pub(crate) fn read<T: 'static>(&self, id: usize) -> std::cell::Ref<T> {
+        let signals = self.signals.borrow();
+        std::cell::Ref::map(signals, |signals| {
+            signals[id].value.downcast_ref::<T>().unwrap()
+        })
+    }
+
+    pub(crate) fn write<T: 'static>(&self, id: usize) -> std::cell::RefMut<T> {
+        let mut signals = self.signals.borrow_mut();
+        std::cell::RefMut::map(signals, |signals| {
+            signals[id].value.downcast_mut::<T>().unwrap()
+        })
     }
 }
 

--- a/packages/signals/src/rt.rs
+++ b/packages/signals/src/rt.rs
@@ -1,0 +1,73 @@
+use std::{
+    any::Any,
+    cell::RefCell,
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
+
+use dioxus_core::ScopeId;
+use slab::Slab;
+
+/// Provide the runtime for signals
+///
+/// This will reuse dead runtimes
+pub fn claim_rt(update_any: Arc<dyn Fn(ScopeId)>) -> &'static SignalRt {
+    Box::leak(Box::new(SignalRt {
+        signals: RefCell::new(Slab::new()),
+        update_any,
+    }))
+}
+
+pub fn reclam_rt(rt: usize) {}
+
+struct GlobalRt {
+    signals: Slab<Inner>,
+}
+
+pub struct SignalRt {
+    signals: RefCell<Slab<Inner>>,
+    update_any: Arc<dyn Fn(ScopeId)>,
+}
+
+impl SignalRt {
+    pub fn init<T: 'static>(&self, val: T) -> usize {
+        self.signals.borrow_mut().insert(Inner {
+            value: Box::new(val),
+            subscribers: Vec::new(),
+        })
+    }
+
+    pub fn subscribe(&self, id: usize, subscriber: ScopeId) {
+        self.signals.borrow_mut()[id].subscribers.push(subscriber);
+    }
+
+    pub fn get<T: Clone + 'static>(&self, id: usize) -> T {
+        self.signals.borrow()[id]
+            .value
+            .downcast_ref::<T>()
+            .cloned()
+            .unwrap()
+    }
+
+    pub fn set<T: 'static>(&self, id: usize, value: T) {
+        let mut signals = self.signals.borrow_mut();
+        let inner = &mut signals[id];
+        inner.value = Box::new(value);
+
+        for subscriber in inner.subscribers.iter() {
+            (self.update_any)(*subscriber);
+        }
+    }
+
+    pub fn with<T: 'static, O>(&self, id: usize, f: impl FnOnce(&T) -> O) -> O {
+        let signals = self.signals.borrow();
+        let inner = &signals[id];
+        let inner = inner.value.downcast_ref::<T>().unwrap();
+        f(&*inner)
+    }
+}
+
+struct Inner {
+    value: Box<dyn Any>,
+    subscribers: Vec<ScopeId>,
+}


### PR DESCRIPTION
Implements a new type of state API using `Copy + 'static` keys. The one downside is that the runtime that backs the signals needs to be leaked. We can reclaim the runtime safely by cycling them into linked list or slab, but can never shrink down to zero.

Currently this is not integrated with templates or diffing, but we can eventually expose hooks for both, allowing for the full signal experience.

This PR doesn't add "create_signal", only "use_signal" which taps into the regular re-render process of Dioxus.



---



Going to merge this in an experimental fashion. Will test it against some examples.

<img width="555" alt="Screenshot 2023-01-01 at 8 04 59 PM" src="https://user-images.githubusercontent.com/10237910/210189161-160a7225-4b55-4820-b51b-90cb38dd508d.png">
