### PR TITLE
Workspace Dependancies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,40 @@ members = [
     "examples/PWA-example",
 ]
 
+# dependencies that are shared across packages
+[workspace.dependencies]
+dioxus = { path = "packages/dioxus" }
+dioxus-core = { path = "packages/core" }
+dioxus-core-macro = { path = "packages/core-macro" }
+dioxus-router = { path = "packages/router" }
+dioxus-html = { path = "packages/html" }
+dioxus-hooks = { path = "packages/hooks" }
+dioxus-web = { path = "packages/web" }
+dioxus-ssr = { path = "packages/ssr" }
+dioxus-desktop = { path = "packages/desktop" }
+dioxus-mobile = { path = "packages/mobile" }
+dioxus-interpreter-js = { path = "packages/interpreter" }
+fermi = { path = "packages/fermi" }
+dioxus-liveview = { path = "packages/liveview" }
+dioxus-autofmt = { path = "packages/autofmt" }
+dioxus-rsx = { path = "packages/rsx" }
+dioxus-tui = { path = "packages/dioxus-tui" }
+rink = { path = "packages/rink" }
+dioxus-native-core = { path = "packages/native-core" }
+dioxus-native-core-macro = { path = "packages/native-core-macro" }
+dioxus-rsx-rosetta = { path = "packages/rsx-rosetta" }
+dioxus-signals = { path = "packages/signals" }
+dioxus-hot-reload = { path = "packages/hot-reload" }
+dioxus-fullstack = { path = "packages/fullstack" }
+dioxus_server_macro = { path = "packages/fullstack/server-macro" }
+log = "0.4.19"
+tokio = "1.28"
+slab = "0.4.2"
+futures-channel = "0.3.21"
+futures-util = { version = "0.3", default-features = false }
+rustc-hash = "1.1.0"
+wasm-bindgen = "0.2.79"
+
 # This is a "virtual package"
 # It is not meant to be published, but is used so "cargo run --example XYZ" works properly
 [package]
@@ -52,12 +86,12 @@ rust-version = "1.60.0"
 publish = false
 
 [dev-dependencies]
-dioxus = { path = "./packages/dioxus" }
-dioxus-desktop = { path = "./packages/desktop", features = ["transparent"] }
-dioxus-ssr = { path = "./packages/ssr" }
-dioxus-router = { path = "./packages/router" }
-dioxus-signals = { path = "./packages/signals" }
-fermi = { path = "./packages/fermi" }
+dioxus = { workspace = true }
+dioxus-desktop = { workspace = true, features = ["transparent"] }
+dioxus-ssr = { workspace = true }
+dioxus-router = { workspace = true }
+dioxus-signals = { workspace = true }
+fermi = { workspace = true }
 futures-util = "0.3.21"
 log = "0.4.14"
 num-format = "0.4.0"

