### PR TITLE
Allow reclaiming signal runtime

### DIFF
--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -23,7 +23,7 @@ fn app(cx: Scope) -> Element {
         button { onclick: move |_| count += 1, "Up high!" }
         button { onclick: move |_| count -= 1, "Down low!" }
 
-        if count() > 5 {
+        if count.get() > 5 {
             rsx!{ h2 { "High five!" } }
         }
     })

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 dioxus-core = { path = "../core" }
 generational-arena = "0.2.8"
 slab = "0.4.7"
+
+[dev-dependencies]
+rand = "0.8.4"

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 
 [dependencies]
 dioxus-core = { path = "../core" }
+generational-arena = "0.2.8"
 slab = "0.4.7"

--- a/packages/signals/src/lib.rs
+++ b/packages/signals/src/lib.rs
@@ -36,7 +36,7 @@ pub fn use_signal<T: 'static>(cx: &ScopeState, f: impl FnOnce() -> T) -> Signal<
         impl<T> Drop for SignalHook<T> {
             fn drop(&mut self) {
                 try_with_rt(self.signal.rt_id, |rt| {
-                    rt.remove(self.signal.id);
+                    rt.remove(&self.signal);
                 });
             }
         }

--- a/packages/signals/src/lib.rs
+++ b/packages/signals/src/lib.rs
@@ -1,27 +1,33 @@
+use core::hash::Hash;
+use dioxus_core::ScopeState;
+use generational_arena::Index;
 use std::{
-    cell::{Ref, RefMut},
-    fmt::Display,
+    fmt::{Debug, Display},
     marker::PhantomData,
-    ops::{Add, Div, Mul, Sub},
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign},
+    rc::Rc,
 };
 
 mod rt;
 
-use dioxus_core::ScopeState;
 pub use rt::*;
 
 pub fn use_init_signal_rt(cx: &ScopeState) {
     cx.use_hook(|| {
-        let rt = crate::rt::claim_rt(cx.schedule_update_any());
-        cx.provide_context(rt);
+        let owner = RuntimeOwner::new(cx.schedule_update_any());
+        cx.provide_context(*owner);
+        owner
     });
 }
 
 pub fn use_signal<T: 'static>(cx: &ScopeState, f: impl FnOnce() -> T) -> Signal<T> {
     cx.use_hook(|| {
-        let rt: &'static SignalRt = cx.consume_context().unwrap();
-        let id = rt.init(f());
-        rt.subscribe(id, cx.scope_id());
+        let rt_id: RunTimeId = cx.consume_context().unwrap();
+        let id = with_rt(rt_id, move |rt| {
+            let id = rt.init(f());
+            rt.subscribe(id, cx.scope_id());
+            id
+        });
 
         struct SignalHook<T> {
             signal: Signal<T>,
@@ -29,14 +35,16 @@ pub fn use_signal<T: 'static>(cx: &ScopeState, f: impl FnOnce() -> T) -> Signal<
 
         impl<T> Drop for SignalHook<T> {
             fn drop(&mut self) {
-                self.signal.rt.remove(self.signal.id);
+                try_with_rt(self.signal.rt_id, |rt| {
+                    rt.remove(self.signal.id);
+                });
             }
         }
 
         SignalHook {
             signal: Signal {
                 id,
-                rt,
+                rt_id,
                 t: PhantomData,
             },
         }
@@ -45,46 +53,49 @@ pub fn use_signal<T: 'static>(cx: &ScopeState, f: impl FnOnce() -> T) -> Signal<
 }
 
 pub struct Signal<T> {
-    id: usize,
-    rt: &'static SignalRt,
+    id: Index,
+    rt_id: RunTimeId,
     t: PhantomData<T>,
 }
 
 impl<T: 'static> Signal<T> {
-    pub fn read(&self) -> Ref<T> {
-        self.rt.read(self.id)
+    /// Create a new signal in a specific runtime. The value will not be dropped until the runtime is dropped.
+    ///
+    /// This is useful largely for testing. For use in Dioxus, use `use_signal` which will drop the signal when the scope is dropped.
+    pub fn new_in(rt_id: RunTimeId, value: T) -> Self {
+        let id = with_rt(rt_id, |rt| rt.init(value));
+        Self {
+            id,
+            rt_id,
+            t: PhantomData,
+        }
     }
 
-    pub fn write(&self) -> RefMut<T> {
-        self.rt.write(self.id)
+    #[inline(always)]
+    fn with_rt<R>(&self, f: impl FnOnce(&SignalRt) -> R) -> R {
+        with_rt(self.rt_id, f)
     }
 
     pub fn set(&mut self, value: T) {
-        self.rt.set(self.id, value);
+        self.with_rt(|rt| rt.set(self.id, value))
     }
 
     pub fn with<O>(&self, f: impl FnOnce(&T) -> O) -> O {
-        let write = self.read();
-        f(&*write)
+        self.with_rt(|rt| rt.with(self.id, f))
     }
 
-    pub fn update<O>(&self, _f: impl FnOnce(&mut T) -> O) -> O {
-        let mut write = self.write();
-        _f(&mut *write)
+    pub fn update<O>(&self, f: impl FnOnce(&mut T) -> O) -> O {
+        self.with_rt(|rt| rt.update(self.id, f))
     }
 }
 
 impl<T: Clone + 'static> Signal<T> {
     pub fn get(&self) -> T {
-        self.rt.get(self.id)
+        self.with_rt(|rt| rt.get(self.id))
     }
-}
 
-impl<T: Clone + 'static> std::ops::Deref for Signal<T> {
-    type Target = dyn Fn() -> T;
-
-    fn deref(&self) -> &Self::Target {
-        self.rt.getter(self.id)
+    pub fn getter(&self) -> Rc<dyn Fn() -> T> {
+        self.with_rt(|rt| rt.getter(self.id))
     }
 }
 
@@ -93,7 +104,7 @@ impl<T> std::clone::Clone for Signal<T> {
         Self {
             t: PhantomData,
             id: self.id,
-            rt: self.rt,
+            rt_id: self.rt_id,
         }
     }
 }
@@ -102,30 +113,106 @@ impl<T> Copy for Signal<T> {}
 
 impl<T: Display + 'static> Display for Signal<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.rt.with::<T, _>(self.id, |v| T::fmt(v, f))
+        self.with(|v| T::fmt(v, f))
     }
 }
 
