### PR TITLE
Fix URL encoded desktop assets

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -38,6 +38,7 @@ slab = "0.4"
 
 futures-util = "0.3.25"
 rfd = "0.11.3"
+urlencoding = "2.1.2"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.7"

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -87,7 +87,9 @@ pub(super) fn desktop_handler(
     }
 
     // Else, try to serve a file from the filesystem.
-    let path = PathBuf::from(request.uri().path().trim_start_matches('/'));
+    let decoded = urlencoding::decode(request.uri().path().trim_start_matches('/'))
+        .expect("expected URL to be UTF-8 encoded");
+    let path = PathBuf::from(&*decoded);
 
     // If the path is relative, we'll try to serve it from the assets directory.
     let mut asset = get_asset_root()


### PR DESCRIPTION
Fixes #1034 

Wry gives precent encoded urls for requests. This PR decodes those urls into real paths for characters like ` `