### PR TITLE
Change the semantics of exprs/for loops allocations strategy

### DIFF
--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -7,6 +7,7 @@ fn main() {
 
 fn app(cx: Scope) -> Element {
     let mut count = dioxus_signals::use_signal(cx, || 0);
+    let saved_values = dioxus_signals::use_signal(cx, || vec![0]);
 
     use_future!(cx, || async move {
         loop {
@@ -19,9 +20,19 @@ fn app(cx: Scope) -> Element {
         h1 { "High-Five counter: {count}" }
         button { onclick: move |_| count += 1, "Up high!" }
         button { onclick: move |_| count -= 1, "Down low!" }
+        button {
+            onclick: move |_| saved_values.push(count.value()),
+            "Save this value"
+        }
 
+        // We can do boolean operations on the current signal value
         if count.value() > 5 {
             rsx!{ h2 { "High five!" } }
+        }
+
+        // We can cleanly map signals with iterators
+        for value in saved_values.read().iter() {
+            h3 { "Saved value: {value}" }
         }
     })
 }

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -40,7 +40,7 @@ fn app(cx: Scope) -> Element {
         }
 
         // We can also use the signal value as a slice
-        if let &[ref first, ..,  ref last] = saved_values.read().as_slice() {
+        if let [ref first, .., ref last] = saved_values.read().as_slice() {
             rsx! { li { "First and last: {first}, {last}" } }
         } else {
             rsx! { "No saved values" }

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -23,7 +23,7 @@ fn app(cx: Scope) -> Element {
         h1 { "High-Five counter: {count}" }
         button { onclick: move |_| count += 1, "Up high!" }
         button { onclick: move |_| count -= 1, "Down low!" }
-        button { onclick: move |_| running.set(!running.value()), "Toggle counter" }
+        button { onclick: move |_| running.toggle(), "Toggle counter" }
         button { onclick: move |_| saved_values.push(count.value()), "Save this value" }
 
         // We can do boolean operations on the current signal value

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -27,6 +27,7 @@ fn app(cx: Scope) -> Element {
         button { onclick: move |_| count -= 1, "Down low!" }
         button { onclick: move |_| running.toggle(), "Toggle counter" }
         button { onclick: move |_| saved_values.push(count.value().to_string()), "Save this value" }
+        button { onclick: move |_| saved_values.write().clear(), "Clear saved values" }
 
         // We can do boolean operations on the current signal value
         if count.value() > 5 {
@@ -40,7 +41,7 @@ fn app(cx: Scope) -> Element {
 
         // We can also use the signal value as a slice
         if let &[ref first, ..,  ref last] = saved_values.read().as_slice() {
-            rsx! { li { "single element: {first}, {last}" } }
+            rsx! { li { "First and last: {first}, {last}" } }
         } else {
             rsx! { "No saved values" }
         }

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -6,12 +6,15 @@ fn main() {
 }
 
 fn app(cx: Scope) -> Element {
+    let running = dioxus_signals::use_signal(cx, || true);
     let mut count = dioxus_signals::use_signal(cx, || 0);
     let saved_values = dioxus_signals::use_signal(cx, || vec![0]);
 
     use_future!(cx, || async move {
         loop {
-            count += 1;
+            if running.value() {
+                count += 1;
+            }
             tokio::time::sleep(Duration::from_millis(400)).await;
         }
     });
@@ -20,10 +23,8 @@ fn app(cx: Scope) -> Element {
         h1 { "High-Five counter: {count}" }
         button { onclick: move |_| count += 1, "Up high!" }
         button { onclick: move |_| count -= 1, "Down low!" }
-        button {
-            onclick: move |_| saved_values.push(count.value()),
-            "Save this value"
-        }
+        button { onclick: move |_| running.set(!running.value()), "Toggle counter" }
+        button { onclick: move |_| saved_values.push(count.value()), "Save this value" }
 
         // We can do boolean operations on the current signal value
         if count.value() > 5 {

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -91,9 +91,9 @@ pub mod prelude {
         consume_context, consume_context_from_scope, current_scope_id, fc_to_builder, has_context,
         provide_context, provide_context_to_scope, provide_root_context, push_future,
         remove_future, schedule_update_any, spawn, spawn_forever, suspend, throw, AnyValue,
-        Component, Element, Event, EventHandler, Fragment, IntoAttributeValue, LazyNodes,
-        Properties, Runtime, RuntimeGuard, Scope, ScopeId, ScopeState, Scoped, TaskId, Template,
-        TemplateAttribute, TemplateNode, Throw, VNode, VirtualDom,
+        Component, Element, Event, EventHandler, Fragment, IntoAttributeValue, IntoDynNode,
+        LazyNodes, Properties, Runtime, RuntimeGuard, Scope, ScopeId, ScopeState, Scoped, TaskId,
+        Template, TemplateAttribute, TemplateNode, Throw, VNode, VirtualDom,
     };
 }
 

--- a/packages/rsx/src/node.rs
+++ b/packages/rsx/src/node.rs
@@ -126,8 +126,7 @@ impl ToTokens for BodyNode {
             }),
             BodyNode::RawExpr(exp) => tokens.append_all(quote! {
                 {
-                    use ::dioxus::core::IntoDynNode;
-                    let ___nodes =(#exp).into_vnode(__cx);
+                    let ___nodes = (#exp).into_vnode(__cx);
                     ___nodes
                 }
             }),
@@ -146,7 +145,6 @@ impl ToTokens for BodyNode {
                 // And then we can return them into the dyn loop
                 tokens.append_all(quote! {
                     {
-                        use ::dioxus::core::IntoDynNode;
                         let ___nodes =(#expr).into_iter().map(|#pat| { #renderer }).into_vnode(__cx);
                         ___nodes
                     }
@@ -155,7 +153,10 @@ impl ToTokens for BodyNode {
             BodyNode::IfChain(chain) => {
                 if is_if_chain_terminated(chain) {
                     tokens.append_all(quote! {
-                         __cx.make_node(#chain)
+                        {
+                            let ___nodes = (#chain).into_vnode(__cx);
+                            ___nodes
+                        }
                     });
                 } else {
                     let ExprIf {
@@ -209,7 +210,10 @@ impl ToTokens for BodyNode {
                     });
 
                     tokens.append_all(quote! {
-                        __cx.make_node(#body)
+                        {
+                            let ___nodes = (#body).into_vnode(__cx);
+                            ___nodes
+                        }
                     });
                 }
             }

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -262,6 +262,13 @@ impl<T: Clone + 'static> Signal<T> {
     }
 }
 
+impl Signal<bool> {
+    /// Invert the boolean value of the signal. This will trigger an update on all subscribers.
+    pub fn toggle(&self) {
+        self.set(!self.value());
+    }
+}
+
 impl<T: 'static> PartialEq for Signal<T> {
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner


### PR DESCRIPTION
This commit adjusts how exprs and for loops are handled within rsx. This is a breaking change in terms of codegen, but has slight semantic changes as well.

Now, when exprs/for loops are allocated, they are given a temporary. The temporary is elided to the <'a> lifetime of the bump, to satisfy the borrow checker. This fixes issues with signals where exprs/for loops mapping vecs out of RefCells would be caught up without a temporary lifetime.

Specifically, before, this component could not compile:

```rust
fn app(cx: Scope) -> Element {
    let todos = use_signal(cx, || vec!["hi"]);

    render! {
        ul {
            for todo in todos.read().iter() {
                li { "{todo}" }
            }

            todos.read().iter().map(|todo| rsx! {
                li { "{todo}" }
            })
        }
    }
}
```

The error we were getting is:

```
error[E0597]: `todos` does not live long enough
  --> src/main.rs:13:25
   |
9  |     let todos = use_signal(cx, || vec!["hi"]);
   |         ----- binding `todos` declared here
...
13 |             for todo in todos.read().iter() {
   |                         ^^^^^^^^^^^^
   |                         |
   |                         borrowed value does not live long enough
   |                         a temporary with access to the borrow is created here ...
...
22 | }
   | -
   | |
   | `todos` dropped here while still borrowed
   | ... and the borrow might be used here, when that temporary is dropped and runs the destructor for type `std::cell::Ref<'_, std::vec::Vec<&str>>`
   |
   = note: the temporary is part of an expression at the end of a block;
           consider forcing this temporary to be dropped sooner, before the block's local variables are dropped
help: for example, you could save the expression's value in a new local variable `x` and then make `x` be the expression at the end of the block
   |
11 ~     let x = render! {
12 |         ul {
 ...
20 |         }
21 ~     }; x
   |

For more information about this error, try `rustc --explain E0597`.
error: could not compile `demo-signals-todo` (bin "demo-signals-todo") due to previous error
```


This is fixed now, fixing a major papercut of signals and the work being done in fermi to allow truly global state.

This works because we now do a codegen from

```
make_node(#expr)
```

to

```
{
    let node = #expr.make_node(cx);
    node
}
```