### PR TITLE
make files optional when deserializing form data

### DIFF
--- a/packages/html/src/events/form.rs
+++ b/packages/html/src/events/form.rs
@@ -14,7 +14,11 @@ pub struct FormData {
 
     #[cfg_attr(
         feature = "serialize",
-        serde(skip_serializing, deserialize_with = "deserialize_file_engine")
+        serde(
+            default,
+            skip_serializing,
+            deserialize_with = "deserialize_file_engine"
+        )
     )]
     pub files: Option<std::sync::Arc<dyn FileEngine>>,
 }


### PR DESCRIPTION
Fixes form events on desktop broken in #965. (I only noticed this issue when updating other PRs with the changes)

Form events on desktop never contain the file field which causes crashes when deserializing input events. This PR makes the field optional when deserializing which fixes the issue