### PR TITLE
Fix the link to tui widgets in the guide

### DIFF
--- a/docs/guide/src/en/custom_renderer/index.md
+++ b/docs/guide/src/en/custom_renderer/index.md
@@ -15,7 +15,7 @@ Essentially, your renderer needs to process edits and generate events to update 
 
 Internally, Dioxus handles the tree relationship, diffing, memory management, and the event system, leaving as little as possible required for renderers to implement themselves.
 
-For reference, check out the [javascript interpreter](https://github.com/DioxusLabs/dioxus/tree/master/packages/interpreter) or [tui renderer](https://github.com/DioxusLabs/dioxus/tree/master/packages/tui) as a starting point for your custom renderer.
+For reference, check out the [javascript interpreter](https://github.com/DioxusLabs/dioxus/tree/master/packages/interpreter) or [tui renderer](https://github.com/DioxusLabs/dioxus/tree/master/packages/dioxus-tui) as a starting point for your custom renderer.
 
 ## Templates
 

--- a/docs/guide/src/en/getting_started/tui.md
+++ b/docs/guide/src/en/getting_started/tui.md
@@ -12,13 +12,11 @@ TUI support is currently quite experimental. But, if you're willing to venture i
 
 - It uses flexbox for the layout
 - It only supports a subset of the attributes and elements
-- Regular widgets will not work in the tui render, but the tui renderer has its own widget components that start with a capital letter. See the [widgets example](https://github.com/DioxusLabs/dioxus/blob/master/packages/tui/examples/widgets.rs)
+- Regular widgets will not work in the tui render, but the tui renderer has its own widget components that start with a capital letter. See the [widgets example](https://github.com/DioxusLabs/dioxus/blob/master/packages/dioxus-tui/examples/widgets.rs)
 - 1px is one character line height. Your regular CSS px does not translate
 - If your app panics, your terminal is wrecked. This will be fixed eventually
 
-
 ## Getting Set up
-
 
 Start by making a new package and adding Dioxus and the TUI renderer as dependancies.
 


### PR DESCRIPTION
Fixes 'widgets example' link in 1.5 of the guide
