### PR TITLE
Update all uncommented commands to remove actions-rs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,52 +85,56 @@ jobs:
 
   matrix_test:
     runs-on: ${{ matrix.platform.os }}
+    env:
+      RUST_CARGO_COMMAND: ${{ matrix.platform.cross == true && 'cross' || 'cargo' }}
     strategy:
       matrix:
         platform:
           - {
               target: x86_64-pc-windows-msvc,
               os: windows-latest,
-              toolchain: '1.70.0',
+              toolchain: "1.70.0",
               cross: false,
-              command: 'test',
-              args: '--all --tests'
+              command: "test",
+              args: "--all --tests",
             }
           - {
               target: x86_64-apple-darwin,
               os: macos-latest,
-              toolchain: '1.70.0',
+              toolchain: "1.70.0",
               cross: false,
-              command: 'test',
-              args: '--all --tests'
+              command: "test",
+              args: "--all --tests",
             }
           - {
               target: aarch64-apple-ios,
               os: macos-latest,
-              toolchain: '1.70.0',
+              toolchain: "1.70.0",
               cross: false,
-              command: 'build',
-              args: '--package dioxus-mobile'
+              command: "build",
+              args: "--package dioxus-mobile",
             }
           - {
               target: aarch64-linux-android,
               os: ubuntu-latest,
-              toolchain: '1.70.0',
+              toolchain: "1.70.0",
               cross: true,
-              command: 'build',
-              args: '--package dioxus-mobile'
+              command: "build",
+              args: "--package dioxus-mobile",
             }
 
     steps:
       - uses: actions/checkout@v3
 
       - name: install stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.platform.toolchain }}
-          target: ${{ matrix.platform.target }}
-          override: true
-          default: true
+          targets: ${{ matrix.platform.target }}
+
+      - name: Install cross
+        if: ${{ matrix.platform.cross == true }}
+        uses: taiki-e/install-action@cross
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -138,13 +142,8 @@ jobs:
           save-if: ${{ matrix.features.key == 'all' }}
 
       - name: test
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.platform.cross }}
-          command: ${{ matrix.platform.command }}
-          args: --target ${{ matrix.platform.target }} ${{ matrix.platform.args }}
-
-
+        run: |
+          ${{ env.RUST_CARGO_COMMAND }} ${{ matrix.platform.command }} ${{ matrix.platform.args }} --target ${{ matrix.platform.target }}
 
   # Coverage is disabled until we can fix it
   # coverage:
@@ -166,4 +165,3 @@ jobs:
   #       uses: codecov/codecov-action@v2
   #       with:
   #         fail_ci_if_error: false
-

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          targets: wasm32-unknown-unknown
+          targets: x86_64-linux-gnu,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
 defaults:
   run:
     working-directory: ./playwright-tests
@@ -18,37 +18,33 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-20.04
     steps:
-    # Do our best to cache the toolchain and node install steps
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - uses: Swatinem/rust-cache@v2
-    - name: Install WASM toolchain
-      run: rustup target add wasm32-unknown-unknown
-    - name: Install dependencies
-      run: npm ci
-    - name: Install Playwright
-      run: npm install -D @playwright/test
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
-    #  Cache the CLI by using cargo run internally
-    # - name: Install Dioxus CLI
-    #   uses: actions-rs/cargo@v1
-    #   with:
-    #     command: install
-    #     args: --path packages/cli
-    - name: Run Playwright tests
-      run: npx playwright test
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      # Do our best to cache the toolchain and node install steps
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install WASM toolchain
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright
+        run: npm install -D @playwright/test
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      #  Cache the CLI by using cargo run internally
+      # - name: Install Dioxus CLI
+      #   uses: actions-rs/cargo@v1
+      #   with:
+      #     command: install
+      #     args: --path packages/cli
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-          targets: x86_64-linux-gnu,wasm32-unknown-unknown
+          targets: x86_64-unknown-linux-gnu,wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     if: github.event.pull_request.draft == false
     timeout-minutes: 60
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Do our best to cache the toolchain and node install steps
       - uses: actions/checkout@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -24,10 +24,11 @@ jobs:
         with:
           node-version: 16
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: Install WASM toolchain
-        run: rustup target add wasm32-unknown-unknown
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright

--- a/packages/cli/.github/workflows/main.yml
+++ b/packages/cli/.github/workflows/main.yml
@@ -8,47 +8,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v1
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   # clippy:
   #  name: Clippy


### PR DESCRIPTION
This commit addresses #1360 by removing references to [actions-rs/toolchain](https://github.com/actions-rs/toolchain/issues/216) and [actions-rs/cargo](https://github.com/actions-rs/cargo/issues/216#issuecomment-1329850830), both of which are unmaintained. 

Some parts of the workflows already use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) and this is the one most of the community has moved to, so I've changed remaining references to actions-rs/toolchain to dtolnay/rust-toolchain. There's no good replacement for actions-rs/cargo so I've instead moved to just running the commands directly. In cases where Cross is required instead of Cargo to run CI tests, I've added a new action [taiki-e/install-action](https://github.com/taiki-e/install-action) to install Cross and then use a dynamic environment variable to select the correct command to use.

There were a few references to actions-rs that were commented out, I have not touched these.