### PR TITLE
Fix doc tests by adding formatting to CLI README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,7 +10,7 @@ It handles building, bundling, development and publishing to simplify developmen
 
 ### Install the stable version (recommended)
 
-```
+```shell
 cargo install dioxus-cli
 ```
 
@@ -20,7 +20,7 @@ To get the latest bug fixes and features, you can install the development versio
 However, this is not fully tested.
 That means you're probably going to have more bugs despite having the latest bug fixes.
 
-```
+```shell
 cargo install --git https://github.com/DioxusLabs/dioxus dioxus-cli
 ```
 
@@ -29,7 +29,7 @@ and install it in Cargo's global binary directory (`~/.cargo/bin/` by default).
 
 ### Install from local folder
 
-```
+```shell
 cargo install --path . --debug
 ```
 
@@ -40,7 +40,7 @@ It will be cloned from the [dioxus-template](https://github.com/DioxusLabs/dioxu
 
 Alternatively, you can specify the template path:
 
-```
+```shell
 dx create hello --template gh:dioxuslabs/dioxus-template
 ```
 


### PR DESCRIPTION
The README for cli gets included in lib.rs via `include_str!`. The code snippets then get assumed to be Rust, which fails if running `cargo test --doc`. This is not a huge problem, but was brought to my attention because Nix's `buildRustPackage` runs `cargo test` including doc tests (unlike what get run for this project on CI). This means I can't update the Nix package to 0.4.3 without changing the test flags (which I think I'll see about doing anyways, as that's how Dioxus runs CI).