### PR TITLE
Add function for creating events with custom data (this feature is documented but seems to be missing)

### DIFF
--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -79,6 +79,36 @@ impl<T> Event<T> {
     pub fn inner(&self) -> &Rc<T> {
         &self.data
     }
+    
+    /// Create event with custom data instead of e.g. MouseData
+    /// 
+    /// ```rust, ignore
+    /// #[inline_props]
+    /// pub fn CustomComponent<'a>(cx: Scope<'a>, on_custom_event: EventHandler<'a, Event<String>>) -> Element<'a> {
+    ///     cx.render(rsx! {
+    ///         button {
+    ///             onclick: move |_| { 
+    ///                 let tmp: Event<String> = Event::new_non_propagated_custom_event(String::from("test"));
+    ///                 on_custom_event.call(tmp);
+    ///             },
+    ///         }
+    ///     })
+    /// }
+    /// 
+    /// pub fn Container(cx: Scope) -> Element {
+    ///     let current_string = use_state(cx, || "".to_string());
+    ///     cx.render(rsx! {
+    ///         CustomComponent {
+    ///             on_custom_event: move |e: Event<String>| {
+    ///                 current_string.set(e.data.as_ref().clone());
+    ///             },
+    ///         },
+    ///     })
+    /// }
+    /// ```
+    pub fn new_non_propagated_custom_event(data: T) -> Self {
+        Self { data: Rc::new(data), propagates: Rc::new(Cell::new(false))}
+    }
 }
 
 impl<T: ?Sized> Clone for Event<T> {


### PR DESCRIPTION
### Description

The documentation found at https://dioxuslabs.com/docs/0.3/guide/en/interactivity/event_handlers.html#handler-props states: 

```
Note: just like any other attribute, you can name the handlers anything you want! 
Though they must start with on, for the prop to be automatically turned into an 
EventHandler at the call site.

You can also put custom data in the event, rather than e.g. MouseData
```

Currently this seems to be incorrect as there is no straight forward way of creating events with custom data. This PR closes this gap between code and documentation by adding  a function (`new_non_propagated_custom_event `) for creating custom events. Custom events of course will not be progagated down to parent components. 

### Why would we want this custom event feature?

Besides the point that it is documented already, this feature allows the user to create an event handler of unspecified type in a parent component that updates state in the parent. Without this we would need to implement an on_click event handler inside the parent for handling click events for some button that exists in a child or sub child component. When changing this child or sub child component to react to events other than button clicks one would need to go back to the parent component and modify the event handler there. This violates the separation of concerns. 

See Example below for clarification:
```
#[inline_props]
 pub fn CustomComponent<'a>(cx: Scope<'a>, on_custom_event: EventHandler<'a, Event<String>>) -> Element<'a> {
     cx.render(rsx! {
         button {
             onclick: move |_| { 
                 let tmp: Event<String> = Event::new_non_propagated_custom_event(String::from("test"));
                 on_custom_event.call(tmp);
             },
         }
     })
 }
 
pub fn Container(cx: Scope) -> Element {
     let current_string = use_state(cx, || "".to_string());
     cx.render(rsx! {
         CustomComponent {
             on_custom_event: move |e: Event<String>| {
                 current_string.set(e.data.as_ref().clone());
             },
        },
    })
 }
```