### PR TITLE
Use invariant lifetime and immutable hooks to allow spawning futures without "to_owned"

### DIFF
--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -2,18 +2,125 @@
 //!
 //! The example from the README.md.
 
-use dioxus::prelude::*;
+use std::{any::Any, cell::RefCell, marker::PhantomData, pin::Pin};
+
+use dioxus::prelude::{use_state, Element, Scoped};
+// use dioxus::prelude::*;
+use futures_util::{future::abortable, Future};
 
 fn main() {
-    dioxus_desktop::launch(app);
+    // dioxus_desktop::launch(app);
 }
 
-fn app(cx: Scope) -> Element {
-    let mut count = use_state(cx, || 0);
+fn app(cx: Scope) {
+    // let name = use_state(cx, || "world".to_string());
 
-    cx.render(rsx! {
-        h1 { "High-Five counter: {count}" }
-        button { onclick: move |_| count += 1, "Up high!" }
-        button { onclick: move |_| count -= 1, "Down low!" }
-    })
+    let name = cx.use_hook(|| "asdasd".to_string());
+
+    cx.spawn(async {
+        println!("Hello, world! {name}");
+    });
+
+    use_future(cx, async move {
+        println!("Hello, world! {name}");
+    });
+
+    todo!()
 }
+
+pub fn use_future<'a>(cx: Scope<'a>, f: impl Future<Output = ()> + 'a) {
+    todo!()
+}
+
+pub fn create_ref<T: 'static>(cx: Scope, value: T) -> &T {
+    todo!()
+    // cx.raw.arena.alloc(value)
+}
+
+pub fn spawn_local_scoped<'a>(cx: Scope<'a>, f: impl Future<Output = ()> + 'a) {
+    let boxed: Pin<Box<dyn Future<Output = ()> + 'a>> = Box::pin(f);
+    // SAFETY: We are just transmuting the lifetime here so that we can spawn the future.
+    // This is safe because we wrap the future in an `Abortable` future which will be
+    // immediately aborted once the reactive scope is dropped.
+    let extended: Pin<Box<dyn Future<Output = ()> + 'static>> =
+        unsafe { std::mem::transmute(boxed) };
+
+    let (abortable, handle) = abortable(extended);
+
+    tokio::task::spawn_local(abortable);
+}
+
+// let mut count = use_state(&cx, || 0);
+// let hook = cx.raw.use_hook(|| 10);
+
+// cx.render(rsx! {
+//     h1 { "High-Five counter: {count}" }
+//     button { onclick: move |_| count += 1, "Up high!" }
+//     button { onclick: move |_| count -= 1, "Down low!" }
+// })
+
+// count.set(10);
+// let r = name.as_bytes();
+
+struct ScopeRaw<'a> {
+    inner: RefCell<ScopeInner<'a>>,
+    /// A pointer to the parent scope.
+    /// # Safety
+    /// The parent scope does not actually have the right lifetime.
+    parent: Option<*const ScopeRaw<'a>>,
+}
+
+/// A wrapper type around a lifetime that forces the lifetime to be invariant.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct InvariantLifetime<'id>(PhantomData<&'id mut &'id ()>);
+
+/// Internal representation for [`Scope`]. This allows only using a single top-level [`RefCell`]
+/// instead of a [`RefCell`] for every field.
+#[derive(Default)]
+struct ScopeInner<'a> {
+    /// The depth of the current scope. The root scope has a depth of 0. Any child scopes have a
+    /// depth of N + 1 where N is the depth of the parent scope.
+    depth: u32,
+    /// If this is true, this will prevent the scope from being dropped.
+    /// This is set when an effect is running to prevent an use-after-free.
+    lock_drop: bool,
+    // Make sure that 'a is invariant.
+    _phantom: InvariantLifetime<'a>,
+}
+
+// impl<'a> ScopeInner<'a> {
+//     fn alloc(&'a self, val: T) -> &'a T {
+//         todo!()
+//     }
+// }
+
+#[derive(Clone, Copy)]
+pub struct BoundedScope<'a> {
+    raw: &'a ScopeRaw<'a>,
+    // /// `&'b` for covariance!
+    // _phantom: PhantomData<&'b ()>,
+}
+
+impl<'a> BoundedScope<'a> {
+    fn alloc<T: 'static>(self, value: T) -> &'a T {
+        todo!()
+    }
+    fn use_hook<T: 'static>(self, value: impl FnOnce() -> T) -> &'a T {
+        todo!()
+    }
+
+    fn spawn(self, f: impl Future<Output = ()> + 'a) {
+        spawn_local_scoped(self, f)
+    }
+}
+
+impl Drop for ScopeRaw<'_> {
+    fn drop(&mut self) {
+        todo!()
+        // // SAFETY: scope cannot be dropped while it is borrowed inside closure.
+        // unsafe { self.dispose() };
+    }
+}
+
+/// A type-alias for [`BoundedScope`] where both lifetimes are the same.
+pub type Scope<'a> = BoundedScope<'a>;

