### PR TITLE
Fix use shared state lint in release mode

### DIFF
--- a/packages/hooks/src/use_shared_state.rs
+++ b/packages/hooks/src/use_shared_state.rs
@@ -26,6 +26,7 @@ macro_rules! debug_location {
 }
 
 pub mod error {
+    #[cfg(debug_assertions)]
     fn locations_display(locations: &[&'static std::panic::Location<'static>]) -> String {
         locations
             .iter()


### PR DESCRIPTION
Fixes the unused lint that the `locations_display` function in `use_shared_state` produces in release mode:
```
warning: function `locations_display` is never used
  --> packages/hooks/src/use_shared_state.rs:29:8
   |
29 |     fn locations_display(locations: &[...
   |        ^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```