### PR TITLE
Add use_memo hook

### DIFF
--- a/packages/hooks/src/lib.rs
+++ b/packages/hooks/src/lib.rs
@@ -44,3 +44,6 @@ pub use useeffect::*;
 
 mod usecallback;
 pub use usecallback::*;
+
+mod usememo;
+pub use usememo::*;

--- a/packages/hooks/src/usememo.rs
+++ b/packages/hooks/src/usememo.rs
@@ -1,0 +1,37 @@
+use dioxus_core::ScopeState;
+
+use crate::UseFutureDep;
+
+/// A hook that provides a callback that executes after the hooks have been applied
+///
+/// Whenever the hooks dependencies change, the callback will be re-evaluated.
+///
+/// - dependencies: a tuple of references to values that are PartialEq + Clone
+///
+/// ## Examples
+///
+/// ```rust, ignore
+///
+/// #[inline_props]
+/// fn app(cx: Scope, name: &str) -> Element {
+///     use_memo(cx, (name,), |(name,)| {
+///         expensive_computation(name);
+///     }))
+/// }
+/// ```
+pub fn use_memo<T, D>(cx: &ScopeState, dependencies: D, callback: impl FnOnce(D::Out) -> T) -> &T
+where
+    T: 'static,
+    D: UseFutureDep,
+{
+    let value = cx.use_hook(|| None);
+
+    let dependancies_vec = cx.use_hook(Vec::new);
+
+    if dependencies.clone().apply(dependancies_vec) || value.is_none() {
+        // Create the new value
+        *value = Some(callback(dependencies.out()));
+    }
+
+    value.as_ref().unwrap()
+}


### PR DESCRIPTION
Adds a use_memo hook for memorizing values. This builds off of the work done on use_effect, but unlike use effect this hook does not spawn a future.