### PR TITLE
FileEngine: expose native file types on different platforms

### DIFF
--- a/packages/html/src/events/form.rs
+++ b/packages/html/src/events/form.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug};
+use std::{any::Any, collections::HashMap, fmt::Debug};
 
 use dioxus_core::Event;
 
@@ -45,6 +45,12 @@ impl FileEngine for SerializedFileEngine {
             .await
             .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
     }
+
+    async fn get_native_file(&self, file: &str) -> Option<Box<dyn Any>> {
+        self.read_file(file)
+            .await
+            .map(|val| Box::new(val) as Box<dyn Any>)
+    }
 }
 
 #[cfg(feature = "serialize")]
@@ -89,6 +95,9 @@ pub trait FileEngine {
 
     // read a file to string
     async fn read_file_to_string(&self, file: &str) -> Option<String>;
+
+    // returns a file in platform's native representation
+    async fn get_native_file(&self, file: &str) -> Option<Box<dyn Any>>;
 }
 
 impl_event! {

--- a/packages/html/src/native_bind/native_file_engine.rs
+++ b/packages/html/src/native_bind/native_file_engine.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::path::PathBuf;
 
 use crate::FileEngine;
@@ -39,5 +40,10 @@ impl FileEngine for NativeFileEngine {
         file.read_to_string(&mut contents).await.ok()?;
 
         Some(contents)
+    }
+
+    async fn get_native_file(&self, file: &str) -> Option<Box<dyn Any>> {
+        let file = File::open(file).await.ok()?;
+        Some(Box::new(file))
     }
 }

--- a/packages/web/src/file_engine.rs
+++ b/packages/web/src/file_engine.rs
@@ -109,8 +109,10 @@ impl FileEngine for WebFileEngine {
     }
 }
 
+/// Helper trait for WebFileEngine
 #[async_trait::async_trait(?Send)]
-trait WebFileEngineExt {
+pub trait WebFileEngineExt {
+    /// returns web_sys::File
     async fn get_web_file(&self, file: &str) -> Option<web_sys::File>;
 }
 

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -54,6 +54,7 @@
 //     - Do DOM work in the next requestAnimationFrame callback
 
 pub use crate::cfg::Config;
+pub use crate::file_engine::WebFileEngineExt;
 use dioxus_core::{Element, Scope, VirtualDom};
 use futures_util::{pin_mut, FutureExt, StreamExt};
 


### PR DESCRIPTION
Impl `get_native_file` to return the native file type on different platforms: `web_sys::File` on wasm and `tokio::fs::File` on desktop.

Fixes https://github.com/DioxusLabs/dioxus/issues/1081