### PR TITLE
Fix prop docs line breaks

### DIFF
--- a/packages/core-macro/src/component_body_deserializers/inline_props.rs
+++ b/packages/core-macro/src/component_body_deserializers/inline_props.rs
@@ -186,13 +186,13 @@ fn get_props_docs(fn_ident: &Ident, inputs: Vec<&FnArg>) -> Vec<Attribute> {
         let arg_name = arg_name.into_token_stream().to_string();
         let arg_type = crate::utils::format_type_string(arg_type);
 
-        let input_arg_doc =
-            keep_up_to_n_consecutive_chars(input_arg_doc.trim(), 2, '\n').replace('\n', "<br/>");
+        let input_arg_doc = keep_up_to_n_consecutive_chars(input_arg_doc.trim(), 2, '\n')
+            .replace("\n\n", "</p><p>");
         let prop_def_link = format!("{props_def_link}::{arg_name}");
         let mut arg_doc = format!("- [`{arg_name}`]({prop_def_link}) : `{arg_type}`");
 
         if let Some(deprecation) = deprecation {
-            arg_doc.push_str("<br/>👎 Deprecated");
+            arg_doc.push_str("<p>👎 Deprecated");
 
             if let Some(since) = deprecation.since {
                 arg_doc.push_str(&format!(" since {since}"));
@@ -205,14 +205,16 @@ fn get_props_docs(fn_ident: &Ident, inputs: Vec<&FnArg>) -> Vec<Attribute> {
                 arg_doc.push_str(&format!(": {note}"));
             }
 
+            arg_doc.push_str("</p>");
+
             if !input_arg_doc.is_empty() {
                 arg_doc.push_str("<hr/>");
             }
-        } else {
-            arg_doc.push_str("<br/>");
         }
 
-        arg_doc.push_str(&input_arg_doc);
+        if !input_arg_doc.is_empty() {
+            arg_doc.push_str(&format!("<p>{input_arg_doc}</p>"));
+        }
 
         props_docs.push(parse_quote! {
             #[doc = #arg_doc]

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -153,7 +153,7 @@ fn get_asset_root() -> Option<PathBuf> {
 
 /// Get the mime type from a path-like string
 fn get_mime_from_path(trimmed: &Path) -> Result<&'static str> {
-    if trimmed.extension().is_some_and(|ext| ext == ".svg") {
+    if trimmed.ends_with(".svg") {
         return Ok("image/svg+xml");
     }
 

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -153,7 +153,7 @@ fn get_asset_root() -> Option<PathBuf> {
 
 /// Get the mime type from a path-like string
 fn get_mime_from_path(trimmed: &Path) -> Result<&'static str> {
-    if trimmed.ends_with(".svg") {
+    if trimmed.extension().is_some_and(|ext| ext == ".svg") {
         return Ok("image/svg+xml");
     }
 


### PR DESCRIPTION
I'm sorry for creating a third PR for this, but I just noticed that there's one too many line breaks in the generated docs for props (see https://github.com/DioxusLabs/dioxus/pull/1563 and https://github.com/DioxusLabs/dioxus/pull/1565). I changed it to use the Rustdoc approach, which puts text separated by two lines into separate `<p>` elements. Previously, it just replaced `\n` with `<br/>`

Right now, this documentation:
```
/// Doc.
/// Next line.
```

Would generate:

```
Doc.
Next line.
```

But it's actually supposed to be:

```
Doc. Next line.
```

And when you used two new lines, the gap between them would be too big. Example image with the bug:
![image](https://github.com/DioxusLabs/dioxus/assets/76173380/190e2737-5408-4774-9dca-6b93d28aa661)
Fixed:
![image](https://github.com/DioxusLabs/dioxus/assets/76173380/ac31649b-330b-42e2-a438-f6e2244bebd8)
Regular Rustdoc:
![image](https://github.com/DioxusLabs/dioxus/assets/76173380/4eed88c4-b76b-4430-b809-5b60a69cc324)
