### PR TITLE
Fix leaked signals created in effects

### DIFF
--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -17,7 +17,7 @@ serde_repr = { version = "0.1", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 euclid = "0.22.7"
 enumset = "1.0.11"
-keyboard-types = "0.6.2"
+keyboard-types = "0.7"
 async-trait = "0.1.58"
 serde-value = "0.7.0"
 tokio = { workspace = true, features = ["fs", "io-util"], optional = true }

--- a/packages/native-core/Cargo.toml
+++ b/packages/native-core/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Jonathan Kelley", "Evan Almloff"]
 [dependencies]
 dioxus-core = { workspace = true, optional = true }
 
-keyboard-types = "0.6.2"
+keyboard-types = "0.7"
 smallvec = "1.6"
 rustc-hash = { workspace = true }
 anymap = "1.0.0-beta.2"

--- a/packages/signals/src/effect.rs
+++ b/packages/signals/src/effect.rs
@@ -54,6 +54,7 @@ pub fn use_effect_with_dependencies<D: Dependency>(
 /// Effects allow you to run code when a signal changes. Effects are run immediately and whenever any signal it reads changes.
 #[derive(Copy, Clone, PartialEq)]
 pub struct Effect {
+    pub(crate) source: ScopeId,
     pub(crate) callback: CopyValue<Box<dyn FnMut()>>,
 }
 
@@ -73,6 +74,7 @@ impl Effect {
     /// The signal will be owned by the current component and will be dropped when the component is dropped.
     pub fn new(callback: impl FnMut() + 'static) -> Self {
         let myself = Self {
+            source: current_scope_id().expect("in a virtual dom"),
             callback: CopyValue::new(Box::new(callback)),
         };
 

--- a/packages/signals/src/effect.rs
+++ b/packages/signals/src/effect.rs
@@ -18,7 +18,8 @@ pub(crate) fn get_effect_stack() -> EffectStack {
         Some(rt) => rt,
         None => {
             let store = EffectStack::default();
-            provide_root_context(store).expect("in a virtual dom")
+            provide_root_context(store.clone());
+            store
         }
     }
 }

--- a/packages/signals/src/selector.rs
+++ b/packages/signals/src/selector.rs
@@ -74,6 +74,7 @@ pub fn selector<R: PartialEq>(mut f: impl FnMut() -> R + 'static) -> ReadOnlySig
         inner: CopyValue::invalid(),
     };
     let effect = Effect {
+        source: current_scope_id().expect("in a virtual dom"),
         callback: CopyValue::invalid(),
     };
 


### PR DESCRIPTION
Currently any signals created in an effect use the root scope as the owner. This essentially leaks the signal for the duration of the application. Instead this sets the owner of signals created in effects to the owner of the effect