### PR TITLE
Minor Proxy Improvements

### DIFF
--- a/packages/cli/docs/src/configure.md
+++ b/packages/cli/docs/src/configure.md
@@ -144,7 +144,7 @@ Configeration related to static resources your application uses in development:
 Configeration related to any proxies your application requires durring development. Proxies will forward requests to a new service
 
 ```
-[web.proxy]
+[[web.proxy]]
 # configuration
 ```
 

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -35,6 +35,9 @@ pub enum Error {
     #[error("Invalid proxy URL: {0}")]
     InvalidProxy(#[from] hyper::http::uri::InvalidUri),
 
+    #[error("Failed to establish proxy: {0}")]
+    ProxySetupError(String),
+
     #[error("Error proxying request: {0}")]
     ProxyRequestError(hyper::Error),
 


### PR DESCRIPTION
Updates a mistake in the docs and provides a better error message for a pathless proxy URL. Without this, `dx serve` panics with this message:

```
Paths must start with a `/`. Use "/" for
 root routes
 ```

 That's not very clear. Instead, we can detect this situation and provide a better error message:

```
Error: 🚫 Serving project failed: Failed to establish proxy: Proxy backend URL must have a non-empty path, e.g. http://localhost:8080/api instead of http://localhost:8080
```
