### PR TITLE
rename onclick_only to provided_onclick_only in dioxus_router's Link

### DIFF
--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -91,11 +91,12 @@ pub struct LinkProps<'a> {
     #[props(default)]
     /// Whether the default behavior should be executed if an `onclick` handler is provided.
     ///
-    /// 1. When `onclick` is [`None`] (default if not specified), `onclick_only` has no effect.
-    /// 2. If `onclick_only` is [`false`] (default if not specified), the provided `onclick` handler
-    ///    will be executed after the links regular functionality.
-    /// 3. If `onclick_only` is [`true`], only the provided `onclick` handler will be executed.
-    pub onclick_only: bool,
+    /// 1. When `onclick` is [`None`] (default if not specified),
+    /// `provided_onclick_only` has no effect.
+    /// 2. If `provided_onclick_only` is [`false`] (default if not specified),
+    /// the provided `onclick` handler will be executed after the links regular functionality.
+    /// 3. If `provided_onclick_only` is [`true`], only the provided `onclick` handler will be executed.
+    pub provided_onclick_only: bool,
     /// The rel attribute for the generated HTML anchor tag.
     ///
     /// For external `target`s, this defaults to `noopener noreferrer`.
@@ -114,7 +115,7 @@ impl Debug for LinkProps<'_> {
             .field("id", &self.id)
             .field("new_tab", &self.new_tab)
             .field("onclick", &self.onclick.as_ref().map(|_| "onclick is set"))
-            .field("onclick_only", &self.onclick_only)
+            .field("provided_onclick_only", &self.provided_onclick_only)
             .field("rel", &self.rel)
             .finish()
     }
@@ -190,7 +191,7 @@ pub fn Link<'a>(cx: Scope<'a, LinkProps<'a>>) -> Element {
         id,
         new_tab,
         onclick,
-        onclick_only,
+        provided_onclick_only,
         rel,
         to,
         ..
@@ -230,7 +231,7 @@ pub fn Link<'a>(cx: Scope<'a, LinkProps<'a>>) -> Element {
         .or_else(|| is_external.then_some("noopener noreferrer"))
         .unwrap_or_default();
 
-    let do_default = onclick.is_none() || !onclick_only;
+    let do_default = onclick.is_none() || !provided_onclick_only;
     let action = move |event| {
         if do_default && is_router_nav {
             router.push_any(router.resolve_into_routable(to.clone()));


### PR DESCRIPTION
otherwise it doesn't work :)

this is needed to allow cmd-clicking link. working example:

```rust
#[component]
fn Link<'a>(cx: Scoped<'a>, class: Option<&'a str>, to: Route, children: Element<'a>) -> Element {
    let navigator = use_navigator(&cx);

    let eval_provider = use_eval(cx);

    let to_url = to.to_string();

    cx.render(rsx! {
        dioxus_router::prelude::Link {
            class: class.unwrap_or(""),
            to: to.clone(),
            onclick: move |e: Event<MouseData>| {
                let ms = e.data.modifiers();
                
                if ms.meta() || ms.ctrl() {
                    if let Err(e) = eval_provider(&format!("
                        window.open('{to_url}', '_blank');
                    ")) {
                        eprintln!("Error evaluating JS: {e:?}");
                    };
                } else {
                    navigator.push(to.clone());
                }
            },
            provided_onclick_only: true,
            children
        }
    })
}
```

~~btw, what would you say if I add this example code to Link as well? (in a separate PR). I think it's important to allow cmd-click for opening in new tabs. I only ever worked with Liveview though, so may be missing something~~

actually, `window.open` doesn't allow the focus to be retained in the original tab anymore. so without some `prevent_default` hackery, I'll have to resort to the normal `a` here. anyway, this particular PR might still be of value, if this attribute is to be around