### PR TITLE
Automatically derive standard query parsing in the router macro

### DIFF
--- a/examples/query_segments_demo/src/main.rs
+++ b/examples/query_segments_demo/src/main.rs
@@ -70,7 +70,6 @@ fn BlogPost(cx: Scope, query_params: ManualBlogQuerySegments) -> Element {
     }
 }
 
-
 #[component]
 fn AutomaticBlogPost(cx: Scope, name: String, surname: String) -> Element {
     render! {

--- a/examples/query_segments_demo/src/main.rs
+++ b/examples/query_segments_demo/src/main.rs
@@ -14,29 +14,35 @@ use dioxus_router::prelude::*;
 #[derive(Routable, Clone)]
 #[rustfmt::skip]
 enum Route {
-    // segments that start with ?: are query segments
-    #[route("/blog?:query_params")]
+    // segments that start with ?:.. are query segments that capture the entire query
+    #[route("/blog?:..query_params")]
     BlogPost {
         // You must include query segments in child variants
-        query_params: BlogQuerySegments,
+        query_params: ManualBlogQuerySegments,
+    },
+    // segments that follow the ?:field&:other_field syntax are query segments that follow the standard url query syntax
+    #[route("/autoblog?:name&:surname")]
+    AutomaticBlogPost {
+        name: String,
+        surname: String,
     },
 }
 
 #[derive(Debug, Clone, PartialEq)]
-struct BlogQuerySegments {
+struct ManualBlogQuerySegments {
     name: String,
     surname: String,
 }
 
 /// The display impl needs to display the query in a way that can be parsed:
-impl Display for BlogQuerySegments {
+impl Display for ManualBlogQuerySegments {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "name={}&surname={}", self.name, self.surname)
     }
 }
 
 /// The query segment is anything that implements <https://docs.rs/dioxus-router/latest/dioxus_router/routable/trait.FromQuery.html>. You can implement that trait for a struct if you want to parse multiple query parameters.
-impl FromQuery for BlogQuerySegments {
+impl FromQuery for ManualBlogQuerySegments {
     fn from_query(query: &str) -> Self {
         let mut name = None;
         let mut surname = None;
@@ -57,10 +63,19 @@ impl FromQuery for BlogQuerySegments {
 }
 
 #[component]
-fn BlogPost(cx: Scope, query_params: BlogQuerySegments) -> Element {
+fn BlogPost(cx: Scope, query_params: ManualBlogQuerySegments) -> Element {
     render! {
         div{"This is your blogpost with a query segment:"}
         div{format!("{:?}", query_params)}
+    }
+}
+
+
+#[component]
+fn AutomaticBlogPost(cx: Scope, name: String, surname: String) -> Element {
+    render! {
+        div{"This is your blogpost with a query segment:"}
+        div{format!("name={}&surname={}", name, surname)}
     }
 }
 

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -36,7 +36,7 @@ mod segment;
 /// 1. Static Segments: "/static"
 /// 2. Dynamic Segments: "/:dynamic" (where dynamic has a type that is FromStr in all child Variants)
 /// 3. Catch all Segments: "/:..segments" (where segments has a type that is FromSegments in all child Variants)
-/// 4. Query Segments: "/?:query" (where query has a type that is FromQuery in all child Variants)
+/// 4. Query Segments: "/?:..query" (where query has a type that is FromQuery in all child Variants) or "/?:query&:other_query" (where query and other_query has a type that is FromQueryArgument in all child Variants)
 ///
 /// Routes are matched:
 /// 1. By there specificity this order: Query Routes ("/?:query"), Static Routes ("/route"), Dynamic Routes ("/:route"), Catch All Routes ("/:..route")

--- a/packages/router-macro/src/query.rs
+++ b/packages/router-macro/src/query.rs
@@ -4,12 +4,62 @@ use syn::{Ident, Type};
 use proc_macro2::TokenStream as TokenStream2;
 
 #[derive(Debug)]
-pub struct QuerySegment {
+pub enum QuerySegment {
+    Single(FullQuerySegment),
+    Segments(Vec<QueryArgument>),
+}
+
+impl QuerySegment {
+    pub fn contains_ident(&self, ident: &Ident) -> bool {
+        match self {
+            QuerySegment::Single(segment) => segment.ident == *ident,
+            QuerySegment::Segments(segments) => {
+                segments.iter().any(|segment| segment.ident == *ident)
+            }
+        }
+    }
+
+    pub fn parse(&self) -> TokenStream2 {
+        match self {
+            QuerySegment::Single(segment) => segment.parse(),
+            QuerySegment::Segments(segments) => {
+                let mut tokens = TokenStream2::new();
+                tokens.extend(quote! { let split_query: std::collections::HashMap<&str, &str> = query.split('&').filter_map(|s| s.split_once('=')).collect(); });
+                for segment in segments {
+                    tokens.extend(segment.parse());
+                }
+                tokens
+            }
+        }
+    }
+
+    pub fn write(&self) -> TokenStream2 {
+        match self {
+            QuerySegment::Single(segment) => segment.write(),
+            QuerySegment::Segments(segments) => {
+                let mut tokens = TokenStream2::new();
+                tokens.extend(quote! { write!(f, "?")?; });
+                let mut segments_iter = segments.iter();
+                if let Some(first_segment) = segments_iter.next() {
+                    tokens.extend(first_segment.write());
+                }
+                for segment in segments_iter {
+                    tokens.extend(quote! { write!(f, "&")?; });
+                    tokens.extend(segment.write());
+                }
+                tokens
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FullQuerySegment {
     pub ident: Ident,
     pub ty: Type,
 }
 
-impl QuerySegment {
+impl FullQuerySegment {
     pub fn parse(&self) -> TokenStream2 {
         let ident = &self.ident;
         let ty = &self.ty;
@@ -22,6 +72,32 @@ impl QuerySegment {
         let ident = &self.ident;
         quote! {
             write!(f, "?{}", #ident)?;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct QueryArgument {
+    pub ident: Ident,
+    pub ty: Type,
+}
+
+impl QueryArgument {
+    pub fn parse(&self) -> TokenStream2 {
+        let ident = &self.ident;
+        let ty = &self.ty;
+        quote! {
+            let #ident = match split_query.get(stringify!(#ident)) {
+                Some(query_argument) => <#ty as dioxus_router::routable::FromQueryArgument>::from_query_argument(query_argument).unwrap_or_default(),
+                None => <#ty as Default>::default(),
+            };
+        }
+    }
+
+    pub fn write(&self) -> TokenStream2 {
+        let ident = &self.ident;
+        quote! {
+            write!(f, "{}={}", stringify!(#ident), #ident)?;
         }
     }
 }

--- a/packages/router-macro/src/route.rs
+++ b/packages/router-macro/src/route.rs
@@ -282,7 +282,7 @@ impl Route {
                 }
             }
             if let Some(query) = &self.query {
-                if &query.ident == name {
+                if query.contains_ident(name) {
                     from_route = true
                 }
             }


### PR DESCRIPTION
This changes the router macro to derive the query segment parsing information for segments like this: `?:myqueryarg&:myotherqueryarg` (in the browser this would look like `?myqueryarg=value&myotherqueryarg=value`), and change fields that capture the full query argument to `?:..myfullquery`.

Closes #1631 