### PR TITLE
Fixed conflict of  "--verbose" and "--quiet" flags

### DIFF
--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -54,8 +54,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
         .arg("build")
         .arg("--target")
         .arg("wasm32-unknown-unknown")
-        .arg("--message-format=json")
-        .arg("--quiet");
+        .arg("--message-format=json");
 
     let cmd = if config.release {
         cmd.arg("--release")
@@ -65,7 +64,7 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
     let cmd = if config.verbose {
         cmd.arg("--verbose")
     } else {
-        cmd
+        cmd.arg("--quiet")
     };
 
     let cmd = if config.custom_profile.is_some() {


### PR DESCRIPTION
When running `dx serve --verbose` an error appears on console stating: "cannot set both --verbose and --quiet"
I noted that in the file "packages/cli/src/builder.rs", the "quiet" flag appeared to be set in default command, and the "verbose" flag was being appended, which caused both flags to be put into the command, so I made them mutually exclusive instead.
