### PR TITLE
Fix parsing spread routes

### DIFF
--- a/packages/router-macro/src/route.rs
+++ b/packages/router-macro/src/route.rs
@@ -277,10 +277,8 @@ impl Route {
                 }
             }
             for segment in &self.segments {
-                if let RouteSegment::Dynamic(other, ..) = segment {
-                    if other == name {
-                        from_route = true
-                    }
+                if segment.name().as_ref() == Some(name) {
+                    from_route = true
                 }
             }
             if let Some(query) = &self.query {


### PR DESCRIPTION
It looks like enum route segments were not being parsed correctly outside of nests. This fixes that issue.

Fixes [#1020](https://github.com/DioxusLabs/dioxus/issues/1293) 