### PR TITLE
Make optional props accept Nothing, T or Option<T>

### DIFF
--- a/examples/optional_props.rs
+++ b/examples/optional_props.rs
@@ -16,6 +16,12 @@ fn app(cx: Scope) -> Element {
             a: "asd".to_string(),
             c: "asd".to_string(),
             d: Some("asd".to_string()),
+            e: Some("asd".to_string()),
+        }
+        Button {
+            a: "asd".to_string(),
+            c: "asd".to_string(),
+            d: Some("asd".to_string()),
             e: "asd".to_string(),
         }
     })

--- a/examples/optional_props.rs
+++ b/examples/optional_props.rs
@@ -20,9 +20,15 @@ fn app(cx: Scope) -> Element {
         }
         Button {
             a: "asd".to_string(),
+            b: "asd".to_string(),
             c: "asd".to_string(),
             d: Some("asd".to_string()),
             e: "asd".to_string(),
+        }
+        Button {
+            a: "asd".to_string(),
+            c: "asd".to_string(),
+            d: Some("asd".to_string()),
         }
     })
 }

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -243,10 +243,6 @@ mod field_info {
             }
             .into()
         }
-
-        pub fn type_from_inside_option(&self, check_option_name: bool) -> Option<&syn::Type> {
-            type_from_inside_option(self.ty, check_option_name)
-        }
     }
 
     #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
This changes optional props to accept either nothing, the inner type or an option of the inner type:

```rust

fn app(cx: Scope) -> Element {
    render! {
        Button {
            optional: Some("asd".to_string()),
        }
        Button {
            optional: "asd".to_string(),
        }
        Button {}
    }
}

#[derive(Props, PartialEq)]
struct ButtonProps {
    optional: Option<String>,
}

fn Button(cx: Scope<ButtonProps>) -> Element {
    render! {
        "{cx.props.optional:?}"
    }
}
```

If you are new to dioxus, don't know about the auto optional feature and you want Option<T>, this should make the first thing you try work