### PR TITLE
Fix panic when waking future on shutdown

### DIFF
--- a/packages/core/src/scheduler/task.rs
+++ b/packages/core/src/scheduler/task.rs
@@ -72,9 +72,9 @@ pub struct LocalTaskHandle {
 
 impl ArcWake for LocalTaskHandle {
     fn wake_by_ref(arc_self: &Arc<Self>) {
-        arc_self
+        // This can fail if the scheduler has been dropped while the application is shutting down
+        let _ = arc_self
             .tx
-            .unbounded_send(SchedulerMsg::TaskNotified(arc_self.id))
-            .unwrap();
+            .unbounded_send(SchedulerMsg::TaskNotified(arc_self.id));
     }
 }


### PR DESCRIPTION
Very rarely a future attempts to wake while the application is shutting down which causes a panic.

This PR ignores the error instead of panicing when a future is polled during shutdown.

For example in this application if you open a several windows and close them it sometimes panics:
```rust
#![allow(non_snake_case)]
use dioxus::prelude::*;
use dioxus_desktop::use_window;

fn main() {
    dioxus_desktop::launch(app);
}

fn app(cx: Scope) -> Element {
    for _ in 0..100 {
        cx.spawn(async move {
            loop {
                print!("!");
                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
            }
        });
    }
    let window = use_window(cx);
    cx.render(rsx! {
        div {
            button {
                onclick: move |_| {
                    let dom = VirtualDom::new(popup);
                    window.new_window(dom, Default::default());
                },
                "New Window"
            }
            button {
                onclick: move |_| window.close(),
                "Close"
            }
        }
    })
}

fn popup(cx: Scope) -> Element {
    for _ in 0..100 {
        cx.spawn(async move {
            loop {
                print!("!");
                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
            }
        });
    }
    cx.render(rsx! {
        div { "This is a popup!" }
    })
}
```