### PR TITLE
Use a temp directory for the hot reloading pipe

### DIFF
--- a/packages/cli/src/server/desktop/mod.rs
+++ b/packages/cli/src/server/desktop/mod.rs
@@ -109,7 +109,8 @@ pub async fn serve(config: CrateConfig, hot_reload_state: Option<HotReloadState>
 }
 
 async fn start_desktop_hot_reload(hot_reload_state: HotReloadState) -> Result<()> {
-    match LocalSocketListener::bind("@dioxusin") {
+    let path = std::env::temp_dir().join("dioxusin");
+    match LocalSocketListener::bind(path) {
         Ok(local_socket_stream) => {
             let aborted = Arc::new(Mutex::new(false));
             // States
@@ -188,7 +189,7 @@ fn clear_paths() {
         // We check if the file socket is already open from an old session and then delete it
         let paths = ["./dioxusin", "./@dioxusin"];
         for path in paths {
-            let path = std::path::PathBuf::from(path);
+            let path = std::env::temp_dir().join(path);
             if path.exists() {
                 let _ = std::fs::remove_file(path);
             }

--- a/packages/hot-reload/src/file_watcher.rs
+++ b/packages/hot-reload/src/file_watcher.rs
@@ -157,16 +157,17 @@ pub fn init<Ctx: HotReloadingContext + Send + 'static>(cfg: Config<Ctx>) {
             // On unix, if you force quit the application, it can leave the file socket open
             // This will cause the local socket listener to fail to open
             // We check if the file socket is already open from an old session and then delete it
-            let paths = ["./dioxusin", "./@dioxusin"];
+            let paths = ["./dioxusin"];
             for path in paths {
-                let path = PathBuf::from(path);
+                let path = std::env::temp_dir().join(path);
                 if path.exists() {
                     let _ = std::fs::remove_file(path);
                 }
             }
         }
 
-        match LocalSocketListener::bind("@dioxusin") {
+        let path = std::env::temp_dir().join("dioxusin");
+        match LocalSocketListener::bind(path) {
             Ok(local_socket_stream) => {
                 let aborted = Arc::new(Mutex::new(false));
 

--- a/packages/hot-reload/src/file_watcher.rs
+++ b/packages/hot-reload/src/file_watcher.rs
@@ -152,22 +152,20 @@ pub fn init<Ctx: HotReloadingContext + Send + 'static>(cfg: Config<Ctx>) {
         }
         let file_map = Arc::new(Mutex::new(file_map));
 
+        let target_dir = crate_dir.join("target");
+        let hot_reload_socket_path = target_dir.join("dioxusin");
+
         #[cfg(target_os = "macos")]
         {
             // On unix, if you force quit the application, it can leave the file socket open
             // This will cause the local socket listener to fail to open
             // We check if the file socket is already open from an old session and then delete it
-            let paths = ["./dioxusin"];
-            for path in paths {
-                let path = std::env::temp_dir().join(path);
-                if path.exists() {
-                    let _ = std::fs::remove_file(path);
-                }
+            if hot_reload_socket_path.exists() {
+                let _ = std::fs::remove_file(hot_reload_socket_path);
             }
         }
 
-        let path = std::env::temp_dir().join("dioxusin");
-        match LocalSocketListener::bind(path) {
+        match LocalSocketListener::bind(hot_reload_socket_path) {
             Ok(local_socket_stream) => {
                 let aborted = Arc::new(Mutex::new(false));
 

--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -1,4 +1,7 @@
-use std::io::{BufRead, BufReader};
+use std::{
+    io::{BufRead, BufReader},
+    path::PathBuf,
+};
 
 use dioxus_core::Template;
 #[cfg(feature = "file_watcher")]
@@ -24,7 +27,7 @@ pub enum HotReloadMsg {
 /// Connect to the hot reloading listener. The callback provided will be called every time a template change is detected
 pub fn connect(mut f: impl FnMut(HotReloadMsg) + Send + 'static) {
     std::thread::spawn(move || {
-        let path = std::env::temp_dir().join("dioxusin");
+        let path = PathBuf::from("./").join("target").join("dioxusin");
         if let Ok(socket) = LocalSocketStream::connect(path) {
             let mut buf_reader = BufReader::new(socket);
             loop {

--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -24,7 +24,8 @@ pub enum HotReloadMsg {
 /// Connect to the hot reloading listener. The callback provided will be called every time a template change is detected
 pub fn connect(mut f: impl FnMut(HotReloadMsg) + Send + 'static) {
     std::thread::spawn(move || {
-        if let Ok(socket) = LocalSocketStream::connect("@dioxusin") {
+        let path = std::env::temp_dir().join("dioxusin");
+        if let Ok(socket) = LocalSocketStream::connect(path) {
             let mut buf_reader = BufReader::new(socket);
             loop {
                 let mut buf = String::new();


### PR DESCRIPTION
This hides the hot reloading file by placing it in the temp directory.

This reverses #842. If the issue is just with `@` in a path, this shouldn't revert that fix.

Closes https://github.com/DioxusLabs/dioxus/issues/1616