### PR TITLE
Update Router book to reflect crate separation and need for `web` feature.

### DIFF
--- a/docs/router/src/README.md
+++ b/docs/router/src/README.md
@@ -1,10 +1,11 @@
 # Dioxus Router: Introduction
+
 Whether or not you're building a website, desktop app, or mobile app, organizing your app's views into "pages" can be an effective method for organization and maintainability. 
 
-Dioxus comes with a router built-in. To start utilizing Dioxus Router, enable the ``router`` feature in your ``Cargo.toml`` file.
-```toml
-[dependencies]
-dioxus = { version = "x.x.x", features = [.., "router"] }
-```
+The `dioxus-router` crate contains the Router module. To add it to your project run:
+
+    cargo add dioxus-router
+
+> **Be sure to include the `web` feature (`--feature web`) for deployment into a browser!**
 
 In this book you'll find a short [guide](./guide/index.md) to get up to speed with Dioxus Router, as well as the router's [reference](./reference/index.md).

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1,4 +1,4 @@
-# Dioxus Native Core
+# Dioxus Router
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]


### PR DESCRIPTION
This tripped me up while setting up my first Dioxus app for deployment in a browser. I believe this changed from 0.2 -> 0.3.