### PR TITLE
docs(cli): update subcommand comments

### DIFF
--- a/packages/cli/docs/src/cmd/README.md
+++ b/packages/cli/docs/src/cmd/README.md
@@ -15,6 +15,7 @@ Commands:
   serve      Build, watch & serve the Rust WASM app and all of its assets
   create     Init a new project for Dioxus
   clean      Clean output artifacts
+  bundle     Bundle the Rust desktop app and all of its assets
   version    Print the version of this extension
   fmt        Format some rsx
   check      Check the Rust files in the project for issues

--- a/packages/cli/src/cli/autoformat.rs
+++ b/packages/cli/src/cli/autoformat.rs
@@ -6,7 +6,7 @@ use super::*;
 // For reference, the rustfmt main.rs file
 // https://github.com/rust-lang/rustfmt/blob/master/src/bin/main.rs
 
-/// Build the Rust WASM app and all of its assets.
+/// Format some rsx
 #[derive(Clone, Debug, Parser)]
 pub struct Autoformat {
     /// Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -6,7 +6,7 @@ use tauri_bundler::{BundleSettings, PackageSettings, SettingsBuilder};
 use super::*;
 use crate::{build_desktop, cfg::ConfigOptsBundle};
 
-/// Build the Rust WASM app and all of its assets.
+/// Bundle the Rust desktop app and all of its assets
 #[derive(Clone, Debug, Parser)]
 #[clap(name = "bundle")]
 pub struct Bundle {

--- a/packages/cli/src/cli/config.rs
+++ b/packages/cli/src/cli/config.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// Build the Rust WASM app and all of its assets.
+/// Dioxus config file controls
 #[derive(Clone, Debug, Deserialize, Subcommand)]
 #[clap(name = "config")]
 pub enum Config {

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -72,6 +72,7 @@ pub enum Commands {
     #[clap(name = "fmt")]
     Autoformat(autoformat::Autoformat),
 
+    /// Check the Rust files in the project for issues.
     #[clap(name = "check")]
     Check(check::Check),
 

--- a/packages/cli/src/cli/plugin.rs
+++ b/packages/cli/src/cli/plugin.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-/// Build the Rust WASM app and all of its assets.
+/// Manage plugins for dioxus cli
 #[derive(Clone, Debug, Deserialize, Subcommand)]
 #[clap(name = "plugin")]
 pub enum Plugin {

--- a/packages/cli/src/cli/translate.rs
+++ b/packages/cli/src/cli/translate.rs
@@ -4,7 +4,7 @@ use dioxus_rsx::{BodyNode, CallBody};
 
 use super::*;
 
-/// Build the Rust WASM app and all of its assets.
+/// Translate some source file into Dioxus code
 #[derive(Clone, Debug, Parser)]
 #[clap(name = "translate")]
 pub struct Translate {

--- a/packages/cli/src/cli/version.rs
+++ b/packages/cli/src/cli/version.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-/// Build the Rust WASM app and all of its assets.
+/// Print the version of this extension
 #[derive(Clone, Debug, Parser)]
 #[clap(name = "version")]
 pub struct Version {}


### PR DESCRIPTION
A bunch of these were copy-pasted from `build`. This commit updates them to be the same as what their `dx help` string is.