### PR TITLE
Reject all external routes when parsing a route

### DIFF
--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -485,7 +485,13 @@ impl RouteEnum {
                     let mut segments = route.split('/');
                     // skip the first empty segment
                     if s.starts_with('/') {
-                        segments.next();
+                        let _ = segments.next();
+                    }
+                    else {
+                        // if this route does not start with a slash, it is not a valid route
+                        return Err(dioxus_router::routable::RouteParseError {
+                            attempted_routes: Vec::new(),
+                        });
                     }
                     let mut errors = Vec::new();
 

--- a/packages/router-macro/src/route_tree.rs
+++ b/packages/router-macro/src/route_tree.rs
@@ -367,7 +367,7 @@ impl<'a> RouteTreeSegmentData<'a> {
                         let child_name = &child.ident;
 
                         quote! {
-                            let mut trailing = String::new();
+                            let mut trailing = String::from("/");
                             for seg in segments.clone() {
                                 trailing += seg;
                                 trailing += "/";


### PR DESCRIPTION
Reject any routes that don't start with `/` when parsing a route in the enum router macro