### PR TITLE
Fix cli compile error due to tauri bundler adding fields

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -381,6 +381,7 @@ impl From<DebianSettings> for tauri_bundler::DebianSettings {
         tauri_bundler::DebianSettings {
             depends: val.depends,
             files: val.files,
+            desktop_template: None,
         }
     }
 }
@@ -522,6 +523,8 @@ impl From<NsisSettings> for tauri_bundler::NsisSettings {
             install_mode: val.install_mode.into(),
             languages: val.languages,
             display_language_selector: val.display_language_selector,
+            custom_language_files: None,
+            template: None,
         }
     }
 }


### PR DESCRIPTION
New fields for debian settings:

- desktop_template

For NSIS settings:

- custom_language_files
- template