--- a/examples/readme2.rs
+++ b/examples/readme2.rs
@@ -14,9 +14,51 @@ fn main() {
 fn app(cx: Scope) -> Element {
     let name = cx.use_hook(|| "asdasd".to_string());
 
-    cx.spawn_local(async {
-        println!("Hello, world! {name}");
+    cx.spawn_local(async move {
+        println!("Hello, world! From the top-level future {name}");
     });
 
-    todo!()
+    cx.render(rsx! {
+        div {
+            // Child {
+            //     onclick: |s| {
+            //         println!("Clicked....: {}", s);
+            //         cx.spawn_local(async move {
+            //             println!("Clicked: {}", s);
+            //         });
+            //     }
+            // }
+        }
+    })
+}
+
+// #[inline_props]
+
+fn Child<'a, 'b>(cx: Scoped<'a, 'b, ()>, onclick: &'a EventHandler<'a, &'a String>) -> Element<'a> {
+    let name = cx.use_hook(|| "asdasd".to_string());
+
+    onclick.call(&name);
+
+    spawn_local(cx, async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            println!("Hello, world! from the bottom level future {name}");
+        }
+    });
+
+    cx.scope.render(rsx! {
+        div {
+            "Hello, world!"
+            button {
+                onclick: move |_| {
+                    onclick.call(&name);
+                },
+                "Click to spawn future"
+            }
+        }
+    })
+}
+
+pub fn spawn_local<'a, 'b>(cx: Scoped<'a, 'b, ()>, fut: impl Future<Output = ()> + 'b) {
+    // self.tasks.spawn_local(self.id, fut);
 }

--- a/examples/readme2.rs
+++ b/examples/readme2.rs
@@ -1,0 +1,22 @@
+//! Example: README.md showcase
+//!
+//! The example from the README.md.
+
+use std::{any::Any, cell::RefCell, marker::PhantomData, pin::Pin};
+
+use dioxus::prelude::*;
+use futures_util::{future::abortable, Future};
+
+fn main() {
+    dioxus_desktop::launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    let name = cx.use_hook(|| "asdasd".to_string());
+
+    cx.spawn_local(async {
+        println!("Hello, world! {name}");
+    });
+
+    todo!()
+}

--- a/packages/core/src/any_props.rs
+++ b/packages/core/src/any_props.rs
@@ -67,7 +67,13 @@ where
             let scope: &mut Scoped<P> = cx.bump().alloc(Scoped {
                 props: &self.props,
                 scope: cx,
+                _p: PhantomData,
             });
+            // let scope: Scoped<P> = Scoped {
+            //     props: &self.props,
+            //     scope: cx,
+            //     _p: PhantomData,
+            // };
 
             (self.render_fn)(scope).into_return(cx)
         }));

--- a/packages/fermi/src/hooks/read.rs
+++ b/packages/fermi/src/hooks/read.rs
@@ -31,6 +31,7 @@ pub fn use_read_rc<V: 'static>(cx: &ScopeState, f: impl Readable<V>) -> &Rc<V> {
 
     let value = inner.root.register(f, cx.scope_id());
 
-    inner.value = Some(value);
+    todo!();
+    // inner.value = Some(value);
     inner.value.as_ref().unwrap()
 }

--- a/packages/fermi/src/hooks/state.rs
+++ b/packages/fermi/src/hooks/state.rs
@@ -40,7 +40,8 @@ pub fn use_atom_state<T: 'static>(cx: &ScopeState, f: impl Writable<T>) -> &Atom
         id: f.unique_id(),
     });
 
-    inner.value = Some(inner.root.register(f, cx.scope_id()));
+    todo!();
+    // inner.value = Some(inner.root.register(f, cx.scope_id()));
 
     inner
 }

--- a/packages/hooks/src/useeffect.rs
+++ b/packages/hooks/src/useeffect.rs
@@ -40,17 +40,18 @@ where
         dependencies: Vec::new(),
     });
 
-    if dependencies.clone().apply(&mut state.dependencies) || state.needs_regen {
-        // We don't need regen anymore
-        state.needs_regen = false;
+    todo!()
+    // if dependencies.clone().apply(&mut state.dependencies) || state.needs_regen {
+    //     // We don't need regen anymore
+    //     state.needs_regen = false;
 
-        // Create the new future
-        let fut = future(dependencies.out());
+    //     // Create the new future
+    //     let fut = future(dependencies.out());
 
-        state.task.set(Some(cx.push_future(async move {
-            fut.await;
-        })));
-    }
+    //     state.task.set(Some(cx.push_future(async move {
+    //         fut.await;
+    //     })));
+    // }
 }
 
 #[cfg(test)]

