### PR TITLE
chore(cli): remove unused function

### DIFF
--- a/packages/cli/src/cli/cfg.rs
+++ b/packages/cli/src/cli/cfg.rs
@@ -101,13 +101,6 @@ pub enum Platform {
     Desktop,
 }
 
-/// Ensure the given value for `--public-url` is formatted correctly.
-pub fn parse_public_url(val: &str) -> String {
-    let prefix = if !val.starts_with('/') { "/" } else { "" };
-    let suffix = if !val.ends_with('/') { "/" } else { "" };
-    format!("{}{}{}", prefix, val, suffix)
-}
-
 /// Config options for the bundling system.
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 pub struct ConfigOptsBundle {


### PR DESCRIPTION
I believe that technically this function is part of the public API via `dioxus_cli::cli::cfg::parse_public_url`. However, I don't see any evidence that this function is actually used inside or outside this crate. The last use within the crate was removed in January 2022 (9bb10c65a3cbabef127f6af5c0d1eadab1d01531).