### PR TITLE
docs(hooks): fix typos

### DIFF
--- a/packages/hooks/src/computed.rs
+++ b/packages/hooks/src/computed.rs
@@ -10,7 +10,7 @@ use std::{
 /// Create a new tracked state.
 /// Tracked state is state that can drive Selector state
 ///
-/// It state will efficiently update any Selector state that is reading from it, but it is not readable on it's own.
+/// It will efficiently update any Selector state that is reading from it, but it is not readable on its own.
 ///
 /// ```rust
 /// use dioxus::prelude::*;


### PR DESCRIPTION
I'm not totally sure how the sentence was supposed to read, but removing "state" from "It state" seemed to work. Also, "it's" is "it is" and not possessive, so I fixed that.