### PR TITLE
fix: Remove dbg that was causing TUI rendering problems

### DIFF
--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -426,7 +426,7 @@ impl VirtualDom {
                         }
                     }
 
-                    parent_path = dbg!(template.parent).and_then(|id| self.elements.get(id.0));
+                    parent_path = template.parent.and_then(|id| self.elements.get(id.0));
                 } else {
                     break;
                 }


### PR DESCRIPTION
Hello! I was just trying out the TUI examples and noticed this `dbg!` was causing problems on the screen

<img width="1800" alt="image" src="https://github.com/DioxusLabs/dioxus/assets/4210949/b624a35a-5d96-4c80-8f1a-23ab5dfcf13c">

After removing the dbg everything seems to be working fine! :)