--- a/packages/hooks/src/usefuture.rs
+++ b/packages/hooks/src/usefuture.rs
@@ -42,34 +42,35 @@ where
 
     *state.waker.borrow_mut() = None;
 
-    if dependencies.clone().apply(&mut state.dependencies) || state.needs_regen.get() {
-        // We don't need regen anymore
-        state.needs_regen.set(false);
+    todo!();
+    // if dependencies.clone().apply(&mut state.dependencies) || state.needs_regen.get() {
+    //     // We don't need regen anymore
+    //     state.needs_regen.set(false);
 
-        // Create the new future
-        let fut = future(dependencies.out());
+    //     // Create the new future
+    //     let fut = future(dependencies.out());
 
-        // Clone in our cells
-        let values = state.values.clone();
-        let schedule_update = state.update.clone();
-        let waker = state.waker.clone();
+    //     // Clone in our cells
+    //     let values = state.values.clone();
+    //     let schedule_update = state.update.clone();
+    //     let waker = state.waker.clone();
 
-        // Cancel the current future
-        if let Some(current) = state.task.take() {
-            cx.remove_future(current);
-        }
+    //     // Cancel the current future
+    //     if let Some(current) = state.task.take() {
+    //         cx.remove_future(current);
+    //     }
 
-        state.task.set(Some(cx.push_future(async move {
-            let res = fut.await;
-            values.borrow_mut().push(Box::leak(Box::new(res)));
+    //     state.task.set(Some(cx.push_future(async move {
+    //         let res = fut.await;
+    //         values.borrow_mut().push(Box::leak(Box::new(res)));
 
-            // if there's a waker, we dont re-render the component. Instead we just progress that future
-            match waker.borrow().as_ref() {
-                Some(waker) => waker.wake_by_ref(),
-                None => schedule_update(),
-            }
-        })));
-    }
+    //         // if there's a waker, we dont re-render the component. Instead we just progress that future
+    //         match waker.borrow().as_ref() {
+    //             Some(waker) => waker.wake_by_ref(),
+    //             None => schedule_update(),
+    //         }
+    //     })));
+    // }
 
     state
 }

--- a/packages/hooks/src/useref.rs
+++ b/packages/hooks/src/useref.rs
@@ -118,10 +118,11 @@ pub fn use_ref<T: 'static>(cx: &ScopeState, initialize_refcell: impl FnOnce() ->
         gen: 0,
     });
 
-    if hook.dirty.get() {
-        hook.gen += 1;
-        hook.dirty.set(false);
-    }
+    todo!();
+    // if hook.dirty.get() {
+    //     hook.gen += 1;
+    //     hook.dirty.set(false);
+    // }
 
     hook
 }

--- a/packages/hooks/src/usestate.rs
+++ b/packages/hooks/src/usestate.rs
@@ -64,7 +64,8 @@ pub fn use_state<T: 'static>(
         }
     });
 
-    hook.current_val = hook.slot.borrow().clone();
+    todo!();
+    // hook.current_val = hook.slot.borrow().clone();
 
     hook
 }

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -78,7 +78,7 @@ pub struct LinkProps<'a> {
 /// }
 /// ```
 pub fn Link<'a>(cx: Scope<'a, LinkProps<'a>>) -> Element {
-    let svc = use_context::<RouterContext>(cx);
+    let svc = use_context::<RouterContext>(&cx);
 
     let LinkProps {
         to,
@@ -108,7 +108,7 @@ pub fn Link<'a>(cx: Scope<'a, LinkProps<'a>>) -> Element {
         }
     };
 
-    let route = use_route(cx);
+    let route = use_route(&cx);
     let url = route.url();
     let path = url.path();
     let active = path == cx.props.to;

--- a/packages/router/src/components/redirect.rs
+++ b/packages/router/src/components/redirect.rs
@@ -32,7 +32,7 @@ pub struct RedirectProps<'a> {
 ///
 /// It will replace the current route rather than pushing the current one to the stack.
 pub fn Redirect<'a>(cx: Scope<'a, RedirectProps<'a>>) -> Element {
