### PR TITLE
Prepare for Sledgehammer Bindgen in Liveview

### DIFF
--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -688,13 +688,13 @@ impl<'src> ScopeState {
                 raw_ref.downcast_mut::<State>()
             })
             .expect(
-                r###"
+                r#"
                 Unable to retrieve the hook that was initialized at this index.
                 Consult the `rules of hooks` to understand how to use hooks properly.
 
                 You likely used the hook in a conditional. Hooks rely on consistent ordering between renders.
                 Functions prefixed with "use" should never be called conditionally.
-                "###,
+                "#,
             )
     }
 }

--- a/packages/liveview/src/adapters/axum_adapter.rs
+++ b/packages/liveview/src/adapters/axum_adapter.rs
@@ -11,13 +11,14 @@ pub fn axum_socket(ws: WebSocket) -> impl LiveViewSocket {
         .sink_map_err(|_| LiveViewError::SendingFailed)
 }
 
-fn transform_rx(message: Result<Message, axum::Error>) -> Result<String, LiveViewError> {
+fn transform_rx(message: Result<Message, axum::Error>) -> Result<Vec<u8>, LiveViewError> {
     message
         .map_err(|_| LiveViewError::SendingFailed)?
         .into_text()
+        .map(|s| s.into_bytes())
         .map_err(|_| LiveViewError::SendingFailed)
 }
 
-async fn transform_tx(message: String) -> Result<Message, axum::Error> {
-    Ok(Message::Text(message))
+async fn transform_tx(message: Vec<u8>) -> Result<Message, axum::Error> {
+    Ok(Message::Text(String::from_utf8_lossy(&message).to_string()))
 }

--- a/packages/liveview/src/adapters/salvo_adapter.rs
+++ b/packages/liveview/src/adapters/salvo_adapter.rs
@@ -12,14 +12,12 @@ pub fn salvo_socket(ws: WebSocket) -> impl LiveViewSocket {
         .sink_map_err(|_| LiveViewError::SendingFailed)
 }
 
-fn transform_rx(message: Result<Message, salvo::Error>) -> Result<String, LiveViewError> {
+fn transform_rx(message: Result<Message, salvo::Error>) -> Result<Vec<u8>, LiveViewError> {
     let as_bytes = message.map_err(|_| LiveViewError::SendingFailed)?;
 
-    let msg = String::from_utf8(as_bytes.into_bytes()).map_err(|_| LiveViewError::SendingFailed)?;
-
-    Ok(msg)
+    Ok(as_bytes.into())
 }
 
-async fn transform_tx(message: String) -> Result<Message, salvo::Error> {
-    Ok(Message::text(message))
+async fn transform_tx(message: Vec<u8>) -> Result<Message, salvo::Error> {
+    Ok(Message::text(String::from_utf8_lossy(&message).to_string()))
 }

--- a/packages/liveview/src/adapters/warp_adapter.rs
+++ b/packages/liveview/src/adapters/warp_adapter.rs
@@ -11,18 +11,15 @@ pub fn warp_socket(ws: WebSocket) -> impl LiveViewSocket {
         .sink_map_err(|_| LiveViewError::SendingFailed)
 }
 
-fn transform_rx(message: Result<Message, warp::Error>) -> Result<String, LiveViewError> {
+fn transform_rx(message: Result<Message, warp::Error>) -> Result<Vec<u8>, LiveViewError> {
     // destructure the message into the buffer we got from warp
     let msg = message
         .map_err(|_| LiveViewError::SendingFailed)?
         .into_bytes();
 
-    // transform it back into a string, saving us the allocation
-    let msg = String::from_utf8(msg).map_err(|_| LiveViewError::SendingFailed)?;
-
     Ok(msg)
 }
 
-async fn transform_tx(message: String) -> Result<Message, warp::Error> {
-    Ok(Message::text(message))
+async fn transform_tx(message: Vec<u8>) -> Result<Message, warp::Error> {
+    Ok(Message::text(String::from_utf8_lossy(&message).to_string()))
 }

--- a/packages/liveview/src/pool.rs
+++ b/packages/liveview/src/pool.rs
@@ -87,16 +87,16 @@ impl LiveViewPool {
 /// }
 /// ```
 pub trait LiveViewSocket:
-    SinkExt<String, Error = LiveViewError>
-    + StreamExt<Item = Result<String, LiveViewError>>
+    SinkExt<Vec<u8>, Error = LiveViewError>
+    + StreamExt<Item = Result<Vec<u8>, LiveViewError>>
     + Send
     + 'static
 {
 }
 
 impl<S> LiveViewSocket for S where
-    S: SinkExt<String, Error = LiveViewError>
-        + StreamExt<Item = Result<String, LiveViewError>>
+    S: SinkExt<Vec<u8>, Error = LiveViewError>
+        + StreamExt<Item = Result<Vec<u8>, LiveViewError>>
         + Send
         + 'static
 {

--- a/packages/liveview/src/pool.rs
+++ b/packages/liveview/src/pool.rs
@@ -160,7 +160,7 @@ pub async fn run(mut vdom: VirtualDom, ws: impl LiveViewSocket) -> Result<(), Li
                         ws.send(b"__pong__".to_vec()).await?;
                     }
                     Some(Ok(evt)) => {
-                        if let Ok(message) = serde_json::from_str::<IpcMessage>(&*String::from_utf8_lossy(evt)) {
+                        if let Ok(message) = serde_json::from_str::<IpcMessage>(&String::from_utf8_lossy(evt)) {
                             match message {
                                 IpcMessage::Event(evt) => {
                                     // Intercept the mounted event and insert a custom element type

--- a/packages/liveview/src/pool.rs
+++ b/packages/liveview/src/pool.rs
@@ -126,7 +126,7 @@ pub async fn run(mut vdom: VirtualDom, ws: impl LiveViewSocket) -> Result<(), Li
     pin_mut!(ws);
 
     // send the initial render to the client
-    ws.send(edits).await?;
+    ws.send(edits.into_bytes()).await?;
 
     // Create the a proxy for query engine
     let (query_tx, mut query_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -156,11 +156,11 @@ pub async fn run(mut vdom: VirtualDom, ws: impl LiveViewSocket) -> Result<(), Li
             evt = ws.next() => {
                 match evt.as_ref().map(|o| o.as_deref()) {
                     // respond with a pong every ping to keep the websocket alive
-                    Some(Ok("__ping__")) => {
-                        ws.send("__pong__".to_string()).await?;
+                    Some(Ok(b"__ping__")) => {
+                        ws.send(b"__pong__".to_vec()).await?;
                     }
                     Some(Ok(evt)) => {
-                        if let Ok(message) = serde_json::from_str::<IpcMessage>(evt) {
+                        if let Ok(message) = serde_json::from_str::<IpcMessage>(&*String::from_utf8_lossy(evt)) {
                             match message {
                                 IpcMessage::Event(evt) => {
                                     // Intercept the mounted event and insert a custom element type
@@ -196,7 +196,7 @@ pub async fn run(mut vdom: VirtualDom, ws: impl LiveViewSocket) -> Result<(), Li
 
             // handle any new queries
             Some(query) = query_rx.recv() => {
-                ws.send(serde_json::to_string(&ClientUpdate::Query(query)).unwrap()).await?;
+                ws.send(serde_json::to_string(&ClientUpdate::Query(query)).unwrap().into_bytes()).await?;
             }
 
             Some(msg) = hot_reload_wait => {
@@ -218,8 +218,12 @@ pub async fn run(mut vdom: VirtualDom, ws: impl LiveViewSocket) -> Result<(), Li
             .render_with_deadline(tokio::time::sleep(Duration::from_millis(10)))
             .await;
 
-        ws.send(serde_json::to_string(&ClientUpdate::Edits(edits)).unwrap())
-            .await?;
+        ws.send(
+            serde_json::to_string(&ClientUpdate::Edits(edits))
+                .unwrap()
+                .into_bytes(),
+        )
+        .await?;
     }
 }
 

--- a/packages/signals/src/lib.rs
+++ b/packages/signals/src/lib.rs
@@ -10,8 +10,6 @@ mod rt;
 use dioxus_core::ScopeState;
 pub use rt::*;
 
-use crate::rt::claim_rt;
-
 pub fn use_init_signal_rt(cx: &ScopeState) {
     cx.use_hook(|| {
         let rt = claim_rt(cx.schedule_update_any());
@@ -96,11 +94,7 @@ impl<T: Clone + 'static> std::ops::Deref for Signal<T> {
 
 impl<T> std::clone::Clone for Signal<T> {
     fn clone(&self) -> Self {
-        Self {
-            t: PhantomData,
-            id: self.id,
-            rt: self.rt,
-        }
+        *self
     }
 }
 


### PR DESCRIPTION
This makes changes to the liveview renderer to prepare for #695. This is the only breaking change that moving to sledgehammer will require for liveview. Sledgehammer bindgen will require a stream of bytes instead of a stream of strings. Integrating with sledgehammer will be done after 0.4, but after this PR it should be a non-breaking change.