### PR TITLE
Add cargo make tidy/miri

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -24,10 +24,52 @@ script = [
 ]
 script_runner = "@duckscript"
 
+[tasks.format]
+command = "cargo"
+args = ["fmt", "--all"]
+
+[tasks.check] 
+command = "cargo"
+args = ["check", "--workspace", "--examples", "--tests"]
+
+[tasks.clippy]
+command = "cargo" 
+args = ["clippy", "--workspace", "--examples", "--tests", "--", "-D", "warnings"]
+
+[tasks.tidy]
+category = "Formatting"
+dependencies = [
+  "format", "check", "clippy"
+]
+description = "Format and Check workspace"
+
+[tasks.install-miri]
+toolchain = "nightly"
+install_crate = { rustup_component_name = "miri", binary = "cargo +nightly miri", test_arg = "--help"}
+private = true
+
+[tasks.miri-native]
+command = "cargo"
+toolchain = "nightly"
+dependencies = ["install-miri"]
+args = ["miri", "test", "--package", "dioxus-native-core", "--test", "miri_native"]
+
+[tasks.miri-stress]  
+command = "cargo"
+toolchain = "nightly"
+dependencies = ["install-miri"]
+args = ["miri", "test", "--package", "dioxus-core", "--test", "miri_stress"]
+
+[tasks.miri]
+dependencies = ["miri-native", "miri-stress"]
+
 [tasks.tests]
 category = "Testing"
-dependencies = ["tests-setup"]
-description = "Run all tests"
+dependencies = [
+  "tests-setup",
+  "tidy",
+]
+description = "Run all tests"  
 env = {CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*"]}
 run_task = {name = ["test-flow", "test-with-browser"], fork = true}
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -78,7 +78,7 @@ dependencies = ["miri-native", "miri-stress"]
 
 [tasks.tests]
 category = "Testing"
-dependencies = ["tests-setup", "tidy"]
+dependencies = ["tests-setup"]
 description = "Run all tests"
 env = { CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*"] }
 run_task = { name = ["test-flow", "test-with-browser"], fork = true }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -28,33 +28,46 @@ script_runner = "@duckscript"
 command = "cargo"
 args = ["fmt", "--all"]
 
-[tasks.check] 
+[tasks.check]
 command = "cargo"
 args = ["check", "--workspace", "--examples", "--tests"]
 
 [tasks.clippy]
-command = "cargo" 
-args = ["clippy", "--workspace", "--examples", "--tests", "--", "-D", "warnings"]
+command = "cargo"
+args = [
+  "clippy",
+  "--workspace",
+  "--examples",
+  "--tests",
+  "--",
+  "-D",
+  "warnings",
+]
 
 [tasks.tidy]
 category = "Formatting"
-dependencies = [
-  "format", "check", "clippy"
-]
+dependencies = ["format", "check", "clippy"]
 description = "Format and Check workspace"
 
 [tasks.install-miri]
 toolchain = "nightly"
-install_crate = { rustup_component_name = "miri", binary = "cargo +nightly miri", test_arg = "--help"}
+install_crate = { rustup_component_name = "miri", binary = "cargo +nightly miri", test_arg = "--help" }
 private = true
 
 [tasks.miri-native]
 command = "cargo"
 toolchain = "nightly"
 dependencies = ["install-miri"]
-args = ["miri", "test", "--package", "dioxus-native-core", "--test", "miri_native"]
+args = [
+  "miri",
+  "test",
+  "--package",
+  "dioxus-native-core",
+  "--test",
+  "miri_native",
+]
 
-[tasks.miri-stress]  
+[tasks.miri-stress]
 command = "cargo"
 toolchain = "nightly"
 dependencies = ["install-miri"]
@@ -65,13 +78,10 @@ dependencies = ["miri-native", "miri-stress"]
 
 [tasks.tests]
 category = "Testing"
-dependencies = [
-  "tests-setup",
-  "tidy",
-]
-description = "Run all tests"  
-env = {CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*"]}
-run_task = {name = ["test-flow", "test-with-browser"], fork = true}
+dependencies = ["tests-setup", "tidy"]
+description = "Run all tests"
+env = { CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["**/examples/*"] }
+run_task = { name = ["test-flow", "test-with-browser"], fork = true }
 
 [tasks.build]
 command = "cargo"
@@ -84,10 +94,24 @@ private = true
 [tasks.test]
 dependencies = ["build"]
 command = "cargo"
-args = ["test", "--lib", "--bins", "--tests", "--examples", "--workspace", "--exclude", "dioxus-router", "--exclude", "dioxus-desktop"]
+args = [
+  "test",
+  "--lib",
+  "--bins",
+  "--tests",
+  "--examples",
+  "--workspace",
+  "--exclude",
+  "dioxus-router",
+  "--exclude",
+  "dioxus-desktop",
+]
 private = true
 
 [tasks.test-with-browser]
-env = { CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS = ["**/packages/router", "**/packages/desktop"] }
+env = { CARGO_MAKE_WORKSPACE_INCLUDE_MEMBERS = [
+  "**/packages/router",
+  "**/packages/desktop",
+] }
 private = true
 workspace = true


### PR DESCRIPTION
Adds `cargo make tidy` and `cargo +nightly make miri` and changes `cargo make tests` to include `tidy`

Closes [1472](https://github.com/DioxusLabs/dioxus/issues/1472)