### PR TITLE
Don't run miri workflow on draft PRs

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -7,6 +7,7 @@ on:
       - 'auto'
       - 'try'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'master'
   schedule:


### PR DESCRIPTION
This changes the Miri workflow to only run on PRs that are ready like all the other check workflows.