### PR TITLE
Fix LiveView Tokio features

### DIFF
--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -18,7 +18,7 @@ futures-util = { version = "0.3.25", default-features = false, features = [
     "sink",
 ] }
 futures-channel = { version = "0.3.25", features = ["sink"] }
-tokio = { version = "1.22.0", features = ["time"] }
+tokio = { version = "1.22.0", features = ["time", "macros"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tokio-util = { version = "0.7.4", features = ["rt"] }
 serde = { version = "1.0.151", features = ["derive"] }


### PR DESCRIPTION
If you try to run cargo check in the LiveView package, it fails because it uses a macro that is not active in the tokio features. This was succeeding in CI because other packages were using the full Tokio features which results in all packages being compiled with all tokio features.