### PR TITLE
Fix use future restarting tasks

### DIFF
--- a/packages/hooks/src/usefuture.rs
+++ b/packages/hooks/src/usefuture.rs
@@ -54,11 +54,6 @@ where
         let schedule_update = state.update.clone();
         let waker = state.waker.clone();
 
-        // Cancel the current future
-        if let Some(current) = state.task.take() {
-            cx.remove_future(current);
-        }
-
         state.task.set(Some(cx.push_future(async move {
             let res = fut.await;
             values.borrow_mut().push(Box::leak(Box::new(res)));


### PR DESCRIPTION
Fixes #1206

When a future was restarted, it canceled the old task. The documentation stated that it would allow the old task to continue. This PR changes that behavior to allow the task to continue.

Problem in 1206:

1. Future 1 starts. It is assigned id 0
2. Future 2 starts. It is assigned id 1
3. Future 1 resolves, and marks the scope as dirty. This restores the id 0 in the id pool.
4. Future 2 resolves, and marks the scope as dirty. This restores the id 1 in the id pool.
5. Future 2's scope reruns and a new future is created. It is assigned the newly restored id 0. It manually restored the already restored id 1 to the pool.
6. Future 1's scope reruns and a new future is created. It is assigned the newly restored id 1. It manually restored the already restored id 0 to the pool. This removes Future 2's task, causing the task to never finish