### PR TITLE
Fix drag* events on the web renderer

### DIFF
--- a/packages/html/src/web_sys_bind/events.rs
+++ b/packages/html/src/web_sys_bind/events.rs
@@ -4,6 +4,7 @@ use crate::events::{
 };
 use crate::geometry::{ClientPoint, Coordinates, ElementPoint, PagePoint, ScreenPoint};
 use crate::input_data::{decode_key_location, decode_mouse_button_set, MouseButton};
+use crate::DragData;
 use keyboard_types::{Code, Key, Modifiers};
 use std::convert::TryInto;
 use std::str::FromStr;
@@ -40,6 +41,7 @@ uncheck_convert![
     CompositionEvent => CompositionData,
     KeyboardEvent    => KeyboardData,
     MouseEvent       => MouseData,
+    MouseEvent       => DragData,
     TouchEvent       => TouchData,
     PointerEvent     => PointerData,
     WheelEvent       => WheelData,
@@ -114,6 +116,14 @@ impl From<&MouseEvent> for MouseData {
             decode_mouse_button_set(e.buttons()),
             modifiers,
         )
+    }
+}
+
+impl From<&MouseEvent> for DragData {
+    fn from(value: &MouseEvent) -> Self {
+        Self {
+            mouse: MouseData::from(value),
+        }
     }
 }
 

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -229,11 +229,13 @@ pub fn virtual_event_from_websys_event(event: web_sys::Event, target: Element) -
 
         "change" | "input" | "invalid" | "reset" | "submit" => read_input_to_data(target),
 
-        "click" | "contextmenu" | "dblclick" | "doubleclick" | "drag" | "dragend" | "dragenter"
-        | "dragexit" | "dragleave" | "dragover" | "dragstart" | "drop" | "mousedown"
-        | "mouseenter" | "mouseleave" | "mousemove" | "mouseout" | "mouseover" | "mouseup" => {
+        "click" | "contextmenu" | "dblclick" | "doubleclick" | "mousedown" | "mouseenter"
+        | "mouseleave" | "mousemove" | "mouseout" | "mouseover" | "mouseup" => {
             Rc::new(MouseData::from(event))
         }
+        "drag" | "dragend" | "dragenter" | "dragexit" | "dragleave" | "dragover" | "dragstart"
+        | "drop" => Rc::new(DragData::from(event)),
+
         "pointerdown" | "pointermove" | "pointerup" | "pointercancel" | "gotpointercapture"
         | "lostpointercapture" | "pointerenter" | "pointerleave" | "pointerover" | "pointerout" => {
             Rc::new(PointerData::from(event))


### PR DESCRIPTION
This fixes drag* events being transmitted as MouseData instead of DragData causing drag events to never fire