### PR TITLE
Mention futures-util in use_coroutine hook

### DIFF
--- a/packages/hooks/src/usecoroutine.rs
+++ b/packages/hooks/src/usecoroutine.rs
@@ -33,6 +33,10 @@ use std::future::Future;
 /// However, you must plan out your own concurrency and synchronization. If you
 /// don't care about actions in your app being synchronized, you can use [`use_callback`]
 /// hook to spawn multiple tasks and run them concurrently.
+/// 
+/// ### Notice
+/// In order to use ``rx.next().await``, you will need to extend the ``Stream`` trait (used by ``UnboundedReceiver``) 
+/// by adding the ``futures-util`` crate as a dependency and adding ``StreamExt`` into scope via ``use futures_util::stream::StreamExt;``
 ///
 /// ## Example
 ///

--- a/packages/hooks/src/usecoroutine.rs
+++ b/packages/hooks/src/usecoroutine.rs
@@ -33,9 +33,9 @@ use std::future::Future;
 /// However, you must plan out your own concurrency and synchronization. If you
 /// don't care about actions in your app being synchronized, you can use [`use_callback`]
 /// hook to spawn multiple tasks and run them concurrently.
-/// 
+///
 /// ### Notice
-/// In order to use ``rx.next().await``, you will need to extend the ``Stream`` trait (used by ``UnboundedReceiver``) 
+/// In order to use ``rx.next().await``, you will need to extend the ``Stream`` trait (used by ``UnboundedReceiver``)
 /// by adding the ``futures-util`` crate as a dependency and adding ``StreamExt`` into scope via ``use futures_util::stream::StreamExt;``
 ///
 /// ## Example


### PR DESCRIPTION
Adds a mention to ``futures-util`` in order to use ``rx.next().await``.