### PR TITLE
PartialOrd for UseState

### DIFF
--- a/packages/hooks/src/usestate.rs
+++ b/packages/hooks/src/usestate.rs
@@ -336,6 +336,50 @@ impl<T> PartialEq<UseState<T>> for UseState<T> {
     }
 }
 
+impl<T: std::cmp::PartialOrd> PartialOrd<T> for UseState<T> {
+    fn ge(&self, other: &T) -> bool {
+        *self.current_val >= *other
+    }
+
+    fn gt(&self, other: &T) -> bool {
+        *self.current_val > *other
+    }
+
+    fn le(&self, other: &T) -> bool {
+        *self.current_val <= *other
+    }
+
+    fn lt(&self, other: &T) -> bool {
+        *self.current_val < *other
+    }
+
+    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+        (*self.current_val).partial_cmp(other)
+    }
+}
+
+impl<T: std::cmp::PartialOrd> PartialOrd<UseState<T>> for UseState<T> {
+    fn ge(&self, other: &UseState<T>) -> bool {
+        self.current_val >= other.current_val
+    }
+
+    fn gt(&self, other: &UseState<T>) -> bool {
+        self.current_val > other.current_val
+    }
+
+    fn le(&self, other: &UseState<T>) -> bool {
+        self.current_val <= other.current_val
+    }
+
+    fn lt(&self, other: &UseState<T>) -> bool {
+        self.current_val < other.current_val
+    }
+
+    fn partial_cmp(&self, other: &UseState<T>) -> Option<std::cmp::Ordering> {
+        self.current_val.partial_cmp(&other.current_val)
+    }
+}
+
 impl<T: Debug> Debug for UseState<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.current_val)


### PR DESCRIPTION
I have implemented PartialOrd for UseState to allow for some better readability. It may be a small change, but I found `.get()` quite annoying. It just makes more sense to have PartialOrd implemented.

Essentially instead of,

```rs
use dioxus::prelude::*;

fn main() {
    dioxus_desktop::launch(app);
}

fn app(cx: Scope) -> Element {
    let mut count = use_state(cx, || 0);
    let other_count = use_state(cx, || 10);

    cx.render(rsx! (
        h1 { "Counter: {count}" }
        button { onclick: move |_| if count.get() < other_count.get() { count += 1 }, "Tick up"}
        button { onclick: move |_| if *count.get() > 0 { count -= 1}, "Tick down"}
    ))
}
```

now we have,

```rs 
use dioxus::prelude::*;

fn main() {
    dioxus_desktop::launch(app);
}

fn app(cx: Scope) -> Element {
    let mut count = use_state(cx, || 0);
    let other_count = use_state(cx, || 10);

    cx.render(rsx! (
        h1 { "Counter: {count}" }
        button { onclick: move |_| if count < other_count { count += 1 }, "Tick up"}
        button { onclick: move |_| if *count > 0 { count -= 1}, "Tick down"}
    ))
}
```

Please let me know if anything needs to be changed to meet the requirements for the merge, i.e. testing, etc.
