### PR TITLE
Re-add provide_root_context for lazy singleton initialization

### DIFF
--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -1,5 +1,4 @@
 use dioxus::prelude::*;
-use dioxus_signals::{use_init_signal_rt, use_signal};
 use std::time::Duration;
 
 fn main() {
@@ -7,9 +6,7 @@ fn main() {
 }
 
 fn app(cx: Scope) -> Element {
-    use_init_signal_rt(cx);
-
-    let mut count = use_signal(cx, || 0);
+    let mut count = dioxus_signals::use_signal(cx, || 0);
 
     use_future!(cx, || async move {
         loop {

--- a/packages/core-macro/tests/ifmt.rs
+++ b/packages/core-macro/tests/ifmt.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::all)]
+
 use std::borrow::Borrow;
 
 use dioxus_core_macro::*;

--- a/packages/core-macro/tests/ifmt.rs
+++ b/packages/core-macro/tests/ifmt.rs
@@ -1,7 +1,3 @@
-#![allow(clippy::all)]
-
-use std::borrow::Borrow;
-
 use dioxus_core_macro::*;
 
 #[test]
@@ -22,8 +18,8 @@ fn formatting_compiles() {
 
     // function calls in formatings work
     assert_eq!(
-        format_args_f!("{x.borrow():?}").to_string(),
-        format!("{:?}", x.borrow())
+        format_args_f!("{blah(&x):?}").to_string(),
+        format!("{:?}", blah(&x))
     );
 
     // allows duplicate format args
@@ -31,4 +27,8 @@ fn formatting_compiles() {
         format_args_f!("{x:?} {x:?}").to_string(),
         format!("{x:?} {x:?}")
     );
+}
+
+fn blah(hi: &(i32, i32)) -> String {
+    format_args_f!("{hi.0} {hi.1}").to_string()
 }

--- a/packages/hooks/src/lib.rs
+++ b/packages/hooks/src/lib.rs
@@ -79,3 +79,6 @@ pub use usecallback::*;
 
 mod usememo;
 pub use usememo::*;
+
+mod userootcontext;
+pub use userootcontext::*;

--- a/packages/hooks/src/userootcontext.rs
+++ b/packages/hooks/src/userootcontext.rs
@@ -1,0 +1,9 @@
+use dioxus_core::ScopeState;
+
+///
+pub fn use_root_context<T: 'static + Clone>(cx: &ScopeState, new: impl FnOnce() -> T) -> &T {
+    cx.use_hook(|| {
+        cx.consume_context::<T>()
+            .unwrap_or_else(|| cx.provide_root_context(new()))
+    })
+}


### PR DESCRIPTION
This PR re-adds provide_root_context so crates like signals, routers, etc can lazily initialize their singletons from anywhere in the app.

This could be considered "magic" but I'm leaning more towards the idea that these are singleton objects that are *meant* to be at the top of your app. It would not make sense to have multiple signal runtimes or multiple routers in a single app. These libraries should provide their own mechanisms for "subtrees" that can be built around this behavior.

```
Provide a context to the root and then consume it

This is intended for "global" state management solutions that would rather be implicit for the entire app. Things like signal runtimes and routers are examples of "singletons" that would benefit from lazy initialization.

Note that you should be checking if the context existed before trying to provide a new one. Providing a context when a context already exists will swap the context out for the new one, which may not be what you want.
```