### PR TITLE
Publish CLI binaries for cargo-binstall

### DIFF
--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -9,7 +9,7 @@ jobs:
   matrix_build:
     runs-on: ${{ matrix.platform.os }}
     env:
-      WORKING_DIR: ${{github.}}/source/packages/cli
+      WORKING_DIR: ${{github.workspace}}/source/packages/cli
     strategy:
       matrix:
         platform:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -92,5 +92,5 @@ jobs:
         run: |
           for file in dx-*/dx-*; do
             echo "Uploading $file"
-            gh release upload ${{ github.event.release.tag_name }} "$file" "${file}.sha256"
+            gh release upload ${{ github.event.release.tag_name }} "$file"
           done

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -24,11 +24,6 @@ jobs:
               toolchain: "1.70.0",
             }
           - {
-              target: aarch64-apple-darwin,
-              os: macos-latest,
-              toolchain: "1.70.0",
-            }
-          - {
               target: x86_64-unknown-linux-gnu,
               os: ubuntu-latest,
               toolchain: "1.70.0",

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -39,8 +39,6 @@ jobs:
           target: ${{ matrix.platform.target }}
           override: true
           default: true
-      - name: enter cli source directory
-        run: cd source ./source/packages/cli
       - name: build cli
         working-directory: ${{ env.WORKING_DIR }}
         run: cargo build --release --target ${{ matrix.platform.target }}

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.platform.os }}
-    env:
-      WORKING_DIR: ${{github.workspace}}/packages/cli
     strategy:
       matrix:
         platform:
@@ -33,7 +31,7 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v3
-      - name: install stable
+      - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.platform.toolchain }}
@@ -43,10 +41,14 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: cli -> ../target
-      - name: build cli
-        working-directory: ${{ env.WORKING_DIR }}
-        run: cargo build --release --target ${{ matrix.platform.target }}
+          workspaces: cli
+      - name: Build CLI
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.platform.target }} --package dioxus-cli
+
+      # Archive the artifacts to either a zip or tar.gz file
       - name: Archive Windows artifact
         if: matrix.platform.os == 'windows-latest'
         run: |
@@ -54,18 +56,19 @@ jobs:
           strip dx.exe
           7z a ../../../${{ matrix.platform.name }} dx.exe
           cd -
-      - name: Archive -Nix artifact
+      - name: Archive *nix artifact
         if: matrix.platform.os != 'windows-latest'
         run: |
           cd target/${{ matrix.platform.target }}/release
           strip dx
           tar czvf ../../../${{ matrix.platform.name }} dx
           cd -
-      - name: upload artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.platform.name }}
           path: ${{ matrix.platform.name }}
+
   publish:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -9,7 +9,7 @@ jobs:
   matrix_build:
     runs-on: ${{ matrix.platform.os }}
     env:
-      WORKING_DIR: ${{github.workspace}}/source/packages/cli
+      WORKING_DIR: ${{github.}}/source/packages/cli
     strategy:
       matrix:
         platform:
@@ -33,6 +33,10 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v3
+      - name: list workspace
+        if: ${{ matrix.platform.os != 'windows-latest' }}
+        run: ls -la
+        working-directory: ${{ github.workspace }}
       - name: install stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -1,6 +1,6 @@
 name: Build CLI for Release
 
-# Will run automatically on every new release, can also be run manually for testing
+# Will run automatically on every new release
 on:
   release:
     types: [published]

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -40,6 +40,10 @@ jobs:
           target: ${{ matrix.platform.target }}
           override: true
           default: true
+      - name: Setup cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: cli -> ../target
       - name: build cli
         working-directory: ${{ env.WORKING_DIR }}
         run: cargo build --release --target ${{ matrix.platform.target }}

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -9,7 +9,7 @@ jobs:
   matrix_build:
     runs-on: ${{ matrix.platform.os }}
     env:
-      WORKING_DIR: ${{github.workspace}}/source/packages/cli
+      WORKING_DIR: ${{github.workspace}}/packages/cli
     strategy:
       matrix:
         platform:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: cli
+          workspaces: packages/cli -> ../../target
       - name: Build CLI
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -83,14 +83,14 @@ jobs:
         uses: actions/download-artifact@v2
 
       - name: Write checksums
-        run: for file in dx-*\dx-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
+        run: for file in dx-*/dx-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
 
       - name: Upload artifacts and checksums
         if: github.event_name == 'release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for file in dx-*\*; do
+          for file in dx-*/dx-*; do
             echo "Uploading $file"
             gh release upload ${{ github.event.release.tag_name }} "$file" "${file}.sha256"
           done

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: list workspace
-        if: ${{ matrix.platform.os != 'windows-latest' }}
+        if: matrix.platform.os != 'windows-latest'
         run: ls -la
         working-directory: ${{ github.workspace }}
       - name: install stable

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -31,12 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.platform.toolchain }}
-          target: ${{ matrix.platform.target }}
-          override: true
-          default: true
+          targets: ${{ matrix.platform.target }}
 
       # Setup the Github Actions Cache for the CLI package
       - name: Setup cache

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -32,9 +32,7 @@ jobs:
               name: dx-x86_64-unknown-linux-gnu.tar.gz,
             }
     steps:
-      - name: echo workspace
-        if: matrix.platform.os != 'windows-latest'
-        run: echo ${{github.workspace}}
+      - uses: actions/checkout@v3
       - name: install stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -16,19 +16,21 @@ jobs:
               target: x86_64-pc-windows-msvc,
               os: windows-latest,
               toolchain: "1.70.0",
-              name: dx-x86_64-pc-windows-msvc.zip,
             }
           - {
               target: x86_64-apple-darwin,
               os: macos-latest,
               toolchain: "1.70.0",
-              name: dx-x86_64-apple-darwin.tar.gz,
+            }
+          - {
+              target: x86_64-apple-aarch64,
+              os: macos-latest,
+              toolchain: "1.70.0",
             }
           - {
               target: x86_64-unknown-linux-gnu,
               os: ubuntu-latest,
               toolchain: "1.70.0",
-              name: dx-x86_64-unknown-linux-gnu.tar.gz,
             }
     steps:
       - uses: actions/checkout@v3
@@ -46,61 +48,12 @@ jobs:
         with:
           workspaces: packages/cli -> ../../target
 
-      # Build the CLI package for the target platform
-      - name: Build CLI
-        uses: actions-rs/cargo@v1
+      - name: Build and upload binary
+        uses: taiki-e/upload-rust-binary-action@v1
         with:
-          command: build
-          args: --release --target ${{ matrix.platform.target }} --package dioxus-cli
-
-      # Archive the artifacts to either a zip or tar.gz file for processing by the next job
-      - name: Archive Windows artifact
-        if: matrix.platform.os == 'windows-latest'
-        run: |
-          cd target/${{ matrix.platform.target }}/release
-          strip dx.exe
-          7z a ../../../${{ matrix.platform.name }} dx.exe
-          cd -
-      - name: Archive *nix artifact
-        if: matrix.platform.os != 'windows-latest'
-        run: |
-          cd target/${{ matrix.platform.target }}/release
-          strip dx
-          tar czvf ../../../${{ matrix.platform.name }} dx
-          cd -
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.platform.name }}
-          path: ${{ matrix.platform.name }}
-
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-
-      # Generate SHA256 checksums for the artifacts
-      - name: Write checksums
-        run: |
-          for file in dx-*/dx-*; do 
-            echo "Writing checksum for $file"
-            openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; 
-          done
-
-      # If the workflow is triggered by a new release, upload the artifacts to the release
-      - name: Upload artifacts and checksums to release
-        if: github.event_name == 'release'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          for file in dx-*/dx-*; do
-            echo "Uploading $file"
-            gh release upload ${{ github.event.release.tag_name }} "$file"
-          done
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target: ${{ matrix.platform.target }}
+          bin: dx
+          archive: dx-${{ matrix.platform.target }}
+          checksum: sha256
+          manifest_path: packages/cli/Cargo.toml

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -49,7 +49,6 @@ jobs:
         run: cargo build --release --target ${{ matrix.platform.target }}
       - name: Archive Windows artifact
         if: matrix.platform.os == 'windows-latest'
