### PR TITLE
Fix `cargo doc` by using a fixed variant of interprocess

### DIFF
--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -16,7 +16,7 @@ dioxus-rsx = { workspace = true }
 dioxus-core = { workspace = true, features = ["serialize"] }
 dioxus-html = { workspace = true, features = ["hot-reload-context"] }
 
-interprocess = { version = "1.2.1" }
+interprocess-docfix = { version = "1.2.1" }
 notify = "5.0.0"
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 serde_json = "1.0.91"


### PR DESCRIPTION
I had to publish a new version of interprocess that fixes the docs issue, but now we can get interprocess properly creating docs, and thusly, our published versions can create docs. 