### PR TITLE
do not box scope states

### DIFF
--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4.17"
 # Serialize the Edits for use in Webview/Liveview instances
 serde = { version = "1", features = ["derive"], optional = true }
 
-bumpslab = { git = "https://github.com/demonthos/bumpslab", branch = "reduce-unsafe"}
+bumpslab = { git = "https://github.com/jkelleyrtp/bumpslab" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4.17"
 # Serialize the Edits for use in Webview/Liveview instances
 serde = { version = "1", features = ["derive"], optional = true }
 
-bumpslab = { git = "https://github.com/jkelleyrtp/bumpslab" }
+bumpslab = { git = "https://github.com/demonthos/bumpslab", branch = "reduce-unsafe"}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4.17"
 # Serialize the Edits for use in Webview/Liveview instances
 serde = { version = "1", features = ["derive"], optional = true }
 
-bumpslab = "0.1.0"
+bumpslab = { git = "https://github.com/jkelleyrtp/bumpslab" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -37,6 +37,8 @@ log = "0.4.17"
 # Serialize the Edits for use in Webview/Liveview instances
 serde = { version = "1", features = ["derive"], optional = true }
 
+bumpslab = "0.1.0"
+
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 dioxus = { path = "../dioxus" }

--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -92,21 +92,21 @@ impl VirtualDom {
     // Note: This will not remove any ids from the arena
     pub(crate) fn drop_scope(&mut self, id: ScopeId, recursive: bool) {
         self.dirty_scopes.remove(&DirtyScope {
-            height: self.scopes[id.0].height,
+            height: self.scopes[id].height,
             id,
         });
 
         self.ensure_drop_safety(id);
 
         if recursive {
-            if let Some(root) = self.scopes[id.0].try_root_node() {
+            if let Some(root) = self.scopes[id].try_root_node() {
                 if let RenderReturn::Ready(node) = unsafe { root.extend_lifetime_ref() } {
                     self.drop_scope_inner(node)
                 }
             }
         }
 
-        let scope = &mut self.scopes[id.0];
+        let scope = &mut self.scopes[id];
 
         // Drop all the hooks once the children are dropped
         // this means we'll drop hooks bottom-up
@@ -119,7 +119,7 @@ impl VirtualDom {
             scope.tasks.remove(task_id);
         }
 
-        self.scopes.remove(id.0);
+        self.scopes.remove(id);
     }
 
     fn drop_scope_inner(&mut self, node: &VNode) {
@@ -140,7 +140,7 @@ impl VirtualDom {
 
     /// Descend through the tree, removing any borrowed props and listeners
     pub(crate) fn ensure_drop_safety(&self, scope_id: ScopeId) {
-        let scope = &self.scopes[scope_id.0];
+        let scope = &self.scopes[scope_id];
 
         // make sure we drop all borrowed props manually to guarantee that their drop implementation is called before we
         // run the hooks (which hold an &mut Reference)

--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -99,7 +99,7 @@ impl VirtualDom {
         self.ensure_drop_safety(id);
 
         if recursive {
-            if let Some(root) = self.scopes[id.0].as_ref().try_root_node() {
+            if let Some(root) = self.scopes[id.0].try_root_node() {
                 if let RenderReturn::Ready(node) = unsafe { root.extend_lifetime_ref() } {
                     self.drop_scope_inner(node)
                 }

--- a/packages/core/src/create.rs
+++ b/packages/core/src/create.rs
@@ -535,7 +535,7 @@ impl<'b> VirtualDom {
         }
 
         // If running the scope has collected some leaves and *this* component is a boundary, then handle the suspense
-        let boundary = match self.scopes[scope.0].has_context::<Rc<SuspenseContext>>() {
+        let boundary = match self.scopes[scope].has_context::<Rc<SuspenseContext>>() {
             Some(boundary) => boundary,
             _ => return created,
         };
@@ -544,7 +544,7 @@ impl<'b> VirtualDom {
         let new_id = self.next_element(new, parent.template.get().node_paths[idx]);
 
         // Now connect everything to the boundary
-        self.scopes[scope.0].placeholder.set(Some(new_id));
+        self.scopes[scope].placeholder.set(Some(new_id));
 
         // This involves breaking off the mutations to this point, and then creating a new placeholder for the boundary
         // Note that we break off dynamic mutations only - since static mutations aren't rendered immediately
@@ -583,7 +583,7 @@ impl<'b> VirtualDom {
         let new_id = self.next_element(template, template.template.get().node_paths[idx]);
 
         // Set the placeholder of the scope
-        self.scopes[scope.0].placeholder.set(Some(new_id));
+        self.scopes[scope].placeholder.set(Some(new_id));
 
         // Since the placeholder is already in the DOM, we don't create any new nodes
         self.mutations.push(AssignId {

--- a/packages/core/src/scheduler/wait.rs
+++ b/packages/core/src/scheduler/wait.rs
@@ -31,7 +31,7 @@ impl VirtualDom {
         // If the task completes...
         if task.task.borrow_mut().as_mut().poll(&mut cx).is_ready() {
             // Remove it from the scope so we dont try to double drop it when the scope dropes
-            let scope = &self.scopes[task.scope.0];
+            let scope = &self.scopes[task.scope];
             scope.spawned_tasks.borrow_mut().remove(&id);
 
             // Remove it from the scheduler
@@ -40,7 +40,7 @@ impl VirtualDom {
     }
 
     pub(crate) fn acquire_suspense_boundary(&self, id: ScopeId) -> Rc<SuspenseContext> {
-        self.scopes[id.0]
+        self.scopes[id]
             .consume_context::<Rc<SuspenseContext>>()
             .unwrap()
     }
@@ -64,7 +64,7 @@ impl VirtualDom {
         if let Poll::Ready(new_nodes) = as_pinned_mut.poll_unpin(&mut cx) {
             let fiber = self.acquire_suspense_boundary(leaf.scope_id);
 
-            let scope = &self.scopes[scope_id.0];
+            let scope = &self.scopes[scope_id];
             let arena = scope.current_frame();
 
             let ret = arena.bump().alloc(match new_nodes {

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -26,7 +26,7 @@ impl VirtualDom {
         let height = unsafe { parent.map(|f| (*f).height + 1).unwrap_or(0) };
         let id = ScopeId(entry.key());
 
-        entry.insert(Box::new(ScopeState {
+        entry.insert(ScopeState {
             parent,
             id,
             height,
@@ -44,13 +44,13 @@ impl VirtualDom {
             shared_contexts: Default::default(),
             borrowed_props: Default::default(),
             attributes_to_drop: Default::default(),
-        }))
+        })
     }
 
     fn acquire_current_scope_raw(&self) -> Option<*const ScopeState> {
         let id = self.scope_stack.last().copied()?;
         let scope = self.scopes.get(id.0)?;
-        Some(scope.as_ref())
+        Some(scope)
     }
 
     pub(crate) fn run_scope(&mut self, scope_id: ScopeId) -> &RenderReturn {

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -49,7 +49,7 @@ impl VirtualDom {
 
     fn acquire_current_scope_raw(&self) -> Option<*const ScopeState> {
         let id = self.scope_stack.last().copied()?;
-        let scope = self.scopes.get(id.0)?;
+        let scope = self.scopes.get(id)?;
         Some(scope)
     }
 
@@ -60,9 +60,9 @@ impl VirtualDom {
         self.ensure_drop_safety(scope_id);
 
         let mut new_nodes = unsafe {
-            self.scopes[scope_id.0].previous_frame().bump_mut().reset();
+            self.scopes[scope_id].previous_frame().bump_mut().reset();
 
-            let scope = &self.scopes[scope_id.0];
+            let scope = &self.scopes[scope_id];
 
             scope.hook_idx.set(0);
 
@@ -127,7 +127,7 @@ impl VirtualDom {
             }
         };
 
-        let scope = &self.scopes[scope_id.0];
+        let scope = &self.scopes[scope_id];
 
         // We write on top of the previous frame and then make it the current by pushing the generation forward
         let frame = scope.previous_frame();

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -24,7 +24,7 @@ impl VirtualDom {
         let parent = self.acquire_current_scope_raw();
         let entry = self.scopes.vacant_entry();
         let height = unsafe { parent.map(|f| (*f).height + 1).unwrap_or(0) };
-        let id = ScopeId(entry.key());
+        let id = entry.key();
 
         entry.insert(ScopeState {
             parent,

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -73,6 +73,15 @@ pub(crate) struct ScopeSlab {
     entries: Slab<Slot<'static, ScopeState>>,
 }
 
+impl Drop for ScopeSlab {
+    fn drop(&mut self) {
+        // Bump slab doesn't drop its contents, so we need to do it manually
+        for slot in self.entries.drain() {
+            self.slab.remove(slot);
+        }
+    }
+}
+
 impl Default for ScopeSlab {
     fn default() -> Self {
         Self {

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -129,8 +129,8 @@ pub(crate) struct ScopeSlabEntry<'a> {
 }
 
 impl<'a> ScopeSlabEntry<'a> {
-    pub(crate) fn key(&self) -> usize {
-        self.entry.key()
+    pub(crate) fn key(&self) -> ScopeId {
+        ScopeId(self.entry.key())
     }
 
     pub(crate) fn insert(self, scope: ScopeState) -> &'a ScopeState {

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -10,12 +10,15 @@ use crate::{
     AnyValue, Attribute, AttributeValue, Element, Event, Properties, TaskId,
 };
 use bumpalo::{boxed::Box as BumpBox, Bump};
+use bumpslab::{BumpSlab, Slot};
 use rustc_hash::{FxHashMap, FxHashSet};
+use slab::{Slab, VacantEntry};
 use std::{
     any::{Any, TypeId},
     cell::{Cell, RefCell},
     fmt::{Arguments, Debug},
     future::Future,
+    ops::{Index, IndexMut},
     rc::Rc,
     sync::Arc,
 };
@@ -62,6 +65,86 @@ impl<'a, T> std::ops::Deref for Scoped<'a, T> {
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, PartialOrd, Ord)]
 pub struct ScopeId(pub usize);
+
+/// A thin wrapper around a BumpSlab that uses ids to index into the slab.
+pub(crate) struct ScopeSlab {
+    slab: BumpSlab<ScopeState>,
+    // a slab of slots of stable pointers to the ScopeState in the bump slab
+    entries: Slab<Slot<'static, ScopeState>>,
+}
+
+impl Default for ScopeSlab {
+    fn default() -> Self {
+        Self {
+            slab: BumpSlab::new(),
+            entries: Slab::new(),
+        }
+    }
+}
+
+impl ScopeSlab {
+    pub(crate) fn get(&self, id: ScopeId) -> Option<&ScopeState> {
+        self.entries.get(id.0).map(|slot| unsafe { &*slot.ptr() })
+    }
+
+    pub(crate) fn get_mut(&mut self, id: ScopeId) -> Option<&mut ScopeState> {
+        self.entries
+            .get(id.0)
+            .map(|slot| unsafe { &mut *slot.ptr_mut() })
+    }
+
+    pub(crate) fn vacant_entry(&mut self) -> ScopeSlabEntry {
+        let entry = self.entries.vacant_entry();
+        ScopeSlabEntry {
+            slab: &mut self.slab,
+            entry,
+        }
+    }
+
+    pub(crate) fn remove(&mut self, id: ScopeId) {
+        self.slab.remove(self.entries.remove(id.0));
+    }
+
+    pub(crate) fn contains(&self, id: ScopeId) -> bool {
+        self.entries.contains(id.0)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &ScopeState> {
+        self.entries.iter().map(|(_, slot)| unsafe { &*slot.ptr() })
+    }
+}
+
+pub(crate) struct ScopeSlabEntry<'a> {
+    slab: &'a mut BumpSlab<ScopeState>,
+    entry: VacantEntry<'a, Slot<'static, ScopeState>>,
+}
+
+impl<'a> ScopeSlabEntry<'a> {
+    pub(crate) fn key(&self) -> usize {
+        self.entry.key()
+    }
+
+    pub(crate) fn insert(self, scope: ScopeState) -> &'a ScopeState {
+        let slot = self.slab.push(scope);
+        // this is safe because the slot is only ever accessed with the lifetime of the borrow of the slab
+        let slot = unsafe { std::mem::transmute(slot) };
+        let entry = self.entry.insert(slot);
+        unsafe { &*entry.ptr() }
+    }
+}
+
+impl Index<ScopeId> for ScopeSlab {
+    type Output = ScopeState;
+    fn index(&self, id: ScopeId) -> &Self::Output {
+        self.get(id).unwrap()
+    }
+}
+
+impl IndexMut<ScopeId> for ScopeSlab {
+    fn index_mut(&mut self, id: ScopeId) -> &mut Self::Output {
+        self.get_mut(id).unwrap()
+    }
+}
 
 /// A component's state separate from its props.
 ///

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -177,7 +177,7 @@ use std::{any::Any, borrow::BorrowMut, cell::Cell, collections::BTreeSet, future
 pub struct VirtualDom {
     // Maps a template path to a map of byteindexes to templates
     pub(crate) templates: FxHashMap<TemplateId, FxHashMap<usize, Template<'static>>>,
-    pub(crate) scopes: Slab<Box<ScopeState>>,
+    pub(crate) scopes: Slab<ScopeState>,
     pub(crate) dirty_scopes: BTreeSet<DirtyScope>,
     pub(crate) scheduler: Rc<Scheduler>,
 
@@ -291,7 +291,7 @@ impl VirtualDom {
     ///
     /// This is useful for inserting or removing contexts from a scope, or rendering out its root node
     pub fn get_scope(&self, id: ScopeId) -> Option<&ScopeState> {
-        self.scopes.get(id.0).map(|f| f.as_ref())
+        self.scopes.get(id.0)
     }
 
     /// Get the single scope at the top of the VirtualDom tree that will always be around


### PR DESCRIPTION
Scope states are currently individually boxed which causes each scope state to create a new memory allocation when created and deallocation when removed. If this box is removed, the Vec backing the slab will often have memory pre-allocated that can be used instead of calling the global allocator. 

This is especially useful any time scopes are created and then destroyed. For example this benchmark is ~15% without boxing scope states:
```rust
use criterion::{criterion_group, criterion_main, Criterion};
use dioxus::prelude::*;
use rand::prelude::*;

criterion_group!(mbenches, create_rows);
criterion_main!(mbenches);

fn create_rows(c: &mut Criterion) {
    fn app(cx: Scope) -> Element {
        let num = if cx.generation() % 2 == 0 { 10_000 } else { 0 };
        render!(
            table {
                tbody {
                    (0..num).map(|f| {
                        let label = Label(["hello world", "this is a test", "testing"]);
                        rsx!( Row { row_id: f, label: label } )
                    })
                }
            }
        )
    }

    c.bench_function("create rows", |b| {
        let mut dom = VirtualDom::new(app);
        let _ = dom.rebuild();

        b.iter(|| {
            // let g = dom.rebuild();
            let g = dom.mark_dirty(ScopeId(0));
            dom.render_immediate();
            // assert!(g.edits.len() > 1);
        })
    });
}

#[derive(PartialEq, Props)]
struct RowProps {
    row_id: usize,
    label: Label,
}
fn Row(cx: Scope<RowProps>) -> Element {
    let [adj, col, noun] = cx.props.label.0;
    cx.render(rsx! {
        tr {
            td { class:"col-md-1", "{cx.props.row_id}" }
            td { class:"col-md-1", onclick: move |_| { /* run onselect */ },
                a { class: "lbl", "{adj}" "{col}" "{noun}" }
            }
            td { class: "col-md-1",
                a { class: "remove", onclick: move |_| {/* remove */},
                    span { class: "glyphicon glyphicon-remove remove", aria_hidden: "true" }
                }
            }
            td { class: "col-md-6" }
        }
    })
}

#[derive(PartialEq)]
struct Label([&'static str; 3]);
```