### PR TITLE
Expose new_in_scope for signals

### DIFF
--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -145,6 +145,21 @@ impl<T: 'static> Signal<T> {
         }
     }
 
+    /// Create a new signal with a custom owner scope. The signal will be dropped when the owner scope is dropped instead of the current scope.
+    pub fn new_in_scope(value: T, owner: ScopeId) -> Self {
+        Self {
+            inner: CopyValue::new_in_scope(
+                SignalData {
+                    subscribers: Default::default(),
+                    effect_subscribers: Default::default(),
+                    update_any: schedule_update_any().expect("in a virtual dom"),
+                    value,
+                },
+                owner,
+            ),
+        }
+    }
+
     /// Get the scope the signal was created in.
     pub fn origin_scope(&self) -> ScopeId {
         self.inner.origin_scope()


### PR DESCRIPTION
Exposes the new_in_scope function for signals which makes it possible for users to make a signal last longer than the current scope.

For example:
```rust
let signals = use_signal(cx, || vec![Signal::new(0)]);
// ...In a Child component...

// Because we use the origin scope of the array, even if the child scope is dropped, the signal will still exist as long as the array does
signals.push(Signal::new_in_scope(123, signals.origin_scope()));
```