### PR TITLE
Adjust `chrono` features to address security advisory.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ tokio = { version = "1.16.1", features = ["full"] }
 reqwest = { version = "0.11.9", features = ["json"] }
 fern = { version = "0.6.0", features = ["colored"] }
 thiserror = "1.0.30"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 simple_logger = "4.0.0"
 
 [profile.release]

--- a/notes/CONTRIBUTING.md
+++ b/notes/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing
+
+On Linux, install the following packages:
+
+```bash
+sudo apt install libgdk3.0-cil libatk1.0-dev libcairo2-dev libpango1.0-dev libgdk-pixbuf2.0-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libwebkit2gtk-4.1-dev
+```
+
+Then run:
+
+```bash
+cargo test --workspace --tests
+```

--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -35,7 +35,7 @@ log = "0.4.14"
 rand = { version = "0.8.4", features = ["small_rng"] }
 criterion = "0.3.5"
 thiserror = "1.0.30"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 tokio = { version = "1.21.2", features = ["full"] }
 # dioxus-edit-stream = { path = "../edit-stream" }
 

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -18,7 +18,7 @@ dioxus-html = { path = "../html", features = ["hot-reload-context"], version = "
 
 interprocess = { version = "1.2.1" }
 notify = "5.0.0"
-chrono = "0.4.23"
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 serde_json = "1.0.91"
 serde = { version = "1", features = ["derive"] }
 execute = "0.2.11"

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -46,7 +46,7 @@ once_cell = "1.17.1"
 # actix-ws = { version = "0.2.5", optional = true }
 
 [dev-dependencies]
-pretty_env_logger = { version = "0.4.0" }
+pretty_env_logger = { version = "0.5.0" }
 tokio = { version = "1.22.0", features = ["full"] }
 dioxus = { path = "../dioxus", version = "0.3.0" }
 warp = "0.3.3"


### PR DESCRIPTION
Closes #1048 (the red part, at least).

* This removes the `time` (red) advisory.
* env_logger is updated from `0.9.0` to `0.10.0`.

I also added some `CONTRIBUTING.md` notes, but only enough to get tests running.

Partially addressed in this PR:

* `atty`, I've updated a few packages, but `simple_logger` and `colored` still depend on it, so we'd have to fix https://github.com/borntyping/rust-simple_logger/issues/74 first.
* `criterion` can be bumped to `0.5.1`, but I haven't had time to do that -- tests fail with an obscure message: ``"for `dioxus-desktop::check_rendering`, line 'html: <div .. </div>' did not end with the string ': test' or ': benchmark'"``.
* `kuchiki` needs https://github.com/tauri-apps/wry/issues/898 fixed.