### PR TITLE
fix: Remove duplicated doc links and improved some descriptions

### DIFF
--- a/packages/autofmt/Cargo.toml
+++ b/packages/autofmt/Cargo.toml
@@ -7,7 +7,6 @@ description = "Autofomatter for Dioxus RSX"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.3.1"
 authors = ["Jonathan Kelley"]
 edition = "2021"
 description = "CLI tool for developing, testing, and publishing Dioxus apps"
+repository = "https://github.com/DioxusLabs/dioxus/"
 license = "MIT/Apache-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # cli core

--- a/packages/core-macro/Cargo.toml
+++ b/packages/core-macro/Cargo.toml
@@ -7,9 +7,7 @@ description = "Core macro for Dioxus Virtual DOM"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
 proc-macro = true

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -7,11 +7,7 @@ description = "Core functionality for Dioxus - a concurrent renderer-agnostic Vi
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
-
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # Bumpalo is used as a micro heap backing each component

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -3,13 +3,11 @@ name = "dioxus-desktop"
 version = "0.3.0"
 authors = ["Jonathan Kelley"]
 edition = "2018"
-description = "Dioxus VirtualDOM renderer for a remote webview instance"
+description = "WebView renderer for Dioxus"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/desktop.html"
 keywords = ["dom", "ui", "gui", "react"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dioxus-core = { workspace = true, features = ["serialize"] }

--- a/packages/dioxus-tui/Cargo.toml
+++ b/packages/dioxus-tui/Cargo.toml
@@ -5,12 +5,9 @@ authors = ["Jonathan Kelley, @dementhos"]
 edition = "2021"
 description = "TUI-based renderer for Dioxus"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/tui.html"
 keywords = ["dom", "ui", "gui", "react", "terminal"]
 license = "MIT/Apache-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dioxus = { workspace = true }

--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -3,11 +3,10 @@ name = "dioxus"
 version = "0.3.2"
 authors = ["Jonathan Kelley", "Dioxus Labs", "ealmloff"]
 edition = "2021"
-description = "Core functionality for Dioxus - a concurrent renderer-agnostic Virtual DOM for interactive user experiences"
+description = "Portable, performant, and ergonomic framework for building cross-platform user interfaces in Rust"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/index.html"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
 rust-version = "1.65.0"
 

--- a/packages/fermi/Cargo.toml
+++ b/packages/fermi/Cargo.toml
@@ -7,10 +7,9 @@ description = "Global state management for Dioxus"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "state-management"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
 dioxus-core = { workspace = true }

--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -6,10 +6,7 @@ description = "Fullstack Dioxus Utilities"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "ssr", "fullstack"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 # server functions

--- a/packages/hooks/Cargo.toml
+++ b/packages/hooks/Cargo.toml
@@ -7,9 +7,8 @@ description = "Basic useful hooks for Dioxus."
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 
 [dependencies]
 dioxus-core = { workspace = true }

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -4,12 +4,9 @@ version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/hot_reload.html"
 description = "Hot reloading utilites for Dioxus"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "hot-reloading"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dioxus-rsx = { workspace = true }

--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -7,7 +7,6 @@ description = "HTML Element pack for Dioxus - a concurrent renderer-agnostic Vir
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
 
 [dependencies]

--- a/packages/interpreter/Cargo.toml
+++ b/packages/interpreter/Cargo.toml
@@ -10,8 +10,6 @@ homepage = "https://dioxuslabs.com"
 documentation = "https://docs.rs/dioxus"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 wasm-bindgen = { workspace = true, optional = true }
 js-sys = { version = "0.3.56", optional = true }

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -3,14 +3,10 @@ name = "dioxus-liveview"
 version = "0.3.1"
 edition = "2021"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/liveview.html"
 keywords = ["dom", "ui", "gui", "react", "liveview"]
 description = "Build server-side apps with Dioxus"
 license = "MIT/Apache-2.0"
-
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 thiserror = "1.0.38"

--- a/packages/mobile/Cargo.toml
+++ b/packages/mobile/Cargo.toml
@@ -5,11 +5,9 @@ authors = ["Jonathan Kelley"]
 edition = "2018"
 description = "Mobile-compatible renderer for Dioxus"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/mobile.html"
 keywords = ["dom", "ui", "gui", "react"]
 license = "MIT/Apache-2.0"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dioxus-desktop = { workspace = true }

--- a/packages/native-core-macro/Cargo.toml
+++ b/packages/native-core-macro/Cargo.toml
@@ -6,14 +6,11 @@ description = "Build natively rendered apps with Dioxus"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
-
 
 [lib]
 proc-macro = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 syn = { version = "1.0.11", features = ["extra-traits", "full"] }
 quote = "1.0"

--- a/packages/native-core/Cargo.toml
+++ b/packages/native-core/Cargo.toml
@@ -6,9 +6,7 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
 description = "Build natively rendered apps with Dioxus"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react"]
-
 
 [dependencies]
 dioxus-core = { workspace = true, optional = true }

--- a/packages/rink/Cargo.toml
+++ b/packages/rink/Cargo.toml
@@ -6,11 +6,8 @@ edition = "2021"
 description = "TUI-based renderer for Dioxus"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "terminal"]
 license = "MIT/Apache-2.0"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dioxus-html = { workspace = true }

--- a/packages/router/Cargo.toml
+++ b/packages/router/Cargo.toml
@@ -6,9 +6,7 @@ description = "Cross-platform router for Dioxus apps"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dioxus = { workspace = true}

--- a/packages/ssr/Cargo.toml
+++ b/packages/ssr/Cargo.toml
@@ -6,11 +6,8 @@ edition = "2018"
 description = "Dioxus render-to-string"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/ssr.html"
 keywords = ["dom", "ui", "gui", "react", "ssr"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 dioxus-core = { workspace = true, features = ["serialize"] }

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -3,11 +3,10 @@ name = "dioxus-web"
 version = "0.3.2"
 authors = ["Jonathan Kelley"]
 edition = "2018"
-description = "Dioxus VirtualDOM renderer for the web browser using websys"
+description = "Web renderer for Dioxus using websys"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
-homepage = "https://dioxuslabs.com"
-documentation = "https://dioxuslabs.com"
+homepage = "https://dioxuslabs.com/docs/0.3/guide/en/getting_started/web.html"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
 
 [dependencies]


### PR DESCRIPTION
## Changes
- Updated some descriptions to make them more clear
- Removed `documentation` links so they get filled with the generated link from `docs.rs`
- Updated some `homepage` links with platform-specific guides (e.g desktop, tui, ssr, etc)

Feel free to edit anything you think didn't have to be modified 👍 