### PR TITLE
Handle removing a future that does not exist

### DIFF
--- a/packages/core/src/scheduler/task.rs
+++ b/packages/core/src/scheduler/task.rs
@@ -59,9 +59,9 @@ impl Scheduler {
 
     /// Drop the future with the given TaskId
     ///
-    /// This does nto abort the task, so you'll want to wrap it in an aborthandle if that's important to you
+    /// This does not abort the task, so you'll want to wrap it in an aborthandle if that's important to you
     pub fn remove(&self, id: TaskId) {
-        self.tasks.borrow_mut().remove(id.0);
+        self.tasks.borrow_mut().try_remove(id.0);
     }
 }
 

--- a/packages/core/src/scheduler/wait.rs
+++ b/packages/core/src/scheduler/wait.rs
@@ -34,7 +34,7 @@ impl VirtualDom {
             self.scopes[task.scope.0].spawned_tasks.remove(&id);
 
             // Remove it from the scheduler
-            tasks.remove(id.0);
+            tasks.try_remove(id.0);
         }
     }
 


### PR DESCRIPTION
This fixes a panic when the future scheduler tries to remove a future that has already completed or been removed.

fixes #681 