### PR TITLE
feat: Simplify `use_tracker_state` and `use_selector`

### DIFF
--- a/packages/hooks/src/computed.rs
+++ b/packages/hooks/src/computed.rs
@@ -11,7 +11,7 @@ use std::{
 /// Create a new tracked state.
 /// Tracked state is state that can drive Selector state
 ///
-/// It will efficiently update any Selector state that is reading from it, but it is not readable on it's own.
+/// It will efficiently update any Selector state that is reading from it, but it is not readable on its own.
 ///
 /// ```rust
 /// use dioxus::prelude::*;
@@ -49,7 +49,7 @@ pub fn use_tracked_state<T: 'static>(cx: &ScopeState, init: impl FnOnce() -> T) 
 pub struct Tracked<I> {
     state: Rc<RefCell<I>>,
     update_any: std::sync::Arc<dyn Fn(ScopeId)>,
-    pub subscribers: SubscribedCallbacks<I>,
+    subscribers: SubscribedCallbacks<I>,
 }
 
 impl<I: PartialEq> PartialEq for Tracked<I> {


### PR DESCRIPTION
Feel free to close if I am wrong but I was casually reading the source code of `use_tracked_state` and `use_selector` and it seemed like `use_selector` was doing unnecessary work, like creating a whole subscriber vector that only was subscribed itself.

I have tested it with my changes, and it seems to work fine, thoughts?