### PR TITLE
Unbox scope states

### DIFF
--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -21,7 +21,7 @@ impl VirtualDom {
         let entry = self.scopes.vacant_entry();
         let id = ScopeId(entry.key());
 
-        let scope = entry.insert(Box::new(ScopeState {
+        let scope = entry.insert(ScopeState {
             runtime: self.runtime.clone(),
             context_id: id,
 
@@ -36,7 +36,7 @@ impl VirtualDom {
 
             borrowed_props: Default::default(),
             attributes_to_drop: Default::default(),
-        }));
+        });
 
         let context =
             ScopeContext::new(name, id, parent_id, height, self.runtime.scheduler.clone());

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -175,7 +175,7 @@ use std::{any::Any, cell::Cell, collections::BTreeSet, future::Future, rc::Rc};
 /// }
 /// ```
 pub struct VirtualDom {
-    pub(crate) scopes: Slab<Box<ScopeState>>,
+    pub(crate) scopes: Slab<ScopeState>,
 
     pub(crate) dirty_scopes: BTreeSet<DirtyScope>,
 
@@ -282,7 +282,7 @@ impl VirtualDom {
     ///
     /// This is useful for inserting or removing contexts from a scope, or rendering out its root node
     pub fn get_scope(&self, id: ScopeId) -> Option<&ScopeState> {
-        self.scopes.get(id.0).map(|s| &**s)
+        self.scopes.get(id.0).map(|s| &*s)
     }
 
     /// Get the single scope at the top of the VirtualDom tree that will always be around


### PR DESCRIPTION
Followup to https://github.com/DioxusLabs/dioxus/pull/1226 and https://github.com/DioxusLabs/dioxus/pull/1300

We no longer use pointers for the context API (we just use ids now). Because of that we don't need the pointer to be stable anymore so we don't need to box them