### PR TITLE
DOC: Add note about form prevent_default behavior.

### DIFF
--- a/docs/guide/src/en/interactivity/event_handlers.md
+++ b/docs/guide/src/en/interactivity/event_handlers.md
@@ -51,6 +51,8 @@ Any event handlers will still be called.
 
 > Normally, in React or JavaScript, you'd call "preventDefault" on the event in the callback. Dioxus does _not_ currently support this behavior. Note: this means you cannot conditionally prevent default behavior based on the data in the event.
 
+> Note for web developers: on Javascript the default behavior is to **submit the form**, while on Dioxus the default behavior is **to not submit the form**. Consequently, specifying `prevent_default: "onsubmit"` will cause the form to be submitted.
+
 ## Handler Props
 
 Sometimes, you might want to make a component that accepts an event handler. A simple example would be a `FancyButton` component, which accepts an `on_click` handler:

--- a/docs/guide/src/en/interactivity/event_handlers.md
+++ b/docs/guide/src/en/interactivity/event_handlers.md
@@ -51,7 +51,7 @@ Any event handlers will still be called.
 
 > Normally, in React or JavaScript, you'd call "preventDefault" on the event in the callback. Dioxus does _not_ currently support this behavior. Note: this means you cannot conditionally prevent default behavior based on the data in the event.
 
-> Note for web developers: on Javascript the default behavior is to **submit the form**, while on Dioxus the default behavior is **to not submit the form**. Consequently, specifying `prevent_default: "onsubmit"` will cause the form to be submitted.
+> Note about forms: if an event handler is attached to the `onsubmit` event of a form, default behavior is to **not submit it**, meaning having `prevent_default: "onsubmit"` will submit it in this case.
 
 ## Handler Props
 

--- a/docs/guide/src/pt-br/interactivity/event_handlers.md
+++ b/docs/guide/src/pt-br/interactivity/event_handlers.md
@@ -64,3 +64,5 @@ Então, você pode usá-lo como qualquer outro manipulador:
 > Nota: assim como qualquer outro atributo, você pode nomear os manipuladores como quiser! Embora eles devam começar com `on`, para que o prop seja automaticamente transformado em um `EventHandler` no local da chamada.
 >
 > Você também pode colocar dados personalizados no evento, em vez de, por exemplo, `MouseData`
+
+> Nota para desenvolvedores web: em Javascript o comportamento padrão é o de **submeter o formulário**, porém no Dioxus o comportamento padrão é de **não submeter o formulário**. Consequentemente, especificar `prevent_default: "onsubmit"` fará com que o formulário seja submetido.

--- a/docs/guide/src/pt-br/interactivity/event_handlers.md
+++ b/docs/guide/src/pt-br/interactivity/event_handlers.md
@@ -65,4 +65,4 @@ Então, você pode usá-lo como qualquer outro manipulador:
 >
 > Você também pode colocar dados personalizados no evento, em vez de, por exemplo, `MouseData`
 
-> Nota para desenvolvedores web: em Javascript o comportamento padrão é o de **submeter o formulário**, porém no Dioxus o comportamento padrão é de **não submeter o formulário**. Consequentemente, especificar `prevent_default: "onsubmit"` fará com que o formulário seja submetido.
+> Nota sobre formulários: se um manipulador de evento está anexado ao evento `onsubmit` em um formulário, o comportamento padrão é de **não submetê-lo**. Portanto, especificar `prevent_default: "onsubmit"` irá submetê-lo.


### PR DESCRIPTION
Starting on version 0.4 (PR #926), the `prevent_default` behavior inverted for forms in `dioxus-web`. This just adds a note to the documentation to document this.