### PR TITLE
Update Cargo.toml (desktop package)

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -58,7 +58,6 @@ transparent = ["wry/transparent"]
 devtools = ["wry/devtools"]
 dox = ["wry/dox"]
 hot-reload = ["dioxus-hot-reload"]
-dox = ["wry/dox"]
 
 [package.metadata.docs.rs]
 default-features = false


### PR DESCRIPTION
Remove duplicate `dox` feature that resulted in build fail