### PR TITLE
Fix android support

### DIFF
--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -9,6 +9,7 @@ use crate::Config;
 use crate::WebviewHandler;
 use dioxus_core::ScopeState;
 use dioxus_core::VirtualDom;
+#[cfg(feature = "hot-reload")]
 use dioxus_hot_reload::HotReloadMsg;
 use serde_json::Value;
 use slab::Slab;
@@ -285,6 +286,7 @@ pub enum EventData {
 
     Ipc(IpcMessage),
 
+    #[cfg(feature = "hot-reload")]
     HotReloadEvent(HotReloadMsg),
 
     NewWindow,

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -185,6 +185,7 @@ pub fn launch_with_props<P: 'static>(root: Component<P>, props: P, cfg: Config) 
             }
 
             Event::UserEvent(event) => match event.0 {
+                #[cfg(feature = "hot-reload")]
                 EventData::HotReloadEvent(msg) => match msg {
                     dioxus_hot_reload::HotReloadMsg::UpdateTemplate(template) => {
                         for webview in webviews.values_mut() {

--- a/packages/mobile/Cargo.toml
+++ b/packages/mobile/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-desktop = { path = "../desktop", version = "^0.3.0" }
+dioxus-desktop = { path = "../desktop", version = "^0.3.0", default-features = false, features = ["tokio_runtime"] }
 
 [lib]
 doctest = false


### PR DESCRIPTION
As for building, I found [cargo-apk and ndk-glue](https://github.com/rust-mobile/ndk) much easier to work with.