### PR TITLE
Fix recycling nodes in native core

### DIFF
--- a/packages/native-core/src/dioxus.rs
+++ b/packages/native-core/src/dioxus.rs
@@ -57,6 +57,12 @@ impl DioxusState {
         node.insert(ElementIdComponent(element_id));
         if self.node_id_mapping.len() <= element_id.0 {
             self.node_id_mapping.resize(element_id.0 + 1, None);
+        } else {
+            if let Some(mut node) =
+                self.node_id_mapping[element_id.0].and_then(|id| node.real_dom_mut().get_mut(id))
+            {
+                node.remove();
+            }
         }
         self.node_id_mapping[element_id.0] = Some(node_id);
     }


### PR DESCRIPTION
When node ids are reused native core should assume that the node that was previously at the id should be removed. This partially fixes the memory leak in #1361 