### PR TITLE
CLI: Clarify where serve warnings come from

### DIFF
--- a/packages/cli/src/server/output.rs
+++ b/packages/cli/src/server/output.rs
@@ -129,7 +129,7 @@ pub fn print_console_info(
         log::warn!(
             "{}",
             format!(
-                "There were {} warning messages during the build.",
+                "There were {} warning messages during the build. Run `cargo check` to see them.",
                 options.warnings.len() - 1
             )
             .yellow()


### PR DESCRIPTION
See https://github.com/DioxusLabs/dioxus/issues/1514. This just appends `'Run cargo check' to see them.` to `There were X warning messages during the build.`. No `--verbose` changes since it's too small of a change to mark it as "verbose".