### PR TITLE
Add loading attribute to img element

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -827,6 +827,7 @@ builder_constructors! {
         decoding: ImageDecoding DEFAULT,
         height: usize DEFAULT,
         ismap: Bool DEFAULT,
+        loading: String DEFAULT,
         src: Uri DEFAULT,
         srcset: String DEFAULT, // FIXME this is much more complicated
         usemap: String DEFAULT, // FIXME should be a fragment starting with '#'


### PR DESCRIPTION
Useful for lazy loading: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading