### PR TITLE
doc: fermi: add counter example to readme

### DIFF
--- a/packages/fermi/README.md
+++ b/packages/fermi/README.md
@@ -44,7 +44,7 @@ From anywhere in our app, we can read the value of our atom:
 
 ```rust, ignores
 fn NameCard(cx: Scope) -> Element {
-    let name = use_atom_state(cx, NAME);
+    let name = use_read(cx, NAME);
     cx.render(rsx!{ h1 { "Hello, {name}"} })
 }
 ```

--- a/packages/fermi/README.md
+++ b/packages/fermi/README.md
@@ -44,7 +44,7 @@ From anywhere in our app, we can read the value of our atom:
 
 ```rust, ignores
 fn NameCard(cx: Scope) -> Element {
-    let name = use_read(cx, NAME);
+    let name = use_atom_state(cx, NAME);
     cx.render(rsx!{ h1 { "Hello, {name}"} })
 }
 ```
@@ -58,6 +58,26 @@ fn NameCard(cx: Scope) -> Element {
         button {
             onclick: move |_| set_name("Fermi"),
             "Set name to fermi"
+        }
+    })
+}
+```
+
+If needed, we can update the atom's value, based on itself:
+
+```rust, ignore
+static COUNT: Atom<i32> = |_| 0;
+
+fn Counter(cx: Scope) -> Element {
+    let mut count = use_atom_state(cx, COUNT);
+
+    cx.render(rsx!{
+        p {
+          "{count}"
+        }
+        button {
+            onclick: move |_| count += 1,
+            "Increment counter"
         }
     })
 }


### PR DESCRIPTION
Partially closes #660, the other half is in DioxusLabs/docsite#59.

The Fermi snippet on the website shows an increment/counter example that doesn't work. The reporter also mentioned the Fermi readme had the same issue, but it's been fixed with the 0.3 release I think.

However the examples in the readme only show reading, and overwriting the value, but a newcomer wouldn't be able to figure out the common scenario of updating a value based on itself (i.e. counters). I added this example:

> If needed, we can update the atom's value, based on itself:

```rust, ignore
static COUNT: Atom<i32> = |_| 0;

fn Counter(cx: Scope) -> Element {
    let mut count = use_atom_state(cx, COUNT);

    cx.render(rsx!{
        p {
          "{count}"
        }
        button {
            onclick: move |_| count += 1,
            "Increment counter"
        }
    })
}
```