### PR TITLE
Make new enum router less breaking

### DIFF
--- a/docs/router/examples/dynamic_route.rs
+++ b/docs/router/examples/dynamic_route.rs
@@ -44,8 +44,8 @@ fn NavBar(cx: Scope) -> Element {
     render! {
         nav {
             ul {
-                li { Link { target: Route::Home {}, "Home" } }
-                li { Link { target: Route::BlogList {}, "Blog" } }
+                li { Link { to: Route::Home {}, "Home" } }
+                li { Link { to: Route::BlogList {}, "Blog" } }
             }
         }
         Outlet {}
@@ -77,13 +77,13 @@ fn BlogList(cx: Scope) -> Element {
         ul {
             li {
                 Link {
-                    target: Route::BlogPost { name: "Blog post 1".into() },
+                    to: Route::BlogPost { name: "Blog post 1".into() },
                     "Read the first blog post"
                 }
             }
             li {
                 Link {
-                    target: Route::BlogPost { name: "Blog post 2".into() },
+                    to: Route::BlogPost { name: "Blog post 2".into() },
                     "Read the second blog post"
                 }
             }

--- a/docs/router/examples/external_link.rs
+++ b/docs/router/examples/external_link.rs
@@ -20,7 +20,7 @@ fn main() {}
 fn GoToDioxus(cx: Scope) -> Element {
     render! {
         Link {
-            target: NavigationTarget::External("https://dioxuslabs.com".into()),
+            to: NavigationTarget::External("https://dioxuslabs.com".into()),
             "ExternalTarget target"
         }
     }

--- a/docs/router/examples/full_example.rs
+++ b/docs/router/examples/full_example.rs
@@ -48,8 +48,8 @@ fn NavBar(cx: Scope) -> Element {
     render! {
         nav {
             ul {
-                li { Link { target: Route::Home {}, "Home" } }
-                li { Link { target: Route::BlogList {}, "Blog" } }
+                li { Link { to: Route::Home {}, "Home" } }
+                li { Link { to: Route::BlogList {}, "Blog" } }
             }
         }
         Outlet {}
@@ -78,13 +78,13 @@ fn BlogList(cx: Scope) -> Element {
         ul {
             li {
                 Link {
-                    target: Route::BlogPost { name: "Blog post 1".into() },
+                    to: Route::BlogPost { name: "Blog post 1".into() },
                     "Read the first blog post"
                 }
             }
             li {
                 Link {
-                    target: Route::BlogPost { name: "Blog post 2".into() },
+                    to: Route::BlogPost { name: "Blog post 2".into() },
                     "Read the second blog post"
                 }
             }

--- a/docs/router/examples/links.rs
+++ b/docs/router/examples/links.rs
@@ -26,7 +26,7 @@ fn NavBar(cx: Scope) -> Element {
                     Link {
                         // The Link component will navigate to the route specified
                         // in the target prop which is checked to exist at compile time
-                        target: Route::Home {},
+                        to: Route::Home {},
                         "Home"
                     }
                 }

--- a/examples/crm.rs
+++ b/examples/crm.rs
@@ -58,12 +58,12 @@ fn ClientList(cx: Scope) -> Element {
         h2 { "List of Clients" }
 
         Link {
-            target: Route::ClientAdd {},
+            to: Route::ClientAdd {},
             class: "pure-button pure-button-primary",
             "Add Client"
         }
         Link {
-            target: Route::Settings {},
+            to: Route::Settings {},
             class: "pure-button",
             "Settings"
         }
@@ -161,7 +161,7 @@ fn ClientAdd(cx: Scope) -> Element {
                         "Save"
                     }
                     Link {
-                        target: Route::ClientList {},
+                        to: Route::ClientList {},
                         class: "pure-button pure-button-primary red",
                         "Cancel"
                     }
@@ -190,7 +190,7 @@ fn Settings(cx: Scope) -> Element {
         }
 
         Link {
-            target: Route::ClientList {},
+            to: Route::ClientList {},
             class: "pure-button",
             "Go back"
         }

--- a/examples/flat_router.rs
+++ b/examples/flat_router.rs
@@ -48,10 +48,10 @@ fn Footer(cx: Scope) -> Element {
 
             nav {
                 ul {
-                    li { Link { target: Route::Home {}, "Home" } }
-                    li { Link { target: Route::Games {}, "Games" } }
-                    li { Link { target: Route::Play {}, "Play" } }
-                    li { Link { target: Route::Settings {}, "Settings" } }
+                    li { Link { to: Route::Home {}, "Home" } }
+                    li { Link { to: Route::Games {}, "Games" } }
+                    li { Link { to: Route::Play {}, "Play" } }
+                    li { Link { to: Route::Settings {}, "Settings" } }
                 }
             }
         }

--- a/examples/link.rs
+++ b/examples/link.rs
@@ -43,8 +43,8 @@ fn Header(cx: Scope) -> Element {
     render! {
         h1 { "Your app here" }
         ul {
-            li { Link { target: Route::Home {}, "home" } }
-            li { Link { target: Route::Settings {}, "settings" } }
+            li { Link { to: Route::Home {}, "home" } }
+            li { Link { to: Route::Settings {}, "settings" } }
         }
         Outlet {}
     }

--- a/examples/router.rs
+++ b/examples/router.rs
@@ -48,8 +48,8 @@ fn NavBar(cx: Scope) -> Element {
     render! {
         nav {
             ul {
-                li { Link { target: Route::Home {}, "Home" } }
-                li { Link { target: Route::BlogList {}, "Blog" } }
+                li { Link { to: Route::Home {}, "Home" } }
+                li { Link { to: Route::BlogList {}, "Blog" } }
             }
         }
         Outlet {}
@@ -78,13 +78,13 @@ fn BlogList(cx: Scope) -> Element {
         ul {
             li {
                 Link {
-                    target: Route::BlogPost { name: "Blog post 1".into() },
+                    to: Route::BlogPost { name: "Blog post 1".into() },
                     "Read the first blog post"
                 }
             }
             li {
                 Link {
-                    target: Route::BlogPost { name: "Blog post 2".into() },
+                    to: Route::BlogPost { name: "Blog post 2".into() },
                     "Read the second blog post"
                 }
             }

--- a/examples/simple_desktop.rs
+++ b/examples/simple_desktop.rs
@@ -41,11 +41,11 @@ fn NavBar(cx: Scope) -> Element {
     render! {
         h1 { "Your app here" }
         ul {
-            li { Link { target: Route::Home {}, "home" } }
-            li { Link { target: Route::BlogList {}, "blog" } }
-            li { Link { target: Route::BlogPost { post: "tim".into() }, "tims' blog" } }
-            li { Link { target: Route::BlogPost { post: "bill".into() }, "bills' blog" } }
-            li { Link { target: Route::BlogPost { post: "james".into() }, "james amazing' blog" } }
+            li { Link { to: Route::Home {}, "home" } }
+            li { Link { to: Route::BlogList {}, "blog" } }
+            li { Link { to: Route::BlogPost { post: "tim".into() }, "tims' blog" } }
+            li { Link { to: Route::BlogPost { post: "bill".into() }, "bills' blog" } }
+            li { Link { to: Route::BlogPost { post: "james".into() }, "james amazing' blog" } }
         }
         Outlet {}
     }
@@ -70,7 +70,7 @@ fn BlogPost(cx: Scope, post: String) -> Element {
     render! {
         div {
             h3 { "blog post: {post}"  }
-            Link { target: Route::BlogList {}, "back to blog list" }
+            Link { to: Route::BlogList {}, "back to blog list" }
         }
     }
 }

--- a/packages/fullstack/examples/axum-router/src/main.rs
+++ b/packages/fullstack/examples/axum-router/src/main.rs
@@ -28,7 +28,7 @@ enum Route {
 #[inline_props]
 fn Blog(cx: Scope, id: i32) -> Element {
     render! {
-        Link { target: Route::Home {}, "Go to counter" }
+        Link { to: Route::Home {}, "Go to counter" }
         table {
             tbody {
                 for _ in 0..*id {
@@ -50,7 +50,7 @@ fn Home(cx: Scope) -> Element {
 
     cx.render(rsx! {
         Link {
-            target: Route::Blog {
+            to: Route::Blog {
                 id: *count.get()
             },
             "Go to blog"

--- a/packages/fullstack/examples/static-hydrated/src/main.rs
+++ b/packages/fullstack/examples/static-hydrated/src/main.rs
@@ -52,7 +52,7 @@ enum Route {
 #[inline_props]
 fn Blog(cx: Scope) -> Element {
     render! {
-        Link { target: Route::Home {}, "Go to counter" }
+        Link { to: Route::Home {}, "Go to counter" }
         table {
             tbody {
                 for _ in 0..100 {
@@ -74,7 +74,7 @@ fn Home(cx: Scope) -> Element {
 
     cx.render(rsx! {
         Link {
-            target: Route::Blog {},
+            to: Route::Blog {},
             "Go to blog"
         }
         div {

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -60,7 +60,7 @@ fn Index(cx: Scope) -> Element {
     render! {
         h1 { "Index" }
         Link {
-            target: Route::BlogList {},
+            to: Route::BlogList {},
             "Go to the blog"
         }
     }
@@ -79,11 +79,11 @@ fn BlogList(cx: Scope) -> Element {
     render! {
         h2 { "List of blog posts" }
         Link {
-            target: Route::BlogPost { blog_id: 0 },
+            to: Route::BlogPost { blog_id: 0 },
             "Blog post 1"
         }
         Link {
-            target: Route::BlogPost { blog_id: 1 },
+            to: Route::BlogPost { blog_id: 1 },
             "Blog post 2"
         }
     }

--- a/packages/router/examples/simple_routes.rs
+++ b/packages/router/examples/simple_routes.rs
@@ -39,12 +39,12 @@ fn Route1(cx: Scope, user_id: usize, dynamic: usize, query: String, extra: Strin
             "Route1{{\n\tuser_id:{user_id},\n\tdynamic:{dynamic},\n\tquery:{query},\n\textra:{extra}\n}}"
         }
         Link {
-            target: Route::Route1 { user_id: *user_id, dynamic: *dynamic, query: String::new(), extra: extra.clone() + "." },
+            to: Route::Route1 { user_id: *user_id, dynamic: *dynamic, query: String::new(), extra: extra.clone() + "." },
             "Route1 with extra+\".\""
         }
         p { "Footer" }
         Link {
-            target: Route::Route3 { dynamic: String::new() },
+            to: Route::Route3 { dynamic: String::new() },
             "Home"
         }
     }
@@ -59,7 +59,7 @@ fn Route2(cx: Scope, user_id: usize) -> Element {
         (0..*user_id).map(|i| rsx!{ p { "{i}" } }),
         p { "Footer" }
         Link {
-            target: Route::Route3 { dynamic: String::new() },
+            to: Route::Route3 { dynamic: String::new() },
             "Home"
         }
     }
@@ -86,7 +86,7 @@ fn Route3(cx: Scope, dynamic: String) -> Element {
         }
         "dynamic: {dynamic}"
         Link {
-            target: Route::Route2 { user_id: 8888 },
+            to: Route::Route2 { user_id: 8888 },
             "hello world link"
         }
         button {
@@ -101,7 +101,7 @@ fn Route3(cx: Scope, dynamic: String) -> Element {
                 if route != current_route {
                     render! {
                         Link {
-                            target: route.clone(),
+                            to: route.clone(),
                             "{route}"
                         }
                     }

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -42,7 +42,7 @@ pub struct GenericLinkProps<'a, R: Routable> {
     pub rel: Option<&'a str>,
     /// The navigation target. Roughly equivalent to the href attribute of an HTML anchor tag.
     #[props(into)]
-    pub target: NavigationTarget<R>,
+    pub to: NavigationTarget<R>,
 }
 
 impl<R: Routable> Debug for GenericLinkProps<'_, R> {
@@ -56,7 +56,7 @@ impl<R: Routable> Debug for GenericLinkProps<'_, R> {
             .field("onclick", &self.onclick.as_ref().map(|_| "onclick is set"))
             .field("onclick_only", &self.onclick_only)
             .field("rel", &self.rel)
-            .field("target", &self.target.to_string())
+            .field("to", &self.to.to_string())
             .finish()
     }
 }
@@ -106,7 +106,7 @@ impl<R: Routable> Debug for GenericLinkProps<'_, R> {
 ///                 id: "link_id",
 ///                 new_tab: true,
 ///                 rel: "link_rel",
-///                 target: Route::Index {},
+///                 to: Route::Index {},
 ///    
 ///                 "A fully configured link"
 ///             }
@@ -132,7 +132,7 @@ pub fn GenericLink<'a, R: Routable + Clone>(cx: Scope<'a, GenericLinkProps<'a, R
         onclick,
         onclick_only,
         rel,
-        target,
+        to,
     } = cx.props;
 
     // hook up to router
@@ -150,7 +150,7 @@ pub fn GenericLink<'a, R: Routable + Clone>(cx: Scope<'a, GenericLinkProps<'a, R
 
     let current_route = router.current();
     let current_url = current_route.to_string();
-    let href = target.to_string();
+    let href = to.to_string();
     let ac = active_class
         .and_then(|active_class| (href == current_url).then(|| format!(" {active_class}")))
         .unwrap_or_default();
@@ -159,7 +159,7 @@ pub fn GenericLink<'a, R: Routable + Clone>(cx: Scope<'a, GenericLinkProps<'a, R
     let class = format!("{}{ac}", class.unwrap_or_default());
     let tag_target = new_tab.then_some("_blank").unwrap_or_default();
 
-    let is_external = matches!(target, NavigationTarget::External(_));
+    let is_external = matches!(to, NavigationTarget::External(_));
     let is_router_nav = !is_external && !new_tab;
     let prevent_default = is_router_nav.then_some("onclick").unwrap_or_default();
     let rel = rel
@@ -169,7 +169,7 @@ pub fn GenericLink<'a, R: Routable + Clone>(cx: Scope<'a, GenericLinkProps<'a, R
     let do_default = onclick.is_none() || !onclick_only;
     let action = move |event| {
         if do_default && is_router_nav {
-            router.push(target.clone());
+            router.push(to.clone());
         }
 
         if let Some(handler) = onclick {

--- a/packages/router/src/navigation.rs
+++ b/packages/router/src/navigation.rs
@@ -1,7 +1,6 @@
 //! Types pertaining to navigation.
 
 use std::{
-    convert::TryFrom,
     fmt::{Debug, Display},
     str::FromStr,
 };
@@ -55,11 +54,23 @@ pub enum NavigationTarget<R: Routable> {
     External(String),
 }
 
-impl<R: Routable> TryFrom<&str> for NavigationTarget<R> {
-    type Error = NavigationTargetParseError<R>;
+impl<R: Routable> From<&str> for NavigationTarget<R> {
+    fn from(value: &str) -> Self {
+        value
+            .parse()
+            .unwrap_or_else(|_| Self::External(value.to_string()))
+    }
+}
 
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        value.parse()
+impl<R: Routable> From<&String> for NavigationTarget<R> {
+    fn from(value: &String) -> Self {
+        value.as_str().into()
+    }
+}
+
+impl<R: Routable> From<String> for NavigationTarget<R> {
+    fn from(value: String) -> Self {
+        value.as_str().into()
     }
 }
 

--- a/packages/router/tests/via_ssr/link.rs
+++ b/packages/router/tests/via_ssr/link.rs
@@ -59,7 +59,7 @@ fn href_internal() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: Route::Test {},
+                to: Route::Test {},
                 "Link"
             }
         }
@@ -97,7 +97,7 @@ fn href_external() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: NavigationTarget::External("https://dioxuslabs.com/".into()),
+                to: NavigationTarget::External("https://dioxuslabs.com/".into()),
                 "Link"
             }
         }
@@ -135,7 +135,7 @@ fn with_class() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: Route::Test {},
+                to: Route::Test {},
                 class: "test_class",
                 "Link"
             }
@@ -167,7 +167,7 @@ fn with_active_class_active() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: Route::Root {},
+                to: Route::Root {},
                 active_class: "active_class",
                 class: "test_class",
                 "Link"
@@ -207,7 +207,7 @@ fn with_active_class_inactive() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: Route::Test {},
+                to: Route::Test {},
                 active_class: "active_class",
                 class: "test_class",
                 "Link"
@@ -247,7 +247,7 @@ fn with_id() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: Route::Test {},
+                to: Route::Test {},
                 id: "test_id",
                 "Link"
             }
@@ -286,7 +286,7 @@ fn with_new_tab() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: Route::Test {},
+                to: Route::Test {},
                 new_tab: true,
                 "Link"
             }
@@ -318,7 +318,7 @@ fn with_new_tab_external() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: NavigationTarget::External("https://dioxuslabs.com/".into()),
+                to: NavigationTarget::External("https://dioxuslabs.com/".into()),
                 new_tab: true,
                 "Link"
             }
@@ -357,7 +357,7 @@ fn with_rel() {
     fn Root(cx: Scope) -> Element {
         render! {
             Link {
-                target: Route::Test {},
+                to: Route::Test {},
                 rel: "test_rel",
                 "Link"
             }


### PR DESCRIPTION
Makes two small changes to the enum router to make it slightly less breaking:

1. `target` is renamed back to `to` to align with the old Link component.

2. `to` now accepts `&str`. This should not be used much outside of migrating things because it is not type checked at compile time, but it does make migrating much less painful

```rust
#![allow(non_snake_case)]

use dioxus::prelude::*;
use dioxus_router::prelude::*;
use std::str::FromStr;

fn main() {
    #[cfg(not(target_arch = "wasm32"))]
    dioxus_desktop::launch(root);

    #[cfg(target_arch = "wasm32")]
    dioxus_web::launch(root);
}

fn root(cx: Scope) -> Element {
    render! {
        Router {}
    }
}

#[inline_props]
fn UserFrame(cx: Scope, user_id: usize) -> Element {
    render! {
        pre {
            "UserFrame{{\n\tuser_id:{user_id}\n}}"
        }
        div {
            background_color: "rgba(0,0,0,50%)",
            "children:"
            Outlet {}
        }
    }
}

#[inline_props]
fn Route1(cx: Scope, user_id: usize, dynamic: usize, query: String, extra: String) -> Element {
    render! {
        pre {
            "Route1{{\n\tuser_id:{user_id},\n\tdynamic:{dynamic},\n\tquery:{query},\n\textra:{extra}\n}}"
        }
        Link {
            to: Route::Route1 { user_id: *user_id, dynamic: *dynamic, query: String::new(), extra: extra.clone() + "." },
            "Route1 with extra+\".\""
        }
        p { "Footer" }
        Link {
            to: Route::Route3 { dynamic: String::new() },
            "Home"
        }
    }
}

#[inline_props]
fn Route2(cx: Scope, user_id: usize) -> Element {
    render! {
        pre {
            "Route2{{\n\tuser_id:{user_id}\n}}"
        }
        (0..*user_id).map(|i| rsx!{ p { "{i}" } }),
        p { "Footer" }
        Link {
            to: Route::Route3 { dynamic: String::new() },
            "Home"
        }
    }
}

#[inline_props]
fn Route3(cx: Scope, dynamic: String) -> Element {
    let navigator = use_navigator(cx);
    let current_route = use_route(cx)?;
    let current_route_str = use_ref(cx, String::new);
    let parsed = Route::from_str(&current_route_str.read());

    let site_map = Route::SITE_MAP
        .iter()
        .flat_map(|seg| seg.flatten().into_iter())
        .collect::<Vec<_>>();

    render! {
        input {
            oninput: move |evt| {
                *current_route_str.write() = evt.value.clone();
            },
            value: "{current_route_str.read()}"
        }
        "dynamic: {dynamic}"
        Link {
            to: Route::Route2 { user_id: 8888 },
            "hello world link"
        }
        button {
            onclick: move |_| { navigator.push("https://www.google.com"); },
            "google link"
        }
        p { "Site Map" }
        pre { "{site_map:#?}" }
        p { "Dynamic link" }
        match parsed {
            Ok(route) => {
                if route != current_route {
                    render! {
                        Link {
                            to: route.clone(),
                            "{route}"
                        }
                    }
                }
                else {
                    None
                }
            }
            Err(err) => {
                render! {
                    pre {
                        color: "red",
                        "Invalid route:\n{err}"
                    }
                }
            }
        }
    }
}

#[rustfmt::skip]
#[derive(Clone, Debug, PartialEq, Routable)]
enum Route {
    #[nest("/test")]
        // Nests with parameters have types taken from child routes
        #[nest("/user/:user_id")]
            // Everything inside the nest has the added parameter `user_id: usize`
            // UserFrame is a layout component that will receive the `user_id: usize` parameter
            #[layout(UserFrame)]
                #[route("/:dynamic?:query")]
                Route1 {
                    // The type is taken from the first instance of the dynamic parameter
                    user_id: usize,
                    dynamic: usize,
                    query: String,
                    extra: String,
                },
                #[route("/hello_world")]
                // You can opt out of the layout by using the `!` prefix
                #[layout(!UserFrame)]
                Route2 { user_id: usize },
            #[end_layout]
        #[end_nest]
    #[end_nest]
    #[redirect("/:id/user", |id: usize| Route::Route3 { dynamic: id.to_string()})]
    #[route("/:dynamic")]
    Route3 { dynamic: String },
}
```