### PR TITLE
Draft: Create hooks that use underlying locks instead of RefCell

### DIFF
--- a/packages/hooks/Cargo.toml
+++ b/packages/hooks/Cargo.toml
@@ -20,6 +20,7 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 slab = { workspace = true }
 dioxus-debug-cell = "0.1.1"
+async-std = "1.12.0"
 
 [dev-dependencies]
 futures-util = { workspace = true, default-features = false }

--- a/packages/hooks/src/lib.rs
+++ b/packages/hooks/src/lib.rs
@@ -91,3 +91,9 @@ mod use_on_create;
 pub use use_on_create::*;
 mod use_root_context;
 pub use use_root_context::*;
+
+mod use_lock;
+pub use use_lock::*;
+
+mod use_async_lock;
+pub use use_async_lock::*;

--- a/packages/hooks/src/use_async_lock.rs
+++ b/packages/hooks/src/use_async_lock.rs
@@ -1,0 +1,84 @@
+use async_std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use dioxus_core::ScopeState;
+use std::cell::Cell;
+use std::sync::Arc;
+
+pub fn use_async_lock<T: 'static>(
+    cx: &ScopeState,
+    initialize_rwlock: impl FnOnce() -> T,
+) -> &UseAsyncLock<T> {
+    let hook = cx.use_hook(|| UseAsyncLock {
+        update: cx.schedule_update(),
+        value: Arc::new(RwLock::new(initialize_rwlock())),
+        dirty: Arc::new(Cell::new(false)),
+        gen: 0,
+    });
+
+    if hook.dirty.get() {
+        hook.gen += 1;
+        hook.dirty.set(false);
+    }
+
+    hook
+}
+
+pub struct UseAsyncLock<T> {
+    update: Arc<dyn Fn()>,
+    value: Arc<RwLock<T>>,
+    dirty: Arc<Cell<bool>>,
+    gen: usize,
+}
+
+impl<T> Clone for UseAsyncLock<T> {
+    fn clone(&self) -> Self {
+        Self {
+            update: self.update.clone(),
+            value: self.value.clone(),
+            dirty: self.dirty.clone(),
+            gen: self.gen,
+        }
+    }
+}
+
+impl<T> UseAsyncLock<T> {
+    pub async fn read(&self) -> RwLockReadGuard<'_, T> {
+        self.value.read().await
+    }
+
+    pub async fn write(&self) -> RwLockWriteGuard<'_, T> {
+        self.needs_update();
+        self.value.write().await
+    }
+
+    pub async fn set(&self, new: T) {
+        *self.value.write().await = new;
+        self.needs_update();
+    }
+
+    pub async fn write_silent(&self) -> RwLockWriteGuard<'_, T> {
+        self.value.write().await
+    }
+
+    pub async fn with<O>(&self, immutable_callback: impl FnOnce(&T) -> O) -> O {
+        immutable_callback(&*self.read().await)
+    }
+
+    pub async fn with_mut<O>(&self, mutable_callback: impl FnOnce(&mut T) -> O) -> O {
+        mutable_callback(&mut *self.write().await)
+    }
+
+    pub fn needs_update(&self) {
+        self.dirty.set(true);
+        (self.update)();
+    }
+}
+
+impl<T> PartialEq for UseAsyncLock<T> {
+    fn eq(&self, other: &Self) -> bool {
+        if Arc::ptr_eq(&self.value, &other.value) {
+            self.gen == other.gen
+        } else {
+            false
+        }
+    }
+}

--- a/packages/hooks/src/use_lock.rs
+++ b/packages/hooks/src/use_lock.rs
@@ -1,0 +1,81 @@
+use dioxus_core::ScopeState;
+use std::cell::Cell;
+use std::sync::Arc;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+pub fn use_lock<T: 'static>(cx: &ScopeState, initialize_rwlock: impl FnOnce() -> T) -> &UseLock<T> {
+    let hook = cx.use_hook(|| UseLock {
+        update: cx.schedule_update(),
+        value: Arc::new(RwLock::new(initialize_rwlock())),
+        dirty: Arc::new(Cell::new(false)),
+        gen: 0,
+    });
+
+    if hook.dirty.get() {
+        hook.gen += 1;
+        hook.dirty.set(false);
+    }
+
+    hook
+}
+
+pub struct UseLock<T> {
+    update: Arc<dyn Fn()>,
+    value: Arc<RwLock<T>>,
+    dirty: Arc<Cell<bool>>,
+    gen: usize,
+}
+
+impl<T> Clone for UseLock<T> {
+    fn clone(&self) -> Self {
+        Self {
+            update: self.update.clone(),
+            value: self.value.clone(),
+            dirty: self.dirty.clone(),
+            gen: self.gen,
+        }
+    }
+}
+
+impl<T> UseLock<T> {
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        self.value.read().unwrap()
+    }
+
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        self.needs_update();
+        self.value.write().unwrap()
+    }
+
+    pub fn set(&self, new: T) {
+        *self.value.write().unwrap() = new;
+        self.needs_update();
+    }
+
+    pub fn write_silent(&self) -> RwLockWriteGuard<'_, T> {
+        self.value.write().unwrap()
+    }
+
+    pub fn with<O>(&self, immutable_callback: impl FnOnce(&T) -> O) -> O {
+        immutable_callback(&*self.read())
+    }
+
+    pub fn with_mut<O>(&self, mutable_callback: impl FnOnce(&mut T) -> O) -> O {
+        mutable_callback(&mut *self.write())
+    }
+
+    pub fn needs_update(&self) {
+        self.dirty.set(true);
+        (self.update)();
+    }
+}
+
+impl<T> PartialEq for UseLock<T> {
+    fn eq(&self, other: &Self) -> bool {
+        if Arc::ptr_eq(&self.value, &other.value) {
+            self.gen == other.gen
+        } else {
+            false
+        }
+    }
+}


### PR DESCRIPTION
I wanted to get some thoughts on:
- If it makes sense to have the separate `use_lock` and `use_async_lock`
- If it would be better to use a `Mutex` instead of an `RwLock`
- If it's necessary to use `Arc` for `value` and `dirty`
