### PR TITLE
Allow multiple prevent default for Web, Desktop and LiveView

### DIFF
--- a/docs/guide/examples/event_prevent_default.rs
+++ b/docs/guide/examples/event_prevent_default.rs
@@ -10,8 +10,7 @@ fn App(cx: Scope) -> Element {
     // ANCHOR: prevent_default
 cx.render(rsx! {
     input {
-        prevent_default: "oninput",
-        prevent_default: "onclick",
+        prevent_default: "oninput onclick",
     }
 })
     // ANCHOR_END: prevent_default

--- a/docs/guide/src/en/interactivity/event_handlers.md
+++ b/docs/guide/src/en/interactivity/event_handlers.md
@@ -41,7 +41,7 @@ If you want to prevent this behavior, you can call `stop_propogation()` on the e
 
 Some events have a default behavior. For keyboard events, this might be entering the typed character. For mouse events, this might be selecting some text.
 
-In some instances, might want to avoid this default behavior. For this, you can add the `prevent_default` attribute with the name of the handler whose default behavior you want to stop. This attribute is special: you can attach it multiple times for multiple attributes:
+In some instances, might want to avoid this default behavior. For this, you can add the `prevent_default` attribute with the name of the handler whose default behavior you want to stop. This attribute can be used for multiple handlers using their name separated by spaces:
 
 ```rust
 {{#include ../../../examples/event_prevent_default.rs:prevent_default}}

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -351,7 +351,7 @@ class Interpreter {
           let target = event.target;
           if (target != null) {
             let realId = target.getAttribute(`data-dioxus-id`);
-            let shouldPreventDefault = target.getAttribute(
+            let preventDefaultRequests = target.getAttribute(
               `dioxus-prevent-default`
             );
 
@@ -360,7 +360,14 @@ class Interpreter {
               let a_element = target.closest("a");
               if (a_element != null) {
                 event.preventDefault();
-                if (shouldPreventDefault !== `onclick` && a_element.getAttribute(`dioxus-prevent-default`) !== `onclick`) {
+
+                let elementShouldPreventDefault =
+                  preventDefaultRequests.includes(`onclick`);
+                let linkShouldPreventDefault = a_element
+                  .getAttribute(`dioxus-prevent-default`)
+                  .includes(`onclick`);
+
+                if (!elementShouldPreventDefault && !linkShouldPreventDefault) {
                   const href = a_element.getAttribute("href");
                   if (href !== "" && href !== null && href !== undefined) {
                     window.ipc.postMessage(
@@ -386,13 +393,13 @@ class Interpreter {
               realId = target.getAttribute(`data-dioxus-id`);
             }
 
-            shouldPreventDefault = target.getAttribute(
+            preventDefaultRequests = target.getAttribute(
               `dioxus-prevent-default`
             );
 
             let contents = serialize_event(event);
 
-            if (shouldPreventDefault === `on${event.type}`) {
+            if (preventDefaultRequests.includes(`on${event.type}`)) {
               event.preventDefault();
             }
 

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -61,8 +61,7 @@ impl WebsysDom {
                     {
                         if prevent_requests
                             .map(|f| f.trim_start_matches("on"))
-                            .find(|f| f == &name)
-                            .is_some()
+                            .any(|f| f == name)
                         {
                             event.prevent_default();
                         }

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -54,13 +54,18 @@ impl WebsysDom {
                 let element = walk_event_for_id(event);
                 let bubbles = dioxus_html::event_bubbles(name.as_str());
                 if let Some((element, target)) = element {
-                    if target
+                    if let Some(prevent_requests) = target
                         .get_attribute("dioxus-prevent-default")
                         .as_deref()
-                        .map(|f| f.trim_start_matches("on"))
-                        == Some(&name)
+                        .map(|f| f.split(" "))
                     {
-                        event.prevent_default();
+                        if prevent_requests
+                            .map(|f| f.trim_start_matches("on"))
+                            .find(|f| f == &name)
+                            .is_some()
+                        {
+                            event.prevent_default();
+                        }
                     }
 
                     let data = virtual_event_from_websys_event(event.clone(), target);

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -57,7 +57,7 @@ impl WebsysDom {
                     if let Some(prevent_requests) = target
                         .get_attribute("dioxus-prevent-default")
                         .as_deref()
-                        .map(|f| f.split(" "))
+                        .map(|f| f.split_whitespace())
                     {
                         if prevent_requests
                             .map(|f| f.trim_start_matches("on"))


### PR DESCRIPTION
At the moment, the DOM interpreter expects only one event to prevent the default behavior. This pr allows defining multiple events separated by spaces and prevent all of them.
This is the most straightforward way to do it, but maybe the code should be reviewed to be simplified.
Fixes  #535