-impl<T: Add<Output = T> + Copy + 'static> std::ops::AddAssign<T> for Signal<T> {
+impl<T: Debug + 'static> Debug for Signal<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.with(|v| T::fmt(v, f))
+    }
+}
+
+impl<T: AddAssign<T> + 'static> std::ops::AddAssign<T> for Signal<T> {
     fn add_assign(&mut self, rhs: T) {
-        self.set(self.get() + rhs);
+        self.update(|v| *v += rhs);
     }
 }
 
-impl<T: Sub<Output = T> + Copy + 'static> std::ops::SubAssign<T> for Signal<T> {
+impl<T: Add<Output = T> + Clone + 'static> std::ops::Add<T> for Signal<T> {
+    type Output = T;
+
+    fn add(self, rhs: T) -> Self::Output {
+        self.get() + rhs
+    }
+}
+
+impl<T: SubAssign<T> + 'static> std::ops::SubAssign<T> for Signal<T> {
     fn sub_assign(&mut self, rhs: T) {
-        self.set(self.get() - rhs);
+        self.update(|v| *v -= rhs);
     }
 }
 
-impl<T: Mul<Output = T> + Copy + 'static> std::ops::MulAssign<T> for Signal<T> {
+impl<T: Sub<Output = T> + Clone + 'static> std::ops::Sub<T> for Signal<T> {
+    type Output = T;
+
+    fn sub(self, rhs: T) -> Self::Output {
+        self.get() - rhs
+    }
+}
+
+impl<T: MulAssign<T> + 'static> std::ops::MulAssign<T> for Signal<T> {
     fn mul_assign(&mut self, rhs: T) {
-        self.set(self.get() * rhs);
+        self.update(|v| *v *= rhs);
     }
 }
 
