### PR TITLE
Drop futures when the scope that spawned them is dropped

### DIFF
--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -111,6 +111,11 @@ impl VirtualDom {
         for hook in scope.hook_list.get_mut().drain(..) {
             drop(unsafe { BumpBox::from_raw(hook) });
         }
+
+        // Drop all the futures once the hooks are dropped
+        for task_id in scope.spawned_tasks.borrow_mut().drain() {
+            scope.tasks.remove(task_id);
+        }
     }
 
     fn drop_scope_inner(&mut self, node: &VNode) {

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -319,7 +319,9 @@ impl<'src> ScopeState {
 
     /// Pushes the future onto the poll queue to be polled after the component renders.
     pub fn push_future(&self, fut: impl Future<Output = ()> + 'static) -> TaskId {
-        self.tasks.spawn(self.id, fut)
+        let id = self.tasks.spawn(self.id, fut);
+        self.spawned_tasks.borrow_mut().insert(id);
+        id
     }
 
     /// Spawns the future but does not return the [`TaskId`]
@@ -339,6 +341,8 @@ impl<'src> ScopeState {
             .sender
             .unbounded_send(SchedulerMsg::TaskNotified(id))
             .expect("Scheduler should exist");
+
+        self.spawned_tasks.borrow_mut().insert(id);
 
         id
     }


### PR DESCRIPTION
Fixes futures being polled after a scope it is spawned in is removed.

Eg:
```rust
use dioxus::prelude::*;

fn main() {
    dioxus_desktop::launch(app);
}

fn app(cx: Scope) -> Element {
    let count = if cx.generation() % 2 == 0 { 10 } else { 0 };
    if cx.generation() < 5 {
        cx.needs_update();
    }

    render! {
        (0..count).map(|_| rsx!{
            rsx!{
                Comp {}
            }
        })
    }
}

#[derive(Props)]
struct RebuildProps {}

impl PartialEq for RebuildProps {
    fn eq(&self, _: &Self) -> bool {
        false
    }
}

fn Comp(cx: Scope<RebuildProps>) -> Element {
    let id = cx.scope_id();
    cx.spawn(async move {
        loop {
            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
            println!("Hello from {id:?}");
        }
    });

    render! {
        "Hello"
    }
}
```

Should only print a few messages at most, instead it currently prints messages forever. This can also cause panics in more complex examples (https://github.com/marc2332/freya-editor)