### PR TITLE
Kill previous CI jobs when new pushed

### DIFF
--- a/.github/workflows/docs stable.yml
+++ b/.github/workflows/docs stable.yml
@@ -3,6 +3,10 @@ name: docs stable
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,6 +24,10 @@ on:
       - lib.rs
       - Cargo.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,10 @@ on:
       - lib.rs
       - Cargo.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -38,7 +38,9 @@ env:
   # - tokio-stream/Cargo.toml
   # rust_min: 1.49.0
 
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,11 @@ on:
 defaults:
   run:
     working-directory: ./playwright-tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,10 @@ on:
       - lib.rs
       - Cargo.toml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
Uses concurrency features of github actions to prevent us from draining CI for hours.