-impl<T: Div<Output = T> + Copy + 'static> std::ops::DivAssign<T> for Signal<T> {
+impl<T: Mul<Output = T> + Clone + 'static> std::ops::Mul<T> for Signal<T> {
+    type Output = T;
+
+    fn mul(self, rhs: T) -> Self::Output {
+        self.get() * rhs
+    }
+}
+
+impl<T: DivAssign<T> + 'static> std::ops::DivAssign<T> for Signal<T> {
     fn div_assign(&mut self, rhs: T) {
-        self.set(self.get() / rhs);
+        self.update(|v| *v /= rhs);
+    }
+}
+
+impl<T: Div<Output = T> + Clone + 'static> std::ops::Div<T> for Signal<T> {
+    type Output = T;
+
+    fn div(self, rhs: T) -> Self::Output {
+        self.get() / rhs
+    }
+}
+
+impl<T: PartialEq + 'static> PartialEq for Signal<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.with(|v| other.with(|v2| v == v2))
+    }
+}
+
+impl<T: Eq + 'static> Eq for Signal<T> {}
+
+impl<T: PartialEq + 'static> PartialEq<T> for Signal<T> {
+    fn eq(&self, other: &T) -> bool {
+        self.with(|v| v == other)
+    }
+}
+
+impl<T: PartialOrd + 'static> PartialOrd for Signal<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.with(|v| other.with(|v2| v.partial_cmp(v2)))
+    }
+}
+
+impl<T: Ord + 'static> Ord for Signal<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.with(|v| other.with(|v2| v.cmp(v2)))
+    }
+}
+
+impl<T: PartialOrd + 'static> PartialOrd<T> for Signal<T> {
+    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+        self.with(|v| v.partial_cmp(other))
+    }
+}
+
+impl<T: Hash + 'static> Hash for Signal<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.with(|v| v.hash(state));
     }
 }

--- a/packages/signals/tests/simple.rs
+++ b/packages/signals/tests/simple.rs
@@ -1,0 +1,45 @@
+// tests simple signal handling
+use dioxus_signals::{with_rt, RuntimeOwner, Signal};
+use std::sync::Arc;
+
+#[test]
+fn creation() {
+    let rt = RuntimeOwner::new(Arc::new(|_| {}));
+    let signal = Signal::new_in(*rt, 0);
+    assert_eq!(signal.get(), 0);
+    signal.update(|v| *v = 1);
+    assert_eq!(signal.get(), 1);
+}
+
+#[test]
+#[should_panic]
+fn escape_runtime() {
+    let rt = RuntimeOwner::new(Arc::new(|_| {}));
+    let signal = Signal::new_in(*rt, 0);
+    drop(rt);
+    signal.get();
+}
+
+#[test]
+fn drops() {
+    let rt = RuntimeOwner::new(Arc::new(|_| {}));
+    let signals = (0..10).map(|_| Signal::new_in(*rt, 0)).collect::<Vec<_>>();
+    assert_eq!(with_rt(*rt, |rt| rt.size()), 10);
+    with_rt(*rt, |rt| {
+        for s in signals.iter() {
+            rt.remove(s);
+        }
+    });
+    assert_eq!(with_rt(*rt, |rt| rt.size()), 0);
+    let signals = (0..1000)
+        .map(|_| Signal::new_in(*rt, 0))
+        .collect::<Vec<_>>();
+    assert_eq!(with_rt(*rt, |rt| rt.size()), 1000);
+    with_rt(*rt, |rt| {
+        for s in signals.iter() {
+            rt.remove(s);
+        }
+    });
+    assert_eq!(with_rt(*rt, |rt| rt.size()), 0);
+    drop(rt);
+}

--- a/packages/signals/tests/stress.rs
+++ b/packages/signals/tests/stress.rs
@@ -1,0 +1,34 @@
+use dioxus_signals::{with_rt, RuntimeOwner, Signal};
+use std::sync::Arc;
+
+#[test]
+fn stress() {
+    let rt = RuntimeOwner::new(Arc::new(|_| {}));
+    let mut signals = Vec::new();
+    for _ in 0..100000 {
+        match rand::random::<u8>() % 3 {
+            // add signals
+            0 => {
+                signals.push(Signal::new_in(*rt, 0));
+                assert_eq!(with_rt(*rt, |rt| rt.size()), signals.len());
+            }
+            // remove signals
+            1 => {
+                if let Some(s) = signals.pop() {
+                    with_rt(*rt, |rt| rt.remove(&s));
+                    assert_eq!(with_rt(*rt, |rt| rt.size()), signals.len());
+                }
+            }
+            // update signals
+            2 => {
+                if let Some(s) = signals.last_mut() {
+                    let prev: i32 = s.get();
+                    s.update(|v| *v = v.wrapping_add(1));
+                    let new = prev.wrapping_add(1);
+                    assert_eq!(s.get(), new);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
This allows reclaiming signal runtimes which improves memory management on the server.

This requires significantly restructuring the API of signals by removing the Deref, Ref and RefMut options. These operations become unsafe when the runtime is dropped and then the value is read.