### PR TITLE
Update tailwind examples to work with multi-page apps

### DIFF
--- a/examples/tailwind/Dioxus.toml
+++ b/examples/tailwind/Dioxus.toml
@@ -30,7 +30,7 @@ watch_path = ["src", "public"]
 [web.resource]
 
 # CSS style file
-style = ["tailwind.css"]
+style = ["/tailwind.css"]
 
 # Javascript code file
 script = []

--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -81,7 +81,7 @@ watch_path = ["src", "public"]
 [web.resource]
 
 # CSS style file
-style = ["tailwind.css"]
+style = ["/tailwind.css"]
 
 # Javascript code file
 script = []


### PR DESCRIPTION
Switches to using absolute paths to refer to `tailwind.css`

closes #1292