### PR TITLE
fix: Read value from root when calling `AtomState::current()`

### DIFF
--- a/packages/fermi/src/hooks/state.rs
+++ b/packages/fermi/src/hooks/state.rs
@@ -86,7 +86,9 @@ impl<T: 'static> AtomState<T> {
     /// ```
     #[must_use]
     pub fn current(&self) -> Rc<T> {
-        self.value.as_ref().unwrap().clone()
+        let atoms = self.root.atoms.borrow();
+        let slot = atoms.get(&self.id).unwrap();
+        slot.value.clone().downcast().unwrap()
     }
 
     /// Get the `setter` function directly without the `AtomState` wrapper.


### PR DESCRIPTION
Fixes https://github.com/DioxusLabs/dioxus/issues/1608

This will make `AtomState::current()` read from the Root value instead of the AtomState inner value, this makes it work properly on async contexts / event handlers