### PR TITLE
Fix route prerendering

### DIFF
--- a/packages/router/src/incremental.rs
+++ b/packages/router/src/incremental.rs
@@ -50,7 +50,8 @@ where
                         &mut tokio::io::sink(),
                         |vdom| {
                             Box::pin(async move {
-                                let _ = vdom.wait_for_suspense().await;
+                                let _ = vdom.rebuild();
+                                vdom.wait_for_suspense().await;
                             })
                         },
                         wrapper,


### PR DESCRIPTION
The router incremental rendering feature currently does not rebuild the router before waiting for suspense. This breaks the static-hydrated example in fullstack. This PR adds rebuilding to fix that.