-    let router = use_router(cx);
+    let router = use_router(&cx);
 
     let immediate_redirect = cx.use_hook(|| {
         if let Some(from) = cx.props.from {

--- a/packages/router/src/components/route.rs
+++ b/packages/router/src/components/route.rs
@@ -25,8 +25,8 @@ pub struct RouteProps<'a> {
 /// )
 /// ```
 pub fn Route<'a>(cx: Scope<'a, RouteProps<'a>>) -> Element {
-    let router_root = use_context::<RouterContext>(cx).unwrap();
-    let root_context = use_context::<RouteContext>(cx);
+    let router_root = use_context::<RouterContext>(&cx).unwrap();
+    let root_context = use_context::<RouteContext>(&cx);
 
     cx.use_hook(|| {
         // create a bigger, better, longer route if one above us exists

--- a/packages/router/src/components/router.rs
+++ b/packages/router/src/components/router.rs
@@ -41,7 +41,7 @@ pub struct RouterProps<'a> {
 pub fn Router<'a>(cx: Scope<'a, RouterProps<'a>>) -> Element {
     let svc = cx.use_hook(|| {
         cx.provide_context(RouterService::new(
-            cx,
+            &cx,
             RouterCfg {
                 base_url: cx.props.base_url.map(|s| s.to_string()),
                 active_class: cx.props.active_class.map(|s| s.to_string()),

--- a/packages/router/src/hooks/use_route.rs
+++ b/packages/router/src/hooks/use_route.rs
@@ -26,7 +26,8 @@ pub fn use_route(cx: &ScopeState) -> &UseRoute {
         }
     });
 
-    handle.state.route = handle.router.current_location();
+    todo!();
+    // handle.state.route = handle.router.current_location();
 
     &handle.state
 }

--- a/packages/ssr/src/lib.rs
+++ b/packages/ssr/src/lib.rs
@@ -23,7 +23,7 @@ pub fn render_lazy(f: LazyNodes<'_, '_>) -> String {
     fn lazy_app<'a>(cx: Scope<'a, RootProps<'static, 'static>>) -> Element<'a> {
         let lazy = cx.props.caller.take().unwrap();
         let lazy: LazyNodes = unsafe { std::mem::transmute(lazy) };
-        Some(lazy.call(cx))
+        Some(lazy.call(&cx))
     }
 
     let props: RootProps = unsafe {


### PR DESCRIPTION
This is an attempt at a pretty major change to Dioxus, namely `use_hook`, borrowing some ideas from Sycamore to make our state management simpler in async contexts.

Thesis
---
Generally, I'm not convinced that `use_state` is a successful hook right now. As per #619 , using use_state in a future can be very confusing and generally lead to wrong results. This is because the current value is accessible through the hook, and needs to stay that way because it's tied to the lifetime of that render. This was the original innovation that enabled hooks to borrow into callbacks, so I'm not necessarily disappointed that it's bad that it works that way.

The current issue we have is that every hook needs to behave the same in async contexts as it does in sync contexts. This requires cloning the hook into an async context, leading to a lot of extra code on the hook side and lots of consideration in how a hook she be "to_owned!" into an async environment. This is also super noisy and gets in the way of writing apps faster.

I'm also not convinced that hooks returning `&mut T` is *that* worth the headache they induce. It's great that it's possible, but I don't think any of the hooks we use right now particularly rely on the fact that they can get a mutable reference. Only `use_state` deeply relies on this, and we've mentioned it's already flawed due to the problems related to this "feature".


---


So, my proposal:  `use_hook` only returns immutable references. This is still tied to bump allocation like before and these values can be shared into handlers, like before. But now, we gain a few things:

- Futures can be spawned inline without calling to_owned on every hook
- Hooks don't need to implement to_owned
- `on` handlers can be async


---


Addressing the holes this leaves:

- Spawning is managed by an invariant lifetime.
- use_state is replaced by a signal-like API 
- hooks like use_route that provide an &T to a value now use a signal-like API 



---

An Example.

What a component with some async looked like before:

```rust
    let emails_sent = use_ref(cx, || vec![]);
    let status = use_state(cx, || Drafting);
    let delay = use_state(cx, || false);

    let tx = use_coroutine(cx, |mut rx| {
        let emails_sent = emails_sent.clone();
        let status = status.clone();
        let delay = delay.clone();

        async move {
            while let Some(message) = rx.next().await {
               status.set(Sending);
               sleep(Duration::from_millis(*delay.get_rc())).await;
                emails_sent.write().push(message);
               status.set(Sent);
            }
        }
    });

```



What it looks like now:

```rust
    let emails_sent = use_state(cx, || vec![]);
    let status = use_state(cx, || Drafting);
    let delay = use_state(cx, || false);

    let tx = use_coroutine(cx, |mut rx| async move {
        while let Some(message) = rx.next().await {
           status.set(Sending);
           sleep(Duration::from_millis(delay()).await;
            emails_sent.write().push(message);
           status.set(Sent);
        }
    });
```