-        working-directory: ${{ env.WORKING_DIR }}
         run: |
           cd target/${{ matrix.platform.target }}/release
           strip dx.exe
@@ -57,7 +56,6 @@ jobs:
           cd -
       - name: Archive -Nix artifact
         if: matrix.platform.os != 'windows-latest'
-        working-directory: ${{ env.WORKING_DIR }}
         run: |
           cd target/${{ matrix.platform.target }}/release
           strip dx
@@ -67,4 +65,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.platform.name }}
-          path: ${{env.WORKING_DIR}}/${{ matrix.platform.name }}
+          path: ${{ matrix.platform.name }}

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -32,6 +32,9 @@ jobs:
               name: dx-x86_64-unknown-linux-gnu.tar.gz,
             }
     steps:
+      - name: echo workspace
+        if: matrix.platform.os != 'windows-latest'
+        run: echo ${{github.workspace}}
       - name: install stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -1,5 +1,6 @@
 name: Build CLI for Release
 
+# Will run automatically on every new release, can also be run manually for testing
 on:
   release:
     types: [published]
@@ -38,17 +39,21 @@ jobs:
           target: ${{ matrix.platform.target }}
           override: true
           default: true
+
+      # Setup the Github Actions Cache for the CLI package
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: packages/cli -> ../../target
+
+      # Build the CLI package for the target platform
       - name: Build CLI
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --target ${{ matrix.platform.target }} --package dioxus-cli
 
-      # Archive the artifacts to either a zip or tar.gz file
+      # Archive the artifacts to either a zip or tar.gz file for processing by the next job
       - name: Archive Windows artifact
         if: matrix.platform.os == 'windows-latest'
         run: |
@@ -78,14 +83,19 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: Download artifacts
         uses: actions/download-artifact@v2
 
+      # Generate SHA256 checksums for the artifacts
       - name: Write checksums
-        run: for file in dx-*/dx-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
+        run: |
+          for file in dx-*/dx-*; do 
+            echo "Writing checksum for $file"
+            openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; 
+          done
 
-      - name: Upload artifacts and checksums
+      # If the workflow is triggered by a new release, upload the artifacts to the release
+      - name: Upload artifacts and checksums to release
         if: github.event_name == 'release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  matrix_build:
+  build:
     runs-on: ${{ matrix.platform.os }}
     env:
       WORKING_DIR: ${{github.workspace}}/packages/cli
@@ -33,10 +33,6 @@ jobs:
             }
     steps:
       - uses: actions/checkout@v3
-      - name: list workspace
-        if: matrix.platform.os != 'windows-latest'
-        run: ls -la
-        working-directory: ${{ github.workspace }}
       - name: install stable
         uses: actions-rs/toolchain@v1
         with:
@@ -66,3 +62,28 @@ jobs:
         with:
           name: ${{ matrix.platform.name }}
           path: ${{ matrix.platform.name }}
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Write checksums
+        run: for file in dx-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
+
+      - name: Upload artifacts and checksums
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for file in dx-*; do
+            echo "Uploading $file"
+            gh release upload ${{ github.event.release.tag_name }} "$file" "${file}.sha256"
+          done

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 jobs:
-  build:
+  build-and-upload:
     permissions:
       contents: write
     runs-on: ${{ matrix.platform.os }}
