### PR TITLE
Create vnode iterator (#1177)

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -77,7 +77,7 @@ pub(crate) mod innerlude {
 
 pub use crate::innerlude::{
     fc_to_builder, vdom_is_rendering, AnyValue, Attribute, AttributeValue, BorrowedAttributeValue,
-    CapturedError, Component, DynamicNode, Element, ElementId, Event, Fragment, IntoDynNode,
+    CapturedError, Component, DynamicNode, Element, ElementId, Event, Fragment, IntoDynNode, Iter,
     LazyNodes, Mutation, Mutations, Properties, RenderReturn, Scope, ScopeId, ScopeState, Scoped,
     TaskId, Template, TemplateAttribute, TemplateNode, VComponent, VNode, VPlaceholder, VText,
     VirtualDom,

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -129,7 +129,10 @@ impl<'a> Iterator for Iter<'a> {
                         return Some(root);
                     }
                 }
-                _ => return Some(root),
+                _ => {
+                    self.root_idx += 1;
+                    return Some(root);
+                }
             }
         }
 


### PR DESCRIPTION
This creates an iterator over a `VNode`'s template nodes. I'm thinking if we could implement `IntoDynNode` for `TemplateNode` that would let us iterate and map children #1177