### PR TITLE
fix: change crossterm poll timeout to 10ms from 1s

### DIFF
--- a/packages/rink/src/lib.rs
+++ b/packages/rink/src/lib.rs
@@ -98,7 +98,8 @@ pub fn render<R: Driver>(
     let event_tx_clone = event_tx.clone();
     if !cfg.headless {
         std::thread::spawn(move || {
-            let tick_rate = Duration::from_millis(1000);
+            // Timeout after 10ms when waiting for events
+            let tick_rate = Duration::from_millis(10);
             loop {
                 if crossterm::event::poll(tick_rate).unwrap() {
                     let evt = crossterm::event::read().unwrap();


### PR DESCRIPTION
Problem: Key events were delayed signifantly in TUI widgets.
Solution: Decrease crossterm event poll timeout from 1000ms to 10ms.

Fixes #978