### PR TITLE
fix rng in svg dice example

### DIFF
--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -26,7 +26,7 @@ fn app(cx: Scope) -> Element {
                     onclick: move |_| {
                         use rand::Rng;
                         let mut rng = rand::thread_rng();
-                        val.set(rng.gen_range(1..6));
+                        val.set(rng.gen_range(1..=6));
                     }
                 }
             }


### PR DESCRIPTION
fixed the rng range so that a 6 can be rolled