### PR TITLE
Use oneshot channels for desktop and liveview query engines

### DIFF
--- a/packages/desktop/src/query.rs
+++ b/packages/desktop/src/query.rs
@@ -72,10 +72,8 @@ pub(crate) struct Query<V: DeserializeOwned> {
 impl<V: DeserializeOwned> Query<V> {
     /// Resolve the query
     pub async fn resolve(self) -> Result<V, QueryError> {
-        let result = self.receiver.await.map_err(QueryError::RecvError)?;
-        let result = V::deserialize(result).map_err(QueryError::DeserializeError);
-
-        result
+        let value = self.receiver.await.map_err(QueryError::RecvError)?;
+        V::deserialize(value).map_err(QueryError::DeserializeError)
     }
 }
 

--- a/packages/desktop/src/query.rs
+++ b/packages/desktop/src/query.rs
@@ -14,17 +14,9 @@ struct SharedSlab {
 }
 
 /// Handles sending and receiving arbitrary queries from the webview. Queries can be resolved non-sequentially, so we use ids to track them.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub(crate) struct QueryEngine {
     active_requests: SharedSlab,
-}
-
-impl Default for QueryEngine {
-    fn default() -> Self {
-        Self {
-            active_requests: SharedSlab::default(),
-        }
-    }
 }
 
 impl QueryEngine {

--- a/packages/desktop/src/query.rs
+++ b/packages/desktop/src/query.rs
@@ -4,27 +4,24 @@ use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
 use slab::Slab;
 use thiserror::Error;
-use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::oneshot::error::RecvError;
 use wry::webview::WebView;
 
 /// Tracks what query ids are currently active
 #[derive(Default, Clone)]
 struct SharedSlab {
-    slab: Rc<RefCell<Slab<()>>>,
+    slab: Rc<RefCell<Slab<tokio::sync::oneshot::Sender<Value>>>>,
 }
 
 /// Handles sending and receiving arbitrary queries from the webview. Queries can be resolved non-sequentially, so we use ids to track them.
 #[derive(Clone)]
 pub(crate) struct QueryEngine {
-    sender: Rc<tokio::sync::broadcast::Sender<QueryResult>>,
     active_requests: SharedSlab,
 }
 
 impl Default for QueryEngine {
     fn default() -> Self {
-        let (sender, _) = tokio::sync::broadcast::channel(8);
         Self {
-            sender: Rc::new(sender),
             active_requests: SharedSlab::default(),
         }
     }
@@ -33,7 +30,8 @@ impl Default for QueryEngine {
 impl QueryEngine {
     /// Creates a new query and returns a handle to it. The query will be resolved when the webview returns a result with the same id.
     pub fn new_query<V: DeserializeOwned>(&self, script: &str, webview: &WebView) -> Query<V> {
-        let request_id = self.active_requests.slab.borrow_mut().insert(());
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let request_id = self.active_requests.slab.borrow_mut().insert(tx);
 
         // start the query
         // We embed the return of the eval in a function so we can send it back to the main thread
@@ -52,44 +50,30 @@ impl QueryEngine {
         }
 
         Query {
-            slab: self.active_requests.clone(),
-            id: request_id,
-            reciever: self.sender.subscribe(),
+            receiver: rx,
             phantom: std::marker::PhantomData,
         }
     }
 
     /// Send a query result
     pub fn send(&self, data: QueryResult) {
-        let _ = self.sender.send(data);
+        let idx = data.id;
+        if let Some(tx) = self.active_requests.slab.borrow_mut().try_remove(idx) {
+            let _ = tx.send(data.data);
+        }
     }
 }
 
 pub(crate) struct Query<V: DeserializeOwned> {
-    slab: SharedSlab,
-    id: usize,
-    reciever: tokio::sync::broadcast::Receiver<QueryResult>,
+    receiver: tokio::sync::oneshot::Receiver<Value>,
     phantom: std::marker::PhantomData<V>,
 }
 
 impl<V: DeserializeOwned> Query<V> {
     /// Resolve the query
-    pub async fn resolve(mut self) -> Result<V, QueryError> {
-        let result = loop {
-            match self.reciever.recv().await {
-                Ok(result) => {
-                    if result.id == self.id {
-                        break V::deserialize(result.data).map_err(QueryError::DeserializeError);
-                    }
-                }
-                Err(err) => {
-                    break Err(QueryError::RecvError(err));
-                }
-            }
-        };
-
-        // Remove the query from the slab
-        self.slab.slab.borrow_mut().remove(self.id);
+    pub async fn resolve(self) -> Result<V, QueryError> {
+        let result = self.receiver.await.map_err(QueryError::RecvError)?;
+        let result = V::deserialize(result).map_err(QueryError::DeserializeError);
 
         result
     }

--- a/packages/liveview/src/query.rs
+++ b/packages/liveview/src/query.rs
@@ -4,26 +4,23 @@ use serde::{de::DeserializeOwned, Deserialize};
 use serde_json::Value;
 use slab::Slab;
 use thiserror::Error;
-use tokio::sync::{broadcast::error::RecvError, mpsc::UnboundedSender};
+use tokio::sync::{mpsc::UnboundedSender, oneshot::error::RecvError};
 
 /// Tracks what query ids are currently active
 #[derive(Default, Clone)]
 struct SharedSlab {
-    slab: Rc<RefCell<Slab<()>>>,
+    slab: Rc<RefCell<Slab<tokio::sync::oneshot::Sender<Value>>>>,
 }
 
 /// Handles sending and receiving arbitrary queries from the webview. Queries can be resolved non-sequentially, so we use ids to track them.
 #[derive(Clone)]
 pub(crate) struct QueryEngine {
-    sender: Rc<tokio::sync::broadcast::Sender<QueryResult>>,
     active_requests: SharedSlab,
 }
 
 impl Default for QueryEngine {
     fn default() -> Self {
-        let (sender, _) = tokio::sync::broadcast::channel(8);
         Self {
-            sender: Rc::new(sender),
             active_requests: SharedSlab::default(),
         }
     }
@@ -34,13 +31,14 @@ impl QueryEngine {
     pub fn new_query<V: DeserializeOwned>(
         &self,
         script: &str,
-        tx: &UnboundedSender<String>,
+        eval_tx: &UnboundedSender<String>,
     ) -> Query<V> {
-        let request_id = self.active_requests.slab.borrow_mut().insert(());
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let request_id = self.active_requests.slab.borrow_mut().insert(tx);
 
         // start the query
         // We embed the return of the eval in a function so we can send it back to the main thread
-        if let Err(err) = tx.send(format!(
+        if let Err(err) = eval_tx.send(format!(
             r#"window.ipc.postMessage(
                 JSON.stringify({{
                     "method":"query",
@@ -55,46 +53,30 @@ impl QueryEngine {
         }
 
         Query {
-            slab: self.active_requests.clone(),
-            id: request_id,
-            reciever: self.sender.subscribe(),
+            receiver: rx,
             phantom: std::marker::PhantomData,
         }
     }
 
     /// Send a query result
     pub fn send(&self, data: QueryResult) {
-        let _ = self.sender.send(data);
+        let idx = data.id;
+        if let Some(tx) = self.active_requests.slab.borrow_mut().try_remove(idx) {
+            let _ = tx.send(data.data);
+        }
     }
 }
 
 pub(crate) struct Query<V: DeserializeOwned> {
-    slab: SharedSlab,
-    id: usize,
-    reciever: tokio::sync::broadcast::Receiver<QueryResult>,
+    receiver: tokio::sync::oneshot::Receiver<Value>,
     phantom: std::marker::PhantomData<V>,
 }
 
 impl<V: DeserializeOwned> Query<V> {
     /// Resolve the query
-    pub async fn resolve(mut self) -> Result<V, QueryError> {
-        let result = loop {
-            match self.reciever.recv().await {
-                Ok(result) => {
-                    if result.id == self.id {
-                        break V::deserialize(result.data).map_err(QueryError::DeserializeError);
-                    }
-                }
-                Err(err) => {
-                    break Err(QueryError::RecvError(err));
-                }
-            }
-        };
-
-        // Remove the query from the slab
-        self.slab.slab.borrow_mut().remove(self.id);
-
-        result
+    pub async fn resolve(self) -> Result<V, QueryError> {
+        let value = self.receiver.await.map_err(QueryError::RecvError)?;
+        V::deserialize(value).map_err(QueryError::DeserializeError)
     }
 }
 

--- a/packages/liveview/src/query.rs
+++ b/packages/liveview/src/query.rs
@@ -13,17 +13,9 @@ struct SharedSlab {
 }
 
 /// Handles sending and receiving arbitrary queries from the webview. Queries can be resolved non-sequentially, so we use ids to track them.
-#[derive(Clone)]
+#[derive(Default, Clone)]
 pub(crate) struct QueryEngine {
     active_requests: SharedSlab,
-}
-
-impl Default for QueryEngine {
-    fn default() -> Self {
-        Self {
-            active_requests: SharedSlab::default(),
-        }
-    }
 }
 
 impl QueryEngine {


### PR DESCRIPTION
Related to https://github.com/DioxusLabs/dioxus/pull/1095 and #1092 

Currently the desktop use eval implementation watches for all values sent from wry and filters out any values with ids that do not match its own id. Instead of making the query broadcast channel larger, this PR uses a slab of oneshot channels which allows us to dispatch the value to a specific listener. This should allow any number of queries to be running at once, and should be somewhat more performant.