### PR TITLE
Fix keyed diffing with fragment node children

### DIFF
--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -717,7 +717,7 @@ impl<'b> VirtualDom {
                     Fragment(nodes) => nodes
                         .iter()
                         .map(|node| self.push_all_real_nodes(node))
-                        .count(),
+                        .sum(),
 
                     Component(comp) => {
                         let scope = comp.scope.get().unwrap();
@@ -729,7 +729,7 @@ impl<'b> VirtualDom {
                     }
                 }
             })
-            .count()
+            .sum()
     }
 
     fn create_children(&mut self, nodes: impl IntoIterator<Item = &'b VNode<'b>>) -> usize {


### PR DESCRIPTION
fixes #821
This changes the push all real nodes from counting the nodes created to summing them to get the true total