### PR TITLE
Fix potential typo: Strign -> String

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1222,7 +1222,7 @@ builder_constructors! {
         rows: usize DEFAULT,
         spellcheck: BoolOrDefault DEFAULT,
         wrap: Wrap DEFAULT,
-        value: Strign volatile,
+        value: String volatile,
     };
 
 


### PR DESCRIPTION
Since it compiles without the fix, I am not sure if this is intentional or a typo.