### PR TITLE
feat: initial_selected attribute for options

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1203,6 +1203,7 @@ builder_constructors! {
         value: String DEFAULT,
 
         selected: Bool volatile,
+        initial_selected: Bool DEFAULT,
     };
 
     /// Build a

--- a/packages/interpreter/src/common.js
+++ b/packages/interpreter/src/common.js
@@ -54,6 +54,9 @@ export function setAttributeInner(node, field, value, ns) {
       case "selected":
         node.selected = truthy(value);
         break;
+      case "initial_selected":
+        node.defaultSelected = truthy(value);
+        break;
       case "dangerous_inner_html":
         node.innerHTML = value;
         break;

--- a/packages/interpreter/src/sledgehammer_bindings.rs
+++ b/packages/interpreter/src/sledgehammer_bindings.rs
@@ -83,6 +83,9 @@ mod js {
                 case "selected":
                     node.selected = truthy(value);
                     break;
+                case "initial_selected":
+                    node.defaultSelected = truthy(value);
+                    break;
                 case "dangerous_inner_html":
                     node.innerHTML = value;
                     break;


### PR DESCRIPTION
Adds the `initial_selected` attribute to set an option element's defaultSelected property as described [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement).
Implemented similarly to https://github.com/DioxusLabs/dioxus/pull/1063