### PR TITLE
Fix missing items in hot reloading diffing

### DIFF
--- a/packages/cli/src/logging.rs
+++ b/packages/cli/src/logging.rs
@@ -28,7 +28,19 @@ pub fn set_up_logging() {
                 message = message,
             ));
         })
-        .level(log::LevelFilter::Info)
+        .level(match std::env::var("DIOXUS_LOG") {
+            Ok(level) => match level.to_lowercase().as_str() {
+                "error" => log::LevelFilter::Error,
+                "warn" => log::LevelFilter::Warn,
+                "info" => log::LevelFilter::Info,
+                "debug" => log::LevelFilter::Debug,
+                "trace" => log::LevelFilter::Trace,
+                _ => {
+                    panic!("Invalid log level: {}", level)
+                }
+            },
+            Err(_) => log::LevelFilter::Info,
+        })
         .chain(std::io::stdout())
         .apply()
         .unwrap();

--- a/packages/cli/src/server/desktop/mod.rs
+++ b/packages/cli/src/server/desktop/mod.rs
@@ -73,6 +73,7 @@ pub async fn serve(config: CrateConfig, hot_reload_state: Option<HotReloadState>
 
             move || {
                 let mut current_child = currently_running_child.write().unwrap();
+                log::trace!("Killing old process");
                 current_child.kill()?;
                 let (child, result) = start_desktop(&config)?;
                 *current_child = child;
@@ -212,6 +213,7 @@ fn send_msg(msg: HotReloadMsg, channel: &mut impl std::io::Write) -> bool {
 
 pub fn start_desktop(config: &CrateConfig) -> Result<(Child, BuildResult)> {
     // Run the desktop application
+    log::trace!("Building application");
     let result = crate::builder::build_desktop(config, true)?;
 
     match &config.executable {
@@ -222,6 +224,7 @@ pub fn start_desktop(config: &CrateConfig) -> Result<(Child, BuildResult)> {
             if cfg!(windows) {
                 file.set_extension("exe");
             }
+            log::trace!("Running application from {:?}", file);
             let child = Command::new(file.to_str().unwrap()).spawn()?;
 
             Ok((child, result))

--- a/packages/cli/src/server/output.rs
+++ b/packages/cli/src/server/output.rs
@@ -22,17 +22,20 @@ pub fn print_console_info(
     options: PrettierOptions,
     web_info: Option<WebServerInfo>,
 ) {
-    if let Ok(native_clearseq) = Command::new(if cfg!(target_os = "windows") {
-        "cls"
-    } else {
-        "clear"
-    })
-    .output()
-    {
-        print!("{}", String::from_utf8_lossy(&native_clearseq.stdout));
-    } else {
-        // Try ANSI-Escape characters
-        print!("\x1b[2J\x1b[H");
+    // Don't clear the screen if the user has set the DIOXUS_LOG environment variable to "trace" so that we can see the logs
+    if Some("trace") != std::env::var("DIOXUS_LOG").ok().as_deref() {
+        if let Ok(native_clearseq) = Command::new(if cfg!(target_os = "windows") {
+            "cls"
+        } else {
+            "clear"
+        })
+        .output()
+        {
+            print!("{}", String::from_utf8_lossy(&native_clearseq.stdout));
+        } else {
+            // Try ANSI-Escape characters
+            print!("\x1b[2J\x1b[H");
+        }
     }
 
     let mut profile = if config.release { "Release" } else { "Debug" }.to_string();

--- a/packages/rsx/Cargo.toml
+++ b/packages/rsx/Cargo.toml
@@ -20,6 +20,7 @@ quote = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 internment = { version = "0.7.0", optional = true }
 krates = { version = "0.12.6", optional = true }
+tracing.workspace = true
 
 [features]
 hot_reload = ["krates", "internment"]


### PR DESCRIPTION
This fixes the liveview part of #1286. When syn was updated some items were not added which causes some more complex code like the liveview hello world example to always preform a full reload instead of hot reloading only the rsx