### PR TITLE
Make SsrState public

### DIFF
--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -164,7 +164,8 @@ pub struct SSRState {
 }
 
 impl SSRState {
-    pub(crate) fn new<P: Clone>(cfg: &ServeConfig<P>) -> Self {
+    /// Create a new [`SSRState`].
+    pub fn new<P: Clone>(cfg: &ServeConfig<P>) -> Self {
         if cfg.incremental.is_some() {
             return Self {
                 renderers: Arc::new(SsrRendererPool::Incremental(RwLock::new(vec![


### PR DESCRIPTION
Makes the fullstack renderer struct (SsrState)'s constructor public. This allows external libraries to create adapters for different frameworks using SsrState