### PR TITLE
fix router book link

### DIFF
--- a/docs/guide/src/en/interactivity/router.md
+++ b/docs/guide/src/en/interactivity/router.md
@@ -84,4 +84,4 @@ rsx!{
 
 ## More reading
 
-This page is just a very brief overview of the router. For more information, check out [the router book](https://dioxuslabs.com/router/guide/) or some of [the router examples](https://github.com/DioxusLabs/dioxus/blob/master/examples/router.rs).
+This page is just a very brief overview of the router. For more information, check out [the router book](https://dioxuslabs.com/docs/0.3/router/) or some of [the router examples](https://github.com/DioxusLabs/dioxus/blob/master/examples/router.rs).

--- a/docs/guide/src/pt-br/interactivity/router.md
+++ b/docs/guide/src/pt-br/interactivity/router.md
@@ -80,4 +80,4 @@ rsx!{
 
 Esta página é apenas uma breve visão geral do roteador para mostrar que existe uma solução poderosa já construída para um problema muito comum. Para obter mais informações sobre o roteador, confira seu livro ou confira alguns dos exemplos.
 
-O roteador tem sua própria documentação! [Disponível aqui](https://dioxuslabs.com/router/guide/).
+O roteador tem sua própria documentação! [Disponível aqui](https://dioxuslabs.com/docs/0.3/router/).


### PR DESCRIPTION
Currently the link to the [router book](https://dioxuslabs.com/docs/0.3/router/) is broken on the [routing](https://dioxuslabs.com/docs/0.3/guide/en/interactivity/router.html#more-reading) section in the docs. The same link can be accessed from the top navigation, but it's better if this one works too.