@@ -44,6 +44,7 @@ jobs:
         with:
           workspaces: packages/cli -> ../../target
 
+      # This neat action can build and upload the binary in one go!
       - name: Build and upload binary
         uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -23,7 +23,7 @@ jobs:
               toolchain: "1.70.0",
             }
           - {
-              target: x86_64-apple-aarch64,
+              target: aarch64-apple-darwin,
               os: macos-latest,
               toolchain: "1.70.0",
             }

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -4,7 +4,6 @@ name: Build CLI for Release
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -1,0 +1,67 @@
+name: Build CLI for Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  matrix_build:
+    runs-on: ${{ matrix.platform.os }}
+    env:
+      WORKING_DIR: ${{github.workspace}}/source/packages/cli
+    strategy:
+      matrix:
+        platform:
+          - {
+              target: x86_64-pc-windows-msvc,
+              os: windows-latest,
+              toolchain: "1.70.0",
+              name: dx-x86_64-pc-windows-msvc.zip,
+            }
+          - {
+              target: x86_64-apple-darwin,
+              os: macos-latest,
+              toolchain: "1.70.0",
+              name: dx-x86_64-apple-darwin.tar.gz,
+            }
+          - {
+              target: x86_64-unknown-linux-gnu,
+              os: ubuntu-latest,
+              toolchain: "1.70.0",
+              name: dx-x86_64-unknown-linux-gnu.tar.gz,
+            }
+    steps:
+      - name: install stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.platform.toolchain }}
+          target: ${{ matrix.platform.target }}
+          override: true
+          default: true
+      - name: enter cli source directory
+        run: cd source ./source/packages/cli
+      - name: build cli
+        working-directory: ${{ env.WORKING_DIR }}
+        run: cargo build --release --target ${{ matrix.platform.target }}
+      - name: Archive Windows artifact
+        if: matrix.platform.os == 'windows-latest'
+        working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          cd target/${{ matrix.platform.target }}/release
+          strip dx.exe
+          7z a ../../../${{ matrix.platform.name }} dx.exe
+          cd -
+      - name: Archive -Nix artifact
+        if: matrix.platform.os != 'windows-latest'
+        working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          cd target/${{ matrix.platform.target }}/release
+          strip dx
+          tar czvf ../../../${{ matrix.platform.name }} dx
+          cd -
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.platform.name }}
+          path: ${{env.WORKING_DIR}}/${{ matrix.platform.name }}

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -80,14 +80,14 @@ jobs:
         uses: actions/download-artifact@v2
 
       - name: Write checksums
-        run: for file in dx-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
+        run: for file in dx-*\dx-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
 
       - name: Upload artifacts and checksums
         if: github.event_name == 'release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for file in dx-*; do
+          for file in dx-*\*; do
             echo "Uploading $file"
             gh release upload ${{ github.event.release.tag_name }} "$file" "${file}.sha256"
           done

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -100,3 +100,9 @@ name = "dx"
 
 [dev-dependencies]
 tempfile = "3.3"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/dx-{ target }{ archive-suffix }"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
# Summary
This PR adds a workflow that will run on every new release to generate binaries of the CLI for Windows, Linux, and macOS. It will then upload these binaries to the release, along with a SHA. This also adds new metadata to the dioxus-cli crate so that [cargo-binstall](https://github.com/cargo-bins/cargo-binstall/tree/main) can find the published artifacts.

# Reason
The goal of this PR is to publish binaries that can be used in downstream partners' GitHub Actions workflows. By using the [install-action](https://github.com/marketplace/actions/install-development-tools), which uses cargo-binstall under the hood, developers can quickly install the latest CLI binary.

Here's a shorthand for installing the CLI using that action:
```yml
- uses: taiki-e/install-action@dioxus-cli
```

# Caveats
Note that I have not tested the install via cargo-binstall yet as I do not have permissions to publish a new version of the package, though I have tested that it publishes the binaries to the GitHub Release.