### PR TITLE
Add query segment example and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     # Full project examples
     "examples/tailwind",
     "examples/PWA-example",
+    "examples/query_segments_demo",
     # Playwright tests
     "playwright-tests/liveview",
     "playwright-tests/web",

--- a/examples/query_segments_demo/Cargo.toml
+++ b/examples/query_segments_demo/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "query_segments_demo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dioxus = { path = "../../packages/dioxus", version = "*" }
+dioxus-router = { path = "../../packages/router", version = "*" }
+dioxus-web = { path = "../../packages/web", version = "*" }
+form_urlencoded = "1.2.0"

--- a/examples/query_segments_demo/src/main.rs
+++ b/examples/query_segments_demo/src/main.rs
@@ -1,0 +1,73 @@
+#![allow(non_snake_case, unused)]
+//! Example: Url query segments usage
+//! ------------------------------------
+//!
+//! This example shows how to access and use multiple query segments present in an url on the web.
+//!
+//! Run `dx serve` and navigate to `http://localhost:8080/blog?name=John&surname=Doe`
+use std::fmt::Display;
+
+use dioxus::prelude::*;
+use dioxus_router::prelude::*;
+
+// ANCHOR: route
+#[derive(Routable, Clone)]
+#[rustfmt::skip]
+enum Route {
+    // segments that start with ?: are query segments
+    #[route("/blog?:query_params")]
+    BlogPost {
+        // You must include query segments in child variants
+        query_params: BlogQuerySegments,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct BlogQuerySegments {
+    name: String,
+    surname: String,
+}
+
+/// The display impl needs to display the query in a way that can be parsed:
+impl Display for BlogQuerySegments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "name={}&surname={}", self.name, self.surname)
+    }
+}
+
+/// The query segment is anything that implements https://docs.rs/dioxus-router/latest/dioxus_router/routable/trait.FromQuery.html. You can implement that trait for a struct if you want to parse multiple query parameters.
+impl FromQuery for BlogQuerySegments {
+    fn from_query(query: &str) -> Self {
+        let mut name = None;
+        let mut surname = None;
+        let pairs = form_urlencoded::parse(query.as_bytes());
+        pairs.for_each(|(key, value)| {
+            if key == "name" {
+                name = Some(value.clone().into());
+            }
+            if key == "surname" {
+                surname = Some(value.clone().into());
+            }
+        });
+        Self {
+            name: name.unwrap(),
+            surname: surname.unwrap(),
+        }
+    }
+}
+
+#[inline_props]
+fn BlogPost(cx: Scope, query_params: BlogQuerySegments) -> Element {
+    render! {
+        div{"This is your blogpost with a query segment:"}
+        div{format!("{:?}", query_params)}
+    }
+}
+
+fn App(cx: Scope) -> Element {
+    render! { Router::<Route>{} }
+}
+
+fn main() {
+    dioxus_web::launch(App);
+}

--- a/packages/router/src/routable.rs
+++ b/packages/router/src/routable.rs
@@ -26,7 +26,7 @@ impl<E: std::fmt::Display> std::fmt::Display for RouteParseError<E> {
 ///
 /// This trait needs to be implemented if you want to turn a query string into a struct.
 ///
-/// A working example can be found in the `examples` folder in the core package under `query_segments_demo`
+/// A working example can be found in the `examples` folder in the root package under `query_segments_demo`
 pub trait FromQuery {
     /// Create an instance of `Self` from a query string
     fn from_query(query: &str) -> Self;

--- a/packages/router/src/routable.rs
+++ b/packages/router/src/routable.rs
@@ -22,7 +22,11 @@ impl<E: std::fmt::Display> std::fmt::Display for RouteParseError<E> {
     }
 }
 
-/// Something that can be created from a query string
+/// Something that can be created from a query string.
+///
+/// This trait needs to be implemented if you want to turn a query string into a struct.
+///
+/// A working example can be found in the `examples` folder in the core package under `query_segments_demo`
 pub trait FromQuery {
     /// Create an instance of `Self` from a query string
     fn from_query(query: &str) -> Self;

--- a/packages/ssr/Cargo.toml
+++ b/packages/ssr/Cargo.toml
@@ -17,7 +17,7 @@ rustc-hash = "1.1.0"
 lru = "0.10.0"
 log = "0.4.13"
 http = "0.2.9"
-tokio = { version = "1.28", features = ["full"] }
+tokio = { version = "1.28", features = ["full"], optional = true }
 
 [dev-dependencies]
 dioxus = { workspace = true }
@@ -29,3 +29,7 @@ argh = "0.1.4"
 serde = "1.0.120"
 serde_json = "1.0.61"
 fs_extra = "1.2.0"
+
+[features]
+default = ["incremental"]
+incremental = ["dep:tokio"]

--- a/packages/ssr/src/lib.rs
+++ b/packages/ssr/src/lib.rs
@@ -3,8 +3,11 @@
 mod cache;
 pub mod config;
 mod fs_cache;
+#[cfg(feature = "incremental")]
 pub mod incremental;
+#[cfg(feature = "incremental")]
 mod incremental_cfg;
+
 pub mod renderer;
 pub mod template;
 


### PR DESCRIPTION
Adds a multiple query segments example and updates the documentation.
The example won't work until #1406 is merged. 