### PR TITLE
Fix event bubbling within a single template

### DIFF
--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -175,10 +175,10 @@ impl VirtualDom {
 }
 
 impl ElementPath {
-    pub(crate) fn is_ascendant(&self, big: &&[u8]) -> bool {
+    pub(crate) fn is_decendant(&self, small: &&[u8]) -> bool {
         match *self {
-            ElementPath::Deep(small) => small.len() <= big.len() && small == &big[..small.len()],
-            ElementPath::Root(r) => big.len() == 1 && big[0] == r as u8,
+            ElementPath::Deep(big) => small.len() <= big.len() && *small == &big[..small.len()],
+            ElementPath::Root(r) => small.len() == 1 && small[0] == r as u8,
         }
     }
 }

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -396,7 +396,7 @@ impl VirtualDom {
 
                 // Remove the "on" prefix if it exists, TODO, we should remove this and settle on one
                 if attr.name.trim_start_matches("on") == name
-                    && target_path.is_ascendant(&this_path)
+                    && target_path.is_decendant(&this_path)
                 {
                     listeners.push(&attr.value);
 


### PR DESCRIPTION
The code to propagate events within a single template was checking if the listener was attached to an element that was an (indirect) child of the element of the element where the event was triggered. This PR changes it to check if it is an (indirect) parent of the element where the event was triggered.

Closes #867 