### PR TITLE
Use more precise timestamp in hot reloading

### DIFF
--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -194,7 +194,6 @@ pub fn init<Ctx: HotReloadingContext + Send + 'static>(cfg: Config<Ctx>) {
                                 println!("Connected to hot reloading 🚀");
                             }
                         }
-                        std::thread::sleep(std::time::Duration::from_millis(10));
                         if *aborted.lock().unwrap() {
                             break;
                         }
@@ -250,7 +249,7 @@ pub fn init<Ctx: HotReloadingContext + Send + 'static>(cfg: Config<Ctx>) {
                 };
 
                 for evt in rx {
-                    if chrono::Local::now().timestamp() > last_update_time {
+                    if chrono::Local::now().timestamp_millis() >= last_update_time {
                         if let Ok(evt) = evt {
                             let real_paths = evt
                                 .paths
@@ -322,7 +321,7 @@ pub fn init<Ctx: HotReloadingContext + Send + 'static>(cfg: Config<Ctx>) {
                                 }
                             }
                         }
-                        last_update_time = chrono::Local::now().timestamp();
+                        last_update_time = chrono::Local::now().timestamp_millis();
                     }
                 }
             });


### PR DESCRIPTION
If you try to hot reload multiple changes per second, the hot reloading code trys to deduplicate those events and only accepts the first edit. This happens because the timestamps of the events happen in the same second. This increases the accuracy of the timestamp to milliseconds to fix the issue.