### PR TITLE
Switch debug logs to trace in the router and web crates

### DIFF
--- a/packages/router/src/components/route.rs
+++ b/packages/router/src/components/route.rs
@@ -45,13 +45,13 @@ pub fn Route<'a>(cx: Scope<'a, RouteProps<'a>>) -> Element {
         router_root.register_total_route(route_context.total_route, cx.scope_id());
     });
 
-    log::debug!("Checking Route: {:?}", cx.props.to);
+    log::trace!("Checking Route: {:?}", cx.props.to);
 
     if router_root.should_render(cx.scope_id()) {
-        log::debug!("Route should render: {:?}", cx.scope_id());
+        log::trace!("Route should render: {:?}", cx.scope_id());
         cx.render(rsx!(&cx.props.children))
     } else {
-        log::debug!("Route should *not* render: {:?}", cx.scope_id());
+        log::trace!("Route should *not* render: {:?}", cx.scope_id());
         cx.render(rsx!(()))
     }
 }

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -225,7 +225,7 @@ pub async fn run_with_props<T: 'static>(root: fn(Scope<T>) -> Element, root_prop
     websys_dom.mount();
 
     loop {
-        log::debug!("waiting for work");
+        log::trace!("waiting for work");
 
         // if virtualdom has nothing, wait for it to have something before requesting idle time
         // if there is work then this future resolves immediately.


### PR DESCRIPTION
Switches debug logs in the router and web crates to traces. (This was done in https://github.com/DioxusLabs/dioxus/pull/334, but reverted at some point)