### PR TITLE
fix syntax error at `#[derive(Props)]` using const generics

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -551,18 +551,16 @@ mod struct_info {
             let generics_with_empty = modify_types_generics_hack(&ty_generics, |args| {
                 args.insert(0, syn::GenericArgument::Type(empties_tuple.clone().into()));
             });
-            let phantom_generics = self.generics.params.iter().map(|param| match param {
+            let phantom_generics = self.generics.params.iter().filter_map(|param| match param {
                 syn::GenericParam::Lifetime(lifetime) => {
                     let lifetime = &lifetime.lifetime;
-                    quote!(::core::marker::PhantomData<&#lifetime ()>)
+                    Some(quote!(::core::marker::PhantomData<&#lifetime ()>))
                 }
                 syn::GenericParam::Type(ty) => {
                     let ty = &ty.ident;
-                    quote!(::core::marker::PhantomData<#ty>)
+                    Some(quote!(::core::marker::PhantomData<#ty>))
                 }
-                syn::GenericParam::Const(_cnst) => {
-                    quote!()
-                }
+                syn::GenericParam::Const(_cnst) => None,
             });
             let builder_method_doc = match self.builder_attr.builder_method_doc {
                 Some(ref doc) => quote!(#doc),


### PR DESCRIPTION
# Reproduce problem
https://github.com/syrflover/derive-props-with-const-generics

To trigger an error, change the version of dioxus to 0.4 in `Cargo.toml`

# What is problem

<img width="1141" alt="image" src="https://github.com/DioxusLabs/dioxus/assets/47150355/30bdccdb-ca27-41be-9efe-ac9ce2675113">

https://github.com/DioxusLabs/dioxus/blob/a3e6d0adcaee49495db5c324dbf9f20d5ec529ed/packages/core-macro/src/props/mod.rs#L554-L566

https://github.com/DioxusLabs/dioxus/blob/a3e6d0adcaee49495db5c324dbf9f20d5ec529ed/packages/core-macro/src/props/mod.rs#L645-L651

When it is `GenericParam::Const`, it doesn't return anything. However, if that item is included in an iterator, a syntax error occurs because it generates commas as many times as the length of the iterator when creating tokens.

# How to fixed it

https://github.com/syrflover/dioxus/blob/4f8b60834af43fef879c7eb0ff46b74d23a6eabe/packages/core-macro/src/props/mod.rs#L554-L564

Changed to returns `None`, when it is `GenericParam::Const` using `filter_map`.