### PR TITLE
Create with_event_handler to expose window event on desktop

### DIFF
--- a/examples/window_focus.rs
+++ b/examples/window_focus.rs
@@ -1,0 +1,42 @@
+use dioxus::prelude::*;
+use dioxus_desktop::tao::event::WindowEvent;
+use dioxus_desktop::use_wry_event_handler;
+use dioxus_desktop::wry::application::event::Event as WryEvent;
+
+fn main() {
+    dioxus_desktop::launch(app);
+}
+
+fn app(cx: Scope) -> Element {
+    let focused = use_state(cx, || false);
+
+    use_wry_event_handler(cx, {
+        to_owned![focused];
+        move |event, _| {
+            if let WryEvent::WindowEvent {
+                event: WindowEvent::Focused(new_focused),
+                ..
+            } = event
+            {
+                focused.set(*new_focused);
+            }
+        }
+    });
+
+    cx.render(rsx! {
+        div{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            flex_direction: "column",
+            align_items: "center",
+            {
+                if *focused.get() {
+                    "This window is focused!"
+                } else {
+                    "This window is not focused!"
+                }
+            }
+        }
+    })
+}

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { version = "1.16.1", features = [
 webbrowser = "0.8.0"
 infer = "0.11.0"
 dunce = "1.0.2"
+slab = "0.4"
 
 interprocess = { version = "1.1.1", optional = true }
 futures-util = "0.3.25"

--- a/packages/desktop/src/cfg.rs
+++ b/packages/desktop/src/cfg.rs
@@ -1,7 +1,5 @@
 use std::path::PathBuf;
 
-use wry::application::event::Event;
-use wry::application::event_loop::EventLoopWindowTarget;
 use wry::application::window::Icon;
 use wry::{
     application::window::{Window, WindowBuilder},
@@ -10,18 +8,14 @@ use wry::{
     Result as WryResult,
 };
 
-use crate::desktop_context::UserWindowEvent;
-
 // pub(crate) type DynEventHandlerFn = dyn Fn(&mut EventLoop<()>, &mut WebView);
 
 /// The configuration for the desktop application.
 pub struct Config {
     pub(crate) window: WindowBuilder,
     pub(crate) file_drop_handler: Option<DropHandler>,
-    pub(crate) event_handler: Option<EventHandler>,
     pub(crate) protocols: Vec<WryProtocol>,
     pub(crate) pre_rendered: Option<String>,
-    // pub(crate) event_handler: Option<Box<DynEventHandlerFn>>,
     pub(crate) disable_context_menu: bool,
     pub(crate) resource_dir: Option<PathBuf>,
     pub(crate) custom_head: Option<String>,
@@ -30,7 +24,6 @@ pub struct Config {
 }
 
 type DropHandler = Box<dyn Fn(&Window, FileDropEvent) -> bool>;
-type EventHandler = Box<dyn Fn(&Event<UserWindowEvent>, &EventLoopWindowTarget<UserWindowEvent>)>;
 
 pub(crate) type WryProtocol = (
     String,
@@ -48,7 +41,6 @@ impl Config {
             window,
             protocols: Vec::new(),
             file_drop_handler: None,
-            event_handler: None,
             pre_rendered: None,
             disable_context_menu: !cfg!(debug_assertions),
             resource_dir: None,
@@ -81,16 +73,6 @@ impl Config {
         // gots to do a swap because the window builder only takes itself as muy self
         // I wish more people knew about returning &mut Self
         self.window = window;
-        self
-    }
-
-    /// Set a custom wry event handler. This can be used to listen to window and webview events
-    /// This only has an effect on the main window
-    pub fn with_event_handler(
-        mut self,
-        handler: impl Fn(&Event<UserWindowEvent>, &EventLoopWindowTarget<UserWindowEvent>) + 'static,
-    ) -> Self {
-        self.event_handler = Some(Box::new(handler));
         self
     }
 

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -342,9 +342,11 @@ impl WindowEventHandlers {
 
 struct WryWindowEventHandlerInner {
     window_id: WindowId,
-    handler:
-        Box<dyn FnMut(&Event<UserWindowEvent>, &EventLoopWindowTarget<UserWindowEvent>) + 'static>,
+    handler: WryEventHandlerCallback,
 }
+
+type WryEventHandlerCallback =
+    Box<dyn FnMut(&Event<UserWindowEvent>, &EventLoopWindowTarget<UserWindowEvent>) + 'static>;
 
 impl WryWindowEventHandlerInner {
     fn apply_event(
@@ -381,7 +383,7 @@ pub fn use_wry_event_handler(
         let id = desktop.create_wry_event_handler(handler);
 
         WryEventHandler {
-            handlers: desktop.event_handlers.clone(),
+            handlers: desktop.event_handlers,
             id,
         }
     })


### PR DESCRIPTION
Exposes a callback for the web view renderer to allow users to listen for web view and window events.