### PR TITLE
Fix spawn forever

### DIFF
--- a/packages/core/src/scope_context.rs
+++ b/packages/core/src/scope_context.rs
@@ -230,17 +230,7 @@ impl ScopeContext {
     /// This is good for tasks that need to be run after the component has been dropped.
     pub fn spawn_forever(&self, fut: impl Future<Output = ()> + 'static) -> TaskId {
         // The root scope will never be unmounted so we can just add the task at the top of the app
-        let id = self.tasks.spawn(ScopeId::ROOT, fut);
-
-        // wake up the scheduler if it is sleeping
-        self.tasks
-            .sender
-            .unbounded_send(SchedulerMsg::TaskNotified(id))
-            .expect("Scheduler should exist");
-
-        self.spawned_tasks.borrow_mut().insert(id);
-
-        id
+        self.tasks.spawn(ScopeId::ROOT, fut)
     }
 
     /// Informs the scheduler that this task is no longer needed and should be removed.


### PR DESCRIPTION
Spawn forever currently removes the future that was spanned when the component is dropped. This changes spawn forever to not add the future to the list of futures that are removed when the component is removed.

Fixes this issue reported on discord:
```
I made a repo with a minimum reproducible example (https://github.com/lukasturcani/dioxus-future-issue) -- the long and short of it is that if I spawn a future with onclick my future reaches an await point but then never gets completed. 

I tried using both spawn and spawn_forever, as well as just returning the future from the onclick handler -- all lead to the same results. the interesting thing is -- this only happens if my onclick is nested inside a custom component. (the repo has both the working and non working code)
```