### PR TITLE
fix: wasm-bindgen version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ slab = "0.4.2"
 futures-channel = "0.3.21"
 futures-util = { version = "0.3", default-features = false }
 rustc-hash = "1.1.0"
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2.88"
 html_parser = "0.7.0"
 thiserror = "1.0.40"
 prettyplease = { package = "prettier-please", version = "0.2", features = [


### PR DESCRIPTION
This PR fixes the issue of `wasm-bindgen` version mismatch by ensuring that all instances of wasm-bindgen in the project are using the same version (`0.2.88`).