### PR TITLE
UnsafeCell<Bump> to UnsafeCellWith<Bump>

### DIFF
--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -703,6 +703,7 @@ where
 {
     fn into_return(self, cx: &'a ScopeState) -> RenderReturn<'a> {
         let f: &mut dyn Future<Output = Element<'a>> = cx.bump().alloc(self);
+        // TODO what is the safety contract here?
         RenderReturn::Pending(unsafe { BumpBox::from_raw(f) })
     }
 }

--- a/packages/core/src/scheduler/wait.rs
+++ b/packages/core/src/scheduler/wait.rs
@@ -67,10 +67,14 @@ impl VirtualDom {
             let scope = &self.scopes[scope_id.0];
             let arena = scope.current_frame();
 
-            let ret = arena.bump().alloc(match new_nodes {
+            // safety: (TODO) how do we know we have exclusive access to the bump allocator at this
+            // time?
+            // safety: and the lifetime of the frame's bump allocation, `ret`, is tied to the
+            // frame in the `node.set(ret)` just below.
+            let ret = arena.bump.with(|bump| unsafe { (*bump).alloc(match new_nodes {
                 Some(new) => RenderReturn::Ready(new),
                 None => RenderReturn::default(),
-            });
+            }) });
 
             arena.node.set(ret);
 


### PR DESCRIPTION
Original intent was to satisfy clippy as this replaces code that used &self to return a &mut Bump with a `with_mut` method.

Idea comes from Tokio. Wrap the UnsafeCell<T> in a new type that provides `with` and a `with_mut` methods. The scope of the unsafe code might be more clear at the call site.

The dereference of the pointer, the *const T, or the *mut T, still has to be wrapped in `unsafe` but it may make it more clear to the caller what safety concerns they are taking into their own hands: whether it is just that they can guarantee exclusive access to the Bump, or whether they also should be guaranteeing the lifetime of the allocation won't exceed the Bump being reset.