### PR TITLE
Fix to cargo-binstall not working for Dioxus CLI

### DIFF
--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -47,7 +47,7 @@ jobs:
         if: ${{matrix.platform.target == 'x86_64-unknown-linux-gnu'}}
         run: |
           # Replace the tag for the cargo-binstall record with the current release tag
-          sed -i 's/\/{ tagName }\//${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
+          sed -i 's/\/{ tagName }\//\/${{ github.event.release.tag_name }}\//g' packages/cli/Cargo.toml
 
           # Commit and push the changes to the tag
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com" # This is a dummy email, copied from https://github.com/stefanzweifel/git-auto-commit-action

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -50,8 +50,8 @@ jobs:
           sed -i 's/\/{ tagName }\//\/${{ github.event.release.tag_name }}\//g' packages/cli/Cargo.toml
 
           # Commit and push the changes to the tag
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com" # This is a dummy email, copied from https://github.com/stefanzweifel/git-auto-commit-action
-          git config --local user.name "github-actions[bot]"
+          # git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com" # This is a dummy email, copied from https://github.com/stefanzweifel/git-auto-commit-action
+          # git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
           git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}"
           git tag -fa ${{ github.event.release.tag_name }} -m "Update pkg-url to ${{ github.event.release.tag_name }}"

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -42,6 +42,13 @@ jobs:
         with:
           workspaces: packages/cli -> ../../target
 
+      # Replace the tag for the cargo-binstall record with the current release tag
+      - name: Replace pkg-url in Cargo.toml
+        run: |
+          sed -i 's/{ tagName }/${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
+      - name: Commit and push changes to tag
+        uses: stefanzweifel/git-auto-commit-action@v4
+
       # This neat action can build and upload the binary in one go!
       - name: Build and upload binary
         uses: taiki-e/upload-rust-binary-action@v1

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Build and upload binary
         uses: taiki-e/upload-rust-binary-action@v1
         with:
+          ref: refs/tags/${{ github.event.release.tag_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           target: ${{ matrix.platform.target }}
           bin: dx

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -59,7 +59,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
           git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}"
-          git tag -fa ${{ github.event.release.tag_name }} -m "release_body"
+          git tag -f ${{ github.event.release.tag_name }}
           git push origin --tags --force
 
       # This neat action can build and upload the binary in one go!

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -49,12 +49,15 @@ jobs:
           # Replace the tag for the cargo-binstall record with the current release tag
           sed -i 's/\/{ tagName }\//\/${{ github.event.release.tag_name }}\//g' packages/cli/Cargo.toml
 
+          # Get release body from GitHub CLI
+          release_body=$(gh release view ${{ github.event.release.tag_name }} --json body --jq '.body')
+
           # Commit and push the changes to the tag
-          # git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com" # This is a dummy email, copied from https://github.com/stefanzweifel/git-auto-commit-action
-          # git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com" # This is a dummy email, copied from https://github.com/stefanzweifel/git-auto-commit-action
+          git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
           git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}"
-          git tag -fa ${{ github.event.release.tag_name }} -m "Update pkg-url to ${{ github.event.release.tag_name }}"
+          git tag -fa ${{ github.event.release.tag_name }} -m "$release_body"
           git push origin --tags --force
 
       # This neat action can build and upload the binary in one go!

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -53,7 +53,7 @@ jobs:
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
-          git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}" --author $author
+          git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}" --author "$author"
           git push -f origin ${{ github.ref }}
 
       # This neat action can build and upload the binary in one go!

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -50,7 +50,7 @@ jobs:
           sed -i 's/\/{ tagName }\//${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
 
           # Commit and push the changes to the tag
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com" # This is a dummy email, copied from https://github.com/stefanzweifel/git-auto-commit-action
           git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
           git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}"

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -59,7 +59,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
           git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}"
-          git tag -fa ${{ github.event.release.tag_name }} -m "$release_body"
+          git tag -fa ${{ github.event.release.tag_name }} -m "release_body"
           git push origin --tags --force
 
       # This neat action can build and upload the binary in one go!

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -54,7 +54,8 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
           git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}" --author "$author"
-          git push -f origin ${{ github.ref }}
+          git tag -fa ${{ github.event.release.tag_name }}
+          git push origin --tags --force
 
       # This neat action can build and upload the binary in one go!
       - name: Build and upload binary

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -46,8 +46,15 @@ jobs:
       - name: Replace pkg-url in Cargo.toml
         run: |
           sed -i 's/{ tagName }/${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
