### PR TITLE
Add a warning about wry gnu support to Dioxus desktop

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -59,6 +59,7 @@ devtools = ["wry/devtools"]
 tray = ["wry/tray"]
 dox = ["wry/dox"]
 hot-reload = ["dioxus-hot-reload"]
+gnu = []
 
 [package.metadata.docs.rs]
 default-features = false

--- a/packages/desktop/build.rs
+++ b/packages/desktop/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // WARN about wry support on windows gnu targets. GNU windows targets don't work well in wry currently
+    if std::env::var("CARGO_CFG_WINDOWS").is_ok()
+        && std::env::var("CARGO_CFG_TARGET_ENV").unwrap() == "gnu"
+        && !cfg!(feature = "gnu")
+    {
+        println!("cargo:warning=GNU windows targets have some limitations within Wry. Using the MSVC windows toolchain is recommended. If you would like to use continue using GNU, you can read https://github.com/wravery/webview2-rs#cross-compilation and disable this warning by adding the gnu feature to dioxus-desktop in your Cargo.toml")
+    }
+}

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -19,17 +19,6 @@ mod webview;
 #[cfg(any(target_os = "ios", target_os = "android"))]
 mod mobile_shortcut;
 
-// WARN about wry support on windows gnu targets. GNU windows targets don't work well in wry currently
-#[cfg(all(windows, target_env = "gnu", not(feature = "gnu")))]
-mod wry_gnu_warning {
-    #[allow(dead_code)]
-    #[must_use = "GNU windows targets have some limitations within Wry. Using the MSVC windows toolchain is recommended. If you would like to use continue using GNU, you can read https://github.com/wravery/webview2-rs#cross-compilation and disable this warning by adding the gnu feature to dioxus-desktop in your Cargo.toml"]
-    struct WryGnuWarning;
-    const _: () = {
-        let dont_use_gnu = WryGnuWarning;
-    };
-}
-
 use crate::query::QueryResult;
 pub use cfg::{Config, WindowCloseBehaviour};
 pub use desktop_context::DesktopContext;

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -19,6 +19,17 @@ mod webview;
 #[cfg(any(target_os = "ios", target_os = "android"))]
 mod mobile_shortcut;
 
+// WARN about wry support on windows gnu targets. GNU windows targets don't work well in wry currently
+#[cfg(all(windows, target_env = "gnu"))]
+mod wry_gnu_warning {
+    #[allow(dead_code)]
+    #[must_use = "GNU windows targets can have issues with Wry. Using the MSVC toolchain is recommended"]
+    struct WryGnuWarning;
+    const _: () = {
+        let dont_use_gnu = WryGnuWarning;
+    };
+}
+
 use crate::query::QueryResult;
 pub use cfg::{Config, WindowCloseBehaviour};
 pub use desktop_context::DesktopContext;

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -20,10 +20,10 @@ mod webview;
 mod mobile_shortcut;
 
 // WARN about wry support on windows gnu targets. GNU windows targets don't work well in wry currently
-#[cfg(all(windows, target_env = "gnu"))]
+#[cfg(all(windows, target_env = "gnu", not(feature = "gnu")))]
 mod wry_gnu_warning {
     #[allow(dead_code)]
-    #[must_use = "GNU windows targets can have issues with Wry. Using the MSVC toolchain is recommended"]
+    #[must_use = "GNU windows targets have some limitations within Wry. Using the MSVC windows toolchain is recommended. If you would like to use continue using GNU, you can read https://github.com/wravery/webview2-rs#cross-compilation and disable this warning by adding the gnu feature to dioxus-desktop in your Cargo.toml"]
     struct WryGnuWarning;
     const _: () = {
         let dont_use_gnu = WryGnuWarning;


### PR DESCRIPTION
Dioxus desktop uses wry internally. There are some [limitations](https://github.com/wravery/webview2-rs#cross-compilation) that make compiling to GNU more difficult. This PR adds a warning about the limitations and suggests that most users switch to the MSVC, but it also provides information for the users that choose not to switch.

(This is an issue that has come up several times in the discord especially when cross compiling to windows)