### PR TITLE
Change missing trailing comma span to be more helpful

### DIFF
--- a/packages/core-macro/Cargo.toml
+++ b/packages/core-macro/Cargo.toml
@@ -22,6 +22,7 @@ dioxus-rsx = { workspace = true }
 
 # testing
 [dev-dependencies]
+dioxus = { workspace = true }
 rustversion = "1.0"
 trybuild = "1.0"
 

--- a/packages/core-macro/tests/rsx.rs
+++ b/packages/core-macro/tests/rsx.rs
@@ -1,0 +1,5 @@
+#[test]
+fn rsx() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/rsx/trailing-comma-0.rs");
+}

--- a/packages/core-macro/tests/rsx/trailing-comma-0.rs
+++ b/packages/core-macro/tests/rsx/trailing-comma-0.rs
@@ -1,0 +1,13 @@
+// Given an `rsx!` invocation with a missing trailing comma,
+// ensure the stderr output has an informative span.
+
+use dioxus::prelude::*;
+
+fn main() {
+    rsx! {
+        p {
+            class: "foo bar"
+            "Hello world"
+        }
+    };
+}

--- a/packages/core-macro/tests/rsx/trailing-comma-0.stderr
+++ b/packages/core-macro/tests/rsx/trailing-comma-0.stderr
@@ -1,0 +1,5 @@
+error: missing trailing comma
+ --> tests/rsx/trailing-comma-0.rs:9:20
+  |
+9 |             class: "foo bar"
+  |                    ^^^^^^^^^

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -76,10 +76,13 @@ impl Parse for Element {
 
             if content.peek(Ident) && content.peek2(Token![:]) && !content.peek3(Token![:]) {
                 let name = content.parse::<Ident>()?;
-                let ident = name.clone();
 
                 let name_str = name.to_string();
                 content.parse::<Token![:]>()?;
+
+                // The span of the content to be parsed,
+                // for example the `hi` part of `class: "hi"`.
+                let span = content.span();
 
                 if name_str.starts_with("on") {
                     attributes.push(ElementAttrNamed {
@@ -127,7 +130,7 @@ impl Parse for Element {
 
                 // todo: add a message saying you need to include commas between fields
                 if content.parse::<Token![,]>().is_err() {
-                    missing_trailing_comma!(ident.span());
+                    missing_trailing_comma!(span);
                 }
                 continue;
             }


### PR DESCRIPTION
First time contributing, let me know if something should be different e.g. where I place the test and so on (or if you disagree with the PR altogether).

I noticed if I forget a trailing comma, the span info pointed to the span _before_ the one I expected.

```rust
// user code
rsx!{
  p { class: "foo bar" 
    "hi"
  }
}

// stderr before
error: missing trailing comma
 --> tests/rsx/trailing-comma-0.rs:9:20
  |
9 |             class: "foo bar"
  |             ^^^^^

// stderr after
error: missing trailing comma
 --> tests/rsx/trailing-comma-0.rs:9:20
  |
9 |             class: "foo bar"
  |                    ^^^^^^^^^
```

So I changed the span to the one after, and added a test to verify the new stderr.