### PR TITLE
Create use_eval for liveview

### DIFF
--- a/packages/desktop/src/eval.rs
+++ b/packages/desktop/src/eval.rs
@@ -31,6 +31,19 @@ impl IntoFuture for EvalResult {
 }
 
 /// Get a closure that executes any JavaScript in the WebView context.
+///
+/// ```rust
+/// fn app(cx: Scope) -> Element {
+///     let eval = use_eval(cx);
+///     let result = eval(r#"
+///         // You can return values from javascript
+///         return document.getElementById("test-id").getAttribute("class");
+///     "#);
+///     cx.spawn(async move {
+///         println!("{:?}", result.await);
+///     });
+/// }
+/// ```
 pub fn use_eval(cx: &ScopeState) -> &Rc<dyn Fn(String) -> EvalResult> {
     let desktop = use_window(cx);
     &*cx.use_hook(|| {

--- a/packages/desktop/src/query.rs
+++ b/packages/desktop/src/query.rs
@@ -35,6 +35,9 @@ impl QueryEngine {
     pub fn new_query<V: DeserializeOwned>(&self, script: &str, webview: &WebView) -> Query<V> {
         let request_id = self.active_requests.slab.borrow_mut().insert(());
 
+        // subscribe to the query result channel
+        let reciever = self.sender.subscribe();
+
         // start the query
         // We embed the return of the eval in a function so we can send it back to the main thread
         if let Err(err) = webview.evaluate_script(&format!(
@@ -54,7 +57,7 @@ impl QueryEngine {
         Query {
             slab: self.active_requests.clone(),
             id: request_id,
-            reciever: self.sender.subscribe(),
+            reciever,
             phantom: std::marker::PhantomData,
         }
     }

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.91"
 dioxus-html = { path = "../html", features = ["serialize"], version = "^0.3.0" }
 dioxus-core = { path = "../core", features = ["serialize"], version = "^0.3.0" }
+dioxus-hooks = { path = "../hooks", version = "^0.3.0" }
 dioxus-interpreter-js = { path = "../interpreter", version = "0.3.0" }
 dioxus-hot-reload = { path = "../hot-reload", optional = true }
 

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -65,6 +65,10 @@ name = "axum"
 required-features = ["axum"]
 
 [[example]]
+name = "eval"
+required-features = ["axum"]
+
+[[example]]
 name = "salvo"
 required-features = ["salvo"]
 

--- a/packages/liveview/examples/eval.rs
+++ b/packages/liveview/examples/eval.rs
@@ -1,0 +1,72 @@
+use axum::{extract::ws::WebSocketUpgrade, response::Html, routing::get, Router};
+use dioxus::prelude::*;
+use dioxus_liveview::use_eval;
+
+fn app(cx: Scope) -> Element {
+    let eval = use_eval(cx);
+
+    cx.render(rsx! {
+        div {
+            button {
+                onclick: move |_| {
+                    let fut = eval("console.log(1)".to_string());
+                    async move {
+                        println!("{:?}", fut.await);
+                    }
+                },
+                "log 1"
+            }
+            button {
+                onclick: move |_| {
+                    let fut = eval("return 1;".to_string());
+                    async move {
+                        println!("{:?}", fut.await);
+                    }
+                },
+                "return 1"
+            }
+        }
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+
+    let addr: std::net::SocketAddr = ([127, 0, 0, 1], 3030).into();
+
+    let view = dioxus_liveview::LiveViewPool::new();
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(move || async move {
+                Html(format!(
+                    r#"
+            <!DOCTYPE html>
+            <html>
+                <head> <title>Dioxus LiveView with axum</title>  </head>
+                <body> <div id="main"></div> </body>
+                {glue}
+            </html>
+            "#,
+                    glue = dioxus_liveview::interpreter_glue(&format!("ws://{addr}/ws"))
+                ))
+            }),
+        )
+        .route(
+            "/ws",
+            get(move |ws: WebSocketUpgrade| async move {
+                ws.on_upgrade(move |socket| async move {
+                    _ = view.launch(dioxus_liveview::axum_socket(socket), app).await;
+                })
+            }),
+        );
+
+    println!("Listening on http://{addr}");
+
+    axum::Server::bind(&addr.to_string().parse().unwrap())
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}

--- a/packages/liveview/src/context.rs
+++ b/packages/liveview/src/context.rs
@@ -1,0 +1,24 @@
+use dioxus_core::ScopeState;
+use dioxus_hooks::use_context;
+
+use crate::{eval::EvalResult, query::QueryEngine};
+
+#[derive(Clone)]
+pub(crate) struct LiveviewContext {
+    query: QueryEngine,
+}
+
+impl LiveviewContext {
+    pub(crate) fn new(query: QueryEngine) -> Self {
+        Self { query }
+    }
+
+    pub(crate) fn eval(&self, script: &str) -> EvalResult {
+        let query = self.query.new_query::<serde_json::Value>(script);
+        EvalResult::new(query)
+    }
+}
+
+pub(crate) fn use_liveview(cx: &ScopeState) -> &LiveviewContext {
+    use_context(cx).expect("LiveviewContext not found")
+}

--- a/packages/liveview/src/eval.rs
+++ b/packages/liveview/src/eval.rs
@@ -31,6 +31,19 @@ impl IntoFuture for EvalResult {
 }
 
 /// Get a closure that executes any JavaScript in the WebView context.
+///
+/// ```rust
+/// fn app(cx: Scope) -> Element {
+///     let eval = use_eval(cx);
+///     let result = eval(r#"
+///         // You can return values from javascript
+///         return document.getElementById("test-id").getAttribute("class");
+///     "#);
+///     cx.spawn(async move {
+///         println!("{:?}", result.await);
+///     });
+/// }
+/// ```
 pub fn use_eval(cx: &ScopeState) -> &Rc<dyn Fn(String) -> EvalResult> {
     let liveview = use_liveview(cx);
 

--- a/packages/liveview/src/eval.rs
+++ b/packages/liveview/src/eval.rs
@@ -1,0 +1,42 @@
+use std::rc::Rc;
+
+use crate::context::use_liveview;
+use crate::query::Query;
+use crate::query::QueryError;
+use dioxus_core::ScopeState;
+use std::future::Future;
+use std::future::IntoFuture;
+use std::pin::Pin;
+
+/// A future that resolves to the result of a JavaScript evaluation.
+pub struct EvalResult {
+    pub(crate) query: Query<serde_json::Value>,
+}
+
+impl EvalResult {
+    pub(crate) fn new(query: Query<serde_json::Value>) -> Self {
+        Self { query }
+    }
+}
+
+impl IntoFuture for EvalResult {
+    type Output = Result<serde_json::Value, QueryError>;
+
+    type IntoFuture = Pin<Box<dyn Future<Output = Result<serde_json::Value, QueryError>>>>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.query.resolve())
+            as Pin<Box<dyn Future<Output = Result<serde_json::Value, QueryError>>>>
+    }
+}
+
+/// Get a closure that executes any JavaScript in the WebView context.
+pub fn use_eval(cx: &ScopeState) -> &Rc<dyn Fn(String) -> EvalResult> {
+    let liveview = use_liveview(cx);
+
+    &*cx.use_hook(|| {
+        let liveview = liveview.clone();
+
+        Rc::new(move |script: String| liveview.eval(&script)) as Rc<dyn Fn(String) -> EvalResult>
+    })
+}

--- a/packages/liveview/src/lib.rs
+++ b/packages/liveview/src/lib.rs
@@ -26,6 +26,7 @@ pub mod pool;
 mod query;
 use futures_util::{SinkExt, StreamExt};
 pub use pool::*;
+pub use query::QueryError;
 
 pub trait WebsocketTx: SinkExt<String, Error = LiveViewError> {}
 impl<T> WebsocketTx for T where T: SinkExt<String, Error = LiveViewError> {}

--- a/packages/liveview/src/lib.rs
+++ b/packages/liveview/src/lib.rs
@@ -18,7 +18,10 @@ pub mod adapters {
 
 pub use adapters::*;
 
+pub(crate) mod context;
 mod element;
+mod eval;
+pub use eval::*;
 pub mod pool;
 mod query;
 use futures_util::{SinkExt, StreamExt};

--- a/packages/liveview/src/query.rs
+++ b/packages/liveview/src/query.rs
@@ -110,5 +110,6 @@ pub enum QueryError {
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct QueryResult {
     id: usize,
+    #[serde(default)]
     data: Value,
 }

--- a/packages/web/src/util.rs
+++ b/packages/web/src/util.rs
@@ -22,6 +22,19 @@ use serde_json::Value;
 ///
 /// The closure will panic if the provided script is not valid JavaScript code
 /// or if it returns an uncaught error.
+///
+/// ```rust
+/// fn app(cx: Scope) -> Element {
+///     let eval = use_eval(cx);
+///     let result = eval(r#"
+///         // You can return values from javascript
+///         return document.getElementById("test-id").getAttribute("class");
+///     "#);
+///     cx.spawn(async move {
+///         println!("{:?}", result.await);
+///     });
+/// }
+/// ```
 pub fn use_eval<S: std::string::ToString>(cx: &ScopeState) -> &dyn Fn(S) -> EvalResult {
     cx.use_hook(|| {
         |script: S| {


### PR DESCRIPTION
Creates a use_eval hook (functioning the same as the desktop use_eval hook) for the liveview renderer to allow liveview programs to interact with browser APIs