### PR TITLE
Log errors when a component fails to render

### DIFF
--- a/packages/core/src/any_props.rs
+++ b/packages/core/src/any_props.rs
@@ -67,7 +67,7 @@ unsafe impl<'a, P> AnyProps<'a> for VProps<'a, P> {
             Ok(Some(e)) => RenderReturn::Ready(e),
             Ok(None) => RenderReturn::default(),
             Err(err) => {
-                let component_name = std::any::type_name::<P>();
+                let component_name = cx.name();
                 log::error!("Error while rendering component `{component_name}`: {err:?}");
                 RenderReturn::default()
             }

--- a/packages/core/src/any_props.rs
+++ b/packages/core/src/any_props.rs
@@ -65,7 +65,12 @@ unsafe impl<'a, P> AnyProps<'a> for VProps<'a, P> {
 
         match res {
             Ok(Some(e)) => RenderReturn::Ready(e),
-            _ => RenderReturn::default(),
+            Ok(None) => RenderReturn::default(),
+            Err(err) => {
+                let component_name = std::any::type_name::<P>();
+                log::error!("Error while rendering component `{component_name}`: {err:?}");
+                RenderReturn::default()
+            }
         }
     }
 }


### PR DESCRIPTION
When a component fails to render on desktop/ssr, dioxus will catch the error and render a placeholder. This PR adds a log::error to let the developer know what component failed to render and what the error was