### PR TITLE
Fix replacing a dynamic text node in native core

### DIFF
--- a/packages/native-core/src/real_dom.rs
+++ b/packages/native-core/src/real_dom.rs
@@ -195,8 +195,7 @@ impl<S: State<V>, V: FromAnyValue> RealDom<S, V> {
                         text: value.to_string(),
                     });
                     let node_id = self.create_node(node);
-                    let node = self.tree.get_mut(node_id).unwrap();
-                    node.node_data.element_id = Some(id);
+                    self.set_element_id(node_id, id);
                     self.stack.push(node_id);
                     mark_dirty(node_id, NodeMask::new().with_text(), &mut nodes_updated);
                 }


### PR DESCRIPTION
This fixes dynamic text nodes not adding their ids to the element id -> node id mapping causing replacing dynamic text nodes to fail

This fixes a bug encountered in #788 