### PR TITLE
Use a `gen` in `PartialEq` for `UseSharedState`

### DIFF
--- a/packages/hooks/src/use_shared_state.rs
+++ b/packages/hooks/src/use_shared_state.rs
@@ -197,7 +197,8 @@ pub struct UseSharedState<T> {
 
 impl<T> UseSharedState<T> {
     fn new(inner: Rc<RefCell<ProvidedStateInner<T>>>) -> Self {
-        Self { inner, gen: 0 }
+        let gen = inner.borrow().gen;
+        Self { inner, gen }
     }
 
     /// Notify all consumers of the state that it has changed. (This is called automatically when you call "write")

--- a/packages/hooks/src/use_shared_state.rs
+++ b/packages/hooks/src/use_shared_state.rs
@@ -314,7 +314,7 @@ impl<T> Clone for UseSharedState<T> {
     }
 }
 
-impl<T: PartialEq> PartialEq for UseSharedState<T> {
+impl<T> PartialEq for UseSharedState<T> {
     fn eq(&self, other: &Self) -> bool {
         self.gen == other.gen
     }


### PR DESCRIPTION
So I had tried using a `UseSharedState` as a dependency for `use_future`, and it wasn't re-running when it changed. I think this was because it was comparing the `.inner` values which still were pointing to the same data. 
I implemented a special `UseFutureDep` so it would compare a `gen` value, sort of following the example of `UseRef`. I did have to remove the `PartialEq` here to avoid conflicting with this: `impl<A: Dep> UseFutureDep for &A`, but this might not be the right thing to do. 