### PR TITLE
Silence desktop build outputs from cargo

### DIFF
--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -254,6 +254,7 @@ pub fn build_desktop(config: &CrateConfig, _is_serve: bool) -> Result<BuildResul
     let mut cmd = subprocess::Exec::cmd("cargo")
         .cwd(&config.crate_dir)
         .arg("build")
+        .arg("--quiet")
         .arg("--message-format=json");
 
     if config.release {


### PR DESCRIPTION
Silence additional disturbing output from cargo in desktop builds