### PR TITLE
Restore the tray feature in the desktop crate

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -56,6 +56,7 @@ tokio_runtime = ["tokio"]
 fullscreen = ["wry/fullscreen"]
 transparent = ["wry/transparent"]
 devtools = ["wry/devtools"]
+tray = ["wry/tray"]
 dox = ["wry/dox"]
 hot-reload = ["dioxus-hot-reload"]
 


### PR DESCRIPTION
https://github.com/DioxusLabs/dioxus/pull/1412 removed the tray feature. wry `0.30` doesn't include a tray feature. Originally that PR also upgraded wry which is why the tray feature was removed.