### PR TITLE
Fix Fermi example

### DIFF
--- a/examples/fermi.rs
+++ b/examples/fermi.rs
@@ -10,6 +10,7 @@ fn main() {
 static NAME: Atom<String> = |_| "world".to_string();
 
 fn app(cx: Scope) -> Element {
+    use_init_atom_root(&cx);
     let name = use_read(cx, NAME);
 
     cx.render(rsx! {


### PR DESCRIPTION
The Fermi example is missing a use_init_atom_root in the root component which causes it to panic

closes #734 