### PR TITLE
Fix style attributes in SSR

### DIFF
--- a/packages/ssr/tests/styles.rs
+++ b/packages/ssr/tests/styles.rs
@@ -1,0 +1,40 @@
+use dioxus::prelude::*;
+
+#[test]
+fn static_styles() {
+    fn app(cx: Scope) -> Element {
+        render! { div { width: "100px" } }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    _ = dom.rebuild();
+
+    assert_eq!(
+        dioxus_ssr::render(&dom),
+        r#"<div style="width:100px;"></div>"#
+    );
+}
+
+#[test]
+fn partially_dynamic_styles() {
+    let dynamic = 123;
+
+    assert_eq!(
+        dioxus_ssr::render_lazy(rsx! {
+            div { width: "100px", height: "{dynamic}px" }
+        }),
+        r#"<div style="width:100px;height:123px;"></div>"#
+    );
+}
+
+#[test]
+fn dynamic_styles() {
+    let dynamic = 123;
+
+    assert_eq!(
+        dioxus_ssr::render_lazy(rsx! {
+            div { width: "{dynamic}px" }
+        }),
+        r#"<div style="width:123px;"></div>"#
+    );
+}


### PR DESCRIPTION
Fixes rendering style attributes in SSR rendering. Currently they are rendered as normal attributes.

This adds a new marker to the pre-rendered template to mark where dynamic styles should be inserted (either after the static styles, or at the end of the attributes). It also adds tests for static, mixed, and dynamic styles. 

This does result in more dynamic allocation, which could effect performance slightly, but the objects that are allocated should be very small (Vecs of references).