### PR TITLE
Fix using signals outside of a scope

### DIFF
--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -153,7 +153,7 @@ fn get_asset_root() -> Option<PathBuf> {
 
 /// Get the mime type from a path-like string
 fn get_mime_from_path(trimmed: &Path) -> Result<&'static str> {
-    if trimmed.ends_with(".svg") {
+    if trimmed.extension().is_some_and(|ext| ext == "svg") {
         return Ok("image/svg+xml");
     }
 

--- a/packages/signals/src/effect.rs
+++ b/packages/signals/src/effect.rs
@@ -30,7 +30,7 @@ pub(crate) fn get_effect_stack() -> EffectStack {
         Some(rt) => rt,
         None => {
             let store = EffectStack::default();
-            provide_root_context(store.clone());
+            provide_root_context(store);
             store
         }
     }

--- a/packages/signals/src/effect.rs
+++ b/packages/signals/src/effect.rs
@@ -1,16 +1,28 @@
 use core::{self, fmt::Debug};
-use std::cell::RefCell;
 use std::fmt::{self, Formatter};
-use std::rc::Rc;
 //
 use dioxus_core::prelude::*;
 
 use crate::use_signal;
 use crate::{dependency::Dependency, CopyValue};
 
-#[derive(Default, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub(crate) struct EffectStack {
-    pub(crate) effects: Rc<RefCell<Vec<Effect>>>,
+    pub(crate) effects: CopyValue<Vec<Effect>>,
+}
+
+impl Default for EffectStack {
+    fn default() -> Self {
+        Self {
+            effects: CopyValue::new_in_scope(Vec::new(), ScopeId::ROOT),
+        }
+    }
+}
+
+impl EffectStack {
+    pub(crate) fn current(&self) -> Option<Effect> {
+        self.effects.read().last().copied()
+    }
 }
 
 pub(crate) fn get_effect_stack() -> EffectStack {
@@ -57,6 +69,7 @@ pub fn use_effect_with_dependencies<D: Dependency>(
 pub struct Effect {
     pub(crate) source: ScopeId,
     pub(crate) callback: CopyValue<Box<dyn FnMut()>>,
+    pub(crate) effect_stack: EffectStack,
 }
 
 impl Debug for Effect {
@@ -67,7 +80,7 @@ impl Debug for Effect {
 
 impl Effect {
     pub(crate) fn current() -> Option<Self> {
-        get_effect_stack().effects.borrow().last().copied()
+        get_effect_stack().effects.read().last().copied()
     }
 
     /// Create a new effect. The effect will be run immediately and whenever any signal it reads changes.
@@ -77,6 +90,7 @@ impl Effect {
         let myself = Self {
             source: current_scope_id().expect("in a virtual dom"),
             callback: CopyValue::new(Box::new(callback)),
+            effect_stack: get_effect_stack(),
         };
 
         myself.try_run();
@@ -88,11 +102,11 @@ impl Effect {
     pub fn try_run(&self) {
         if let Some(mut callback) = self.callback.try_write() {
             {
-                get_effect_stack().effects.borrow_mut().push(*self);
+                self.effect_stack.effects.write().push(*self);
             }
             callback();
             {
-                get_effect_stack().effects.borrow_mut().pop();
+                self.effect_stack.effects.write().pop();
             }
         }
     }

--- a/packages/signals/src/selector.rs
+++ b/packages/signals/src/selector.rs
@@ -78,19 +78,21 @@ pub fn selector<R: PartialEq>(mut f: impl FnMut() -> R + 'static) -> ReadOnlySig
     let effect = Effect {
         source: current_scope_id().expect("in a virtual dom"),
         callback: CopyValue::invalid(),
+        effect_stack: get_effect_stack(),
     };
 
     {
-        get_effect_stack().effects.borrow_mut().push(effect);
+        get_effect_stack().effects.write().push(effect);
     }
     state.inner.value.set(SignalData {
         subscribers: Default::default(),
         effect_subscribers: Default::default(),
         update_any: schedule_update_any().expect("in a virtual dom"),
         value: f(),
+        effect_stack: get_effect_stack(),
     });
     {
-        get_effect_stack().effects.borrow_mut().pop();
+        get_effect_stack().effects.write().pop();
     }
 
     effect.callback.value.set(Box::new(move || {


### PR DESCRIPTION
Currently signals can only be used inside of the Dioxus runtime. When they are used outside of the Dioxus runtime, they fail silently. This can be confusing when you try to integrate Dioxus with external futures like tokio futures, or external event handlers like web-sys closures.

This PR changes signals so that the runtime is only needed for signal creation instead of requiring a runtime any time you read or write to a signal