### PR TITLE
Make the layer module public in fullstack

### DIFF
--- a/packages/fullstack/src/layer.rs
+++ b/packages/fullstack/src/layer.rs
@@ -3,7 +3,9 @@ use tracing_futures::Instrument;
 
 use http::{Request, Response};
 
+/// A layer that wraps a service. This can be used to add additional information to the request, or response on top of some other service
 pub trait Layer: Send + Sync + 'static {
+    /// Wrap a boxed service with this layer
     fn layer(&self, inner: BoxedService) -> BoxedService;
 }
 
@@ -17,7 +19,9 @@ where
     }
 }
 
+/// A service is a function that takes a request and returns an async response
 pub trait Service {
+    /// Run the service and produce a future that resolves to a response
     fn run(
         &mut self,
         req: http::Request<hyper::body::Body>,
@@ -55,6 +59,7 @@ where
     }
 }
 
+/// A boxed service is a type-erased service that can be used without knowing the underlying type
 pub struct BoxedService(pub Box<dyn Service + Send>);
 
 impl tower::Service<http::Request<hyper::body::Body>> for BoxedService {

--- a/packages/fullstack/src/lib.rs
+++ b/packages/fullstack/src/lib.rs
@@ -19,7 +19,7 @@ mod hooks;
 mod hot_reload;
 pub mod launch;
 #[cfg(feature = "ssr")]
-mod layer;
+pub mod layer;
 #[cfg(feature = "ssr")]
 mod render;
 #[cfg(feature = "ssr")]

--- a/packages/fullstack/src/lib.rs
+++ b/packages/fullstack/src/lib.rs
@@ -19,7 +19,7 @@ mod hooks;
 mod hot_reload;
 pub mod launch;
 #[cfg(feature = "ssr")]
-pub mod layer;
+mod layer;
 #[cfg(feature = "ssr")]
 mod render;
 #[cfg(feature = "ssr")]
@@ -40,6 +40,8 @@ pub mod prelude {
     #[cfg(not(feature = "ssr"))]
     pub use crate::html_storage::deserialize::get_root_props_from_document;
     pub use crate::launch::LaunchBuilder;
+    #[cfg(feature = "ssr")]
+    pub use crate::layer::{Layer, Service};
     #[cfg(all(feature = "ssr", feature = "router"))]
     pub use crate::render::pre_cache_static_routes_with_props;
     #[cfg(feature = "ssr")]


### PR DESCRIPTION
Makes the layer module with the layer trait in the fullstack crate public. This makes it possible to implement Fullstack layers in other crates and makes implementing a custom server function handler easier