### PR TITLE
Fix liveview interpreter JS

### DIFF
--- a/packages/liveview/src/lib.rs
+++ b/packages/liveview/src/lib.rs
@@ -77,14 +77,14 @@ static INTERPRETER_JS: Lazy<String> = Lazy::new(|| {
         return;
       }
     }"#;
-    
+
     let interpreter = interpreter.replace("/*POST_EVENT_SERIALIZATION*/", serialize_file_uploads);
     interpreter.replace("import { setAttributeInner } from \"./common.js\";", "")
 });
 
 static COMMON_JS: Lazy<String> = Lazy::new(|| {
-  let common = dioxus_interpreter_js::COMMON_JS;
-  common.replace("export", "")
+    let common = dioxus_interpreter_js::COMMON_JS;
+    common.replace("export", "")
 });
 
 static MAIN_JS: &str = include_str!("./main.js");

--- a/packages/liveview/src/lib.rs
+++ b/packages/liveview/src/lib.rs
@@ -77,8 +77,14 @@ static INTERPRETER_JS: Lazy<String> = Lazy::new(|| {
         return;
       }
     }"#;
+    
+    let interpreter = interpreter.replace("/*POST_EVENT_SERIALIZATION*/", serialize_file_uploads);
+    interpreter.replace("import { setAttributeInner } from \"./common.js\";", "")
+});
 
-    interpreter.replace("/*POST_EVENT_SERIALIZATION*/", serialize_file_uploads)
+static COMMON_JS: Lazy<String> = Lazy::new(|| {
+  let common = dioxus_interpreter_js::COMMON_JS;
+  common.replace("export", "")
 });
 
 static MAIN_JS: &str = include_str!("./main.js");
@@ -89,11 +95,13 @@ static MAIN_JS: &str = include_str!("./main.js");
 /// processing user events and returning edits to the liveview instance
 pub fn interpreter_glue(url: &str) -> String {
     let js = &*INTERPRETER_JS;
+    let common = &*COMMON_JS;
     format!(
         r#"
 <script>
     var WS_ADDR = "{url}";
     {js}
+    {common}
     {MAIN_JS}
     main();
 </script>


### PR DESCRIPTION
Previous PR #1063 changed how the javascript interpreter code is handled. Liveview didn't have the necessary changes to accommodate the new JS organization. (Hopefully this is the last thing that #1063 broke 👀)