### PR TITLE
Fix hot reloading in a workspace

### DIFF
--- a/packages/rsx/Cargo.toml
+++ b/packages/rsx/Cargo.toml
@@ -18,3 +18,4 @@ syn = { version = "1.0", features = ["full", "extra-traits"] }
 quote = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 internment = "0.7.0"
+krates = "0.12.6"


### PR DESCRIPTION
Fixes hot reloading for child crates in workspaces with the macro and CLI

closes #848 