### PR TITLE
Related to #1547: use `dioxus-cli` within a workspace (wildcard-members, real package names)

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["react", "gui", "cli", "dioxus", "wasm"]
 [dependencies]
 # cli core
 clap = { version = "4.2", features = ["derive"] }
-glob = "^0.3"
 thiserror = { workspace = true }
 wasm-bindgen-cli-support = "0.2"
 colored = "2.0.0"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["react", "gui", "cli", "dioxus", "wasm"]
 [dependencies]
 # cli core
 clap = { version = "4.2", features = ["derive"] }
+glob = "^0.3"
 thiserror = { workspace = true }
 wasm-bindgen-cli-support = "0.2"
 colored = "2.0.0"

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -29,6 +29,9 @@ pub enum Error {
     #[error("Cargo Error: {0}")]
     CargoError(String),
 
+    #[error("Couldn't retrieve cargo metadata")]
+    CargoMetadata(#[source] cargo_metadata::Error),
+
     #[error("{0}")]
     CustomError(String),
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -9,43 +9,31 @@ use dioxus_cli::plugin::PluginManager;
 
 use Commands::*;
 
-fn get_bin(bin: Option<String>) -> Result<Option<PathBuf>> {
-    const ERR_MSG_NOT_A_WORKSPACE: &str = "The `--bin` flag has to be ran in a Cargo workspace.";
-    const ERR_MSG_BAD_WORKSPACE_MEMBER: &str = "Could not read workspace member's manifest.";
+fn get_bin(bin: Option<String>) -> Result<PathBuf> {
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .map_err(Error::CargoMetadata)?;
+    let package = if let Some(bin) = bin {
+        metadata
+            .workspace_packages()
+            .into_iter()
+            .find(|p| p.name == bin)
+            .ok_or(format!("no such package: {}", bin))
+            .map_err(Error::CargoError)?
+    } else {
+        metadata
+            .root_package()
+            .ok_or("no root package?".into())
+            .map_err(Error::CargoError)?
+    };
 
-    if let Some(ref bin) = bin {
-        let manifest = cargo_toml::Manifest::from_path("./Cargo.toml")
-            .map_err(|_| Error::CargoError(ERR_MSG_NOT_A_WORKSPACE.to_string()))?;
+    let crate_dir = package
+        .manifest_path
+        .parent()
+        .ok_or("couldn't take parent dir".into())
+        .map_err(Error::CargoError)?;
 
-        if let Some(workspace) = manifest.workspace {
-            for member_spec in workspace.members.iter() {
-                for member_dir in glob::glob(member_spec).map_err(anyhow::Error::from)? {
-                    let member_dir = member_dir.map_err(anyhow::Error::from)?;
-                    let member_manifest_file = member_dir.join("Cargo.toml");
-
-                    let member_manifest = cargo_toml::Manifest::from_path(member_manifest_file)
-                        .map_err(|_| Error::CargoError(ERR_MSG_BAD_WORKSPACE_MEMBER.to_string()))?;
-
-                    if let Some(package) = member_manifest.package.as_ref() {
-                        if package.name() == bin {
-                            return Ok(Some(member_dir));
-                        }
-                    }
-                }
-            }
-        } else {
-            return Err(Error::CargoError(ERR_MSG_NOT_A_WORKSPACE.to_string()));
-        }
-    }
-
-    // If the bin exists but we couldn't find it
-    if bin.is_some() {
-        return Err(Error::CargoError(
-            "The specified bin does not exist.".to_string(),
-        ));
-    }
-
-    Ok(None)
+    Ok(crate_dir.into())
 }
 
 #[tokio::main]
@@ -56,7 +44,7 @@ async fn main() -> anyhow::Result<()> {
 
     let bin = get_bin(args.bin)?;
 
-    let _dioxus_config = DioxusConfig::load(bin.clone())
+    let _dioxus_config = DioxusConfig::load(Some(bin.clone()))
         .map_err(|e| anyhow!("Failed to load Dioxus config because: {e}"))?
         .unwrap_or_else(|| {
             log::warn!("You appear to be creating a Dioxus project from scratch; we will use the default config");
@@ -73,15 +61,15 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow!("🚫 Translation of HTML into RSX failed: {}", e)),
 
         Build(opts) => opts
-            .build(bin.clone())
+            .build(Some(bin.clone()))
             .map_err(|e| anyhow!("🚫 Building project failed: {}", e)),
 
         Clean(opts) => opts
-            .clean(bin.clone())
+            .clean(Some(bin.clone()))
             .map_err(|e| anyhow!("🚫 Cleaning project failed: {}", e)),
 
         Serve(opts) => opts
-            .serve(bin.clone())
+            .serve(Some(bin.clone()))
             .await
             .map_err(|e| anyhow!("🚫 Serving project failed: {}", e)),
 
@@ -94,7 +82,7 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow!("🚫 Configuring new project failed: {}", e)),
 
         Bundle(opts) => opts
-            .bundle(bin.clone())
+            .bundle(Some(bin.clone()))
             .map_err(|e| anyhow!("🚫 Bundling project failed: {}", e)),
 
         #[cfg(feature = "plugin")]


### PR DESCRIPTION
(Related to #1547)

Although the `dx` CLI allows to specify a package name to chose from workspace members, it does not support workspace members specified as glob-wildcards. Neither it respects the effective package name, specified in the crate's `Cargo.toml`.

This PR addresses that issue:
- upon `dx build ...`, if the `--bin` CLI-argument is provided, treat the current dir as a workspace;
- search through the workspace's `members`: resolve each of them with `glob`;
- assume that any workspace member has a `Cargo.toml` in it (cargo does it, so it's okay);
- read said manifest, and check the package name in it;
- if found — there we have our sought package.