### PR TITLE
feat: initial_checked attribute for inputs

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1107,6 +1107,7 @@ builder_constructors! {
         formnovalidate: Bool DEFAULT,
         formtarget: Target DEFAULT,
         height: isize DEFAULT,
+        initial_checked: Bool DEFAULT,
         list: Id DEFAULT,
         max: String DEFAULT,
         maxlength: usize DEFAULT,

--- a/packages/interpreter/src/common.js
+++ b/packages/interpreter/src/common.js
@@ -51,6 +51,9 @@ export function setAttributeInner(node, field, value, ns) {
       case "checked":
         node.checked = truthy(value);
         break;
+      case "initial_checked":
+        node.defaultChecked = truthy(value);
+        break;
       case "selected":
         node.selected = truthy(value);
         break;

--- a/packages/interpreter/src/sledgehammer_bindings.rs
+++ b/packages/interpreter/src/sledgehammer_bindings.rs
@@ -80,6 +80,9 @@ mod js {
                 case "checked":
                     node.checked = truthy(value);
                     break;
+                case "initial_checked":
+                    node.defaultChecked = truthy(value);
+                    break;
                 case "selected":
                     node.selected = truthy(value);
                     break;


### PR DESCRIPTION
Adds the `initial_checked` attribute to set an input element's defaultChecked property as described [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement).
Implemented just like previous `initial_selected` attribute in https://github.com/DioxusLabs/dioxus/pull/1508