### PR TITLE
Fixed typo in Router guide getting-started.md

### DIFF
--- a/docs/router/src/guide/getting-started.md
+++ b/docs/router/src/guide/getting-started.md
@@ -6,7 +6,7 @@ If you haven't already, make sure you install the [dioxus-cli](https://dioxuslab
 ```
 $ cargo install dioxus-cli
     ...
-$ rustup target add wasm32-unkown-unknown
+$ rustup target add wasm32-unknown-unknown
     ...
 ```
 


### PR DESCRIPTION
PR is largely self-explanatory.

The [Getting Started page for the Dioxus Router](https://dioxuslabs.com/docs/0.3/router/guide/getting-started.html) says we should use:
`rustup target add wasm32-unkown-unknown`, however the correct target is
`rustup target add wasm32-unknown-unknown`.

This PR adds the missing `n` to the first `unknown`.