### PR TITLE
Update `dioxus-core-macro` README as per #1448

### DIFF
--- a/packages/core-macro/README.md
+++ b/packages/core-macro/README.md
@@ -23,9 +23,12 @@
 
 `dioxus-core-macro` provides a handful of helpful macros used by the `dioxus` crate. These include:
 
-- The `rsx!` macro that underpins templates and node creation
-- The `inline_props` macro transforms function arguments into an auto-derived struct
-- The `format_args_f` macro which allows f-string formatting with support for expressions
+- The `rsx!` macro that underpins templates and node creation.
+- The `component` attribute macro denotes a function as a Dioxus component. Currently, this:
+  - Transforms function arguments into an auto-derived struct.
+  - Ensures that your component name uses PascalCase.
+  - Probably more stuff in the future. This macro allows us to have a way of distinguishing functions and components, which can be quite handy.
+- The `format_args_f` macro which allows f-string formatting with support for expressions.
 
 ## Contributing
 


### PR DESCRIPTION
This updates the README with the new changes from #1448. Specifically:
- Adds a description for the `component` attribute macro.
- Removes the description of the deprecated `inline_props` attribute macro.
- Adds dots after each bullet point description.

A bit late to the party, I know. Maybe I searched for `#[inline_props]` (instead of just `inline_props`) when replacing all occurrences of it? I'll see if I find any other occurrences of this tomorrow.