### PR TITLE
build(web): fix `default-features` warning

### DIFF
--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["dom", "ui", "gui", "react", "wasm"]
 
 [dependencies]
 dioxus-core = { workspace = true, features = ["serialize"] }
-dioxus-html = { workspace = true, features = ["wasm-bind"], default-features = false }
+dioxus-html = { workspace = true, features = ["wasm-bind"] }
 dioxus-interpreter-js = { workspace = true, features = [
     "sledgehammer",
     "minimal_bindings",


### PR DESCRIPTION
`cargo build` would print this warning:

```
warning: dioxus/packages/web/Cargo.toml: `default-features` is ignored for dioxus-html, since `default-features` was not specified for `workspace.dependencies.dioxus-html`, this could become a hard error in the future
```

Since it's being ignored anyway and that doesn't seem to be causing problems, I figured I'd remove it and get rid of the warning.