### PR TITLE
feat: Optional web support for hot-reload crate

### DIFF
--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -26,5 +26,5 @@ ignore = { version = "0.4.19", optional = true }
 [features]
 default = ["web"]
 web = ["dep:dioxus-html"]
-native_file_watcher = ["ignore", "chrono", "notify", "execute", "once_cell", "ignore"]
-file_watcher = ["web", "native_file_watcher", "dioxus-html/hot-reload-context"]
+custom_file_watcher = ["ignore", "chrono", "notify", "execute", "once_cell", "ignore"]
+file_watcher = ["web", "custom_file_watcher", "dioxus-html/hot-reload-context"]

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["dom", "ui", "gui", "react", "hot-reloading"]
 [dependencies]
 dioxus-rsx = { workspace = true }
 dioxus-core = { workspace = true, features = ["serialize"] }
-dioxus-html = { workspace = true }
+dioxus-html = { workspace = true, optional = true }
 
 interprocess-docfix = { version = "1.2.2" }
 notify = { version = "5.0.0", optional = true }
@@ -24,5 +24,7 @@ once_cell = { version = "1.17.0", optional = true }
 ignore = { version = "0.4.19", optional = true }
 
 [features]
-default = []
-file_watcher = ["ignore", "chrono", "notify", "execute", "once_cell", "ignore", "dioxus-html/hot-reload-context"]
+default = ["web"]
+web = ["dep:dioxus-html"]
+native_file_watcher = ["ignore", "chrono", "notify", "execute", "once_cell", "ignore"]
+file_watcher = ["web", "native_file_watcher", "dioxus-html/hot-reload-context"]

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -27,4 +27,4 @@ ignore = { version = "0.4.19", optional = true }
 default = ["web"]
 web = ["dep:dioxus-html"]
 custom_file_watcher = ["ignore", "chrono", "notify", "execute", "once_cell", "ignore"]
-file_watcher = ["web", "custom_file_watcher", "dioxus-html/hot-reload-context"]
+file_watcher = ["custom_file_watcher", "dioxus-html/hot-reload-context"]

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -24,7 +24,6 @@ once_cell = { version = "1.17.0", optional = true }
 ignore = { version = "0.4.19", optional = true }
 
 [features]
-default = ["web"]
-web = ["dep:dioxus-html"]
+default = ["dioxus-html"]
 custom_file_watcher = ["ignore", "chrono", "notify", "execute", "once_cell", "ignore"]
 file_watcher = ["custom_file_watcher", "dioxus-html/hot-reload-context"]

--- a/packages/hot-reload/src/file_watcher.rs
+++ b/packages/hot-reload/src/file_watcher.rs
@@ -13,11 +13,12 @@ use dioxus_rsx::{
 };
 use interprocess_docfix::local_socket::{LocalSocketListener, LocalSocketStream};
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
-
-pub use dioxus_html::HtmlCtx;
 use serde::{Deserialize, Serialize};
 
-pub struct Config<Ctx: HotReloadingContext = HtmlCtx> {
+#[cfg(feature = "file_watcher")]
+use dioxus_html::HtmlCtx;
+
+pub struct Config<Ctx: HotReloadingContext> {
     root_path: &'static str,
     listening_paths: &'static [&'static str],
     excluded_paths: &'static [&'static str],
@@ -39,6 +40,7 @@ impl<Ctx: HotReloadingContext> Default for Config<Ctx> {
     }
 }
 
+#[cfg(feature = "file_watcher")]
 impl Config<HtmlCtx> {
     pub const fn new() -> Self {
         Self {

--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -6,9 +6,9 @@ pub use dioxus_html::HtmlCtx;
 use interprocess_docfix::local_socket::LocalSocketStream;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "file_watcher")]
+#[cfg(feature = "native_file_watcher")]
 mod file_watcher;
-#[cfg(feature = "file_watcher")]
+#[cfg(feature = "native_file_watcher")]
 pub use file_watcher::*;
 
 /// A message the hot reloading server sends to the client

--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -6,9 +6,9 @@ pub use dioxus_html::HtmlCtx;
 use interprocess_docfix::local_socket::LocalSocketStream;
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "native_file_watcher")]
+#[cfg(feature = "custom_file_watcher")]
 mod file_watcher;
-#[cfg(feature = "native_file_watcher")]
+#[cfg(feature = "custom_file_watcher")]
 pub use file_watcher::*;
 
 /// A message the hot reloading server sends to the client


### PR DESCRIPTION
### Changes in `hot-reload`
- Enable `dioxus-html` by default but make it optional
- New `custom_file_watcher` feature, it's like the old `file_watcher` but doesn't depend on `dioxus-html`, I will use this one for Freya with `default-features = false` so web is disabled
- `file_watcher` feature now just enables `custom_file_watcher` and `dioxus-html`

No breaking changes and I will be able to not pull `dioxus-html` in freya