### PR TITLE
Create default enabled features for large web events

### DIFF
--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -29,31 +29,26 @@ serde_json = { version = "1", optional = true }
 optional = true
 version = "0.3.56"
 features = [
-    "TouchEvent",
-    "MouseEvent",
-    "InputEvent",
-    "ClipboardEvent",
-    "KeyboardEvent",
-    "TouchEvent",
-    "WheelEvent",
-    "AnimationEvent",
-    "TransitionEvent",
-    "PointerEvent",
-    "FocusEvent",
-    "CompositionEvent",
-    "ClipboardEvent",
-    "Element",
-    "DomRect",
-    "ScrollIntoViewOptions",
-    "ScrollLogicalPosition",
-    "ScrollBehavior",
+     "TouchEvent",
+     "MouseEvent",
+     "InputEvent",
+     "ClipboardEvent",
+     "KeyboardEvent",
+     "TouchEvent",
+     "WheelEvent",
+     "AnimationEvent",
+     "TransitionEvent",
+     "PointerEvent",
+     "FocusEvent",
+     "CompositionEvent",
+     "ClipboardEvent",
 ]
 
 [dev-dependencies]
 serde_json = "1"
 
 [features]
-default = ["serialize"]
+default = ["serialize", "mounted"]
 serialize = [
     "serde",
     "serde_repr",
@@ -61,6 +56,14 @@ serialize = [
     "euclid/serde",
     "keyboard-types/serde",
     "dioxus-core/serialize",
+]
+mounted = [
+    "web-sys/Element",
+    "web-sys/DomRect",
+    "web-sys/ScrollIntoViewOptions",
+    "web-sys/ScrollLogicalPosition",
+    "web-sys/ScrollBehavior",
+    "web-sys/HtmlElement",
 ]
 wasm-bind = ["web-sys", "wasm-bindgen"]
 native-bind = ["tokio"]

--- a/packages/html/src/web_sys_bind/events.rs
+++ b/packages/html/src/web_sys_bind/events.rs
@@ -4,18 +4,14 @@ use crate::events::{
 };
 use crate::geometry::{ClientPoint, Coordinates, ElementPoint, PagePoint, ScreenPoint};
 use crate::input_data::{decode_key_location, decode_mouse_button_set, MouseButton};
-use crate::{
-    DragData, MountedData, MountedError, MountedResult, RenderedElementBacking, ScrollBehavior,
-};
+use crate::{DragData, MountedData};
 use keyboard_types::{Code, Key, Modifiers};
 use std::convert::TryInto;
-use std::future::Future;
-use std::pin::Pin;
 use std::str::FromStr;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{
-    AnimationEvent, CompositionEvent, Event, KeyboardEvent, MouseEvent, PointerEvent,
-    ScrollIntoViewOptions, TouchEvent, TransitionEvent, WheelEvent,
+    AnimationEvent, CompositionEvent, Event, KeyboardEvent, MouseEvent, PointerEvent, TouchEvent,
+    TransitionEvent, WheelEvent,
 };
 
 macro_rules! uncheck_convert {
@@ -198,16 +194,20 @@ impl From<&TransitionEvent> for TransitionData {
     }
 }
 
+#[cfg(feature = "mounted")]
 impl From<&web_sys::Element> for MountedData {
     fn from(e: &web_sys::Element) -> Self {
         MountedData::new(e.clone())
     }
 }
 
-impl RenderedElementBacking for web_sys::Element {
+#[cfg(feature = "mounted")]
+impl crate::RenderedElementBacking for web_sys::Element {
     fn get_client_rect(
         &self,
-    ) -> Pin<Box<dyn Future<Output = MountedResult<euclid::Rect<f64, f64>>>>> {
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = crate::MountedResult<euclid::Rect<f64, f64>>>>,
+    > {
         let rect = self.get_bounding_client_rect();
         let result = Ok(euclid::Rect::new(
             euclid::Point2D::new(rect.left(), rect.top()),
@@ -216,33 +216,36 @@ impl RenderedElementBacking for web_sys::Element {
         Box::pin(async { result })
     }
 
-    fn get_raw_element(&self) -> MountedResult<&dyn std::any::Any> {
+    fn get_raw_element(&self) -> crate::MountedResult<&dyn std::any::Any> {
         Ok(self)
     }
 
     fn scroll_to(
         &self,
-        behavior: ScrollBehavior,
-    ) -> Pin<Box<dyn Future<Output = MountedResult<()>>>> {
+        behavior: crate::ScrollBehavior,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::MountedResult<()>>>> {
         match behavior {
-            ScrollBehavior::Instant => self.scroll_into_view_with_scroll_into_view_options(
-                ScrollIntoViewOptions::new().behavior(web_sys::ScrollBehavior::Instant),
+            crate::ScrollBehavior::Instant => self.scroll_into_view_with_scroll_into_view_options(
+                web_sys::ScrollIntoViewOptions::new().behavior(web_sys::ScrollBehavior::Instant),
             ),
-            ScrollBehavior::Smooth => self.scroll_into_view_with_scroll_into_view_options(
-                ScrollIntoViewOptions::new().behavior(web_sys::ScrollBehavior::Smooth),
+            crate::ScrollBehavior::Smooth => self.scroll_into_view_with_scroll_into_view_options(
+                web_sys::ScrollIntoViewOptions::new().behavior(web_sys::ScrollBehavior::Smooth),
             ),
         }
 
         Box::pin(async { Ok(()) })
     }
 
-    fn set_focus(&self, focus: bool) -> Pin<Box<dyn Future<Output = MountedResult<()>>>> {
+    fn set_focus(
+        &self,
+        focus: bool,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = crate::MountedResult<()>>>> {
         let result = self
             .dyn_ref::<web_sys::HtmlElement>()
-            .ok_or_else(|| MountedError::OperationFailed(Box::new(FocusError(self.into()))))
+            .ok_or_else(|| crate::MountedError::OperationFailed(Box::new(FocusError(self.into()))))
             .and_then(|e| {
                 (if focus { e.focus() } else { e.blur() })
-                    .map_err(|err| MountedError::OperationFailed(Box::new(FocusError(err))))
+                    .map_err(|err| crate::MountedError::OperationFailed(Box::new(FocusError(err))))
             });
         Box::pin(async { result })
     }

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["dom", "ui", "gui", "react", "wasm"]
 
 [dependencies]
 dioxus-core = { workspace = true, features = ["serialize"] }
-dioxus-html = { workspace = true, features = ["wasm-bind"] }
+dioxus-html = { workspace = true, features = ["wasm-bind"], default-features = false }
 dioxus-interpreter-js = { workspace = true, features = [
     "sledgehammer",
     "minimal_bindings",
@@ -23,11 +23,7 @@ wasm-bindgen-futures = "0.4.29"
 log = { workspace = true }
 rustc-hash = { workspace = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
-once_cell = "1.9.0"
-anyhow = "1.0.53"
-gloo-timers = { version = "0.2.3", features = ["futures"] }
 futures-util = { workspace = true, features = ["std", "async-await", "async-await-macro"] }
-smallstr = "0.2.0"
 futures-channel = { workspace = true }
 serde_json = { version = "1.0" }
 serde = { version = "1.0" }
@@ -38,55 +34,38 @@ async-channel = "1.8.0"
 [dependencies.web-sys]
 version = "0.3.56"
 features = [
-    "Comment",
-    "Attr",
     "Document",
-    "Element",
-    "CssStyleDeclaration",
     "HtmlElement",
     "HtmlInputElement",
     "HtmlSelectElement",
     "HtmlTextAreaElement",
     "HtmlFormElement",
-    "EventTarget",
-    "HtmlCollection",
-    "Node",
-    "NodeList",
     "Text",
     "Window",
-    "Event",
-    "MouseEvent",
-    "InputEvent",
-    "ClipboardEvent",
-    "NamedNodeMap",
-    "KeyboardEvent",
-    "TouchEvent",
-    "WheelEvent",
-    "AnimationEvent",
-    "TransitionEvent",
-    "PointerEvent",
-    "FocusEvent",
-    "CompositionEvent",
-    "ClipboardEvent",
-    "DocumentType",
-    "CharacterData",
-    "SvgElement",
-    "SvgAnimatedString",
-    "HtmlOptionElement",
-    "IdleDeadline",
-    "WebSocket",
-    "Location",
-    "MessageEvent",
-    "console",
-    "FileList",
-    "File",
-    "FileReader"
 ]
 
 [features]
-default = ["panic_hook"]
+default = ["panic_hook", "mounted", "file_engine", "hot_reload", "eval"]
 panic_hook = ["console_error_panic_hook"]
-hydrate = []
+hydrate = [
+    "web-sys/Comment",
+    "web-sys/console",
+]
+mounted = [
+    "web-sys/Element",
+    "dioxus-html/mounted"
+]
+file_engine = [
+    "web-sys/File",
+    "web-sys/FileList",
+    "web-sys/FileReader",
+]
+hot_reload = [
+    "web-sys/MessageEvent",
+    "web-sys/WebSocket",
+    "web-sys/Location",
+]
+eval = []
 
 [dev-dependencies]
 dioxus = { workspace = true }

--- a/packages/web/src/hot_reload.rs
+++ b/packages/web/src/hot_reload.rs
@@ -3,22 +3,12 @@
 use futures_channel::mpsc::UnboundedReceiver;
 
 use dioxus_core::Template;
-use wasm_bindgen::closure::Closure;
-use wasm_bindgen::JsCast;
-use web_sys::{MessageEvent, WebSocket};
 
-#[cfg(not(debug_assertions))]
-pub(crate) fn init() -> UnboundedReceiver<Template<'static>> {
-    let (tx, rx) = futures_channel::mpsc::unbounded();
-
-    std::mem::forget(tx);
-
-    rx
-}
-
-#[cfg(debug_assertions)]
 pub(crate) fn init() -> UnboundedReceiver<Template<'static>> {
     use std::convert::TryInto;
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast;
+    use web_sys::{MessageEvent, WebSocket};
 
     use serde::Deserialize;
 


### PR DESCRIPTION
Some of the web events are quite large and rairly used. For example, the onmounted event will not be used in most applications. This PR pulls those events out into features that are enabled by default so that users can use the crate with no default features for smaller binary sizes