### PR TITLE
Proposal: truncate files before uploading from liveview

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1155,6 +1155,8 @@ builder_constructors! {
         // value: String,
         value: String volatile,
         initial_value: String DEFAULT,
+
+        _liveview_truncate_at: usize "1048576",
     };
 
     /// Build a

--- a/packages/html/src/events/form.rs
+++ b/packages/html/src/events/form.rs
@@ -27,6 +27,9 @@ pub struct FormData {
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SerializedFileEngine {
     files: HashMap<String, Vec<u8>>,
+
+    #[serde(default)]
+    sizes: Option<HashMap<String, usize>>,
 }
 
 #[cfg(feature = "serialize")]
@@ -35,6 +38,16 @@ impl FileEngine for SerializedFileEngine {
     fn files(&self) -> Vec<String> {
         self.files.keys().cloned().collect()
     }
+
+    /*    fn sizes(&self) -> HashMap<String, usize> {
+            match self.sizes {
+                Some(ref sizes) => sizes.clone(),
+                None => {
+                    self.files.iter().map(|(k, v)| (k.clone(), v.len())).collect()
+                }
+            }
+        }
+    */
 
     async fn read_file(&self, file: &str) -> Option<Vec<u8>> {
         self.files.get(file).cloned()

--- a/packages/liveview/src/lib.rs
+++ b/packages/liveview/src/lib.rs
@@ -45,20 +45,25 @@ static INTERPRETER_JS: Lazy<String> = Lazy::new(|| {
       (event.type === "change" || event.type === "input")
     ) {
       const type = target.getAttribute("type");
+      const _liveview_truncate_at = target.getAttribute("_liveview_truncate_at");
+        
       if (type === "file") {
         async function read_files() {
           const files = target.files;
           const file_contents = {};
+          const file_sizes = {};
 
           for (let i = 0; i < files.length; i++) {
             const file = files[i];
 
             file_contents[file.name] = Array.from(
-              new Uint8Array(await file.arrayBuffer())
+              new Uint8Array(await file.slice(0, _liveview_truncate_at).arrayBuffer())
             );
+            file_sizes[file.name] = file.size;
           }
           let file_engine = {
             files: file_contents,
+            sizes: file_sizes
           };
           contents.files = file_engine;
 


### PR DESCRIPTION
In `liveview`, even when `onchange` is not set for an `input type="file"`, every chosen file is serialised and sent as one big WS message. In case of choosing a large file, even accidentally, this leads to JS errors (for hundreds-of-megabytes-big files), WS disconnections (for tens of megabytes), or UI freezes (for couples of megabytes).

Eventually and ideally, file uploads would be streamed piece by piece. However, probably even in that case there should be a modicum of control over those uploads, e.g. a limitation on the size of the uploaded file, otherwise one can see a potential for DDoS.

This PR is very modest, but would go a long way toward helping me to overcome this limitation until a better solution is devised. I think the approach I take here would be quite useful even when the streaming uploads are done.

I'm really not sure about the exact API and naming, and whether it makes sense to limit this attribute to liveview-only. 

The PR adds an attribute called `_liveview_truncate_at`, with a default of 1 mb. The files chosen in the file-input are truncated to this size prior to sending them along the WS. I'd also propose to send and expose the original file sizes (the client side of this is also implemented in the PR), to make sure that the truncated files aren't accidentally taken to be complete. However, I wanted to discuss this before I start reworking major APIs across the different engines.

(A simple way to expose the size, as commented out in the PR, is through exposing the sizes as a method. A type-safer method could perhaps return a file as an enum: `Complete(Contents), Truncated(usize, Contents), Streamed(impl Stream, Contents)`...)