### PR TITLE
Add `hgroup` html tag

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -360,6 +360,11 @@ builder_constructors! {
     header None {};
 
     /// Build a
+    /// [`<hgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup)
+    /// element.
+    hgroup None {};
+
+    /// Build a
     /// [`<h1>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1)
     /// element.
     ///


### PR DESCRIPTION
The [`<hgroup>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hgroup) HTML element represents a heading and related content. It groups a single `<h1>–<h6>` element with one or more `<p>`.

Closes #1013 