### PR TITLE
fix: immediate exprs in autofmt

### DIFF
--- a/packages/autofmt/src/expr.rs
+++ b/packages/autofmt/src/expr.rs
@@ -16,11 +16,8 @@ impl Writer<'_> {
 
         // if the expr is on one line, just write it directly
         if start.line == end.line {
-            write!(
-                self.out,
-                "{}",
-                &self.src[start.line - 1][start.column - 1..end.column].trim()
-            )?;
+            let row = &self.src[start.line - 1][start.column..end.column].trim();
+            write!(self.out, "{}", row)?;
             return Ok(());
         }
 

--- a/packages/autofmt/src/lib.rs
+++ b/packages/autofmt/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::writer::*;
 use collect_macros::byte_offset;
-use dioxus_rsx::CallBody;
+use dioxus_rsx::{BodyNode, CallBody};
 use proc_macro2::LineColumn;
 use syn::{ExprMacro, MacroDelimiter};
 
@@ -105,7 +105,11 @@ pub fn fmt_file(contents: &str) -> Vec<FormattedBlock> {
         let start = byte_offset(contents, span.start()) + 1;
         let end = byte_offset(contents, span.end()) - 1;
 
-        if formatted.len() <= 80 && !formatted.contains('\n') {
+        // Rustfmt will remove the space between the macro and the opening paren if the macro is a single expression
+        let body_is_solo_expr =
+            body.roots.len() == 1 && matches!(body.roots[0], BodyNode::RawExpr(_));
+
+        if formatted.len() <= 80 && !formatted.contains('\n') && !body_is_solo_expr {
             formatted = format!(" {} ", formatted);
         }
 

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -37,5 +37,6 @@ twoway![
     long_exprs,
     ifchain_forloop,
     t2,
-    reallylong
+    reallylong,
+    immediate_expr
 ];

--- a/packages/autofmt/tests/samples/immediate_expr.rsx
+++ b/packages/autofmt/tests/samples/immediate_expr.rsx
@@ -1,0 +1,4 @@
+fn it_works() {
+    cx.render(rsx!(()))
+}
+


### PR DESCRIPTION
The alignment for rendering short exprs was off. This fixes that.