### PR TITLE
Find attributes and components to drop when rendering any lazy nodes

### DIFF
--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -691,7 +691,7 @@ impl<'a> IntoDynNode<'a> for &Element<'a> {
 
 impl<'a, 'b> IntoDynNode<'a> for LazyNodes<'a, 'b> {
     fn into_vnode(self, cx: &'a ScopeState) -> DynamicNode<'a> {
-        DynamicNode::Fragment(cx.bump().alloc([self.call(cx)]))
+        DynamicNode::Fragment(cx.bump().alloc([cx.render(self).unwrap()]))
     }
 }
 
@@ -750,7 +750,7 @@ impl<'a> IntoTemplate<'a> for Element<'a> {
 }
 impl<'a, 'b> IntoTemplate<'a> for LazyNodes<'a, 'b> {
     fn into_template(self, cx: &'a ScopeState) -> VNode<'a> {
-        self.call(cx)
+        cx.render(self).unwrap()
     }
 }
 


### PR DESCRIPTION
Currently the `ScopeState` will only drop elements that are `render!`ed, not any nodes that are created through the `IntoDynNode` or `IntoTemplate` trait. This PR fixes the two trait impls to drop any attributes and components that were rendered by the `VirtualDom`

Fixes #1365 ? At least the no-native-core version