### PR TITLE
Make RuntimeGuard public

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -32,7 +32,7 @@ pub(crate) mod innerlude {
     pub use crate::nodes::RenderReturn;
     pub use crate::nodes::*;
     pub use crate::properties::*;
-    pub use crate::runtime::{in_runtime, override_runtime, Runtime};
+    pub use crate::runtime::{Runtime, RuntimeGuard};
     pub use crate::scheduler::*;
     pub use crate::scope_context::*;
     pub use crate::scopes::*;
@@ -87,11 +87,11 @@ pub use crate::innerlude::{
 pub mod prelude {
     pub use crate::innerlude::{
         consume_context, consume_context_from_scope, current_scope_id, fc_to_builder, has_context,
-        in_runtime, override_runtime, provide_context, provide_context_to_scope,
-        provide_root_context, push_future, remove_future, schedule_update_any, spawn,
-        spawn_forever, suspend, throw, AnyValue, Component, Element, Event, EventHandler, Fragment,
-        IntoAttributeValue, LazyNodes, Properties, Runtime, Scope, ScopeId, ScopeState, Scoped,
-        TaskId, Template, TemplateAttribute, TemplateNode, Throw, VNode, VirtualDom,
+        provide_context, provide_context_to_scope, provide_root_context, push_future,
+        remove_future, schedule_update_any, spawn, spawn_forever, suspend, throw, AnyValue,
+        Component, Element, Event, EventHandler, Fragment, IntoAttributeValue, LazyNodes,
+        Properties, Runtime, RuntimeGuard, Scope, ScopeId, ScopeState, Scoped, TaskId, Template,
+        TemplateAttribute, TemplateNode, Throw, VNode, VirtualDom,
     };
 }
 

--- a/packages/fullstack/src/adapters/warp_adapter.rs
+++ b/packages/fullstack/src/adapters/warp_adapter.rs
@@ -143,7 +143,7 @@ pub fn register_server_fns(server_fn_route: &'static str) -> BoxedFilter<(impl R
                     let req = warp::hyper::Request::from_parts(parts, bytes.into());
                     service.run(req).await.map_err(|err| {
                         tracing::error!("Server function error: {}", err);
-                      
+
                         struct WarpServerFnError(String);
                         impl std::fmt::Debug for WarpServerFnError {
                             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -152,7 +152,7 @@ pub fn register_server_fns(server_fn_route: &'static str) -> BoxedFilter<(impl R
                         }
 
                         impl warp::reject::Reject for WarpServerFnError {}
-                      
+
                         warp::reject::custom(WarpServerFnError(err.to_string()))
                     })
                 }


### PR DESCRIPTION
This is a different approach to https://github.com/DioxusLabs/dioxus/pull/1441 that just makes the runtime guard public. This API is slightly more complex because it uses drop handlers, but can be more flexible

Closes https://github.com/DioxusLabs/dioxus/issues/1465