### PR TITLE
fix Guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
     <span> | </span>
     <a href="https://github.com/DioxusLabs/example-projects"> Examples </a>
     <span> | </span>
-    <a href="https://dioxuslabs.com/guide/en/"> Guide </a>
+    <a href="https://dioxuslabs.com/docs/0.3/guide/en/"> Guide </a>
     <span> | </span>
     <a href="https://github.com/DioxusLabs/dioxus/blob/master/notes/README/ZH_CN.md"> 中文 </a>
     <span> | </span>


### PR DESCRIPTION
This fixes the Guide link in the README, at the cost of pinning the link to version 0.3.  I couldn't find a way to get to the guide without 0.3 being in the URL, but maybe there's another way, like a `/docs/guide/` that aliases to latest?