### PR TITLE
Add Newtype so that Rust-url can be IntoRoutable

### DIFF
--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -54,6 +54,8 @@ impl From<&str> for IntoRoutable {
         IntoRoutable::FromStr(value.to_string())
     }
 }
+
+/// Newtype to make is easier to work with rust-url type that other crates commonly use.
 pub struct Url(RustUrl);
 
 impl From<Url> for IntoRoutable {

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -11,6 +11,8 @@ use crate::navigation::NavigationTarget;
 use crate::prelude::Routable;
 use crate::utils::use_router_internal::use_router_internal;
 
+use url::Url as RustUrl;
+
 /// Something that can be converted into a [`NavigationTarget`].
 #[derive(Clone)]
 pub enum IntoRoutable {
@@ -50,6 +52,19 @@ impl From<&String> for IntoRoutable {
 impl From<&str> for IntoRoutable {
     fn from(value: &str) -> Self {
         IntoRoutable::FromStr(value.to_string())
+    }
+}
+pub struct Url(RustUrl);
+
+impl From<Url> for IntoRoutable {
+    fn from(url: Url) -> Self {
+        IntoRoutable::FromStr(url.0.to_string())
+    }
+}
+
+impl From<&Url> for IntoRoutable {
+    fn from(url: &Url) -> Self {
+        IntoRoutable::FromStr(url.0.to_string())
     }
 }
 

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -11,7 +11,7 @@ use crate::navigation::NavigationTarget;
 use crate::prelude::Routable;
 use crate::utils::use_router_internal::use_router_internal;
 
-use url::Url as RustUrl;
+use url::Url;
 
 /// Something that can be converted into a [`NavigationTarget`].
 #[derive(Clone)]
@@ -55,18 +55,15 @@ impl From<&str> for IntoRoutable {
     }
 }
 
-/// Newtype to make is easier to work with rust-url type that other crates commonly use.
-pub struct Url(RustUrl);
-
 impl From<Url> for IntoRoutable {
     fn from(url: Url) -> Self {
-        IntoRoutable::FromStr(url.0.to_string())
+        IntoRoutable::FromStr(url.to_string())
     }
 }
 
 impl From<&Url> for IntoRoutable {
     fn from(url: &Url) -> Self {
-        IntoRoutable::FromStr(url.0.to_string())
+        IntoRoutable::FromStr(url.to_string())
     }
 }
 


### PR DESCRIPTION
since url::Url is commonly used for many crates, impl IntoRoutable for a rust-url newtype can make it more ergonomic to work with some crates. 