### PR TITLE
Always update root node refs

### DIFF
--- a/packages/core/src/create.rs
+++ b/packages/core/src/create.rs
@@ -35,6 +35,7 @@ fn sort_bfs(paths: &[&'static [u8]]) -> Vec<(usize, &'static [u8])> {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 fn sorting() {
     let r: [(usize, &[u8]); 5] = [
         (0, &[0, 1]),

--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -148,6 +148,13 @@ impl<'b> VirtualDom {
 
         // Make sure the roots get transferred over while we're here
         right_template.root_ids.transfer(&left_template.root_ids);
+
+        // Update the node refs
+        for i in 0..right_template.root_ids.len() {
+            if let Some(root_id) = right_template.root_ids.get(i) {
+                self.update_template(root_id, right_template);
+            }
+        }
     }
 
     fn diff_dynamic_node(


### PR DESCRIPTION
When an event bubbles up the tree after a component rerenders, the bubbling code will attempt to read a node ref that has become out of date because we don't always update the node refs at the root of the element. This changes the code to always update those node refs.

To reproduce this bug, check out this PR on blitz (https://github.com/DioxusLabs/blitz/pull/22) and run the buttons example. Click the add buttons button twice and hit tab. On windows this causes a seg fault.