### PR TITLE
Fix the namespace and volatility of dynamic attributes

### DIFF
--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -246,8 +246,8 @@ impl ToTokens for ElementAttrNamed {
                     __cx.attr(
                         dioxus_elements::#el_name::#name.0,
                         #value,
-                        None,
-                        false
+                        dioxus_elements::#el_name::#name.1,
+                        dioxus_elements::#el_name::#name.2
                     )
                 }
             }
@@ -256,8 +256,8 @@ impl ToTokens for ElementAttrNamed {
                     __cx.attr(
                         dioxus_elements::#el_name::#name.0,
                         #value,
-                        None,
-                        false
+                        dioxus_elements::#el_name::#name.1,
+                        dioxus_elements::#el_name::#name.2
                     )
                 }
             }


### PR DESCRIPTION
The current implementation defaults to None for the namespace and false for volatile instead of using the values defined in the html crate.
This breaks the following example:
```rust
use dioxus::prelude::*;

fn main() {
    dioxus_desktop::launch(app);
}

fn app(cx: Scope) -> Element {
    cx.render(rsx! {
        h1 {
            color: "{\"red\"}",
            "This should be red"
        }
    })
}
```

This PR fixes that issue.