### PR TITLE
update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ slab = "0.4.2"
 futures-channel = "0.3.21"
 futures-util = { version = "0.3", default-features = false }
 rustc-hash = "1.1.0"
-wasm-bindgen = "0.2.87"
+wasm-bindgen = "0.2.88"
 html_parser = "0.7.0"
 thiserror = "1.0.40"
 prettyplease = { package = "prettier-please", version = "0.2", features = [

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -11,7 +11,7 @@ It handles building, bundling, development and publishing to simplify developmen
 ### Install the stable version (recommended)
 
 ```
-cargo install dioxus-cli --locked
+cargo install dioxus-cli
 ```
 
 ### Install the latest development build through git


### PR DESCRIPTION
Removes remaining `--locked` option within the instructions to install the CLI at `packages/cli`s README.md.