### PR TITLE
deps: Update keyboard-types to 0.7.

### DIFF
--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -17,7 +17,7 @@ serde_repr = { version = "0.1", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 euclid = "0.22.7"
 enumset = "1.0.11"
-keyboard-types = "0.6.2"
+keyboard-types = "0.7"
 async-trait = "0.1.58"
 serde-value = "0.7.0"
 tokio = { workspace = true, features = ["fs", "io-util"], optional = true }

--- a/packages/native-core/Cargo.toml
+++ b/packages/native-core/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Jonathan Kelley", "Evan Almloff"]
 [dependencies]
 dioxus-core = { workspace = true, optional = true }
 
-keyboard-types = "0.6.2"
+keyboard-types = "0.7"
 smallvec = "1.6"
 rustc-hash = { workspace = true }
 anymap = "1.0.0-beta.2"


### PR DESCRIPTION
This brings a use of bitflags 2 and a couple of minor features.