### PR TITLE
Create a reactive selector called comparer

### DIFF
--- a/packages/core/src/diff.rs
+++ b/packages/core/src/diff.rs
@@ -560,7 +560,7 @@ impl<'b> VirtualDom {
         // If none of the old keys are reused by the new children, then we remove all the remaining old children and
         // create the new children afresh.
         if shared_keys.is_empty() {
-            if old.get(0).is_some() {
+            if old.first().is_some() {
                 self.remove_nodes(&old[1..]);
                 self.replace(&old[0], new);
             } else {

--- a/packages/fermi/src/lib.rs
+++ b/packages/fermi/src/lib.rs
@@ -22,8 +22,6 @@ mod atoms {
     pub use atom::*;
     pub use atomfamily::*;
     pub use atomref::*;
-    pub use selector::*;
-    pub use selectorfamily::*;
 }
 
 pub mod hooks {

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -193,7 +193,7 @@ impl<'a> ToTokens for TemplateRenderer<'a> {
     fn to_tokens(&self, out_tokens: &mut TokenStream2) {
         let mut context = DynamicContext::default();
 
-        let key = match self.roots.get(0) {
+        let key = match self.roots.first() {
             Some(BodyNode::Element(el)) if self.roots.len() == 1 => el.key.clone(),
             Some(BodyNode::Component(comp)) if self.roots.len() == 1 => comp.key().cloned(),
             _ => None,

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -12,6 +12,7 @@ generational-box = { workspace = true }
 tracing = { workspace = true }
 simple_logger = "4.2.0"
 serde = { version = "1", features = ["derive"], optional = true }
+rustc-hash.workspace = true
 
 [dev-dependencies]
 dioxus = { workspace = true }

--- a/packages/signals/src/comparer.rs
+++ b/packages/signals/src/comparer.rs
@@ -1,0 +1,109 @@
+use std::hash::Hash;
+
+use dioxus_core::prelude::*;
+
+use crate::{CopyValue, Effect, ReadOnlySignal, Signal};
+use rustc_hash::FxHashMap;
+
+/// An object that can efficiently compare a value to a set of values.
+#[derive(Debug)]
+pub struct Comparer<R: 'static> {
+    subscribers: CopyValue<FxHashMap<R, Signal<bool>>>,
+}
+
+impl<R: Eq + Hash> Comparer<R> {
+    /// Returns a signal which is true when the value is equal to the value passed to this function.
+    pub fn equal(&self, value: R) -> ReadOnlySignal<bool> {
+        let subscribers = self.subscribers.read();
+
+        match subscribers.get(&value) {
+            Some(&signal) => signal.into(),
+            None => {
+                drop(subscribers);
+                let mut subscribers = self.subscribers.write();
+                let signal = Signal::new(false);
+                subscribers.insert(value, signal.clone());
+                signal.into()
+            }
+        }
+    }
+}
+
+impl<R> Clone for Comparer<R> {
+    fn clone(&self) -> Self {
+        Self {
+            subscribers: self.subscribers.clone(),
+        }
+    }
+}
+
+impl<R> Copy for Comparer<R> {}
+
+/// Creates a new Comparer which efficiently tracks when a value changes to check if it is equal to a set of values.
+///
+/// Generally, you shouldn't need to use this hook. Instead you can use [`crate::use_selector`]. If you have many values that you need to compare to a single value, this hook will change updates from O(n) to O(1) where n is the number of values you are comparing to.
+///
+/// ```rust
+/// use dioxus::prelude::*;
+/// use dioxus_signals::*;
+///
+/// fn App(cx: Scope) -> Element {
+///     let mut count = use_signal(cx, || 0);
+///     let comparer = use_comparer(cx, move || count.value());
+///
+///     render! {
+///         for i in 0..10 {
+///             // Child will only re-render when i == count
+///             Child { active: comparer.equal(i) }
+///         }
+///         button {
+///             // This will only rerender the child with the old and new value of i == count
+///             // Because we are using a comparer, this will be O(1) instead of the O(n) performance of a selector
+///             onclick: move |_| count += 1,
+///             "Increment"
+///         }
+///     }
+/// }
+///
+/// #[component]
+/// fn Child(cx: Scope, active: ReadOnlySignal<bool>) -> Element {
+///     if *active() {
+///         render! { "Active" }
+///     } else {
+///         render! { "Inactive" }
+///     }
+/// }
+/// ```
+#[must_use]
+pub fn use_comparer<R: Eq + Hash>(cx: &ScopeState, f: impl FnMut() -> R + 'static) -> Comparer<R> {
+    *cx.use_hook(move || comparer(f))
+}
+
+/// Creates a new Comparer which efficiently tracks when a value changes to check if it is equal to a set of values.
+///
+/// Generally, you shouldn't need to use this hook. Instead you can use [`crate::use_selector`]. If you have many values that you need to compare to a single value, this hook will change updates from O(n) to O(1) where n is the number of values you are comparing to.
+pub fn comparer<R: Eq + Hash>(mut f: impl FnMut() -> R + 'static) -> Comparer<R> {
+    let subscribers: CopyValue<FxHashMap<R, Signal<bool>>> = CopyValue::new(FxHashMap::default());
+    let previous = CopyValue::new(None);
+
+    Effect::new(move || {
+        let subscribers = subscribers.read();
+        let mut previous = previous.write();
+
+        if let Some(previous) = previous.take() {
+            if let Some(value) = subscribers.get(&previous) {
+                value.set(false);
+            }
+        }
+
+        let current = f();
+
+        if let Some(value) = subscribers.get(&current) {
+            value.set(true);
+        }
+
+        *previous = Some(current);
+    });
+
+    Comparer { subscribers }
+}

--- a/packages/signals/src/comparer.rs
+++ b/packages/signals/src/comparer.rs
@@ -22,7 +22,7 @@ impl<R: Eq + Hash> Comparer<R> {
                 drop(subscribers);
                 let mut subscribers = self.subscribers.write();
                 let signal = Signal::new(false);
-                subscribers.insert(value, signal.clone());
+                subscribers.insert(value, signal);
                 signal.into()
             }
         }
@@ -31,9 +31,7 @@ impl<R: Eq + Hash> Comparer<R> {
 
 impl<R> Clone for Comparer<R> {
     fn clone(&self) -> Self {
-        Self {
-            subscribers: self.subscribers.clone(),
-        }
+        *self
     }
 }
 

--- a/packages/signals/src/lib.rs
+++ b/packages/signals/src/lib.rs
@@ -14,3 +14,5 @@ pub(crate) mod signal;
 pub use signal::*;
 mod dependency;
 pub use dependency::*;
+mod comparer;
+pub use comparer::*;

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -369,6 +369,12 @@ pub struct ReadOnlySignal<T: 'static> {
     inner: Signal<T>,
 }
 
+impl<T: 'static> From<Signal<T>> for ReadOnlySignal<T> {
+    fn from(inner: Signal<T>) -> Self {
+        Self { inner }
+    }
+}
+
 impl<T: 'static> ReadOnlySignal<T> {
     /// Create a new read-only signal.
     pub fn new(signal: Signal<T>) -> Self {


### PR DESCRIPTION
Creates a hook that is equivalent to [Solid's selector](https://docs.solidjs.com/references/api-reference/secondary-primitives/createSelector). This allows comparing one value to many different values with O(1) time when the value updates.

(This hook is the reason the select row benchmark in the js-framework-benchmark tends to be higher for reactive-frameworks. They only have to re-render the exact row that changed and they don't need to check any other rows because they track the currently selected row with a selector)

I don't love the name `comparer`. We are already using the name selector for a different hook, but suggestions are welcome!