### PR TITLE
Fix deref for Write struct in dioxus-signals

### DIFF
--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -305,7 +305,7 @@ impl<'a, T: 'static, I: 'static> Write<'a, T, I> {
     }
 }
 
-impl<'a, T: 'static> Deref for Write<'a, T> {
+impl<'a, T: 'static, I: 'static> Deref for Write<'a, T, I> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -313,7 +313,7 @@ impl<'a, T: 'static> Deref for Write<'a, T> {
     }
 }
 
-impl<T> DerefMut for Write<'_, T> {
+impl<T, I> DerefMut for Write<'_, T, I> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.write
     }


### PR DESCRIPTION
When mapping a write struct in dioxus-signals, the new Write that is created cannot be dereferenced. This is because the default constraint for the Write struct ties the inner type to the type for the signal. When mapping the inner type to a new type, this constraint is broken. Explicitly separating the type constraints for the inner and the signal allows for dereferencing of the new mapped Write. 