### PR TITLE
Fix non-bubbling listener hydration

### DIFF
--- a/packages/web/src/rehydrate.rs
+++ b/packages/web/src/rehydrate.rs
@@ -128,10 +128,11 @@ impl WebsysDom {
                         mounted_id = Some(id);
                         let name = attribute.name;
                         if let AttributeValue::Listener(_) = value {
+                            let event_name = &name[2..];
                             self.interpreter.new_event_listener(
-                                &name[2..],
+                                event_name,
                                 id.0 as u32,
-                                event_bubbles(name) as u8,
+                                event_bubbles(event_name) as u8,
                             );
                         }
                     }


### PR DESCRIPTION
Fix hydration of listeners with events that do not bubble. The event_bubbles function checks if a event (without the on prefix) bubbles or not and defaults to true. This was always returning true because the code was passing in the on prefix and the event was never being found.