### PR TITLE
Add versions to all workspace packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,32 +49,32 @@ exclude = ["examples/mobile_demo"]
 
 # dependencies that are shared across packages
 [workspace.dependencies]
-dioxus = { path = "packages/dioxus" }
-dioxus-core = { path = "packages/core" }
-dioxus-core-macro = { path = "packages/core-macro" }
-dioxus-router = { path = "packages/router" }
-dioxus-router-macro = { path = "packages/router-macro" }
-dioxus-html = { path = "packages/html" }
-dioxus-hooks = { path = "packages/hooks" }
-dioxus-web = { path = "packages/web" }
-dioxus-ssr = { path = "packages/ssr" }
-dioxus-desktop = { path = "packages/desktop" }
-dioxus-mobile = { path = "packages/mobile" }
-dioxus-interpreter-js = { path = "packages/interpreter" }
-fermi = { path = "packages/fermi" }
-dioxus-liveview = { path = "packages/liveview" }
-dioxus-autofmt = { path = "packages/autofmt" }
-dioxus-check = { path = "packages/check" }
-dioxus-rsx = { path = "packages/rsx" }
-dioxus-tui = { path = "packages/dioxus-tui" }
+dioxus = { path = "packages/dioxus", version = "0.3.2" }
+dioxus-core = { path = "packages/core", version = "0.3.3" }
+dioxus-core-macro = { path = "packages/core-macro", version = "0.3.0" }
+dioxus-router = { path = "packages/router", version = "0.3.0" }
+dioxus-router-macro = { path = "packages/router-macro", version = "0.3.0" }
+dioxus-html = { path = "packages/html", version = "0.3.1" }
+dioxus-hooks = { path = "packages/hooks", version = "0.3.1" }
+dioxus-web = { path = "packages/web", version = "0.3.2" }
+dioxus-ssr = { path = "packages/ssr", version = "0.3.0" }
+dioxus-desktop = { path = "packages/desktop", version = "0.3.0" }
+dioxus-mobile = { path = "packages/mobile", version = "0.3.0" }
+dioxus-interpreter-js = { path = "packages/interpreter", version = "0.3.3" }
+fermi = { path = "packages/fermi", version = "0.3.0" }
+dioxus-liveview = { path = "packages/liveview", version = "0.3.0" }
+dioxus-autofmt = { path = "packages/autofmt", version = "0.3.0" }
+dioxus-rsx = { path = "packages/rsx", version = "0.0.3" }
+dioxus-tui = { path = "packages/dioxus-tui", version = "0.2.2" }
 rink = { path = "packages/rink" }
-dioxus-native-core = { path = "packages/native-core" }
-dioxus-native-core-macro = { path = "packages/native-core-macro" }
-rsx-rosetta = { path = "packages/rsx-rosetta" }
-dioxus-signals = { path = "packages/signals" }
-dioxus-hot-reload = { path = "packages/hot-reload" }
-dioxus-fullstack = { path = "packages/fullstack" }
-dioxus_server_macro = { path = "packages/fullstack/server-macro" }
+dioxus-native-core = { path = "packages/native-core", version = "0.3.0" }
+dioxus-native-core-macro = { path = "packages/native-core-macro", version = "0.2.0" }
+rsx-rosetta = { path = "packages/rsx-rosetta", version = "0.3.0" }
+dioxus-check = { path = "packages/check", version = "0.1.0" }
+dioxus-signals = { path = "packages/signals", version = "0.1.0" }
+dioxus-hot-reload = { path = "packages/hot-reload", version = "0.1.1" }
+dioxus-fullstack = { path = "packages/fullstack", version = "0.1.0" }
+dioxus_server_macro = { path = "packages/fullstack/server-macro", version = "0.1.0" }
 log = "0.4.19"
 tokio = "1.28"
 slab = "0.4.2"


### PR DESCRIPTION
Add the versions that cargo publish will require to all of the workspace dependancies. These versions are unchanged from the published versions of the crates.