### PR TITLE
Fix playwright tests on windows

### DIFF
--- a/playwright-tests/playwright.config.js
+++ b/playwright-tests/playwright.config.js
@@ -90,7 +90,7 @@ module.exports = defineConfig({
     },
     {
       cwd: path.join(process.cwd(), 'fullstack'),
-      command: 'cargo run --package dioxus-cli -- build --features web --release\ncargo run --release --features ssr',
+      command: 'cargo run --package dioxus-cli -- build --features web --release && cargo run --release --features ssr',
       port: 3333,
       timeout: 10 * 60 * 1000,
       reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
Playwright tests on windows were failing because playwright does not execute the second command  because it is on a newline. This PR fixes that issue by combining the two commands into one line separated by `&&`