### PR TITLE
Fix leak in the render macro

### DIFF
--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -1,4 +1,4 @@
-use std::ptr::NonNull;
+use crate::ScopeState;use std::ptr::NonNull;
 
 use crate::{
     innerlude::DirtyScope, nodes::RenderReturn, nodes::VNode, virtual_dom::VirtualDom,
@@ -174,7 +174,14 @@ impl VirtualDom {
         scope.borrowed_props.borrow_mut().clear();
 
         // Now that all the references are gone, we can safely drop our own references in our listeners.
-        let mut listeners = scope.attributes_to_drop_before_render.borrow_mut();
+        scope.drop_listeners();
+    }
+}
+
+impl ScopeState {
+    /// Drop all listeners that were allocated in the bump allocator.
+    pub(crate) fn drop_listeners(&self) {
+        let mut listeners = self.attributes_to_drop_before_render.borrow_mut();
         listeners.drain(..).for_each(|listener| {
             let listener = unsafe { &*listener };
             if let AttributeValue::Listener(l) = &listener.value {

--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -1,4 +1,5 @@
-use crate::ScopeState;use std::ptr::NonNull;
+use crate::ScopeState;
+use std::ptr::NonNull;
 
 use crate::{
     innerlude::DirtyScope, nodes::RenderReturn, nodes::VNode, virtual_dom::VirtualDom,

--- a/packages/core/src/fragment.rs
+++ b/packages/core/src/fragment.rs
@@ -28,15 +28,14 @@ use crate::innerlude::*;
 #[allow(non_upper_case_globals, non_snake_case)]
 pub fn Fragment<'a>(cx: Scope<'a, FragmentProps<'a>>) -> Element {
     let children = cx.props.0.as_ref()?;
-    Some(VNode {
-        key: children.key,
-        parent: children.parent.clone(),
-        stable_id: children.stable_id.clone(),
-        template: children.template.clone(),
-        root_ids: children.root_ids.clone(),
-        dynamic_nodes: children.dynamic_nodes,
-        dynamic_attrs: children.dynamic_attrs,
-    })
+    Some(cx.vnode(
+        children.parent.clone(),
+        children.key,
+        children.template.clone(),
+        children.root_ids.clone(),
+        children.dynamic_nodes,
+        children.dynamic_attrs,
+    ))
 }
 
 pub struct FragmentProps<'a>(Element<'a>);

--- a/packages/core/src/lazynodes.rs
+++ b/packages/core/src/lazynodes.rs
@@ -24,7 +24,7 @@ use crate::{innerlude::VNode, ScopeState};
 ///
 /// ```rust, ignore
 /// LazyNodes::new(|f| {
-///        static TEMPLATE: dioxus::core::Template = dioxus::core::Template {
+///     static TEMPLATE: dioxus::core::Template = dioxus::core::Template {
 ///         name: "main.rs:5:5:20", // Source location of the template for hot reloading
 ///         roots: &[
 ///             dioxus::core::TemplateNode::Element {
@@ -37,19 +37,19 @@ use crate::{innerlude::VNode, ScopeState};
 ///         node_paths: &[],
 ///         attr_paths: &[],
 ///     };
-///     dioxus::core::VNode {
-///         parent: None,
-///         key: None,
-///         template: std::cell::Cell::new(TEMPLATE),
-///         root_ids: dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(
+///     f.vnode(
+///         None,
+///         None,
+///         std::cell::Cell::new(TEMPLATE),
+///         dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(
 ///                 1usize,
 ///                 f.bump(),
 ///             )
 ///             .into(),
-///         dynamic_nodes: f.bump().alloc([]),
-///         dynamic_attrs: f.bump().alloc([]),
-///     })
-/// }
+///         f.bump().alloc([]),
+///         f.bump().alloc([]),
+///     )
+/// })
 /// ```
 ///
 /// Find more information about how to construct [`VNode`] at <https://dioxuslabs.com/learn/0.4/contributing/walkthrough_readme#the-rsx-macro>

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -348,49 +348,8 @@ impl<'src> ScopeState {
     /// }
     /// ```
     pub fn render(&'src self, rsx: LazyNodes<'src, '_>) -> Element<'src> {
-        // <<<<<<< HEAD
-        //         let element = rsx.call(self);
-
-        //         let mut listeners = self.attributes_to_drop_before_render.borrow_mut();
-        //         for attr in element.dynamic_attrs {
-        //             attr.ty.for_each(|attr| {
-        //                 match attr.value {
-        //                     // We need to drop listeners before the next render because they may borrow data from the borrowed props which will be dropped
-        //                     AttributeValue::Listener(_) => {
-        //                         let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
-        //                         listeners.push(unbounded);
-        //                     }
-        //                     // We need to drop any values manually to make sure that their drop implementation is called before the next render
-        //                     AttributeValue::Any(_) => {
-        //                         let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
-        //                         self.previous_frame().add_attribute_to_drop(unbounded);
-        //                     }
-
-        //                     _ => (),
-        //                 }
-        //             })
-        //         }
-
-        //         let mut props = self.borrowed_props.borrow_mut();
-        //         let mut drop_props = self
-        //             .previous_frame()
-        //             .props_to_drop_before_reset
-        //             .borrow_mut();
-        //         for node in element.dynamic_nodes {
-        //             if let DynamicNode::Component(comp) = node {
-        //                 let unbounded = unsafe { std::mem::transmute(comp as *const VComponent) };
-        //                 if !comp.static_props {
-        //                     props.push(unbounded);
-        //                 }
-        //                 drop_props.push(unbounded);
-        //             }
-        //         }
-
-        //         Some(element)
-        // =======
         // Note: We can't do anything in this function related to safety because the user could always circumvent it by creating a VNode manually and return it without calling this function
         Some(rsx.call(self))
-        // >>>>>>> 9fe172e9 (Fix leak in render macro)
     }
 
     /// Create a [`crate::VNode`] from the component parts

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -2,13 +2,13 @@ use crate::{
     any_props::AnyProps,
     any_props::VProps,
     bump_frame::BumpFrame,
-    innerlude::{DynamicNode, EventHandler, VComponent, VNodeId, VText},
+    innerlude::{DynamicNode, ElementRef, EventHandler, VComponent, VNodeId, VText},
     lazynodes::LazyNodes,
     nodes::{IntoAttributeValue, IntoDynNode, RenderReturn},
     runtime::Runtime,
     scope_context::ScopeContext,
-    AnyValue, Attribute, AttributeType, AttributeValue, Element, Event, MountedAttribute,
-    Properties, TaskId,
+    AnyValue, Attribute, AttributeType, AttributeValue, Element, ElementId, Event,
+    MountedAttribute, Properties, TaskId, Template, VNode,
 };
 use bumpalo::{boxed::Box as BumpBox, Bump};
 use std::{
@@ -348,17 +348,76 @@ impl<'src> ScopeState {
     /// }
     /// ```
     pub fn render(&'src self, rsx: LazyNodes<'src, '_>) -> Element<'src> {
-        let element = rsx.call(self);
+        // <<<<<<< HEAD
+        //         let element = rsx.call(self);
 
+        //         let mut listeners = self.attributes_to_drop_before_render.borrow_mut();
+        //         for attr in element.dynamic_attrs {
+        //             attr.ty.for_each(|attr| {
+        //                 match attr.value {
+        //                     // We need to drop listeners before the next render because they may borrow data from the borrowed props which will be dropped
+        //                     AttributeValue::Listener(_) => {
+        //                         let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
+        //                         listeners.push(unbounded);
+        //                     }
+        //                     // We need to drop any values manually to make sure that their drop implementation is called before the next render
+        //                     AttributeValue::Any(_) => {
+        //                         let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
+        //                         self.previous_frame().add_attribute_to_drop(unbounded);
+        //                     }
+
+        //                     _ => (),
+        //                 }
+        //             })
+        //         }
+
+        //         let mut props = self.borrowed_props.borrow_mut();
+        //         let mut drop_props = self
+        //             .previous_frame()
+        //             .props_to_drop_before_reset
+        //             .borrow_mut();
+        //         for node in element.dynamic_nodes {
+        //             if let DynamicNode::Component(comp) = node {
+        //                 let unbounded = unsafe { std::mem::transmute(comp as *const VComponent) };
+        //                 if !comp.static_props {
+        //                     props.push(unbounded);
+        //                 }
+        //                 drop_props.push(unbounded);
+        //             }
+        //         }
+
+        //         Some(element)
+        // =======
+        // Note: We can't do anything in this function related to safety because the user could always circumvent it by creating a VNode manually and return it without calling this function
+        Some(rsx.call(self))
+        // >>>>>>> 9fe172e9 (Fix leak in render macro)
+    }
+
+    /// Create a [`crate::VNode`] from the component parts
+    pub fn vnode(
+        &'src self,
+        parent: Cell<Option<ElementRef>>,
+        key: Option<&'src str>,
+        template: Cell<Template<'static>>,
+        root_ids: RefCell<bumpalo::collections::Vec<'src, ElementId>>,
+        dynamic_nodes: &'src [DynamicNode<'src>],
+        dynamic_attrs: &'src [MountedAttribute<'src>],
+    ) -> VNode<'src> {
         let mut listeners = self.attributes_to_drop_before_render.borrow_mut();
-        for attr in element.dynamic_attrs {
-            attr.ty.for_each(|attr| {
+        for attr in dynamic_attrs {
+            let attrs = match attr.ty {
+                AttributeType::Single(ref attr) => std::slice::from_ref(attr),
+                AttributeType::Many(attrs) => attrs,
+            };
+
+            for attr in attrs {
                 match attr.value {
                     // We need to drop listeners before the next render because they may borrow data from the borrowed props which will be dropped
                     AttributeValue::Listener(_) => {
                         let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
                         listeners.push(unbounded);
                     }
+
                     // We need to drop any values manually to make sure that their drop implementation is called before the next render
                     AttributeValue::Any(_) => {
                         let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
@@ -367,7 +426,7 @@ impl<'src> ScopeState {
 
                     _ => (),
                 }
-            })
+            }
         }
 
         let mut props = self.borrowed_props.borrow_mut();
@@ -375,7 +434,7 @@ impl<'src> ScopeState {
             .previous_frame()
             .props_to_drop_before_reset
             .borrow_mut();
-        for node in element.dynamic_nodes {
+        for node in dynamic_nodes {
             if let DynamicNode::Component(comp) = node {
                 let unbounded = unsafe { std::mem::transmute(comp as *const VComponent) };
                 if !comp.static_props {
@@ -385,45 +444,14 @@ impl<'src> ScopeState {
             }
         }
 
-        Some(element)
-    }
-
-    #[doc(hidden)]
-    /// Take a [`crate::VNode`] and link it to a [`ScopeState`]
-    /// 
-    /// This is used internally in the render macro
-    pub fn link_node(&'src self, element: &crate::VNode<'src>) {
-        let mut listeners = self.attributes_to_drop_before_render.borrow_mut();
-        for attr in element.dynamic_attrs {
-            match attr.value {
-                // We need to drop listeners before the next render because they may borrow data from the borrowed props which will be dropped
-                AttributeValue::Listener(_) => {
-                    let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
-                    listeners.push(unbounded);
-                }
-                // We need to drop any values manually to make sure that their drop implementation is called before the next render
-                AttributeValue::Any(_) => {
-                    let unbounded = unsafe { std::mem::transmute(attr as *const Attribute) };
-                    self.previous_frame().add_attribute_to_drop(unbounded);
-                }
-
-                _ => (),
-            }
-        }
-
-        let mut props = self.borrowed_props.borrow_mut();
-        let mut drop_props = self
-            .previous_frame()
-            .props_to_drop_before_reset
-            .borrow_mut();
-        for node in element.dynamic_nodes {
-            if let DynamicNode::Component(comp) = node {
-                let unbounded = unsafe { std::mem::transmute(comp as *const VComponent) };
-                if !comp.static_props {
-                    props.push(unbounded);
-                }
-                drop_props.push(unbounded);
-            }
+        VNode {
+            stable_id: Default::default(),
+            key,
+            parent,
+            template,
+            root_ids,
+            dynamic_nodes,
+            dynamic_attrs,
         }
     }
 

--- a/packages/core/tests/fuzzing.rs
+++ b/packages/core/tests/fuzzing.rs
@@ -171,15 +171,27 @@ fn create_random_dynamic_node(cx: &ScopeState, depth: usize) -> DynamicNode {
     match rand::random::<u8>() % range {
         0 => DynamicNode::Placeholder(Default::default()),
         1 => cx.make_node((0..(rand::random::<u8>() % 5)).map(|_| {
-            VNode::new(
+            // <<<<<<< HEAD
+            //             VNode::new(
+            //                 None,
+            //                 Template {
+            // =======
+            cx.vnode(
                 None,
-                Template {
+                Default::default(),
+                Cell::new(Template {
+                    // >>>>>>> 9fe172e9 (Fix leak in render macro)
                     name: concat!(file!(), ":", line!(), ":", column!(), ":0"),
                     roots: &[TemplateNode::Dynamic { id: 0 }],
                     node_paths: &[&[0]],
                     attr_paths: &[],
-                },
-                bumpalo::collections::Vec::new_in(cx.bump()),
+                    // <<<<<<< HEAD
+                    //                 },
+                    //                 bumpalo::collections::Vec::new_in(cx.bump()),
+                    // =======
+                }),
+                bumpalo::collections::Vec::new_in(cx.bump()).into(),
+                // >>>>>>> 9fe172e9 (Fix leak in render macro)
                 cx.bump().alloc([cx.component(
                     create_random_element,
                     DepthProps { depth, root: false },
@@ -273,10 +285,19 @@ fn create_random_element(cx: Scope<DepthProps>) -> Element {
                 )
                 .into_boxed_str(),
             ));
-            let node = VNode::new(
+            // <<<<<<< HEAD
+            //             let node = VNode::new(
+            //                 None,
+            //                 template,
+            //                 bumpalo::collections::Vec::new_in(cx.bump()),
+            // =======
+            // println!("{template:#?}");
+            let node = cx.vnode(
                 None,
-                template,
-                bumpalo::collections::Vec::new_in(cx.bump()),
+                None,
+                Cell::new(template),
+                bumpalo::collections::Vec::new_in(cx.bump()).into(),
+                // >>>>>>> 9fe172e9 (Fix leak in render macro)
                 {
                     let dynamic_nodes: Vec<_> = dynamic_node_types
                         .iter()

--- a/packages/core/tests/fuzzing.rs
+++ b/packages/core/tests/fuzzing.rs
@@ -2,7 +2,7 @@
 
 use dioxus::prelude::Props;
 use dioxus_core::{MountedAttribute, *};
-use std::{cfg, collections::HashSet};
+use std::{cell::Cell, cfg, collections::HashSet};
 
 fn random_ns() -> Option<&'static str> {
     let namespace = rand::random::<u8>() % 2;
@@ -177,7 +177,7 @@ fn create_random_dynamic_node(cx: &ScopeState, depth: usize) -> DynamicNode {
             //                 Template {
             // =======
             cx.vnode(
-                None,
+                None.into(),
                 Default::default(),
                 Cell::new(Template {
                     // >>>>>>> 9fe172e9 (Fix leak in render macro)
@@ -293,7 +293,7 @@ fn create_random_element(cx: Scope<DepthProps>) -> Element {
             // =======
             // println!("{template:#?}");
             let node = cx.vnode(
-                None,
+                None.into(),
                 None,
                 Cell::new(template),
                 bumpalo::collections::Vec::new_in(cx.bump()).into(),

--- a/packages/core/tests/fuzzing.rs
+++ b/packages/core/tests/fuzzing.rs
@@ -171,27 +171,16 @@ fn create_random_dynamic_node(cx: &ScopeState, depth: usize) -> DynamicNode {
     match rand::random::<u8>() % range {
         0 => DynamicNode::Placeholder(Default::default()),
         1 => cx.make_node((0..(rand::random::<u8>() % 5)).map(|_| {
-            // <<<<<<< HEAD
-            //             VNode::new(
-            //                 None,
-            //                 Template {
-            // =======
             cx.vnode(
                 None.into(),
                 Default::default(),
                 Cell::new(Template {
-                    // >>>>>>> 9fe172e9 (Fix leak in render macro)
                     name: concat!(file!(), ":", line!(), ":", column!(), ":0"),
                     roots: &[TemplateNode::Dynamic { id: 0 }],
                     node_paths: &[&[0]],
                     attr_paths: &[],
-                    // <<<<<<< HEAD
-                    //                 },
-                    //                 bumpalo::collections::Vec::new_in(cx.bump()),
-                    // =======
                 }),
                 bumpalo::collections::Vec::new_in(cx.bump()).into(),
-                // >>>>>>> 9fe172e9 (Fix leak in render macro)
                 cx.bump().alloc([cx.component(
                     create_random_element,
                     DepthProps { depth, root: false },
@@ -285,19 +274,12 @@ fn create_random_element(cx: Scope<DepthProps>) -> Element {
                 )
                 .into_boxed_str(),
             ));
-            // <<<<<<< HEAD
-            //             let node = VNode::new(
-            //                 None,
-            //                 template,
-            //                 bumpalo::collections::Vec::new_in(cx.bump()),
-            // =======
-            // println!("{template:#?}");
+            println!("{template:#?}");
             let node = cx.vnode(
                 None.into(),
                 None,
                 Cell::new(template),
                 bumpalo::collections::Vec::new_in(cx.bump()).into(),
-                // >>>>>>> 9fe172e9 (Fix leak in render macro)
                 {
                     let dynamic_nodes: Vec<_> = dynamic_node_types
                         .iter()

--- a/packages/dioxus-tui/examples/many_small_edit_stress.rs
+++ b/packages/dioxus-tui/examples/many_small_edit_stress.rs
@@ -83,7 +83,7 @@ fn Grid(cx: Scope<GridProps>) -> Element {
                                     let alpha = y as f32*100.0/size as f32 + counts.read()[x*size + y] as f32;
                                     let key = format!("{}-{}", x, y);
                                     rsx! {
-                                        Box{
+                                        Box {
                                             x: x,
                                             y: y,
                                             alpha: 100.0,

--- a/packages/native-core/tests/fuzzing.rs
+++ b/packages/native-core/tests/fuzzing.rs
@@ -178,15 +178,27 @@ fn create_random_dynamic_node(cx: &ScopeState, depth: usize) -> DynamicNode {
     match rand::random::<u8>() % range {
         0 => DynamicNode::Placeholder(Default::default()),
         1 => cx.make_node((0..(rand::random::<u8>() % 5)).map(|_| {
-            VNode::new(
+            // <<<<<<< HEAD
+            //             VNode::new(
+            //                 None,
+            //                 Template {
+            // =======
+            cx.vnode(
                 None,
-                Template {
+                Default::default(),
+                Cell::new(Template {
+                    // >>>>>>> 9fe172e9 (Fix leak in render macro)
                     name: concat!(file!(), ":", line!(), ":", column!(), ":0"),
                     roots: &[TemplateNode::Dynamic { id: 0 }],
                     node_paths: &[&[0]],
                     attr_paths: &[],
-                },
-                dioxus::core::exports::bumpalo::collections::Vec::new_in(cx.bump()),
+                    // <<<<<<< HEAD
+                    //                 },
+                    //                 dioxus::core::exports::bumpalo::collections::Vec::new_in(cx.bump()),
+                    // =======
+                }),
+                dioxus::core::exports::bumpalo::collections::Vec::new_in(cx.bump()).into(),
+                // >>>>>>> 9fe172e9 (Fix leak in render macro)
                 cx.bump().alloc([cx.component(
                     create_random_element,
                     DepthProps { depth, root: false },
@@ -266,10 +278,18 @@ fn create_random_element(cx: Scope<DepthProps>) -> Element {
                 .into_boxed_str(),
             ));
             println!("{template:#?}");
-            let node = VNode::new(
+            // <<<<<<< HEAD
+            //             let node = VNode::new(
+            //                 None,
+            //                 template,
+            //                 dioxus::core::exports::bumpalo::collections::Vec::new_in(cx.bump()),
+            // =======
+            let node = cx.vnode(
                 None,
-                template,
-                dioxus::core::exports::bumpalo::collections::Vec::new_in(cx.bump()),
+                None,
+                Cell::new(template),
+                dioxus::core::exports::bumpalo::collections::Vec::new_in(cx.bump()).into(),
+                // >>>>>>> 9fe172e9 (Fix leak in render macro)
                 {
                     let dynamic_nodes: Vec<_> = dynamic_node_types
                         .iter()
@@ -284,13 +304,21 @@ fn create_random_element(cx: Scope<DepthProps>) -> Element {
                         .collect();
                     cx.bump().alloc(dynamic_nodes)
                 },
-                cx.bump()
-                    .alloc(
-                        (0..template.attr_paths.len())
-                            .map(|_| create_random_dynamic_mounted_attr(cx))
-                            .collect::<Vec<_>>(),
-                    )
-                    .as_slice(),
+                // <<<<<<< HEAD
+                //                 cx.bump()
+                //                     .alloc(
+                //                         (0..template.attr_paths.len())
+                //                             .map(|_| create_random_dynamic_mounted_attr(cx))
+                //                             .collect::<Vec<_>>(),
+                //                     )
+                //                     .as_slice(),
+                // =======
+                cx.bump().alloc(
+                    (0..template.attr_paths.len())
+                        .map(|_| create_random_dynamic_attr(cx))
+                        .collect::<Vec<_>>(),
+                ),
+                // >>>>>>> 9fe172e9 (Fix leak in render macro)
             );
             Some(node)
         }

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -139,9 +139,7 @@ impl ToTokens for RenderCallBody {
         out_tokens.append_all(quote! {
             Some({
                 let __cx = cx;
-                let __element = { #body };
-                cx.link_node(&__element);
-                __element
+                #body
             })
         })
     }
@@ -256,10 +254,18 @@ impl<'a> ToTokens for TemplateRenderer<'a> {
                 node_paths: &[ #(#node_paths),* ],
                 attr_paths: &[ #(#attr_paths),* ],
             };
-            ::dioxus::core::VNode::new(
+// <<<<<<< HEAD
+//             ::dioxus::core::VNode::new(
+//                 #key_tokens,
+//                 TEMPLATE,
+//                 dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(#root_count, __cx.bump()),
+// =======
+            __cx.vnode(
+                None,
                 #key_tokens,
-                TEMPLATE,
-                dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(#root_count, __cx.bump()),
+                std::cell::Cell::new(TEMPLATE),
+                dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(#root_count, __cx.bump()).into(),
+// >>>>>>> 9fe172e9 (Fix leak in render macro)
                 __cx.bump().alloc([ #( #node_printer ),* ]),
                 __cx.bump().alloc([ #( #dyn_attr_printer ),* ]),
             )

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -139,7 +139,9 @@ impl ToTokens for RenderCallBody {
         out_tokens.append_all(quote! {
             Some({
                 let __cx = cx;
-                #body
+                let __element = { #body };
+                cx.link_node(&__element);
+                __element
             })
         })
     }

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -261,7 +261,7 @@ impl<'a> ToTokens for TemplateRenderer<'a> {
 //                 dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(#root_count, __cx.bump()),
 // =======
             __cx.vnode(
-                None,
+                None.into(),
                 #key_tokens,
                 std::cell::Cell::new(TEMPLATE),
                 dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(#root_count, __cx.bump()).into(),

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -254,18 +254,12 @@ impl<'a> ToTokens for TemplateRenderer<'a> {
                 node_paths: &[ #(#node_paths),* ],
                 attr_paths: &[ #(#attr_paths),* ],
             };
-// <<<<<<< HEAD
-//             ::dioxus::core::VNode::new(
-//                 #key_tokens,
-//                 TEMPLATE,
-//                 dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(#root_count, __cx.bump()),
-// =======
+
             __cx.vnode(
                 None.into(),
                 #key_tokens,
                 std::cell::Cell::new(TEMPLATE),
                 dioxus::core::exports::bumpalo::collections::Vec::with_capacity_in(#root_count, __cx.bump()).into(),
-// >>>>>>> 9fe172e9 (Fix leak in render macro)
                 __cx.bump().alloc([ #( #node_printer ),* ]),
                 __cx.bump().alloc([ #( #dyn_attr_printer ),* ]),
             )


### PR DESCRIPTION
This fixes an issue where the render macro does not drop any listeners that are added to elements within the macro. It also change the VNode to be non exhaustive and adds a constructor that adds any dynamically allocated parts of the VNode to a drop list to prevent similar leaking issues in the future.