### PR TITLE
Fix duplicated work on dropping scopes

### DIFF
--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -934,7 +934,7 @@ impl<'b> VirtualDom {
         *comp.props.borrow_mut() = unsafe { std::mem::transmute(props) };
 
         // Now drop all the resouces
-        self.drop_scope(scope);
+        self.drop_scope(scope, false);
     }
 
     fn find_first_element(&self, node: &'b VNode<'b>) -> ElementId {

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -195,14 +195,6 @@ impl<'a> VNode<'a> {
             }
         }
     }
-
-    pub(crate) fn clear_listeners(&self) {
-        for attr in self.dynamic_attrs {
-            if let AttributeValue::Listener(l) = &attr.value {
-                l.borrow_mut().take();
-            }
-        }
-    }
 }
 
 /// A static layout of a UI tree that describes a set of dynamic and static nodes.

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -682,6 +682,6 @@ impl VirtualDom {
 impl Drop for VirtualDom {
     fn drop(&mut self) {
         // Simply drop this scope which drops all of its children
-        self.drop_scope(ScopeId(0));
+        self.drop_scope(ScopeId(0), true);
     }
 }


### PR DESCRIPTION
Follow up to #771 to fix some subtle bugs

1) Some rendering cases cause node id's to be reclaimed twice. Once when the scope was dropped and once when generating mutations to remove nodes (causing this failure: https://github.com/DioxusLabs/dioxus/actions/runs/3925259917/jobs/6710058694)
2) Scopes never being removed when the component that owns them is removed