### PR TITLE
Update docs for the web cfg cache option

### DIFF
--- a/packages/web/src/cfg.rs
+++ b/packages/web/src/cfg.rs
@@ -49,15 +49,16 @@ impl Config {
 
     /// Set the name of the element that Dioxus will use as the root.
     ///
-    /// This is akint to calling React.render() on the element with the specified name.
+    /// This is akin to calling React.render() on the element with the specified name.
     pub fn rootname(mut self, name: impl Into<String>) -> Self {
         self.rootname = name.into();
         self
     }
 
-    /// Set the name of the element that Dioxus will use as the root.
+    /// Sets a string cache for wasm bindgen to [intern](https://docs.rs/wasm-bindgen/0.2.84/wasm_bindgen/fn.intern.html). This can help reduce the time it takes for wasm bindgen to pass
+    /// strings from rust to javascript. This can significantly improve pefromance when passing strings to javascript, but can have a negative impact on startup time.
     ///
-    /// This is akint to calling React.render() on the element with the specified name.
+    /// > Currently this cache is only used when creating static elements and attributes.
     pub fn with_string_cache(mut self, cache: Vec<String>) -> Self {
         self.cached_strings = cache;
         self


### PR DESCRIPTION
Updates the docs for the cache option on the web config.

Most strings are currently passed through sledgehammer instead of WASM bindgen, so caching custom strings in wasm bindgen is much less useful. Sledgehammer does not cache strings in the same way as wasm-bindgen. It can lazily cache strings in a LRU cache by value or by pointer for static strings, but it does not currently accept a list of strings to pre-cache. Currently this just adds a note that the cache is only used when creating static elements and attributes. In the future I would like to support this feature in sledgehammer bindgen.

Fixes #919