### PR TITLE
Don't accept raw attributes in components without trailing commas

### DIFF
--- a/packages/router/tests/web_router.rs
+++ b/packages/router/tests/web_router.rs
@@ -22,7 +22,7 @@ fn simple_test() {
                 onchange: move |router: RouterContext| log::trace!("route changed to {:?}", router.current_location()),
                 active_class: "is-active",
                 Route { to: "/", Home {} }
-                Route { to: "blog"
+                Route { to: "blog",
                     Route { to: "/", BlogList {} }
                     Route { to: ":id", BlogPost {} }
                 }

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -250,7 +250,7 @@ impl Parse for ComponentField {
             }
         };
         if input.peek(LitStr) || input.peek(Ident) {
-            missing_trailing_comma!(input.span());
+            missing_trailing_comma!(content.span());
         }
         Ok(Self { name, content })
     }

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -230,26 +230,28 @@ impl Parse for ComponentField {
         let name = Ident::parse_any(input)?;
         input.parse::<Token![:]>()?;
 
-        if name.to_string().starts_with("on") {
-            let content = ContentField::OnHandlerRaw(input.parse()?);
-            return Ok(Self { name, content });
-        }
-
-        if name == "key" {
-            let content = ContentField::Formatted(input.parse()?);
-            return Ok(Self { name, content });
-        }
-        if input.peek(LitStr) {
-            let forked = input.fork();
-            let t: LitStr = forked.parse()?;
-            // the string literal must either be the end of the input or a followed by a comma
-            if is_literal_foramtted(&t) {
+        let content = {
+            if name.to_string().starts_with("on") {
+                ContentField::OnHandlerRaw(input.parse()?)
+            } else if name == "key" {
                 let content = ContentField::Formatted(input.parse()?);
                 return Ok(Self { name, content });
+            } else if input.peek(LitStr) {
+                let forked = input.fork();
+                let t: LitStr = forked.parse()?;
+                // the string literal must either be the end of the input or a followed by a comma
+                if (forked.is_empty() || forked.peek(Token![,])) && is_literal_foramtted(&t) {
+                    ContentField::Formatted(input.parse()?)
+                } else {
+                    ContentField::ManExpr(input.parse()?)
+                }
+            } else {
+                ContentField::ManExpr(input.parse()?)
             }
+        };
+        if input.peek(LitStr) || input.peek(Ident) {
+            missing_trailing_comma!(input.span());
         }
-
-        let content = ContentField::ManExpr(input.parse()?);
         Ok(Self { name, content })
     }
 }

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -243,14 +243,10 @@ impl Parse for ComponentField {
             let forked = input.fork();
             let t: LitStr = forked.parse()?;
             // the string literal must either be the end of the input or a followed by a comma
-            if (forked.is_empty() || forked.peek(Token![,])) && is_literal_foramtted(&t) {
+            if is_literal_foramtted(&t) {
                 let content = ContentField::Formatted(input.parse()?);
                 return Ok(Self { name, content });
             }
-        }
-
-        if input.peek(LitStr) && input.peek2(LitStr) {
-            missing_trailing_comma!(input.span());
         }
 
         let content = ContentField::ManExpr(input.parse()?);


### PR DESCRIPTION
fixes #876 

It appears that commas are already optional for non-string attribute values in components. This PR makes it optional for all component attributes