### PR TITLE
`chore:` change `tokio` to support `shuttle-service`

### DIFF
--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -18,7 +18,7 @@ futures-util = { version = "0.3.25", default-features = false, features = [
     "sink",
 ] }
 futures-channel = { version = "0.3.25", features = ["sink"] }
-tokio = { version = "1.23.0", features = ["time"] }
+tokio = { version = "1.22.0", features = ["time"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tokio-util = { version = "0.7.4", features = ["rt"] }
 serde = { version = "1.0.151", features = ["derive"] }
@@ -44,7 +44,7 @@ salvo = { version = "0.37.7", optional = true, features = ["ws"] }
 
 [dev-dependencies]
 pretty_env_logger = { version = "0.4.0" }
-tokio = { version = "1.23.0", features = ["full"] }
+tokio = { version = "1.22.0", features = ["full"] }
 dioxus = { path = "../dioxus", version = "0.3.0" }
 warp = "0.3.3"
 axum = { version = "0.6.1", features = ["ws"] }


### PR DESCRIPTION
Closes #798 

Widening support for the `tokio` crate to version `1.22.0` in the `[dependencies.tokio]` and `[dev-dependencies.tokio]`.

This change will enable compatibility with `shuttle-service` crate.