### PR TITLE
Fix anchor link for block-level elements.

### DIFF
--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -358,7 +358,8 @@ class Interpreter {
             if (event.type === "click") {
               // todo call prevent default if it's the right type of event
               if (shouldPreventDefault !== `onclick`) {
-                if (target.tagName === "A") {
+                target = target.closest("a");
+                if (target != null) {
                   event.preventDefault();
                   const href = target.getAttribute("href");
                   if (href !== "" && href !== null && href !== undefined) {


### PR DESCRIPTION
Block-level elements/tags does not open the systems browser for external links.

An edited version of the "link" example demonstrates this.

```Rust
p {
    a { href: "http://dioxuslabs.com/", div { "Default link - links outside of your app" } }
}
```
The code above would try to open the link in the application itself. External links would only work with *direct* anchor element links (just text).

This fix searches for the closest anchor parent element (or self) in the DOM and fetches that.