### PR TITLE
Bump the version of Salvo

### DIFF
--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -26,7 +26,7 @@ tower = { version = "0.4.13", features = ["util"], optional = true }
 axum-macros = "0.3.7"
 
 # salvo
-salvo = { version = "0.46.0", optional = true, features = ["serve-static", "websocket", "compression"] }
+salvo = { version = "0.63.0", optional = true, features = ["serve-static", "websocket", "compression"] }
 serde = "1.0.159"
 
 # Dioxus + SSR

--- a/packages/fullstack/examples/salvo-hello-world/Cargo.toml
+++ b/packages/fullstack/examples/salvo-hello-world/Cargo.toml
@@ -12,7 +12,7 @@ dioxus = { workspace = true }
 dioxus-fullstack = { workspace = true }
 tokio = { workspace = true, features = ["full"], optional = true }
 serde = "1.0.159"
-salvo = { version = "0.37.9", optional = true }
+salvo = { version = "0.63.0", optional = true }
 execute = "0.2.12"
 reqwest = "0.11.18"
 simple_logger = "4.2.0"

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -34,7 +34,7 @@ warp = { version = "0.3.3", optional = true }
 axum = { version = "0.6.1", optional = true, features = ["ws"] }
 
 # salvo
-salvo = { version = "0.44.1", optional = true, features = ["ws"] }
+salvo = { version = "0.63.0", optional = true, features = ["websocket"] }
 once_cell = "1.17.1"
 async-trait = "0.1.71"
 
@@ -49,7 +49,7 @@ tokio = { workspace = true, features = ["full"] }
 dioxus = { workspace = true }
 warp = "0.3.3"
 axum = { version = "0.6.1", features = ["ws"] }
-salvo = { version = "0.44.1", features = ["affix", "ws"] }
+salvo = { version = "0.63.0", features = ["affix", "websocket"] }
 tower = "0.4.13"
 
 [features]


### PR DESCRIPTION
The old version of Salvo we depend on broke which is causing CI failures in https://github.com/DioxusLabs/dioxus/pull/1727, https://github.com/DioxusLabs/dioxus/pull/1369, and https://github.com/DioxusLabs/dioxus/actions/runs/7277746350/job/19830455478?pr=1736. This PR bumps the version of Salvo to the most recent release to fix the issue