### PR TITLE
Update guide doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
     <span> | </span>
     <a href="https://github.com/DioxusLabs/example-projects"> Examples </a>
     <span> | </span>
-    <a href="https://dioxuslabs.com/guide"> Guide </a>
+    <a href="https://dioxuslabs.com/guide/en/"> Guide </a>
     <span> | </span>
     <a href="https://github.com/DioxusLabs/dioxus/blob/master/notes/README/ZH_CN.md"> 中文 </a>
     <span> | </span>

--- a/docs/posts/release.md
+++ b/docs/posts/release.md
@@ -63,7 +63,7 @@ This very site is built with Dioxus, and the source code is available [here](htt
 
 To get started with Dioxus, check out any of the "Getting Started" guides for your platform of choice, or check out the GitHub Repository for more details.
 
-- [Getting Started with Dioxus](https://dioxuslabs.com/guide)
+- [Getting Started with Dioxus](https://dioxuslabs.com/guide/en)
 - [Getting Started with Web](https://dioxuslabs.com/reference/web)
 - [Getting Started with Desktop](https://dioxuslabs.com/reference/desktop)
 - [Getting Started with Mobile](https://dioxuslabs.com/reference/mobile)
@@ -163,7 +163,7 @@ Today, to publish a Dioxus app, you don't need NPM/WebPack/Parcel/etc. Dioxus si
 
 ## Show me more
 
-Here, we'll dive into some features of Dioxus and why it's so fun to use. The [guide](https://dioxuslabs.com/guide/) serves as a deeper and more comprehensive look at what Dioxus can do.
+Here, we'll dive into some features of Dioxus and why it's so fun to use. The [guide](https://dioxuslabs.com/guide/en/) serves as a deeper and more comprehensive look at what Dioxus can do.
 
 ## Building a new project is simple
 

--- a/docs/reference/src/README_pt-br.md
+++ b/docs/reference/src/README_pt-br.md
@@ -4,7 +4,7 @@
 
 **Dioxus** é um framework e ecossistema para desenvolver interfaces rápidas, escaláveis e robustas com a linguagem de Programação Rust. Este guia irá ajudar você a começar com o Dioxus para Web, Desktop, Móvel e mais.
 
-> Este livro é a Referência e Guias Avançados para o framework Dioxus. Para um tutorial em como de fato _usar_ o Dioxus, procure o [guia oficial](https://dioxuslabs.com/guide/).
+> Este livro é a Referência e Guias Avançados para o framework Dioxus. Para um tutorial em como de fato _usar_ o Dioxus, procure o [guia oficial](https://dioxuslabs.com/guide/en/).
 
 ## Guias e Referência
 

--- a/docs/reference/src/platforms/desktop.md
+++ b/docs/reference/src/platforms/desktop.md
@@ -42,4 +42,4 @@ To configure the webview, menubar, and other important desktop-specific features
 
 ## Future Steps
 
-Make sure to read the [Dioxus Guide](https://dioxuslabs.com/guide) if you already haven't!
+Make sure to read the [Dioxus Guide](https://dioxuslabs.com/guide/en) if you already haven't!

--- a/notes/README/ZH_CN.md
+++ b/notes/README/ZH_CN.md
@@ -40,7 +40,7 @@
     <span> | </span>
     <a href="https://github.com/DioxusLabs/example-projects"> 代码示例 </a>
     <span> | </span>
-    <a href="https://dioxuslabs.com/guide"> 开发指南 </a>
+    <a href="https://dioxuslabs.com/guide/en"> 开发指南 </a>
     <span> | </span>
     <a href="https://github.com/DioxusLabs/dioxus/blob/master/README.md"> English </a>
     <span> | </span>

--- a/packages/autofmt/README.md
+++ b/packages/autofmt/README.md
@@ -19,7 +19,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-autofmt/latest/dioxus_autofmt) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/core-macro/README.md
+++ b/packages/core-macro/README.md
@@ -19,7 +19,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-core-macro/latest/dioxus_core_macro) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -19,7 +19,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-desktop/latest/dioxus_desktop) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 
@@ -30,7 +30,7 @@
 
 This requires that webview is installed on the target system. WebView is installed by default on macOS and iOS devices, but might not come preinstalled on Windows or Linux devices. To fix these issues, follow the [instructions in the guide](guide-url).
 
-[guide-url]: https://dioxuslabs.com/guide/setup.html#platform-specific-dependencies
+[guide-url]: https://dioxuslabs.com/guide/en/setup.html#platform-specific-dependencies
 
 
 

--- a/packages/desktop/src/readme.md
+++ b/packages/desktop/src/readme.md
@@ -49,4 +49,4 @@ To configure the webview, menubar, and other important desktop-specific features
 
 ## Future Steps
 
-Make sure to read the [Dioxus Guide](https://dioxuslabs.com/guide) if you already haven't!
+Make sure to read the [Dioxus Guide](https://dioxuslabs.com/guide/en) if you already haven't!

--- a/packages/dioxus/README.md
+++ b/packages/dioxus/README.md
@@ -9,8 +9,8 @@
 
 This overview provides a brief introduction to Dioxus. For a more in-depth guide, make sure to check out:
 
-- [Getting Started](https://dioxuslabs.com/guide/setup.html)
-- [Book](https://dioxuslabs.com/guide/)
+- [Getting Started](https://dioxuslabs.com/guide/en/setup.html)
+- [Book](https://dioxuslabs.com/guide/en/)
 - [Reference](https://dioxuslabs.com/reference)
 - [Examples](https://github.com/DioxusLabs/example-projects)
 

--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -19,7 +19,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-hooks/latest/dioxus_hooks) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/html/README.md
+++ b/packages/html/README.md
@@ -19,7 +19,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-html/latest/dioxus_html) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/interpreter/README.md
+++ b/packages/interpreter/README.md
@@ -19,7 +19,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-interpreter-js/latest/dioxus_interpreter_js) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/liveview/README.md
+++ b/packages/liveview/README.md
@@ -19,7 +19,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-liveview/latest/dioxus_liveview) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/mobile/README.md
+++ b/packages/mobile/README.md
@@ -18,7 +18,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-mobile/latest/dioxus_mobile) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 
@@ -98,7 +98,7 @@ To configure the web view, menubar, and other important desktop-specific feature
 
 ## Future Steps
 
-Make sure to read the [Dioxus Guide](https://dioxuslabs.com/guide) if you already haven't!
+Make sure to read the [Dioxus Guide](https://dioxuslabs.com/guide/en) if you already haven't!
 
 
 

--- a/packages/native-core-macro/README.md
+++ b/packages/native-core-macro/README.md
@@ -18,7 +18,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-native-core-macro/latest/dioxus_native_core_macro) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/native-core/README.md
+++ b/packages/native-core/README.md
@@ -18,7 +18,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-native-core/latest/dioxus_native_core) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -18,7 +18,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-router/latest/dioxus_router) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/rsx-rosetta/README.md
+++ b/packages/rsx-rosetta/README.md
@@ -20,7 +20,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/rsx-rosetta/latest/rsx-rosetta) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/rsx/README.md
+++ b/packages/rsx/README.md
@@ -18,7 +18,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-rsx/latest/dioxus_rsx) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -18,7 +18,7 @@
 [discord-url]: https://discord.gg/XgGxMSkvUM
 
 [Website](https://dioxuslabs.com) |
-[Guides](https://dioxuslabs.com/guide/) |
+[Guides](https://dioxuslabs.com/guide/en/) |
 [API Docs](https://docs.rs/dioxus-web/latest/dioxus_web) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 

--- a/translations/pt-br/README.md
+++ b/translations/pt-br/README.md
@@ -40,7 +40,7 @@
     <span> | </span>
     <a href="https://github.com/DioxusLabs/example-projects"> Exemplos </a>
     <span> | </span>
-    <a href="https://dioxuslabs.com/guide"> Guia </a>
+    <a href="https://dioxuslabs.com/guide/pt-br"> Guia </a>
     <span> | </span>
     <a href="https://github.com/DioxusLabs/dioxus/blob/master/notes/README/ZH_CN.md"> 中文 </a>
   </h3>
@@ -83,7 +83,7 @@ Se você conhece React, então você já conhece o Dioxus.
 
 <table style="width:100%" align="center">
     <tr>
-        <th><a href="https://dioxuslabs.com/guide/">Tutorial</a></th>
+        <th><a href="https://dioxuslabs.com/guide/pt-br/">Tutorial</a></th>
         <th><a href="https://dioxuslabs.com/reference/web">Web</a></th>
         <th><a href="https://dioxuslabs.com/reference/desktop/">Desktop</a></th>
         <th><a href="https://dioxuslabs.com/reference/ssr/">SSR</a></th>
@@ -159,7 +159,7 @@ Dioxus é único no ecossistema do Rust por suportar:
 - SSR com `hydration` feito pelo Cliente
 - Suporte à aplicação Desktop
 
-Para mais informações sobre quais funções estão atualmente disponíveis e para o progresso futuro, veja [O Guia](https://dioxuslabs.com/guide/).
+Para mais informações sobre quais funções estão atualmente disponíveis e para o progresso futuro, veja [O Guia](https://dioxuslabs.com/guide/pt-br/).
 
 ## Projeto dentro do ecossistema Dioxus
 


### PR DESCRIPTION
When translate support was added it added an extra segment for the language in the url. This updates all the links to the docs to include that extra segment.

This PR is done, but it currently breaks the links: **do not merge until the docs are published as stable**