### PR TITLE
Add must use to several hooks

### DIFF
--- a/packages/fermi/src/callback.rs
+++ b/packages/fermi/src/callback.rs
@@ -28,6 +28,7 @@ impl CallbackApi {
     }
 }
 
+#[must_use]
 pub fn use_atom_context(cx: &ScopeState) -> &CallbackApi {
     todo!()
 }

--- a/packages/fermi/src/hooks/atom_ref.rs
+++ b/packages/fermi/src/hooks/atom_ref.rs
@@ -13,6 +13,7 @@ use std::{
 ///
 ///
 ///
+#[must_use]
 pub fn use_atom_ref<'a, T: 'static>(
     cx: &'a ScopeState,
     atom: &'static AtomRef<T>,

--- a/packages/fermi/src/hooks/read.rs
+++ b/packages/fermi/src/hooks/read.rs
@@ -2,10 +2,12 @@ use crate::{use_atom_root, AtomId, AtomRoot, Readable};
 use dioxus_core::{ScopeId, ScopeState};
 use std::rc::Rc;
 
+#[must_use]
 pub fn use_read<V: 'static>(cx: &ScopeState, f: impl Readable<V>) -> &V {
     use_read_rc(cx, f).as_ref()
 }
 
+#[must_use]
 pub fn use_read_rc<V: 'static>(cx: &ScopeState, f: impl Readable<V>) -> &Rc<V> {
     let root = use_atom_root(cx);
 

--- a/packages/fermi/src/hooks/set.rs
+++ b/packages/fermi/src/hooks/set.rs
@@ -2,6 +2,7 @@ use crate::{use_atom_root, Writable};
 use dioxus_core::ScopeState;
 use std::rc::Rc;
 
+#[must_use]
 pub fn use_set<T: 'static>(cx: &ScopeState, f: impl Writable<T>) -> &Rc<dyn Fn(T)> {
     let root = use_atom_root(cx);
     cx.use_hook(|| {

--- a/packages/fermi/src/hooks/state.rs
+++ b/packages/fermi/src/hooks/state.rs
@@ -30,6 +30,7 @@ use std::{
 ///     ))
 /// }
 /// ```
+#[must_use]
 pub fn use_atom_state<T: 'static>(cx: &ScopeState, f: impl Writable<T>) -> &AtomState<T> {
     let root = crate::use_atom_root(cx);
 

--- a/packages/fullstack/src/hooks/server_future.rs
+++ b/packages/fullstack/src/hooks/server_future.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 /// will be allowed to continue
 ///
 /// - dependencies: a tuple of references to values that are PartialEq + Clone
+#[must_use = "Consider using `cx.spawn` to run a future without reading its value"]
 pub fn use_server_future<T, F, D>(
     cx: &ScopeState,
     dependencies: D,

--- a/packages/hooks/src/computed.rs
+++ b/packages/hooks/src/computed.rs
@@ -37,6 +37,7 @@ use std::{
 ///    }
 /// }
 /// ```
+#[must_use]
 pub fn use_tracked_state<T: 'static>(cx: &ScopeState, init: impl FnOnce() -> T) -> &Tracked<T> {
     cx.use_hook(|| {
         let init = init();
@@ -160,6 +161,7 @@ impl<I> Drop for Tracker<I> {
     }
 }
 
+#[must_use = "Consider using the `use_effect` hook to rerun an effect whenever the tracked state changes if you don't need the result of the computation"]
 pub fn use_selector<I: 'static, O: Clone + PartialEq + 'static>(
     cx: &ScopeState,
     tracked: &Tracked<I>,

--- a/packages/hooks/src/use_callback.rs
+++ b/packages/hooks/src/use_callback.rs
@@ -24,6 +24,8 @@ macro_rules! use_callback {
         )
     };
 }
+
+#[must_use]
 pub fn use_callback<T, R, F>(cx: &ScopeState, make: impl FnOnce() -> R) -> impl FnMut(T) + '_
 where
     R: FnMut(T) -> F + 'static,

--- a/packages/hooks/src/use_context.rs
+++ b/packages/hooks/src/use_context.rs
@@ -3,6 +3,7 @@ use dioxus_core::ScopeState;
 /// Consume some context in the tree, providing a sharable handle to the value
 ///
 /// Does not regenerate the value if the value is changed at the parent.
+#[must_use]
 pub fn use_context<T: 'static + Clone>(cx: &ScopeState) -> Option<&T> {
     cx.use_hook(|| cx.consume_context::<T>()).as_ref()
 }

--- a/packages/hooks/src/use_coroutine.rs
+++ b/packages/hooks/src/use_coroutine.rs
@@ -79,6 +79,7 @@ where
 /// Get a handle to a coroutine higher in the tree
 ///
 /// See the docs for [`use_coroutine`] for more details.
+#[must_use]
 pub fn use_coroutine_handle<M: 'static>(cx: &ScopeState) -> Option<&Coroutine<M>> {
     cx.use_hook(|| cx.consume_context::<Coroutine<M>>())
         .as_ref()

--- a/packages/hooks/src/use_future.rs
+++ b/packages/hooks/src/use_future.rs
@@ -17,6 +17,7 @@ use crate::{use_state, UseState};
 /// will be canceled before the new one is started.
 ///
 /// - dependencies: a tuple of references to values that are PartialEq + Clone
+#[must_use = "Consider using `cx.spawn` to run a future without reading its value"]
 pub fn use_future<T, F, D>(
     cx: &ScopeState,
     dependencies: D,

--- a/packages/hooks/src/use_memo.rs
+++ b/packages/hooks/src/use_memo.rs
@@ -28,6 +28,7 @@ use crate::UseFutureDep;
 ///     render!(Calculator { number: 0 })
 /// }
 /// ```
+#[must_use = "Consider using `use_effect` to run rerun a callback when dependencies change"]
 pub fn use_memo<T, D>(cx: &ScopeState, dependencies: D, callback: impl FnOnce(D::Out) -> T) -> &T
 where
     T: 'static,

--- a/packages/hooks/src/use_ref.rs
+++ b/packages/hooks/src/use_ref.rs
@@ -110,6 +110,7 @@ use std::{
 ///     }
 /// })
 /// ```
+#[must_use]
 pub fn use_ref<T: 'static>(cx: &ScopeState, initialize_refcell: impl FnOnce() -> T) -> &UseRef<T> {
     let hook = cx.use_hook(|| UseRef {
         update: cx.schedule_update(),

--- a/packages/hooks/src/use_shared_state.rs
+++ b/packages/hooks/src/use_shared_state.rs
@@ -158,6 +158,7 @@ impl<T> ProvidedStateInner<T> {
 /// Any time a component calls `write`, every consumer of the state will be notified - excluding the provider.
 ///
 /// Right now, there is not a distinction between read-only and write-only, so every consumer will be notified.
+#[must_use]
 pub fn use_shared_state<T: 'static>(cx: &ScopeState) -> Option<&UseSharedState<T>> {
     let state_owner: &mut Option<UseSharedStateOwner<T>> = &mut *cx.use_hook(move || {
         let scope_id = cx.scope_id();

--- a/packages/hooks/src/use_state.rs
+++ b/packages/hooks/src/use_state.rs
@@ -30,6 +30,7 @@ use std::{
 ///     ))
 /// }
 /// ```
+#[must_use]
 pub fn use_state<T: 'static>(
     cx: &ScopeState,
     initial_state_fn: impl FnOnce() -> T,

--- a/packages/html/src/eval.rs
+++ b/packages/html/src/eval.rs
@@ -33,6 +33,7 @@ type EvalCreator = Rc<dyn Fn(&str) -> Result<UseEval, EvalError>>;
 /// parts is practically asking for a hacker to find an XSS vulnerability in
 /// it. **This applies especially to web targets, where the JavaScript context
 /// has access to most, if not all of your application data.**
+#[must_use]
 pub fn use_eval(cx: &ScopeState) -> &EvalCreator {
     &*cx.use_hook(|| {
         let eval_provider = cx

--- a/packages/router/src/hooks/use_navigator.rs
+++ b/packages/router/src/hooks/use_navigator.rs
@@ -48,6 +48,7 @@ use crate::prelude::{Navigator, RouterContext};
 /// # let mut vdom = VirtualDom::new(App);
 /// # let _ = vdom.rebuild();
 /// ```
+#[must_use]
 pub fn use_navigator(cx: &ScopeState) -> &Navigator {
     &*cx.use_hook(|| {
         let router = cx

--- a/packages/router/src/hooks/use_route.rs
+++ b/packages/router/src/hooks/use_route.rs
@@ -46,6 +46,7 @@ use crate::utils::use_router_internal::use_router_internal;
 /// # let _ = vdom.rebuild();
 /// # assert_eq!(dioxus_ssr::render(&vdom), "<h1>App</h1><h2>Current Path</h2><p>/</p>")
 /// ```
+#[must_use]
 pub fn use_route<R: Routable + Clone>(cx: &ScopeState) -> Option<R> {
     match use_router_internal(cx) {
         Some(r) => Some(r.current()),

--- a/packages/router/src/hooks/use_router.rs
+++ b/packages/router/src/hooks/use_router.rs
@@ -3,6 +3,7 @@ use dioxus::prelude::ScopeState;
 use crate::{prelude::RouterContext, utils::use_router_internal::use_router_internal};
 
 #[deprecated = "prefer the use_navigator or use_route functions"]
+#[must_use]
 /// A hook that provides access to information about the router.
 pub fn use_router(cx: &ScopeState) -> &RouterContext {
     use_router_internal(cx)

--- a/packages/signals/src/selector.rs
+++ b/packages/signals/src/selector.rs
@@ -21,6 +21,7 @@ use crate::{get_effect_stack, signal::SignalData, CopyValue, Effect, ReadOnlySig
 ///     render! { "{double}" }
 /// }
 /// ```
+#[must_use = "Consider using `use_effect` to rerun a callback when dependencies change"]
 pub fn use_selector<R: PartialEq>(
     cx: &ScopeState,
     f: impl FnMut() -> R + 'static,
@@ -44,6 +45,7 @@ pub fn use_selector<R: PartialEq>(
 ///     render! { "{double}" }
 /// }
 /// ```
+#[must_use = "Consider using `use_effect` to rerun a callback when dependencies change"]
 pub fn use_selector_with_dependencies<R: PartialEq, D: Dependency>(
     cx: &ScopeState,
     dependencies: D,

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -43,6 +43,7 @@ use crate::{CopyValue, Effect};
 ///     }
 /// }
 /// ```
+#[must_use]
 pub fn use_signal<T: 'static>(cx: &ScopeState, f: impl FnOnce() -> T) -> Signal<T> {
     *cx.use_hook(|| Signal::new(f()))
 }


### PR DESCRIPTION
Adds the must use lint to several hooks along with possible alternatives to use if you don't care about the return value. This should help users notice when they have an unnecessary hook or there is a different hook they should be using instead