### PR TITLE
liveview: Add `interpreter_glue_relative_uri

### DIFF
--- a/packages/liveview/src/lib.rs
+++ b/packages/liveview/src/lib.rs
@@ -110,7 +110,7 @@ static MAIN_JS: &str = include_str!("./main.js");
 /// ```
 pub fn interpreter_glue(url_or_path: &str) -> String {
     // If the url starts with a `/`, generate glue which reuses current host
-    let get_ws_url = if url_or_path.starts_with("/") {
+    let get_ws_url = if url_or_path.starts_with('/') {
         r#"
   let loc = window.location; 
   let new_url = "";


### PR DESCRIPTION
By utilizing `window.location.host` in the client-side JavaScript, we can easily derive the WebSocket URI from a relative path URI. This approach obviates the need for host address retrieval on the server side, unlike the method of serving glue code in liveview using `interpreter_glue`.