### PR TITLE
Stable Docs Workflow

### DIFF
--- a/.github/workflows/docs stable.yml
+++ b/.github/workflows/docs stable.yml
@@ -1,0 +1,37 @@
+name: docs stable
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    environment: docs
+    steps:
+
+      # NOTE: Comment out when https://github.com/rust-lang/mdBook/pull/1306 is merged and released
+      # - name: Setup mdBook
+      #   uses: peaceiris/actions-mdbook@v1
+      #   with:
+      #     mdbook-version: "0.4.10"
+
+      # NOTE: Delete when the previous one is enabled
+      - name: Setup mdBook
+        run: |
+          cargo install mdbook --git https://github.com/Demonthos/mdBook.git --branch master
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: cd docs &&
+          cd guide && mdbook build -d ../nightly/guide && cd .. &&
+          cd router && mdbook build -d ../nightly/router  && cd ..
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: docs/nightly # The folder the action should deploy.
+          target-folder: docs
+          repository-name: dioxuslabs/docsite
+          clean: false
+          token: ${{ secrets.DEPLOY_KEY }} # let's pretend I don't need it for now


### PR DESCRIPTION
Creates a manually triggered workflow to publish the docs on the stable directory instead of nightly