### PR TITLE
Update All Element Ids

### DIFF
--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -7,7 +7,7 @@ use crate::{
     nodes::{DynamicNode, VNode},
     scopes::ScopeId,
     virtual_dom::VirtualDom,
-    Attribute, AttributeValue, TemplateNode,
+    Attribute, TemplateNode,
 };
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -125,10 +125,8 @@ impl<'b> VirtualDom {
                     .mounted_element
                     .set(left_attr.mounted_element.get());
 
-                // We want to make sure anything listener that gets pulled is valid
-                if let AttributeValue::Listener(_) = right_attr.value {
-                    self.update_template(left_attr.mounted_element.get(), right_template);
-                }
+                // We want to make sure anything that gets pulled is valid
+                self.update_template(left_attr.mounted_element.get(), right_template);
 
                 // If the attributes are different (or volatile), we need to update them
                 if left_attr.value != right_attr.value || left_attr.volatile {


### PR DESCRIPTION
Fixes #846 

Because we expose the handle_event on the virtual method which dereferences an arbitrary element id pointer, we always need to update the references for element ids, even if we never use the reference internally.