--- a/packages/autofmt/Cargo.toml
+++ b/packages/autofmt/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["dom", "ui", "gui", "react"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-rsx = { path = "../rsx", version = "^0.0.3" }
+dioxus-rsx = { workspace = true }
 proc-macro2 = { version = "1.0.6", features = ["span-locations"] }
 quote = "1.0"
 syn = { version = "1.0.11", features = ["full", "extra-traits"] }

--- a/packages/core-macro/Cargo.toml
+++ b/packages/core-macro/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 proc-macro2 = { version = "1.0" }
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-dioxus-rsx = {  path = "../rsx", version = "^0.0.3" }
+dioxus-rsx = { workspace = true }
 
 # testing
 [dev-dependencies]

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -18,23 +18,23 @@ keywords = ["dom", "ui", "gui", "react"]
 bumpalo = { version = "3.6", features = ["collections", "boxed"] }
 
 # faster hashmaps
-rustc-hash = "1.1.0"
+rustc-hash = { workspace = true }
 
 # Used in diffing
 longest-increasing-subsequence = "0.1.0"
 
-futures-util = { version = "0.3", default-features = false, features = [
+futures-util = { workspace = true, default-features = false, features = [
     "alloc",
 ] }
 
-slab = "0.4"
+slab = { workspace = true }
 
-futures-channel = "0.3.21"
+futures-channel = { workspace = true }
 
 indexmap = "1.7"
 
 smallbox = "0.8.1"
-log = "0.4.17"
+log = { workspace = true }
 
 # Serialize the Edits for use in Webview/Liveview instances
 serde = { version = "1", features = ["derive"], optional = true }
@@ -42,8 +42,8 @@ serde = { version = "1", features = ["derive"], optional = true }
 bumpslab = { version = "0.2.0" }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
-dioxus = { path = "../dioxus" }
+tokio = { workspace = true, features = ["full"] }
+dioxus = { workspace = true }
 pretty_assertions = "1.3.0"
 rand = "0.8.5"
 

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -12,18 +12,18 @@ keywords = ["dom", "ui", "gui", "react"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-core = { path = "../core", version = "^0.3.0", features = ["serialize"] }
-dioxus-html = { path = "../html", features = ["serialize", "native-bind"], version = "^0.3.0" }
-dioxus-interpreter-js = { path = "../interpreter", version = "^0.3.0" }
-dioxus-hot-reload = { path = "../hot-reload", optional = true }
+dioxus-core = { workspace = true, features = ["serialize"] }
+dioxus-html = { workspace = true, features = ["serialize", "native-bind"] }
+dioxus-interpreter-js = { workspace = true }
+dioxus-hot-reload = { workspace = true, optional = true }
 
 serde = "1.0.136"
 serde_json = "1.0.79"
 thiserror = "1.0.30"
-log = "0.4.14"
+log = { workspace = true }
 wry = { version = "0.27.2" }
-futures-channel = "0.3.21"
-tokio = { version = "1.27", features = [
+futures-channel = { workspace = true }
+tokio = { workspace = true, features = [
     "sync",
     "rt-multi-thread",
     "rt",
@@ -34,9 +34,9 @@ tokio = { version = "1.27", features = [
 webbrowser = "0.8.0"
 infer = "0.11.0"
 dunce = "1.0.2"
-slab = "0.4"
+slab = { workspace = true }
 
-futures-util = "0.3.25"
+futures-util = { workspace = true }
 rfd = "0.11.3"
 urlencoding = "2.1.2"
 
@@ -56,9 +56,9 @@ tray = ["wry/tray"]
 hot-reload = ["dioxus-hot-reload"]
 
 [dev-dependencies]
-dioxus-core-macro = { path = "../core-macro" }
-dioxus-hooks = { path = "../hooks" }
-dioxus = { path = "../dioxus" }
+dioxus-core-macro = { workspace = true }
+dioxus-hooks = { workspace = true }
+dioxus = { workspace = true }
 exitcode = "1.1.2"
 scraper = "0.16.0"
 

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { workspace = true, features = [
     "time",
     "macros",
     "fs",
-], optional = true, default-features = false }
+], optional = true }
 webbrowser = "0.8.0"
 infer = "0.11.0"
 dunce = "1.0.2"

--- a/packages/dioxus-tui/Cargo.toml
+++ b/packages/dioxus-tui/Cargo.toml
@@ -13,21 +13,21 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { path = "../dioxus", version = "^0.3.0" }
-dioxus-core = { path = "../core", version = "^0.3.0", features = ["serialize"] }
-dioxus-html = { path = "../html", version = "^0.3.0" }
-dioxus-native-core = { path = "../native-core", version = "^0.2.0", features = ["dioxus"] }
-dioxus-native-core-macro = { path = "../native-core-macro", version = "^0.3.0" }
-dioxus-hot-reload = { path = "../hot-reload", optional = true }
-rink = { path = "../rink" }
+dioxus = { workspace = true }
+dioxus-core = { workspace = true, features = ["serialize"] }
+dioxus-html = { workspace = true }
+dioxus-native-core = { workspace = true, features = ["dioxus"] }
+dioxus-native-core-macro = { workspace = true }
+dioxus-hot-reload = { workspace = true, optional = true }
+rink = { workspace = true }
 
 crossterm = "0.23.0"
-tokio = { version = "1.15.0", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 futures = "0.3.19"
 taffy = "0.3.12"
 
 [dev-dependencies]
-dioxus = { path = "../dioxus" }
+dioxus = { workspace = true }
 tokio = { version = "1" }
 criterion = "0.3.5"
 

--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["dom", "ui", "gui", "react", "wasm"]
 rust-version = "1.65.0"
 
 [dependencies]
-dioxus-core = { path = "../core", version = "^0.3.0" }
-dioxus-html = { path = "../html", version = "^0.3.0", optional = true }
-dioxus-core-macro = { path = "../core-macro", version = "^0.3.0", optional = true }
-dioxus-hooks = { path = "../hooks", version = "^0.3.0", optional = true }
-dioxus-rsx = { path = "../rsx", version = "^0.0.3", optional = true }
+dioxus-core = { workspace = true }
+dioxus-html = { workspace = true, optional = true }
+dioxus-core-macro = { workspace = true, optional = true }
+dioxus-hooks = { workspace = true, optional = true }
+dioxus-rsx = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-dioxus-hot-reload = { path = "../hot-reload", version = "0.1.0", optional = true }
+dioxus-hot-reload = { workspace = true, optional = true }
 
 [features]
 default = ["macro", "hooks", "html", "hot-reload"]
@@ -30,14 +30,14 @@ hot-reload = ["dioxus-hot-reload"]
 
 
 [dev-dependencies]
-futures-util = "0.3.21"
-log = "0.4.14"
+futures-util = { workspace = true }
+log = { workspace = true }
 rand = { version = "0.8.4", features = ["small_rng"] }
 criterion = "0.3.5"
 thiserror = "1.0.30"
 env_logger = "0.10.0"
-tokio = { version = "1.21.2", features = ["full"] }
-# dioxus-edit-stream = { path = "../edit-stream" }
+tokio = { workspace = true, features = ["full"] }
+# dioxus-edit-stream = { workspace = true }
 
 
 [[bench]]

--- a/packages/fermi/Cargo.toml
+++ b/packages/fermi/Cargo.toml
@@ -13,9 +13,9 @@ keywords = ["dom", "ui", "gui", "react", "state-management"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-core = { path = "../core", version = "^0.3.0" }
+dioxus-core = { workspace = true }
 im-rc = { version = "15.0.0", features = ["serde"] }
-log = "0.4.14"
+log = { workspace = true }
 
 [dev-dependencies]
 closure = "0.3.0"

--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -30,27 +30,27 @@ salvo = { version = "0.37.7", optional = true, features = ["serve-static", "ws"]
 serde = "1.0.159"
 
 # Dioxus + SSR
-dioxus-core = { path = "../core", version = "^0.3.0" }
-dioxus-ssr = { path = "../ssr", version = "^0.3.0", optional = true }
+dioxus-core = { workspace = true }
+dioxus-ssr = { workspace = true, optional = true }
 hyper = { version = "0.14.25", optional = true }
 http = { version = "0.2.9", optional = true }
 
-log = "0.4.17"
+log = { workspace = true }
 once_cell = "1.17.1"
 thiserror = "1.0.40"
-tokio = { version = "1.27.0", features = ["full"], optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 object-pool = "0.5.4"
 anymap = "0.12.1"
 
 serde_json = { version = "1.0.95", optional = true }
 tokio-stream = { version = "0.1.12", features = ["sync"], optional = true }
-futures-util = { version = "0.3.28", optional = true }
+futures-util = { workspace = true, optional = true }
 postcard = { version = "1.0.4", features = ["use-std"] }
 yazi = "0.1.5"
 base64 = "0.21.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-dioxus-hot-reload = { path = "../hot-reload" }
+dioxus-hot-reload = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3.61", features = ["Window", "Document", "Element", "HtmlDocument", "Storage", "console"] }

--- a/packages/fullstack/examples/axum-desktop/Cargo.toml
+++ b/packages/fullstack/examples/axum-desktop/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 [lib]
 
 [dependencies]
-dioxus-desktop = { path = "../../../desktop", optional = true }
-dioxus = { path = "../../../dioxus" }
-dioxus-router = { path = "../../../router" }
-dioxus-fullstack = { path = "../../" }
+dioxus-desktop = { workspace = true, optional = true }
+dioxus = { workspace = true }
+dioxus-router = { workspace = true }
+dioxus-fullstack = { workspace = true }
 axum = { version = "0.6.12", optional = true }
-tokio = { version = "1.27.0", features = ["full"], optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 serde = "1.0.159"
 
 [features]

--- a/packages/fullstack/examples/axum-hello-world/Cargo.toml
+++ b/packages/fullstack/examples/axum-hello-world/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-web = { path = "../../../web", features=["hydrate"], optional = true }
-dioxus = { path = "../../../dioxus" }
-dioxus-fullstack = { path = "../../" }
+dioxus-web = { workspace = true, features=["hydrate"], optional = true }
+dioxus = { workspace = true }
+dioxus-fullstack = { workspace = true }
 axum = { version = "0.6.12", optional = true }
-tokio = { version = "1.27.0", features = ["full"], optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 serde = "1.0.159"
 execute = "0.2.12"
 

--- a/packages/fullstack/examples/axum-router/Cargo.toml
+++ b/packages/fullstack/examples/axum-router/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-web = { path = "../../../web", features=["hydrate"], optional = true }
-dioxus = { path = "../../../dioxus" }
-dioxus-router = { path = "../../../router" }
-dioxus-fullstack = { path = "../../" }
+dioxus-web = { workspace = true, features=["hydrate"], optional = true }
+dioxus = { workspace = true }
+dioxus-router = { workspace = true }
+dioxus-fullstack = { workspace = true }
 axum = { version = "0.6.12", optional = true }
-tokio = { version = "1.27.0", features = ["full"], optional = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 serde = "1.0.159"
 tower-http = { version = "0.4.0", features = ["fs"], optional = true }
 http = { version = "0.2.9", optional = true }

--- a/packages/fullstack/examples/salvo-hello-world/Cargo.toml
+++ b/packages/fullstack/examples/salvo-hello-world/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-web = { path = "../../../web", features=["hydrate"], optional = true }
-dioxus = { path = "../../../dioxus" }
-dioxus-fullstack = { path = "../../" }
-tokio = { version = "1.27.0", features = ["full"], optional = true }
+dioxus-web = { workspace = true, features=["hydrate"], optional = true }
+dioxus = { workspace = true }
+dioxus-fullstack = { workspace = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 serde = "1.0.159"
 salvo = { version = "0.37.9", optional = true }
 execute = "0.2.12"

--- a/packages/fullstack/examples/warp-hello-world/Cargo.toml
+++ b/packages/fullstack/examples/warp-hello-world/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-web = { path = "../../../web", features=["hydrate"], optional = true }
-dioxus = { path = "../../../dioxus" }
-dioxus-fullstack = { path = "../../" }
-tokio = { version = "1.27.0", features = ["full"], optional = true }
+dioxus-web = { workspace = true, features=["hydrate"], optional = true }
+dioxus = { workspace = true }
+dioxus-fullstack = { workspace = true }
+tokio = { workspace = true, features = ["full"], optional = true }
 serde = "1.0.159"
 warp = { version = "0.3.3", optional = true }
 execute = "0.2.12"

--- a/packages/hooks/Cargo.toml
+++ b/packages/hooks/Cargo.toml
@@ -12,12 +12,12 @@ keywords = ["dom", "ui", "gui", "react"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-core = { path = "../../packages/core", version = "^0.3.0" }
-futures-channel = "0.3.21"
-log = "0.4"
+dioxus-core = { workspace = true }
+futures-channel = { workspace = true }
+log = { workspace = true }
 
 
 [dev-dependencies]
-futures-util = { version = "0.3", default-features = false }
-dioxus-core = { path = "../../packages/core", version = "^0.3.0" }
-dioxus = { path = "../../packages/dioxus", version = "^0.3.0" }
+futures-util = { workspace = true, default-features = false }
+dioxus-core = { workspace = true }
+dioxus = { workspace = true }

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["dom", "ui", "gui", "react", "hot-reloading"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-rsx = { path = "../rsx" , version = "^0.0.3" }
-dioxus-core = { path = "../core", features = ["serialize"], version = "^0.3.2"}
-dioxus-html = { path = "../html", features = ["hot-reload-context"], version = "^0.3.0" }
+dioxus-rsx = { workspace = true }
+dioxus-core = { workspace = true, features = ["serialize"] }
+dioxus-html = { workspace = true, features = ["hot-reload-context"] }
 
 interprocess = { version = "1.2.1" }
 notify = "5.0.0"

--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -11,17 +11,17 @@ documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
 
 [dependencies]
-dioxus-core = { path = "../core", version = "^0.3.0" }
-dioxus-rsx = { path = "../rsx", version = "^0.0.3", optional = true }
+dioxus-core = { workspace = true }
+dioxus-rsx = { workspace = true, optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_repr = { version = "0.1", optional = true }
-wasm-bindgen = { version = "0.2.79", optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 euclid = "0.22.7"
 enumset = "1.0.11"
 keyboard-types = "0.6.2"
 async-trait = "0.1.58"
 serde-value = "0.7.0"
-tokio = { version = "1.27", features = ["fs", "io-util"], optional = true }
+tokio = { workspace = true, features = ["fs", "io-util"], optional = true }
 rfd = { version = "0.11.3", optional = true }
 
 [dependencies.web-sys]

--- a/packages/interpreter/Cargo.toml
+++ b/packages/interpreter/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["dom", "ui", "gui", "react", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasm-bindgen = { version = "0.2.79", optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 js-sys = { version = "0.3.56", optional = true }
 web-sys = { version = "0.3.56", optional = true, features = ["Element", "Node"] }
 sledgehammer_bindgen = { version = "0.2.1", optional = true }

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -14,21 +14,21 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 thiserror = "1.0.38"
-log = "0.4.14"
-slab = "0.4"
-futures-util = { version = "0.3.25", default-features = false, features = [
+log = { workspace = true }
+slab = { workspace = true }
+futures-util = { workspace = true, default-features = false, features = [
     "sink",
 ] }
-futures-channel = { version = "0.3.25", features = ["sink"] }
-tokio = { version = "1.22.0", features = ["time", "macros"] }
+futures-channel = { workspace = true }
+tokio = { workspace = true, features = ["time", "macros"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tokio-util = { version = "0.7.4", features = ["rt"] }
 serde = { version = "1.0.151", features = ["derive"] }
 serde_json = "1.0.91"
-dioxus-html = { path = "../html", features = ["serialize"], version = "^0.3.0" }
-dioxus-core = { path = "../core", features = ["serialize"], version = "^0.3.0" }
-dioxus-interpreter-js = { path = "../interpreter", version = "0.3.0" }
-dioxus-hot-reload = { path = "../hot-reload", optional = true }
+dioxus-html = { workspace = true, features = ["serialize"] }
+dioxus-core = { workspace = true, features = ["serialize"] }
+dioxus-interpreter-js = { workspace = true }
+dioxus-hot-reload = { workspace = true, optional = true }
 
 # warp
 warp = { version = "0.3.3", optional = true }
@@ -47,8 +47,8 @@ once_cell = "1.17.1"
 
 [dev-dependencies]
 pretty_env_logger = { version = "0.5.0" }
-tokio = { version = "1.22.0", features = ["full"] }
-dioxus = { path = "../dioxus", version = "0.3.0" }
+tokio = { workspace = true, features = ["full"] }
+dioxus = { workspace = true }
 warp = "0.3.3"
 axum = { version = "0.6.1", features = ["ws"] }
 salvo = { version = "0.37.7", features = ["affix", "ws"] }

--- a/packages/mobile/Cargo.toml
+++ b/packages/mobile/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-desktop = { path = "../desktop", version = "^0.3.0" }
+dioxus-desktop = { workspace = true }
 
 [lib]
 doctest = false

--- a/packages/native-core-macro/Cargo.toml
+++ b/packages/native-core-macro/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0"
 
 [dev-dependencies]
 smallvec = "1.6"
-rustc-hash = "1.1.0"
+rustc-hash = { workspace = true }
 anymap = "0.12.1"
-dioxus = { path = "../dioxus" }
-dioxus-native-core = { path = "../native-core" }
+dioxus = { workspace = true }
+dioxus-native-core = { workspace = true }

--- a/packages/native-core/Cargo.toml
+++ b/packages/native-core/Cargo.toml
@@ -11,14 +11,14 @@ keywords = ["dom", "ui", "gui", "react"]
 
 
 [dependencies]
-dioxus-core = { path = "../core", version = "^0.3.0", optional = true }
+dioxus-core = { workspace = true, optional = true }
 
 keyboard-types = "0.6.2"
 taffy = "0.3.12"
 smallvec = "1.6"
-rustc-hash = "1.1.0"
+rustc-hash = { workspace = true }
 anymap = "1.0.0-beta.2"
-slab = "0.4"
+slab = { workspace = true }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 crossbeam-deque = "0.8.2"
 dashmap = "5.4.0"
@@ -32,10 +32,10 @@ shipyard = { version = "0.6.2", features = ["proc", "std"], default-features = f
 
 [dev-dependencies]
 rand = "0.8.5"
-dioxus = { path = "../dioxus", version = "^0.3.0" }
-tokio = { version = "*", features = ["full"] }
-dioxus-native-core = { path = ".", features = ["dioxus"] }
-dioxus-native-core-macro = { path = "../native-core-macro" }
+dioxus = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+dioxus-native-core = { workspace = true, features = ["dioxus"] }
+dioxus-native-core-macro = { workspace = true }
 
 [features]
 default = []

--- a/packages/rink/Cargo.toml
+++ b/packages/rink/Cargo.toml
@@ -13,20 +13,20 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-html = { path = "../html", version = "^0.3.0" }
-dioxus-native-core = { path = "../native-core", version = "^0.2.0" }
-dioxus-native-core-macro = { path = "../native-core-macro", version = "^0.3.0" }
+dioxus-html = { workspace = true }
+dioxus-native-core = { workspace = true }
+dioxus-native-core-macro = { workspace = true }
 
 tui = "0.17.0"
 crossterm = "0.23.0"
 anyhow = "1.0.42"
-tokio = { version = "1.15.0", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 futures = "0.3.19"
 taffy = "0.3.12"
 smallvec = "1.6"
-rustc-hash = "1.1.0"
+rustc-hash = { workspace = true }
 anymap = "1.0.0-beta.2"
-futures-channel = "0.3.25"
+futures-channel = { workspace = true }
 shipyard = { version = "0.6.2", features = ["proc", "std"], default-features = false }
 once_cell = "1.17.1"
 

--- a/packages/router/Cargo.toml
+++ b/packages/router/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["dom", "ui", "gui", "react", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus = { path = "../dioxus", version = "0.3.0"}
-futures-channel = "0.3.21"
+dioxus = { workspace = true}
+futures-channel = { workspace = true }
 url = { version = "2.2.2", default-features = false }
 
 # for wasm
@@ -28,12 +28,12 @@ web-sys = { version = "0.3", features = [
     "Window",
     "Location",
 ], optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 js-sys = { version = "0.3", optional = true }
 gloo-events = { version = "0.1.1", optional = true }
-log = "0.4.14"
+log = { workspace = true }
 thiserror = "1.0.30"
-futures-util = "0.3.21"
+futures-util = { workspace = true }
 serde = { version = "1", optional = true }
 serde_urlencoded = { version = "0.7.1", optional = true }
 
@@ -48,13 +48,13 @@ console_error_panic_hook = "0.1.7"
 wasm-logger = "0.2.0"
 wasm-bindgen-test = "0.3"
 gloo-utils = "0.1.2"
-dioxus-web = { path = "../web", version = "0.3.0" }
-# dioxus-desktop = { path = "../desktop", optional = true }
+dioxus-web = { workspace = true }
+# dioxus-desktop = { workspace = true, optional = true }
 
 # not wasm
 
 [target.wasm32-unknown-unknown.dev-dependencies]
-dioxus-router = { path = ".", features = ["web"] }
+dioxus-router = { workspace = true, features = ["web"] }
 
 [dev-dependencies.web-sys]
 version = "0.3"

--- a/packages/rsx-rosetta/Cargo.toml
+++ b/packages/rsx-rosetta/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["dom", "ui", "gui", "react"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-autofmt = { path = "../autofmt", version = "0.3.0" }
-dioxus-rsx = { path = "../rsx" , version = "^0.0.3" }
+dioxus-autofmt = { workspace = true }
+dioxus-rsx = { workspace = true }
 html_parser = "0.6.3"
 proc-macro2 = "1.0.49"
 quote = "1.0.23"

--- a/packages/rsx/Cargo.toml
+++ b/packages/rsx/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["dom", "ui", "gui", "react"]
 
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
-dioxus-core = { path = "../core", version = "^0.3.0"}
+dioxus-core = { workspace = true}
 syn = { version = "1.0", features = ["full", "extra-traits"] }
 quote = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-core = { path = "../core" }
-slab = "0.4.7"
+dioxus-core = { workspace = true }
+slab = { workspace = true }

--- a/packages/ssr/Cargo.toml
+++ b/packages/ssr/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["dom", "ui", "gui", "react", "ssr"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dioxus-core = { path = "../core", version = "^0.3.0", features = ["serialize"] }
+dioxus-core = { workspace = true, features = ["serialize"] }
 askama_escape = "0.10.3"
 
 [dev-dependencies]
-dioxus = { path = "../dioxus", version = "0.3.0" }
+dioxus = { workspace = true }
 thiserror = "1.0.23"
-log = "0.4.13"
+log = { workspace = true }
 fern = { version = "0.6.0", features = ["colored"] }
 anyhow = "1.0"
 argh = "0.1.4"

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -11,25 +11,25 @@ documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
 
 [dependencies]
-dioxus-core = { path = "../core", version = "^0.3.0", features = ["serialize"] }
-dioxus-html = { path = "../html", version = "^0.3.0", features = ["wasm-bind"] }
-dioxus-interpreter-js = { path = "../interpreter", version = "^0.3.0", features = [
+dioxus-core = { workspace = true, features = ["serialize"] }
+dioxus-html = { workspace = true, features = ["wasm-bind"] }
+dioxus-interpreter-js = { workspace = true, features = [
     "sledgehammer",
     "minimal_bindings",
 ] }
 
 js-sys = "0.3.56"
-wasm-bindgen = { version = "0.2.79", features = ["enable-interning"] }
+wasm-bindgen = { workspace = true, features = ["enable-interning"] }
 wasm-bindgen-futures = "0.4.29"
-log = "0.4.14"
-rustc-hash = "1.1.0"
+log = { workspace = true }
+rustc-hash = { workspace = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 once_cell = "1.9.0"
 anyhow = "1.0.53"
 gloo-timers = { version = "0.2.3", features = ["futures"] }
-futures-util = "0.3.19"
+futures-util = { workspace = true }
 smallstr = "0.2.0"
-futures-channel = "0.3.21"
+futures-channel = { workspace = true }
 serde_json = { version = "1.0" }
 serde = { version = "1.0" }
 serde-wasm-bindgen = "0.4.5"
@@ -89,8 +89,8 @@ panic_hook = ["console_error_panic_hook"]
 hydrate = []
 
 [dev-dependencies]
-dioxus = { path = "../dioxus", version = "0.3.0" }
+dioxus = { workspace = true }
 wasm-bindgen-test = "0.3.29"
-dioxus-ssr = { path = "../ssr", version = "0.3.0"}
+dioxus-ssr = { workspace = true}
 wasm-logger = "0.2.0"
-dioxus-web = { path = ".", features = ["hydrate"] }
+dioxus-web = { workspace = true, features = ["hydrate"] }

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -27,7 +27,7 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 once_cell = "1.9.0"
 anyhow = "1.0.53"
 gloo-timers = { version = "0.2.3", features = ["futures"] }
-futures-util = { workspace = true }
+futures-util = { workspace = true, features = ["std", "async-await", "async-await-macro"] }
 smallstr = "0.2.0"
 futures-channel = { workspace = true }
 serde_json = { version = "1.0" }


### PR DESCRIPTION
Updates the dependencies that are used commonly across Dioxus crates to use [workspace dependencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table). This should be helpful keeping the versions of crates across the workspace synced and make it easier to move packages.