### PR TITLE
Deduplicate route history

### DIFF
--- a/packages/router/src/history/memory.rs
+++ b/packages/router/src/history/memory.rs
@@ -88,6 +88,10 @@ impl<R: Routable> HistoryProvider<R> for MemoryHistory<R> {
     }
 
     fn push(&mut self, new: R) {
+        // don't push the same route twice
+        if self.current.to_string() == new.to_string() {
+            return;
+        }
         let old = std::mem::replace(&mut self.current, new);
         self.history.push(old);
         self.future.clear();

--- a/packages/router/src/history/web.rs
+++ b/packages/router/src/history/web.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use gloo::{console::error, events::EventListener, render::AnimationFrame};
+
 use wasm_bindgen::JsValue;
 use web_sys::{window, History, ScrollRestoration, Window};
 
@@ -296,6 +297,11 @@ where
     }
 
     fn push(&mut self, state: R) {
+        use gloo_utils::format::JsValueSerdeExt;
+        if JsValue::from_serde(&state) != JsValue::from_serde(&self.current_route()) {
+            // don't push the same state twice
+            return;
+        }
         let path = self.full_path(&state);
 
         let state = self.create_state(state);
@@ -362,6 +368,10 @@ where
     }
 
     fn push(&mut self, state: R) {
+        if state.to_string() == self.current_route().to_string() {
+            // don't push the same state twice
+            return;
+        }
         let path = self.full_path(&state);
 
         let state: [f64; 2] = self.create_state(state);


### PR DESCRIPTION
Don't push a new route when the old and new routes are the same on web or desktop.