### PR TITLE
Fix Clippy warnings in core

### DIFF
--- a/docs/guide/examples/hello_world_liveview.rs
+++ b/docs/guide/examples/hello_world_liveview.rs
@@ -39,7 +39,7 @@ async fn main() {
             }),
         );
 
-    println!("Listening on http://{}", addr);
+    println!("Listening on http://{addr}");
 
     axum::Server::bind(&addr.to_string().parse().unwrap())
         .serve(app.into_make_service())

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -82,7 +82,7 @@ fn app(cx: Scope) -> Element {
                                     onclick: move |_| {
                                         let temp = calc_val(val.as_str());
                                         if temp > 0.0 {
-                                            val.set(format!("-{}", temp));
+                                            val.set(format!("-{temp}"));
                                         } else {
                                             val.set(format!("{}", temp.abs()));
                                         }

--- a/examples/callback.rs
+++ b/examples/callback.rs
@@ -13,7 +13,7 @@ fn app(cx: Scope) -> Element {
             .await
             .unwrap();
 
-        println!("{:#?}, ", res);
+        println!("{res:#?}, ");
     });
 
     cx.render(rsx! {

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -18,7 +18,7 @@ fn app(cx: Scope) -> Element {
         loop {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             count += 1;
-            println!("current: {}", count);
+            println!("current: {count}");
         }
     });
 

--- a/examples/dog_app.rs
+++ b/examples/dog_app.rs
@@ -52,7 +52,7 @@ struct DogApi {
 #[inline_props]
 async fn breed_pic(cx: Scope, breed: String) -> Element {
     let fut = use_future!(cx, |breed| async move {
-        reqwest::get(format!("https://dog.ceo/api/breed/{}/images/random", breed))
+        reqwest::get(format!("https://dog.ceo/api/breed/{breed}/images/random"))
             .await
             .unwrap()
             .json::<DogApi>()

--- a/examples/file_explorer.rs
+++ b/examples/file_explorer.rs
@@ -89,7 +89,7 @@ impl Files {
         let paths = match std::fs::read_dir(cur_path) {
             Ok(e) => e,
             Err(err) => {
-                let err = format!("An error occured: {:?}", err);
+                let err = format!("An error occured: {err:?}");
                 self.err = Some(err);
                 self.path_stack.pop();
                 return;

--- a/examples/filedragdrop.rs
+++ b/examples/filedragdrop.rs
@@ -3,7 +3,7 @@ use dioxus_desktop::Config;
 
 fn main() {
     let cfg = Config::new().with_file_drop_handler(|_w, e| {
-        println!("{:?}", e);
+        println!("{e:?}");
         true
     });
 

--- a/examples/inputs.rs
+++ b/examples/inputs.rs
@@ -42,7 +42,7 @@ fn app(cx: Scope) -> Element {
                 // so the value of our input event will be either huey, dewey, louie, or true/false (because of the checkboxe)
                 // be mindful in grouping inputs together, as they will all be handled by the same event handler
                 oninput: move |evt| {
-                    println!("{:?}", evt);
+                    println!("{evt:?}");
                 },
                 div {
                     input {
@@ -104,7 +104,7 @@ fn app(cx: Scope) -> Element {
                     name: "pdf",
                     r#type: "checkbox",
                     oninput: move |evt| {
-                        println!("{:?}", evt);
+                        println!("{evt:?}");
                     },
                 }
                 label {
@@ -121,7 +121,7 @@ fn app(cx: Scope) -> Element {
                         r#type: "{field}",
                         value: "{value}",
                         oninput: move |evt: FormEvent| {
-                            println!("{:?}", evt);
+                            println!("{evt:?}");
                         },
                     }
                     label {

--- a/examples/rsx_usage.rs
+++ b/examples/rsx_usage.rs
@@ -83,7 +83,7 @@ fn app(cx: Scope) -> Element {
                 div {
                     class: {
                         const WORD: &str = "expressions";
-                        format_args!("Arguments can be passed in through curly braces for complex {}", WORD)
+                        format_args!("Arguments can be passed in through curly braces for complex {WORD}")
                     }
                 }
             }
@@ -214,7 +214,7 @@ fn app(cx: Scope) -> Element {
 }
 
 fn format_dollars(dollars: u32, cents: u32) -> String {
-    format!("${}.{:02}", dollars, cents)
+    format!("${dollars}.{cents:02}")
 }
 
 fn helper<'a>(cx: &'a ScopeState, text: &str) -> Element<'a> {

--- a/examples/ssr.rs
+++ b/examples/ssr.rs
@@ -27,7 +27,7 @@ fn main() {
     let mut file = String::new();
     let mut renderer = dioxus_ssr::Renderer::default();
     renderer.render_to(&mut file, &vdom).unwrap();
-    println!("{}", file);
+    println!("{file}");
 }
 
 fn app(cx: Scope) -> Element {

--- a/examples/textarea.rs
+++ b/examples/textarea.rs
@@ -9,7 +9,7 @@ fn main() {
 fn app(cx: Scope) -> Element {
     let model = use_state(cx, || String::from("asd"));
 
-    println!("{}", model);
+    println!("{model}");
 
     cx.render(rsx! {
         textarea {

--- a/packages/autofmt/src/component.rs
+++ b/packages/autofmt/src/component.rs
@@ -140,7 +140,7 @@ impl Writer<'_> {
             let mut written = generics.to_token_stream().to_string();
             written.retain(|c| !c.is_whitespace());
 
-            write!(self.out, "{}", written)?;
+            write!(self.out, "{written}")?;
         }
 
         write!(self.out, " {{")?;
@@ -165,7 +165,7 @@ impl Writer<'_> {
             match &field.content {
                 ContentField::ManExpr(exp) => {
                     let out = prettyplease::unparse_expr(exp);
-                    write!(self.out, "{}: {}", name, out)?;
+                    write!(self.out, "{name}: {out}")?;
                 }
                 ContentField::Formatted(s) => {
                     write!(
@@ -179,11 +179,11 @@ impl Writer<'_> {
                     let out = prettyplease::unparse_expr(exp);
                     let mut lines = out.split('\n').peekable();
                     let first = lines.next().unwrap();
-                    write!(self.out, "{}: {}", name, first)?;
+                    write!(self.out, "{name}: {first}")?;
                     for line in lines {
                         self.out.new_line()?;
                         self.out.indented_tab()?;
-                        write!(self.out, "{}", line)?;
+                        write!(self.out, "{line}")?;
                     }
                 }
             }

--- a/packages/autofmt/src/element.rs
+++ b/packages/autofmt/src/element.rs
@@ -224,7 +224,7 @@ impl Writer<'_> {
             }
             ElementAttr::AttrExpression { name, value } => {
                 let out = prettyplease::unparse_expr(value);
-                write!(self.out, "{}: {}", name, out)?;
+                write!(self.out, "{name}: {out}")?;
             }
 
             ElementAttr::CustomAttrText { name, value } => {
@@ -250,13 +250,13 @@ impl Writer<'_> {
                 // a one-liner for whatever reason
                 // Does not need a new line
                 if lines.peek().is_none() {
-                    write!(self.out, "{}: {}", name, first)?;
+                    write!(self.out, "{name}: {first}")?;
                 } else {
-                    writeln!(self.out, "{}: {}", name, first)?;
+                    writeln!(self.out, "{name}: {first}")?;
 
                     while let Some(line) = lines.next() {
                         self.out.indented_tab()?;
-                        write!(self.out, "{}", line)?;
+                        write!(self.out, "{line}")?;
                         if lines.peek().is_none() {
                             write!(self.out, "")?;
                         } else {

--- a/packages/autofmt/src/expr.rs
+++ b/packages/autofmt/src/expr.rs
@@ -20,7 +20,7 @@ impl Writer<'_> {
             let start = byte_offset(self.raw_src, start);
             let end = byte_offset(self.raw_src, end);
             let row = self.raw_src[start..end].trim();
-            write!(self.out, "{}", row)?;
+            write!(self.out, "{row}")?;
             return Ok(());
         }
 
@@ -56,11 +56,11 @@ impl Writer<'_> {
                     write!(self.out, " ")?;
                 }
 
-                write!(self.out, "{}", line)?;
+                write!(self.out, "{line}")?;
             } else {
                 let offset = offset as usize;
                 let right = &line[offset..];
-                write!(self.out, "{}", right)?;
+                write!(self.out, "{right}")?;
             }
         }
 

--- a/packages/autofmt/src/lib.rs
+++ b/packages/autofmt/src/lib.rs
@@ -102,7 +102,7 @@ pub fn fmt_file(contents: &str) -> Vec<FormattedBlock> {
             && matches!(body.roots[0], BodyNode::RawExpr(_) | BodyNode::Text(_));
 
         if formatted.len() <= 80 && !formatted.contains('\n') && !body_is_solo_expr {
-            formatted = format!(" {} ", formatted);
+            formatted = format!(" {formatted} ");
         }
 
         end_span = span.end();

--- a/packages/core-macro/src/inlineprops.rs
+++ b/packages/core-macro/src/inlineprops.rs
@@ -95,7 +95,7 @@ impl ToTokens for InlinePropsBody {
             quote! { #vis #f }
         });
 
-        let struct_name = Ident::new(&format!("{}Props", ident), Span::call_site());
+        let struct_name = Ident::new(&format!("{ident}Props"), Span::call_site());
 
         let field_names = inputs.iter().filter_map(|f| match f {
             FnArg::Receiver(_) => todo!(),

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -323,7 +323,7 @@ mod field_info {
                                 let tokenized_code = TokenStream::from_str(&code.value())?;
                                 self.default = Some(
                                     syn::parse(tokenized_code.into())
-                                        .map_err(|e| Error::new_spanned(code, format!("{}", e)))?,
+                                        .map_err(|e| Error::new_spanned(code, format!("{e}")))?,
                                 );
                             } else {
                                 return Err(Error::new_spanned(assign.right, "Expected string"));
@@ -332,7 +332,7 @@ mod field_info {
                         }
                         _ => Err(Error::new_spanned(
                             &assign,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }
@@ -503,11 +503,11 @@ mod struct_info {
                 builder_attr,
                 builder_name: syn::Ident::new(&builder_name, proc_macro2::Span::call_site()),
                 conversion_helper_trait_name: syn::Ident::new(
-                    &format!("{}_Optional", builder_name),
+                    &format!("{builder_name}_Optional"),
                     proc_macro2::Span::call_site(),
                 ),
                 core: syn::Ident::new(
-                    &format!("{}_core", builder_name),
+                    &format!("{builder_name}_core"),
                     proc_macro2::Span::call_site(),
                 ),
             })
@@ -594,7 +594,6 @@ Finally, call `.build()` to create the instance of `{name}`.
                     None => {
                         let doc = format!(
                         "Builder for [`{name}`] instances.\n\nSee [`{name}::builder()`] for more info.",
-                        name = name
                     );
                         quote!(#[doc = #doc])
                     }
@@ -709,9 +708,9 @@ Finally, call `.build()` to create the instance of `{name}`.
             });
             let reconstructing = self.included_fields().map(|f| f.name);
 
-            let &FieldInfo {
-                name: ref field_name,
-                ty: ref field_type,
+            let FieldInfo {
+                name: field_name,
+                ty: field_type,
                 ..
             } = field;
             let mut ty_generics: Vec<syn::GenericArgument> = self
@@ -810,7 +809,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                 ),
                 proc_macro2::Span::call_site(),
             );
-            let repeated_fields_error_message = format!("Repeated field {}", field_name);
+            let repeated_fields_error_message = format!("Repeated field {field_name}");
 
             Ok(quote! {
                 #[allow(dead_code, non_camel_case_types, missing_docs)]
@@ -929,7 +928,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                 ),
                 proc_macro2::Span::call_site(),
             );
-            let early_build_error_message = format!("Missing required field {}", field_name);
+            let early_build_error_message = format!("Missing required field {field_name}");
 
             Ok(quote! {
                 #[doc(hidden)]
@@ -1037,7 +1036,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                         // I’d prefer “a” or “an” to “its”, but determining which is grammatically
                         // correct is roughly impossible.
                         let doc =
-                            format!("Finalise the builder and create its [`{}`] instance", name);
+                            format!("Finalise the builder and create its [`{name}`] instance");
                         quote!(#[doc = #doc])
                     }
                 }
@@ -1132,7 +1131,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                         }
                         _ => Err(Error::new_spanned(
                             &assign,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }
@@ -1146,7 +1145,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                         }
                         _ => Err(Error::new_spanned(
                             &path,
-                            format!("Unknown parameter {:?}", name),
+                            format!("Unknown parameter {name:?}"),
                         )),
                     }
                 }
@@ -1161,7 +1160,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                         let call_func = quote!(#call_func);
                         Error::new_spanned(
                             &call.func,
-                            format!("Illegal builder setting group {}", call_func),
+                            format!("Illegal builder setting group {call_func}"),
                         )
                     })?;
                     match subsetting_name.as_str() {
@@ -1173,7 +1172,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                         }
                         _ => Err(Error::new_spanned(
                             &call.func,
-                            format!("Illegal builder setting group name {}", subsetting_name),
+                            format!("Illegal builder setting group name {subsetting_name}"),
                         )),
                     }
                 }

--- a/packages/core-macro/tests/ifmt.rs
+++ b/packages/core-macro/tests/ifmt.rs
@@ -8,11 +8,11 @@ fn formatting_compiles() {
     // escape sequences work
     assert_eq!(
         format_args_f!("{x:?} {{}}}}").to_string(),
-        format!("{:?} {{}}}}", x)
+        format!("{x:?} {{}}}}")
     );
     assert_eq!(
         format_args_f!("{{{{}} {x:?}").to_string(),
-        format!("{{{{}} {:?}", x)
+        format!("{{{{}} {x:?}")
     );
 
     // paths in formating works
@@ -27,6 +27,6 @@ fn formatting_compiles() {
     // allows duplicate format args
     assert_eq!(
         format_args_f!("{x:?} {x:?}").to_string(),
-        format!("{:?} {:?}", x, x)
+        format!("{x:?} {x:?}")
     );
 }

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -757,15 +757,21 @@ impl<'a, 'b> IntoDynNode<'a> for LazyNodes<'a, 'b> {
     }
 }
 
-impl<'a> IntoDynNode<'_> for &'a str {
-    fn into_vnode(self, cx: &ScopeState) -> DynamicNode {
-        cx.text_node(format_args!("{}", self))
+impl<'a, 'b> IntoDynNode<'b> for &'a str {
+    fn into_vnode(self, cx: &'b ScopeState) -> DynamicNode<'b> {
+        DynamicNode::Text(VText {
+            value: bumpalo::collections::String::from_str_in(self, cx.bump()).into_bump_str(),
+            id: Default::default(),
+        })
     }
 }
 
 impl IntoDynNode<'_> for String {
     fn into_vnode(self, cx: &ScopeState) -> DynamicNode {
-        cx.text_node(format_args!("{}", self))
+        DynamicNode::Text(VText {
+            value: cx.bump().alloc(self),
+            id: Default::default(),
+        })
     }
 }
 

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -207,13 +207,12 @@ impl DesktopContext {
                     "method":"eval_result",
                     "params": (
                         function(){{
-                            {}
+                            {code}
                         }}
                     )()
                 }})
             );
-            "#,
-            code
+            "#
         );
 
         if let Err(e) = self.webview.evaluate_script(&script) {

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -326,5 +326,5 @@ fn send_edits(edits: Mutations, webview: &WebView) {
     let serialized = serde_json::to_string(&edits).unwrap();
 
     // todo: use SSE and binary data to send the edits with lower overhead
-    _ = webview.evaluate_script(&format!("window.interpreter.handleEdits({})", serialized));
+    _ = webview.evaluate_script(&format!("window.interpreter.handleEdits({serialized})"));
 }

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -11,15 +11,14 @@ fn module_loader(root_name: &str) -> String {
 <script>
     {INTERPRETER_JS}
 
-    let rootname = "{}";
+    let rootname = "{root_name}";
     let root = window.document.getElementById(rootname);
     if (root != null) {{
         window.interpreter = new Interpreter(root);
         window.ipc.postMessage(serializeIpcMessage("initialize"));
     }}
 </script>
-"#,
-        root_name
+"#
     )
 }
 

--- a/packages/hooks/src/usecoroutine.rs
+++ b/packages/hooks/src/usecoroutine.rs
@@ -120,7 +120,7 @@ mod tests {
     fn app(cx: Scope, name: String) -> Element {
         let task = use_coroutine(cx, |mut rx: UnboundedReceiver<i32>| async move {
             while let Some(msg) = rx.next().await {
-                println!("got message: {}", msg);
+                println!("got message: {msg}");
             }
         });
 
@@ -133,7 +133,7 @@ mod tests {
 
     async fn view_task(mut rx: UnboundedReceiver<i32>) {
         while let Some(msg) = rx.next().await {
-            println!("got message: {}", msg);
+            println!("got message: {msg}");
         }
     }
 

--- a/packages/html/src/render_template.rs
+++ b/packages/html/src/render_template.rs
@@ -25,7 +25,7 @@ fn render_template_node(node: &TemplateNode, out: &mut String) -> std::fmt::Resu
             write!(out, "<{tag}")?;
             for attr in *attrs {
                 if let TemplateAttribute::Static { name, value, .. } = attr {
-                    write!(out, "{}=\"{}\"", name, value)?;
+                    write!(out, "{name}=\"{value}\"")?;
                 }
             }
             for child in *children {

--- a/packages/liveview/examples/axum.rs
+++ b/packages/liveview/examples/axum.rs
@@ -46,7 +46,7 @@ async fn main() {
             }),
         );
 
-    println!("Listening on http://{}", addr);
+    println!("Listening on http://{addr}");
 
     axum::Server::bind(&addr.to_string().parse().unwrap())
         .serve(app.into_make_service())

--- a/packages/native-core-macro/src/lib.rs
+++ b/packages/native-core-macro/src/lib.rs
@@ -311,7 +311,7 @@ impl Parse for Dependency {
                 input
                     .parse::<Ident>()
                     .ok()
-                    .filter(|i: &Ident| format!("{}", i) != "NONE")
+                    .filter(|i: &Ident| i != "NONE")
                     .map(|i| vec![i])
             })
             .unwrap_or_default();

--- a/packages/native-core/src/passes.rs
+++ b/packages/native-core/src/passes.rs
@@ -151,10 +151,10 @@ pub trait Pass {
 }
 
 pub trait UpwardPass<T>: Pass {
-    fn pass<'a>(
+    fn pass(
         &self,
         node: &mut T,
-        children: &mut dyn Iterator<Item = &'a mut T>,
+        children: &mut dyn Iterator<Item = &mut T>,
         ctx: &SendAnyMap,
     ) -> PassReturn;
 }
@@ -764,10 +764,10 @@ fn up_pass() {
         }
     }
     impl UpwardPass<i32> for AddPass {
-        fn pass<'a>(
+        fn pass(
             &self,
             node: &mut i32,
-            children: &mut dyn Iterator<Item = &'a mut i32>,
+            children: &mut dyn Iterator<Item = &mut i32>,
             _: &SendAnyMap,
         ) -> PassReturn {
             *node += children.map(|i| *i).sum::<i32>();
@@ -830,10 +830,10 @@ fn dependant_up_pass() {
         }
     }
     impl UpwardPass<i32> for AddPass {
-        fn pass<'a>(
+        fn pass(
             &self,
             node: &mut i32,
-            children: &mut dyn Iterator<Item = &'a mut i32>,
+            children: &mut dyn Iterator<Item = &mut i32>,
             _: &SendAnyMap,
         ) -> PassReturn {
             *node += children.map(|i| *i).sum::<i32>();
@@ -863,10 +863,10 @@ fn dependant_up_pass() {
         }
     }
     impl UpwardPass<i32> for SubtractPass {
-        fn pass<'a>(
+        fn pass(
             &self,
             node: &mut i32,
-            children: &mut dyn Iterator<Item = &'a mut i32>,
+            children: &mut dyn Iterator<Item = &mut i32>,
             _: &SendAnyMap,
         ) -> PassReturn {
             *node -= children.map(|i| *i).sum::<i32>();

--- a/packages/native-core/src/state.rs
+++ b/packages/native-core/src/state.rs
@@ -251,7 +251,7 @@ impl ChildDepState for () {
 impl ParentDepState for () {
     type Ctx = ();
     type DepState = ();
-    fn reduce<'a>(&mut self, _: NodeView<'a>, _: Option<()>, _: &Self::Ctx) -> bool {
+    fn reduce(&mut self, _: NodeView, _: Option<()>, _: &Self::Ctx) -> bool {
         false
     }
 }
@@ -259,7 +259,7 @@ impl ParentDepState for () {
 impl NodeDepState for () {
     type DepState = ();
     type Ctx = ();
-    fn reduce<'a>(&mut self, _: NodeView<'a>, _sibling: (), _: &Self::Ctx) -> bool {
+    fn reduce(&mut self, _: NodeView, _sibling: (), _: &Self::Ctx) -> bool {
         false
     }
 }

--- a/packages/native-core/src/tree.rs
+++ b/packages/native-core/src/tree.rs
@@ -426,7 +426,7 @@ fn creation() {
     let child = tree.create_node(0);
     tree.add_child(parent, child);
 
-    println!("Tree: {:#?}", tree);
+    println!("Tree: {tree:#?}");
     assert_eq!(tree.size(), 2);
     assert_eq!(tree.height(parent), Some(0));
     assert_eq!(tree.height(child), Some(1));
@@ -448,7 +448,7 @@ fn insertion() {
     let after = tree.create_node(3);
     tree.insert_after(child, after);
 
-    println!("Tree: {:#?}", tree);
+    println!("Tree: {tree:#?}");
     assert_eq!(tree.size(), 4);
     assert_eq!(tree.height(parent), Some(0));
     assert_eq!(tree.height(child), Some(1));
@@ -475,7 +475,7 @@ fn deletion() {
     let after = tree.create_node(3);
     tree.insert_after(child, after);
 
-    println!("Tree: {:#?}", tree);
+    println!("Tree: {tree:#?}");
     assert_eq!(tree.size(), 4);
     assert_eq!(tree.height(parent), Some(0));
     assert_eq!(tree.height(child), Some(1));
@@ -492,7 +492,7 @@ fn deletion() {
 
     tree.remove(child);
 
-    println!("Tree: {:#?}", tree);
+    println!("Tree: {tree:#?}");
     assert_eq!(tree.size(), 3);
     assert_eq!(tree.height(parent), Some(0));
     assert_eq!(tree.height(before), Some(1));
@@ -507,7 +507,7 @@ fn deletion() {
 
     tree.remove(before);
 
-    println!("Tree: {:#?}", tree);
+    println!("Tree: {tree:#?}");
     assert_eq!(tree.size(), 2);
     assert_eq!(tree.height(parent), Some(0));
     assert_eq!(tree.height(after), Some(1));
@@ -519,7 +519,7 @@ fn deletion() {
 
     tree.remove(after);
 
-    println!("Tree: {:#?}", tree);
+    println!("Tree: {tree:#?}");
     assert_eq!(tree.size(), 1);
     assert_eq!(tree.height(parent), Some(0));
     assert_eq!(*tree.get(parent).unwrap(), 0);
@@ -562,7 +562,7 @@ fn get_node_children_mut() {
     for (i, child) in children.enumerate() {
         assert_eq!(*child, i + 1);
     }
-    println!("Parent: {:#?}", parent);
+    println!("Parent: {parent:#?}");
 }
 
 #[test]
@@ -574,7 +574,7 @@ fn get_many_mut_unchecked() {
 
     let all =
         unsafe { slab.get_many_mut_unchecked([parent, child, grandchild].into_iter()) }.unwrap();
-    println!("All: {:#?}", all);
+    println!("All: {all:#?}");
 }
 
 #[derive(Debug)]

--- a/packages/native-core/src/utils/persistant_iterator.rs
+++ b/packages/native-core/src/utils/persistant_iterator.rs
@@ -368,7 +368,7 @@ fn persist_removes() {
     let mut rdom: RealDom<Empty> = RealDom::new();
 
     let build = vdom.rebuild();
-    println!("{:#?}", build);
+    println!("{build:#?}");
     let _to_update = rdom.apply_mutations(build);
 
     // this will end on the node that is removed
@@ -400,7 +400,7 @@ fn persist_removes() {
 
     vdom.mark_dirty(ScopeId(0));
     let update = vdom.render_immediate();
-    println!("{:#?}", update);
+    println!("{update:#?}");
     iter1.prune(&update, &rdom);
     iter2.prune(&update, &rdom);
     let _to_update = rdom.apply_mutations(update);

--- a/packages/native-core/tests/miri_native.rs
+++ b/packages/native-core/tests/miri_native.rs
@@ -20,12 +20,7 @@ impl ParentDepState for BlablaState {
     const NODE_MASK: NodeMask =
         NodeMask::new_with_attrs(AttributeMask::Static(&sorted_str_slice!(["blabla",])));
 
-    fn reduce<'a>(
-        &mut self,
-        _node: NodeView,
-        _parent: Option<(&'a Self,)>,
-        _ctx: &Self::Ctx,
-    ) -> bool {
+    fn reduce(&mut self, _node: NodeView, _parent: Option<(&Self,)>, _ctx: &Self::Ctx) -> bool {
         false
     }
 }

--- a/packages/rsx-rosetta/examples/html.rs
+++ b/packages/rsx-rosetta/examples/html.rs
@@ -20,5 +20,5 @@ fn main() {
 
     let out = dioxus_autofmt::write_block_out(body).unwrap();
 
-    println!("{}", out);
+    println!("{out}");
 }

--- a/packages/rsx/src/ifmt.rs
+++ b/packages/rsx/src/ifmt.rs
@@ -193,7 +193,7 @@ pub struct FormattedSegment {
 impl ToTokens for FormattedSegment {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let (fmt, seg) = (&self.format_args, &self.segment);
-        let fmt = format!("{{0:{}}}", fmt);
+        let fmt = format!("{{0:{fmt}}}");
         tokens.append_all(quote! {
             format_args!(#fmt, #seg)
         });

--- a/packages/ssr/src/cache.rs
+++ b/packages/ssr/src/cache.rs
@@ -60,11 +60,11 @@ impl StringCache {
                 ..
             } => {
                 cur_path.push(root_idx);
-                write!(chain, "<{}", tag)?;
+                write!(chain, "<{tag}")?;
                 for attr in *attrs {
                     match attr {
                         TemplateAttribute::Static { name, value, .. } => {
-                            write!(chain, " {}=\"{}\"", name, value)?;
+                            write!(chain, " {name}=\"{value}\"")?;
                         }
                         TemplateAttribute::Dynamic { id: index } => {
                             chain.segments.push(Segment::Attr(*index))
@@ -78,11 +78,11 @@ impl StringCache {
                     for child in *children {
                         Self::recurse(child, cur_path, root_idx, chain)?;
                     }
-                    write!(chain, "</{}>", tag)?;
+                    write!(chain, "</{tag}>")?;
                 }
                 cur_path.pop();
             }
-            TemplateNode::Text { text } => write!(chain, "{}", text)?,
+            TemplateNode::Text { text } => write!(chain, "{text}")?,
             TemplateNode::Dynamic { id: idx } | TemplateNode::DynamicText { id: idx } => {
                 chain.segments.push(Segment::Node(*idx))
             }

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -124,7 +124,7 @@ impl Renderer {
                     }
                 },
 
-                Segment::PreRendered(contents) => write!(buf, "{}", contents)?,
+                Segment::PreRendered(contents) => write!(buf, "{contents}")?,
             }
         }
 

--- a/packages/tui/src/render.rs
+++ b/packages/tui/src/render.rs
@@ -115,10 +115,7 @@ impl RinkWidget for &TuiNode {
                 [0, 1] => Direction::Down,
                 [0, -1] => Direction::Up,
                 [a, b] => {
-                    panic!(
-                        "draw({:?} {:?} {:?}) {}, {} no cell adjacent",
-                        before, current, after, a, b
-                    )
+                    panic!("draw({before:?} {current:?} {after:?}) {a}, {b} no cell adjacent")
                 }
             };
             let end_dir = match [after[0] - current[0], after[1] - current[1]] {
@@ -127,10 +124,7 @@ impl RinkWidget for &TuiNode {
                 [0, 1] => Direction::Down,
                 [0, -1] => Direction::Up,
                 [a, b] => {
-                    panic!(
-                        "draw({:?} {:?} {:?}) {}, {} no cell adjacent",
-                        before, current, after, a, b
-                    )
+                    panic!("draw({before:?} {current:?} {after:?}) {a}, {b} no cell adjacent")
                 }
             };
 
@@ -151,10 +145,7 @@ impl RinkWidget for &TuiNode {
                 [Direction::Left, Direction::Up] => symbols.bottom_right,
                 [Direction::Left, Direction::Right] => symbols.horizontal,
                 [Direction::Left, Direction::Down] => symbols.top_right,
-                _ => panic!(
-                    "{:?} {:?} {:?} cannont connect cell to itself",
-                    before, current, after
-                ),
+                _ => panic!("{before:?} {current:?} {after:?} cannont connect cell to itself"),
             }
             .to_string();
             buf.set(

--- a/packages/web/tests/hydrate.rs
+++ b/packages/web/tests/hydrate.rs
@@ -58,7 +58,7 @@ fn rehydrates() {
         .unwrap()
         .body()
         .unwrap()
-        .set_inner_html(&format!("<div id='main'>{}</div>", out));
+        .set_inner_html(&format!("<div id='main'>{out}</div>"));
 
     dioxus_web::launch_cfg(app, Config::new().hydrate(true));
 }


### PR DESCRIPTION
The Clippy version of CI seems to have updated to warn about non-inlined arguments in format_arguments