### PR TITLE
Increase the size of the queue for the query engine

### DIFF
--- a/packages/desktop/src/query.rs
+++ b/packages/desktop/src/query.rs
@@ -22,7 +22,7 @@ pub(crate) struct QueryEngine {
 
 impl Default for QueryEngine {
     fn default() -> Self {
-        let (sender, _) = tokio::sync::broadcast::channel(8);
+        let (sender, _) = tokio::sync::broadcast::channel(1000);
         Self {
             sender: Rc::new(sender),
             active_requests: SharedSlab::default(),


### PR DESCRIPTION
# Description

Increase the number of tokio channels for the query engine from 8 to 1000. This fixes issues where making many calls to `eval` or `unmounted` would cause said calls to fail with error `Error receiving query result: channel lagged by 8`.

Solves https://github.com/DioxusLabs/dioxus/issues/1092