### PR TITLE
Switch outdated tui crate for ratatui

### DIFF
--- a/packages/rink/Cargo.toml
+++ b/packages/rink/Cargo.toml
@@ -14,7 +14,7 @@ dioxus-html = { workspace = true }
 dioxus-native-core = { workspace = true, features = ["layout-attributes"] }
 dioxus-native-core-macro = { workspace = true }
 
-tui = "0.17.0"
+ratatui = "0.24.0"
 crossterm = "0.26.1"
 anyhow = "1.0.42"
 tokio = { workspace = true, features = ["full"] }

--- a/packages/rink/src/lib.rs
+++ b/packages/rink/src/lib.rs
@@ -17,6 +17,7 @@ use futures::{channel::mpsc::UnboundedSender, pin_mut, Future, StreamExt};
 use futures_channel::mpsc::unbounded;
 use layout::TaffyLayout;
 use prevent_default::PreventDefault;
+use ratatui::{backend::CrosstermBackend, Terminal};
 use std::{io, time::Duration};
 use std::{
     pin::Pin,
@@ -26,7 +27,6 @@ use std::{rc::Rc, sync::RwLock};
 use style_attributes::StyleModifier;
 pub use taffy::{geometry::Point, prelude::*};
 use tokio::select;
-use tui::{backend::CrosstermBackend, Terminal};
 use widgets::{register_widgets, RinkWidgetResponder, RinkWidgetTraitObject};
 
 mod config;
@@ -180,7 +180,7 @@ pub fn render<R: Driver>(
 
                 if !to_rerender.is_empty() || updated {
                     updated = false;
-                    fn resize(dims: tui::layout::Rect, taffy: &mut Taffy, rdom: &RealDom) {
+                    fn resize(dims: ratatui::layout::Rect, taffy: &mut Taffy, rdom: &RealDom) {
                         let width = screen_to_layout_space(dims.width);
                         let height = screen_to_layout_space(dims.height);
                         let root_node = rdom
@@ -222,7 +222,7 @@ pub fn render<R: Driver>(
                     } else {
                         let rdom = rdom.read().unwrap();
                         resize(
-                            tui::layout::Rect {
+                            ratatui::layout::Rect {
                                 x: 0,
                                 y: 0,
                                 width: 1000,

--- a/packages/rink/src/query.rs
+++ b/packages/rink/src/query.rs
@@ -15,11 +15,11 @@ use crate::{get_abs_layout, layout_to_screen_space};
 /// # Example
 /// ```rust, ignore
 /// use dioxus::prelude::*;
-/// use dioxus_ratatui::query::Query;
-/// use dioxus_ratatui::Size;
+/// use dioxus_tui::query::Query;
+/// use dioxus_tui::Size;
 ///
 /// fn main() {
-///     dioxus_ratatui::launch(app);
+///     dioxus_tui::launch(app);
 /// }
 ///
 /// fn app(cx: Scope) -> Element {

--- a/packages/rink/src/query.rs
+++ b/packages/rink/src/query.rs
@@ -15,11 +15,11 @@ use crate::{get_abs_layout, layout_to_screen_space};
 /// # Example
 /// ```rust, ignore
 /// use dioxus::prelude::*;
-/// use dioxus_tui::query::Query;
-/// use dioxus_tui::Size;
+/// use dioxus_ratatui::query::Query;
+/// use dioxus_ratatui::Size;
 ///
 /// fn main() {
-///     dioxus_tui::launch(app);
+///     dioxus_ratatui::launch(app);
 /// }
 ///
 /// fn app(cx: Scope) -> Element {

--- a/packages/rink/src/render.rs
+++ b/packages/rink/src/render.rs
@@ -1,11 +1,10 @@
 use dioxus_native_core::{prelude::*, tree::TreeRef};
-use std::io::Stdout;
+use ratatui::{layout::Rect, style::Color};
 use taffy::{
     geometry::Point,
     prelude::{Dimension, Layout, Size},
     Taffy,
 };
-use tui::{backend::CrosstermBackend, layout::Rect, style::Color};
 
 use crate::{
     focus::Focused,
@@ -20,7 +19,7 @@ use crate::{
 const RADIUS_MULTIPLIER: [f32; 2] = [1.0, 0.5];
 
 pub(crate) fn render_vnode(
-    frame: &mut tui::Frame<CrosstermBackend<Stdout>>,
+    frame: &mut ratatui::Frame,
     layout: &Taffy,
     node: NodeRef,
     cfg: Config,
@@ -96,7 +95,7 @@ pub(crate) fn render_vnode(
 
 impl RinkWidget for NodeRef<'_> {
     fn render(self, area: Rect, mut buf: RinkBuffer<'_>) {
-        use tui::symbols::line::*;
+        use ratatui::symbols::line::*;
 
         enum Direction {
             Left,

--- a/packages/rink/src/style.rs
+++ b/packages/rink/src/style.rs
@@ -1,6 +1,6 @@
 use std::{num::ParseFloatError, str::FromStr};
 
-use tui::style::{Color, Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 
 use crate::RenderingMode;
 
@@ -442,6 +442,7 @@ impl RinkStyle {
 impl From<RinkStyle> for Style {
     fn from(val: RinkStyle) -> Self {
         Style {
+            underline_color: None,
             fg: val.fg.map(|c| c.color),
             bg: val.bg.map(|c| c.color),
             add_modifier: val.add_modifier,

--- a/packages/rink/src/style_attributes.rs
+++ b/packages/rink/src/style_attributes.rs
@@ -187,8 +187,8 @@ pub enum BorderStyle {
 }
 
 impl BorderStyle {
-    pub fn symbol_set(&self) -> Option<tui::symbols::line::Set> {
-        use tui::symbols::line::*;
+    pub fn symbol_set(&self) -> Option<ratatui::symbols::line::Set> {
+        use ratatui::symbols::line::*;
         const DASHED: Set = Set {
             horizontal: "╌",
             vertical: "╎",
@@ -570,7 +570,7 @@ fn apply_animation(name: &str, _value: &str, _style: &mut StyleModifier) {
 }
 
 fn apply_font(name: &str, value: &str, style: &mut StyleModifier) {
-    use tui::style::Modifier;
+    use ratatui::style::Modifier;
     match name {
         "font" => (),
         "font-family" => (),
@@ -593,7 +593,7 @@ fn apply_font(name: &str, value: &str, style: &mut StyleModifier) {
 }
 
 fn apply_text(name: &str, value: &str, style: &mut StyleModifier) {
-    use tui::style::Modifier;
+    use ratatui::style::Modifier;
 
     match name {
         "text-align" => todo!(),

--- a/packages/rink/src/widget.rs
+++ b/packages/rink/src/widget.rs
@@ -1,4 +1,4 @@
-use tui::{
+use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::{Color, Modifier},


### PR DESCRIPTION
It would probably be pretty simple to take it one step lower and use [`termwiz`](https://docs.rs/termwiz/latest/termwiz/index.html) directly, but for now `ratatui` is a drop in replacement for an outdated crate.
Fixes [1311](https://github.com/DioxusLabs/dioxus/issues/1311)