### PR TITLE
Fix #1367

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 toml = "0.5.8"
 fs_extra = "1.2.0"
-cargo_toml = "0.11.4"
+cargo_toml = "0.16.0"
 futures = "0.3.21"
 notify = { version = "5.0.0-pre.16", features = ["serde"] }
 html_parser  = { workspace = true }

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -132,10 +132,10 @@ impl Bundle {
             .project_out_directory(crate_config.out_dir)
             .package_settings(PackageSettings {
                 product_name: crate_config.dioxus_config.application.name.clone(),
-                version: package.version,
-                description: package.description.unwrap_or_default(),
-                homepage: package.homepage,
-                authors: Some(package.authors),
+                version: package.version().to_string(),
+                description: package.description().unwrap_or_default().to_string(),
+                homepage: Some(package.homepage().unwrap_or_default().to_string()),
+                authors: Some(Vec::from(package.authors())),
                 default_run: Some(crate_config.dioxus_config.application.name.clone()),
             })
             .binaries(binaries)

--- a/packages/fullstack/src/adapters/warp_adapter.rs
+++ b/packages/fullstack/src/adapters/warp_adapter.rs
@@ -143,7 +143,7 @@ pub fn register_server_fns(server_fn_route: &'static str) -> BoxedFilter<(impl R
                     let req = warp::hyper::Request::from_parts(parts, bytes.into());
                     service.run(req).await.map_err(|err| {
                         tracing::error!("Server function error: {}", err);
-                      
+
                         struct WarpServerFnError(String);
                         impl std::fmt::Debug for WarpServerFnError {
                             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -152,7 +152,7 @@ pub fn register_server_fns(server_fn_route: &'static str) -> BoxedFilter<(impl R
                         }
 
                         impl warp::reject::Reject for WarpServerFnError {}
-                      
+
                         warp::reject::custom(WarpServerFnError(err.to_string()))
                     })
                 }


### PR DESCRIPTION
Fix #1367. Bumps `cargo_toml` to `1.16.0` and adjusts for the new inherited fields. Tested with all `workspace.package` fields.