-      - name: Commit and push changes to tag
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Commit and push changes to tag # Only run on Linux
+        if: ${{matrix.platform.target == 'x86_64-unknown-linux-gnu'}}
+        run: |
+          author="$(git log -1 --pretty=format:'%an <%ae>')"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add packages/cli/Cargo.toml
+          git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}" --author $author
+          git push -f origin ${{ github.ref }}
 
       # This neat action can build and upload the binary in one go!
       - name: Build and upload binary

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -46,12 +46,14 @@ jobs:
       - name: Replace pkg-url in Cargo.toml and push changes to tag # Only run on Linux
         if: ${{matrix.platform.target == 'x86_64-unknown-linux-gnu'}}
         run: |
-          sed -i 's/{ tagName }/${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
-          author="$(git log -1 --pretty=format:'%an <%ae>')"
+          # Replace the tag for the cargo-binstall record with the current release tag
+          sed -i 's/\/{ tagName }\//${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
+
+          # Commit and push the changes to the tag
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
-          git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}" --author "$author"
+          git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}"
           git tag -fa ${{ github.event.release.tag_name }} -m "Update pkg-url to ${{ github.event.release.tag_name }}"
           git push origin --tags --force
 

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -45,6 +45,8 @@ jobs:
       # Replace the tag for the cargo-binstall record with the current release tag
       - name: Replace pkg-url in Cargo.toml and push changes to tag # Only run on Linux
         if: ${{matrix.platform.target == 'x86_64-unknown-linux-gnu'}}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           # Replace the tag for the cargo-binstall record with the current release tag
           sed -i 's/\/{ tagName }\//\/${{ github.event.release.tag_name }}\//g' packages/cli/Cargo.toml

--- a/.github/workflows/cli_release.yml
+++ b/.github/workflows/cli_release.yml
@@ -43,18 +43,16 @@ jobs:
           workspaces: packages/cli -> ../../target
 
       # Replace the tag for the cargo-binstall record with the current release tag
-      - name: Replace pkg-url in Cargo.toml
-        run: |
-          sed -i 's/{ tagName }/${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
-      - name: Commit and push changes to tag # Only run on Linux
+      - name: Replace pkg-url in Cargo.toml and push changes to tag # Only run on Linux
         if: ${{matrix.platform.target == 'x86_64-unknown-linux-gnu'}}
         run: |
+          sed -i 's/{ tagName }/${{ github.event.release.tag_name }}/g' packages/cli/Cargo.toml
           author="$(git log -1 --pretty=format:'%an <%ae>')"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add packages/cli/Cargo.toml
           git commit -m "Update pkg-url to ${{ github.event.release.tag_name }}" --author "$author"
-          git tag -fa ${{ github.event.release.tag_name }}
+          git tag -fa ${{ github.event.release.tag_name }} -m "Update pkg-url to ${{ github.event.release.tag_name }}"
           git push origin --tags --force
 
       # This neat action can build and upload the binary in one go!

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -101,7 +101,8 @@ name = "dx"
 tempfile = "3.3"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/dx-{ target }{ archive-suffix }"
+# '{ tagName }' will be replaced in the CI with the actual tag of the release
+pkg-url = "{ repo }/releases/download/{ tagName }/dx-{ target }{ archive-suffix }"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"


### PR DESCRIPTION
## Summary
This PR is an attempt to fix cargo-binstall's ability to find the correct pre-built binary regardless of the name of the release tag, identified in #1430. Rather than using the crate version to fill the `pkg-url` field in the Dioxus CLI Cargo.toml file, now the workflow that publishes the binaries to the release will also commit a change to the release tag that updates the pkg-url directly with the name of the tag.

## Caveats
### The workflow must run before the crate is published
For this to work, the workflow must be run before the new package version is published to Crates.io, otherwise the pkg-url will be malformed and cargo-binstall will fall back to `cargo install`.

A future improvement here would be to automate Crates.io publishing into a workflow as well.

### The commit will appear from a spoofed author
I needed to provide an author for the commit so I used a fake email and name that I took from a similar project [git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action). This is a bit janky. Ideally, we should provision a proper service account to publish and sign the commit. See [Machine users](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#machine-users) for more info.