### PR TITLE
Fix boolean attributes with raw boolean values

### DIFF
--- a/packages/interpreter/src/common.js
+++ b/packages/interpreter/src/common.js
@@ -48,21 +48,25 @@ export function setAttributeInner(node, field, value, ns) {
         node.defaultValue = value;
         break;
       case "checked":
-        node.checked = value === "true" || value === true;
+        node.checked = truthy(value);
         break;
       case "selected":
-        node.selected = value === "true" || value === true;
+        node.selected = truthy(value);
         break;
       case "dangerous_inner_html":
         node.innerHTML = value;
         break;
       default:
         // https://github.com/facebook/react/blob/8b88ac2592c5f555f315f9440cbb665dd1e7457a/packages/react-dom/src/shared/DOMProperty.js#L352-L364
-        if (value === "false" && bool_attrs.hasOwnProperty(name)) {
+        if (!truthy(value) && bool_attrs.hasOwnProperty(name)) {
           node.removeAttribute(name);
         } else {
           node.setAttribute(name, value);
         }
     }
   }
+}
+
+function truthy(val) {
+  return val === "true" || val === true;
 }

--- a/packages/interpreter/src/sledgehammer_bindings.rs
+++ b/packages/interpreter/src/sledgehammer_bindings.rs
@@ -78,17 +78,17 @@ mod js {
                     node.defaultValue = value;
                     break;
                 case "checked":
-                    node.checked = value === "true";
+                    node.checked = truthy(value);
                     break;
                 case "selected":
-                    node.selected = value === "true";
+                    node.selected = truthy(value);
                     break;
                 case "dangerous_inner_html":
                     node.innerHTML = value;
                     break;
                 default:
                     // https://github.com/facebook/react/blob/8b88ac2592c5f555f315f9440cbb665dd1e7457a/packages/react-dom/src/shared/DOMProperty.js#L352-L364
-                    if (value === "false" && bool_attrs.hasOwnProperty(name)) {
+                    if (!truthy(value) && bool_attrs.hasOwnProperty(name)) {
                         node.removeAttribute(name);
                     } else {
                         node.setAttribute(name, value);
@@ -164,6 +164,9 @@ mod js {
         selected: true,
         truespeed: true,
       };
+      function truthy(val) {
+        return val === "true" || val === true;
+      }
     "#;
 
     extern "C" {


### PR DESCRIPTION
Checks if boolean attributes are equal to either the value `true` or the string `"true"` before choosing to either add or remove the attribute

fixes https://github.com/DioxusLabs/dioxus/issues/1086