### PR TITLE
Hotfix wry segfaulting by commenting out webcontext

### DIFF
--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -7,7 +7,7 @@ use tao::event_loop::{EventLoopProxy, EventLoopWindowTarget};
 pub use wry;
 pub use wry::application as tao;
 use wry::application::window::Window;
-use wry::webview::{WebContext, WebView, WebViewBuilder};
+use wry::webview::{WebView, WebViewBuilder};
 
 pub fn build(
     cfg: &mut Config,

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -33,8 +33,6 @@ pub fn build(
         ));
     }
 
-    let mut web_context = WebContext::new(cfg.data_dir.clone());
-
     let mut webview = WebViewBuilder::new(window)
         .unwrap()
         .with_transparent(cfg.window.window.transparent)
@@ -54,8 +52,11 @@ pub fn build(
                 .as_ref()
                 .map(|handler| handler(window, evet))
                 .unwrap_or_default()
-        })
-        .with_web_context(&mut web_context);
+        });
+
+    // These are commented out because wry is currently broken in wry
+    // let mut web_context = WebContext::new(cfg.data_dir.clone());
+    // .with_web_context(&mut web_context);
 
     for (name, handler) in cfg.protocols.drain(..) {
         webview = webview.with_custom_protocol(name, handler)


### PR DESCRIPTION
Seems to be an issue in wry where passing the data directory pointer doesn't follow proper lifetime rules.

This just comments out the webcontext code. We should find a long term solution - like leaking the webcontext.