### PR TITLE
fix: Use correct cfg for file_watcher feature in dioxus-hot-reload

### DIFF
--- a/packages/hot-reload/src/file_watcher.rs
+++ b/packages/hot-reload/src/file_watcher.rs
@@ -12,6 +12,7 @@ use dioxus_rsx::{
 };
 use interprocess_docfix::local_socket::{LocalSocketListener, LocalSocketStream};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+use crate::HotReloadMsg;
 
 pub use dioxus_html::HtmlCtx;
 use serde::{Deserialize, Serialize};

--- a/packages/hot-reload/src/file_watcher.rs
+++ b/packages/hot-reload/src/file_watcher.rs
@@ -5,6 +5,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use crate::HotReloadMsg;
 use dioxus_core::Template;
 use dioxus_rsx::{
     hot_reload::{FileMap, FileMapBuildResult, UpdateResult},
@@ -12,7 +13,6 @@ use dioxus_rsx::{
 };
 use interprocess_docfix::local_socket::{LocalSocketListener, LocalSocketStream};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
-use crate::HotReloadMsg;
 
 pub use dioxus_html::HtmlCtx;
 use serde::{Deserialize, Serialize};

--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "file_watcher")]
 mod file_watcher;
 #[cfg(feature = "file_watcher")]
-use file_watcher::*;
+pub use file_watcher::*;
 
 /// A message the hot reloading server sends to the client
 #[derive(Debug, Serialize, Deserialize, Clone, Copy)]

--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -1,14 +1,14 @@
 use std::io::{BufRead, BufReader};
 
 use dioxus_core::Template;
-#[cfg(file_watcher)]
+#[cfg(feature = "file_watcher")]
 pub use dioxus_html::HtmlCtx;
 use interprocess_docfix::local_socket::LocalSocketStream;
 use serde::{Deserialize, Serialize};
 
-#[cfg(file_watcher)]
+#[cfg(feature = "file_watcher")]
 mod file_watcher;
-#[cfg(file_watcher)]
+#[cfg(feature = "file_watcher")]
 use file_watcher::*;
 
 /// A message the hot reloading server sends to the client


### PR DESCRIPTION
- Made `Config` public again
- Fix import in file_watcher.rs
- Use correct cfg syntax for `file_watcher` feature