### PR TITLE
Make launch functions pub

### DIFF
--- a/packages/fullstack/src/launch.rs
+++ b/packages/fullstack/src/launch.rs
@@ -119,13 +119,13 @@ impl<Props: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync
     }
 
     #[cfg(feature = "web")]
-    fn launch_web(self) {
+    pub fn launch_web(self) {
         let cfg = self.web_cfg.hydrate(true);
         dioxus_web::launch_with_props(self.component, get_root_props_from_document().unwrap(), cfg);
     }
 
     #[cfg(feature = "desktop")]
-    fn launch_desktop(self) {
+    pub fn launch_desktop(self) {
         let cfg = self.desktop_cfg;
         dioxus_desktop::launch_with_props(self.component, self.props, cfg);
     }
@@ -133,7 +133,7 @@ impl<Props: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync
     /// Launch a server with the given configuration
     /// This will use the routing integration of the currently enabled integration feature
     #[cfg(feature = "ssr")]
-    async fn launch_server(self) {
+    pub async fn launch_server(self) {
         let addr = self.addr;
         println!("Listening on {}", addr);
         let cfg = self.server_cfg.build();

--- a/packages/fullstack/src/launch.rs
+++ b/packages/fullstack/src/launch.rs
@@ -119,20 +119,21 @@ impl<Props: Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync
     }
 
     #[cfg(feature = "web")]
+    /// Launch the web application
     pub fn launch_web(self) {
         let cfg = self.web_cfg.hydrate(true);
         dioxus_web::launch_with_props(self.component, get_root_props_from_document().unwrap(), cfg);
     }
 
     #[cfg(feature = "desktop")]
+    /// Launch the web application
     pub fn launch_desktop(self) {
         let cfg = self.desktop_cfg;
         dioxus_desktop::launch_with_props(self.component, self.props, cfg);
     }
 
-    /// Launch a server with the given configuration
-    /// This will use the routing integration of the currently enabled integration feature
     #[cfg(feature = "ssr")]
+    /// Launch a server application
     pub async fn launch_server(self) {
         let addr = self.addr;
         println!("Listening on {}", addr);


### PR DESCRIPTION
I am currently working on a project where I need to run server-side code concurrently with Dioxus Fullstack. However, I noticed that there is no way to reuse the Tokio runtime created in the launch function. As a result, the only option available to me right now is to spawn a new thread and runtime, which seems inefficient.

I propose making the launch functions public. This would allow developers like me to copy the launch function's code into our codebases and manipulate the Tokio runtime as needed, such as spawning new functions onto it. This change would provide more flexibility and efficiency in running concurrent server-side code.