### PR TITLE
Fix tailwind.css 404 in Cli web platform build

### DIFF
--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -469,7 +469,7 @@ pub fn gen_page(config: &DioxusConfig, serve: bool) -> String {
         .unwrap_or_default()
         .contains_key("tailwindcss")
     {
-        style_str.push_str("<link rel=\"stylesheet\" href=\"tailwind.css\">\n");
+        style_str.push_str("<link rel=\"stylesheet\" href=\"/{base_path}/tailwind.css\">\n");
     }
 
     replace_or_insert_before("{style_include}", &style_str, "</head", &mut html);


### PR DESCRIPTION
```
[application]
default_platform = "web"
[application.tools]
tailwindcss = { input = "input.css", config = "tailwind.config.js" }
```

when enable tailwindcss, CLI will auto insert `<link rel="stylesheet" href="tailwind.css">` into `index.html`.

this will cause 404 when route enabled.

this PR change the path to absolute path to fix this.


