### PR TITLE
PartialEq for UseState/UseCoroutine

### DIFF
--- a/packages/hooks/src/usecoroutine.rs
+++ b/packages/hooks/src/usecoroutine.rs
@@ -108,6 +108,12 @@ impl<T> Coroutine<T> {
     }
 }
 
+impl<T> PartialEq for Coroutine<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.task == other.task
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(unused)]

--- a/packages/hooks/src/usestate.rs
+++ b/packages/hooks/src/usestate.rs
@@ -329,7 +329,7 @@ impl PartialEq<bool> for &UseState<bool> {
     }
 }
 
-impl<T: PartialEq> PartialEq<UseState<T>> for UseState<T> {
+impl<T> PartialEq<UseState<T>> for UseState<T> {
     fn eq(&self, other: &UseState<T>) -> bool {
         Rc::ptr_eq(&self.current_val, &other.current_val)
     }


### PR DESCRIPTION
Add `PartialEq`-implementation for `dioxus_hooks::Coroutine` and `dioxus_hooks::UseState`.

Both are good candidates to pass as a prop. `UseState` already implements `PartialEq`, but I removed the trait bound on T.