### PR TITLE
Revert Control R Shortcut

### DIFF
--- a/packages/desktop/src/shortcut.rs
+++ b/packages/desktop/src/shortcut.rs
@@ -41,17 +41,10 @@ impl Shortcut {
 
 impl ShortcutRegistry {
     pub fn new<T>(target: &EventLoopWindowTarget<T>) -> Self {
-        let myself = Self {
+        Self {
             manager: Rc::new(RefCell::new(ShortcutManager::new(target))),
             shortcuts: Rc::new(RefCell::new(HashMap::new())),
-        };
-        // prevent CTRL+R from reloading the page which breaks apps
-        let _ = myself.add_shortcut(
-            Some(ModifiersState::CONTROL),
-            KeyCode::KeyR,
-            Box::new(|| {}),
-        );
-        myself
+        }
     }
 
     pub(crate) fn call_handlers(&self, id: AcceleratorId) {


### PR DESCRIPTION
Removes the ctrl-r as a default global shortcut because it causes issues in other applications. All browser shortcuts are disabled in webview2 on windows, we may need to wait for a similar option for other platforms to disable the shortcut. 

closes #1040 