### PR TITLE
Fix non-ascii string decoding

### DIFF
--- a/packages/interpreter/Cargo.toml
+++ b/packages/interpreter/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["dom", "ui", "gui", "react", "wasm"]
 wasm-bindgen = { version = "0.2.79", optional = true }
 js-sys = { version = "0.3.56", optional = true }
 web-sys = { version = "0.3.56", optional = true, features = ["Element", "Node"] }
-sledgehammer_bindgen = { version = "0.2.0", optional = true }
+sledgehammer_bindgen = { version = "0.2.1", optional = true }
 sledgehammer_utils = { version = "0.1.1", optional = true }
 
 [features]


### PR DESCRIPTION
Fixes a regression in sledgehammer-bindgen `0.2` for non-ascii string decoding on small strings.

Fixes #961 