### PR TITLE
Add DesktopElement::eval method and export it

### DIFF
--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -29,7 +29,7 @@ use desktop_context::{EventData, UserWindowEvent, WebviewQueue, WindowEventHandl
 use dioxus_core::*;
 use dioxus_html::MountedData;
 use dioxus_html::{native_bind::NativeFileEngine, FormData, HtmlEvent};
-use element::DesktopElement;
+pub use element::DesktopElement;
 use eval::init_eval;
 use futures_util::{pin_mut, FutureExt};
 use shortcut::ShortcutRegistry;

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -198,6 +198,22 @@ class Interpreter {
     };
   }
 
+  Eval(id, js) {
+    const node = this.nodes[id];
+    if (!node) {
+      return;
+    }
+
+    window.currentNode = node;
+    const output = eval(js);
+    window.currentNode = null;
+
+    return {
+      type: "Eval",
+      output,
+    };
+  }
+
   ScrollTo(id, behavior) {
     const node = this.nodes[id];
     if (!node) {
@@ -404,7 +420,8 @@ function handler(event, name, bubbles, config) {
           event.preventDefault();
 
           let elementShouldPreventDefault =
-            preventDefaultRequests && preventDefaultRequests.includes(`onclick`);
+            preventDefaultRequests &&
+            preventDefaultRequests.includes(`onclick`);
           let aElementShouldPreventDefault = a_element.getAttribute(
             `dioxus-prevent-default`
           );
@@ -458,10 +475,7 @@ function handler(event, name, bubbles, config) {
       }
     }
 
-    if (
-      target.tagName === "SELECT" &&
-      event.type === "input"
-    ) {
+    if (target.tagName === "SELECT" && event.type === "input") {
       const selectData = target.options;
       contents.values["options"] = [];
       for (let i = 0; i < selectData.length; i++) {


### PR DESCRIPTION
Adds a new method `eval` to the `DesktopElement` struct and makes the struct public.

This allows calling javascript from dioxus-desktop using an html element. The difference with `use_eval` is the javascript being executed here has access to `window.currentNode` which is the currently mounted HTML node.

It's still pretty rough code but I'd love to know what you guys think!