### PR TITLE
Feat: add `dx` as a package and move plugin to feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ dioxus-tui = { path = "packages/dioxus-tui" }
 rink = { path = "packages/rink" }
 dioxus-native-core = { path = "packages/native-core" }
 dioxus-native-core-macro = { path = "packages/native-core-macro" }
-dioxus-rsx-rosetta = { path = "packages/rsx-rosetta" }
+rsx-rosetta = { path = "packages/rsx-rosetta" }
 dioxus-signals = { path = "packages/signals" }
 dioxus-hot-reload = { path = "packages/hot-reload" }
 dioxus-fullstack = { path = "packages/fullstack" }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT/Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
 # cli core
 clap = { version = "4.2", features = ["derive"] }
 thiserror = "1.0.30"
@@ -58,10 +57,7 @@ flate2 = "1.0.22"
 tar = "0.4.38"
 zip = "0.6.2"
 tower = "0.4.12"
-
 syn = { version = "1.0", features = ["full", "extra-traits"] }
-
-
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 lazy_static = "1.4.0"
 
@@ -72,21 +68,31 @@ mlua = { version = "0.8.1", features = [
     "async",
     "send",
     "macros",
-] }
+], optional = true }
 ctrlc = "3.2.3"
-# dioxus-rsx = "0.0.1"
 gitignore = "1.0.7"
-
-dioxus-rsx = { git = "https://github.com/DioxusLabs/dioxus" }
-dioxus-html = { git = "https://github.com/DioxusLabs/dioxus", features = ["hot-reload-context"] }
-dioxus-core = { git = "https://github.com/DioxusLabs/dioxus", features = ["serialize"] }
-dioxus-autofmt = { git = "https://github.com/DioxusLabs/dioxus" }
-rsx-rosetta = { git = "https://github.com/DioxusLabs/dioxus" }
 open = "4.1.0"
 cargo-generate = "0.18.3"
 toml_edit = "0.19.11"
+# dioxus-rsx = "0.0.1"
+
+dioxus-autofmt = { workspace = true }
+rsx-rosetta = { workspace = true }
+dioxus-rsx = { workspace = true }
+dioxus-html = { workspace = true, features = ["hot-reload-context"] }
+dioxus-core = { workspace = true, features = ["serialize"] }
+
+[features]
+default = []
+plugin = ["mlua"]
+
+# install path dx and dioxus as the same command
+# so, they're not really aliases
+# eventually dx will defer to the right version of dioxus
+[[bin]]
+path = "src/main.rs"
+name = "dioxus"
 
 [[bin]]
 path = "src/main.rs"
-
-name = "dioxus"
+name = "dx"

--- a/packages/cli/src/cli/build/mod.rs
+++ b/packages/cli/src/cli/build/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "plugin")]
 use crate::plugin::PluginManager;
 
 use super::*;
@@ -38,6 +39,7 @@ impl Build {
                 .clone()
         });
 
+        #[cfg(feature = "plugin")]
         let _ = PluginManager::on_build_start(&crate_config, &platform);
 
         match platform.as_str() {
@@ -69,6 +71,7 @@ impl Build {
         )?;
         file.write_all(temp.as_bytes())?;
 
+        #[cfg(feature = "plugin")]
         let _ = PluginManager::on_build_finish(&crate_config, &platform);
 
         Ok(())

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -68,6 +68,7 @@ pub enum Commands {
     Config(config::Config),
 
     /// Manage plugins for dioxus cli
+    #[cfg(feature = "plugin")]
     #[clap(subcommand)]
     Plugin(plugin::Plugin),
 }
@@ -81,9 +82,11 @@ impl Display for Commands {
             Commands::Create(_) => write!(f, "create"),
             Commands::Clean(_) => write!(f, "clean"),
             Commands::Config(_) => write!(f, "config"),
-            Commands::Plugin(_) => write!(f, "plugin"),
             Commands::Version(_) => write!(f, "version"),
             Commands::Autoformat(_) => write!(f, "fmt"),
+
+            #[cfg(feature = "plugin")]
+            Commands::Plugin(_) => write!(f, "plugin"),
         }
     }
 }

--- a/packages/cli/src/cli/plugin/mod.rs
+++ b/packages/cli/src/cli/plugin/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "plugin")]
+
 use super::*;
 
 /// Build the Rust WASM app and all of its assets.

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -21,4 +21,5 @@ pub use error::*;
 pub mod logging;
 pub use logging::*;
 
+#[cfg(feature = "plugin")]
 pub mod plugin;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -1,6 +1,10 @@
 use anyhow::anyhow;
 use clap::Parser;
-use dioxus_cli::{plugin::PluginManager, *};
+use dioxus_cli::*;
+
+#[cfg(feature = "plugin")]
+use dioxus_cli::plugin::PluginManager;
+
 use Commands::*;
 
 #[tokio::main]
@@ -9,14 +13,15 @@ async fn main() -> anyhow::Result<()> {
 
     set_up_logging();
 
-    let dioxus_config = DioxusConfig::load()
+    let _dioxus_config = DioxusConfig::load()
         .map_err(|e| anyhow!("Failed to load `Dioxus.toml` because: {e}"))?
         .unwrap_or_else(|| {
             log::warn!("You appear to be creating a Dioxus project from scratch; we will use the default config");
             DioxusConfig::default()
         });
 
-    PluginManager::init(dioxus_config.plugin)
+    #[cfg(feature = "plugin")]
+    PluginManager::init(_dioxus_config.plugin)
         .map_err(|e| anyhow!("🚫 Plugin system initialization failed: {e}"))?;
 
     match args.action {
@@ -45,6 +50,7 @@ async fn main() -> anyhow::Result<()> {
             .config()
             .map_err(|e| anyhow!("🚫 Configuring new project failed: {}", e)),
 
+        #[cfg(feature = "plugin")]
         Plugin(opts) => opts
             .plugin()
             .await

--- a/packages/cli/src/server/mod.rs
+++ b/packages/cli/src/server/mod.rs
@@ -422,6 +422,8 @@ pub async fn startup_default(
                 match build_manager.rebuild() {
                     Ok(res) => {
                         last_update_time = chrono::Local::now().timestamp();
+
+                        #[allow(clippy::redundant_clone)]
                         print_console_info(
                             &watcher_ip,
                             port,


### PR DESCRIPTION
We want to alias dioxus to dx now, so the easiest way is to install both so people aren't confused.

`dx` = `dioxus` on the CLI.

Kinda like vc = vercel.

Also, this pulls out the plugin system into a feature to help reduce build times. They're still quite long :/