### PR TITLE
Fix root component suspense

### DIFF
--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -542,7 +542,12 @@ impl VirtualDom {
                 });
             }
             // If an error occurs, we should try to render the default error component and context where the error occured
-            RenderReturn::Aborted(_placeholder) => panic!("Cannot catch errors during rebuild"),
+            RenderReturn::Aborted(placeholder) => {
+                log::info!("Ran into suspended or aborted scope during rebuild");
+                let id = self.next_null();
+                placeholder.id.set(Some(id));
+                self.mutations.push(Mutation::CreatePlaceholder { id });
+            }
         }
 
         self.finalize()

--- a/packages/fullstack/examples/axum-hello-world/src/main.rs
+++ b/packages/fullstack/examples/axum-hello-world/src/main.rs
@@ -16,12 +16,6 @@ struct AppProps {
 }
 
 fn app(cx: Scope<AppProps>) -> Element {
-    render! {
-        Child {}
-    }
-}
-
-fn Child(cx: Scope) -> Element {
     let state =
         use_server_future(cx, (), |()| async move { get_server_data().await.unwrap() })?.value();
 
@@ -52,7 +46,7 @@ fn Child(cx: Scope) -> Element {
     })
 }
 
-#[server(PostServerData)]
+#[server]
 async fn post_server_data(data: String) -> Result<(), ServerFnError> {
     let axum::extract::Host(host): axum::extract::Host = extract().await?;
     println!("Server received: {}", data);
@@ -61,7 +55,7 @@ async fn post_server_data(data: String) -> Result<(), ServerFnError> {
     Ok(())
 }
 
-#[server(GetServerData)]
+#[server]
 async fn get_server_data() -> Result<String, ServerFnError> {
     Ok(reqwest::get("https://httpbin.org/ip").await?.text().await?)
 }

--- a/packages/fullstack/examples/salvo-hello-world/src/main.rs
+++ b/packages/fullstack/examples/salvo-hello-world/src/main.rs
@@ -16,12 +16,6 @@ struct AppProps {
 }
 
 fn app(cx: Scope<AppProps>) -> Element {
-    render! {
-        Child {}
-    }
-}
-
-fn Child(cx: Scope) -> Element {
     let state =
         use_server_future(cx, (), |()| async move { get_server_data().await.unwrap() })?.value();
 

--- a/packages/fullstack/examples/warp-hello-world/src/main.rs
+++ b/packages/fullstack/examples/warp-hello-world/src/main.rs
@@ -16,12 +16,6 @@ struct AppProps {
 }
 
 fn app(cx: Scope<AppProps>) -> Element {
-    render! {
-        Child {}
-    }
-}
-
-fn Child(cx: Scope) -> Element {
     let state =
         use_server_future(cx, (), |()| async move { get_server_data().await.unwrap() })?.value();
 


### PR DESCRIPTION
Currently, the Vdom panics when the root component is suspended. This PR treats the root component like any other aborted component instead.

This should let us simplify our examples and docs a bit