### PR TITLE
Fix pre tag typo

### DIFF
--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -119,7 +119,7 @@ impl Renderer {
 
                     DynamicNode::Placeholder(_el) => {
                         if self.pre_render {
-                            write!(buf, "<pre><pre/>")?;
+                            write!(buf, "<pre></pre>")?;
                         }
                     }
                 },


### PR DESCRIPTION
Fixes a typo in ssr causing placeholder elements to render incorrectly