### PR TITLE
Fix use_future always spawning a new task and never updating

### DIFF
--- a/packages/hooks/src/usefuture.rs
+++ b/packages/hooks/src/usefuture.rs
@@ -52,6 +52,9 @@ where
             val.set(Some(fut.await));
             task.take();
         })));
+
+        // Mark that we don't need to regenerate
+        state.needs_regen.set(false);
     }
 
     state

--- a/packages/hooks/src/usefuture.rs
+++ b/packages/hooks/src/usefuture.rs
@@ -57,6 +57,9 @@ where
         state.needs_regen.set(false);
     }
 
+    // update the current value
+    state.state.current_val = val.current_val.clone();
+
     state
 }
 


### PR DESCRIPTION
Fixes a regression on use future that makes it always respawn the task and always return a stale unresolved value