### PR TITLE
Fix string memory leak

### DIFF
--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -707,7 +707,7 @@ impl<'a, 'b> IntoDynNode<'b> for &'a str {
 impl IntoDynNode<'_> for String {
     fn into_vnode(self, cx: &ScopeState) -> DynamicNode {
         DynamicNode::Text(VText {
-            value: cx.bump().alloc(self),
+            value: cx.bump().alloc_str(&self),
             id: Default::default(),
         })
     }


### PR DESCRIPTION
Fixes a memory leak caused by allocating a string in the bump allocator. The string needs to have it's drop handler called to be dropped to drop the memory but bump allocators do not drop objects allocated in them. Instead this PR changes the bump allocator to copy the &str out of the string