### PR TITLE
Partial hydration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "packages/fullstack",
     "packages/server-macro",
     "packages/fullstack/examples/axum-hello-world",
+    "packages/fullstack/examples/axum-islands",
     "packages/fullstack/examples/axum-router",
     "packages/fullstack/examples/axum-desktop",
     "packages/fullstack/examples/axum-auth",

--- a/packages/core-macro/Cargo.toml
+++ b/packages/core-macro/Cargo.toml
@@ -29,3 +29,5 @@ trybuild = "1.0"
 
 [features]
 default = []
+islands = []
+ssr = []

--- a/packages/core-macro/src/component_body_deserializers/component.rs
+++ b/packages/core-macro/src/component_body_deserializers/component.rs
@@ -62,7 +62,19 @@ impl ToTokens for ComponentDeserializerOutput {
         let props_struct = &self.props_struct;
 
         if !self.island && cfg!(all(feature = "islands", not(feature = "ssr"))) {
-            return;
+            // if this is not an island, we snip the body of the component function and replace it with unreachable!()
+            let sig = &comp_fn.sig;
+            let attrs = &comp_fn.attrs;
+            let vis = &comp_fn.vis;
+            tokens.append_all(quote! {
+                #props_struct
+
+                #[allow(non_snake_case)]
+                #(#attrs)*
+                #vis #sig {
+                    unreachable!()
+                }
+            });
         }
 
         tokens.append_all(quote! {

--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -35,6 +35,9 @@ dioxus-ssr = { workspace = true, optional = true }
 hyper = { version = "0.14.25", optional = true }
 http = { version = "0.2.9", optional = true }
 
+# Islands
+dioxus-core-macro = { workspace = true, optional = true }
+
 # Web Integration
 dioxus-web = { workspace = true, features = ["hydrate"], optional = true }
 
@@ -79,9 +82,10 @@ desktop = ["dioxus-desktop"]
 warp = ["dep:warp", "ssr"]
 axum = ["dep:axum", "tower-http", "ssr"]
 salvo = ["dep:salvo", "ssr"]
-ssr = ["server_fn/ssr", "dioxus_server_macro/ssr", "tokio", "tokio-util", "dioxus-ssr", "tower", "hyper", "http", "http-body", "dioxus-router/ssr", "tokio-stream"]
+ssr = ["server_fn/ssr", "dioxus_server_macro/ssr", "tokio", "tokio-util", "dioxus-ssr", "tower", "hyper", "http", "http-body", "dioxus-router/ssr", "tokio-stream", "dioxus-core-macro?/ssr"]
 default-tls = ["server_fn/default-tls"]
 rustls = ["server_fn/rustls"]
+islands = ["dioxus-core-macro"]
 
 [dev-dependencies]
 dioxus-fullstack = { path = ".", features = ["router"] }

--- a/packages/fullstack/examples/axum-islands/.gitignore
+++ b/packages/fullstack/examples/axum-islands/.gitignore
@@ -1,0 +1,4 @@
+/.dioxus
+dist
+target
+static

--- a/packages/fullstack/examples/axum-islands/Cargo.toml
+++ b/packages/fullstack/examples/axum-islands/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "axum-islands"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dioxus = { workspace = true }
+dioxus-fullstack = { features = ["islands"], workspace = true }
+axum = { version = "0.6.12", optional = true }
+serde = "1.0.159"
+simple_logger = "4.2.0"
+tracing-wasm = "0.2.1"
+tracing.workspace = true
+tracing-subscriber = "0.3.17"
+reqwest = "0.11.18"
+
+[features]
+default = []
+ssr = ["axum", "dioxus-fullstack/axum"]
+web = ["dioxus-fullstack/web"]

--- a/packages/fullstack/examples/axum-islands/src/main.rs
+++ b/packages/fullstack/examples/axum-islands/src/main.rs
@@ -1,0 +1,39 @@
+//! Run with:
+//!
+//! ```sh
+//! dx build --features web --release
+//! cargo run --features ssr --release
+//! ```
+
+#![allow(non_snake_case, unused)]
+use dioxus::prelude::*;
+use dioxus_fullstack::{
+    launch::{self, LaunchBuilder},
+    prelude::*,
+};
+use serde::{Deserialize, Serialize};
+
+#[component]
+fn app(cx: Scope) -> Element {
+    let text =
+        use_server_future(cx, (), |()| async move { get_server_data().await.unwrap() })?.value();
+
+    #[cfg(not(feature = "ssr"))]
+    panic!("This component will only ever be rendered on the server!");
+
+    cx.render(rsx! { Child { state: text.clone() } })
+}
+
+#[component(island)]
+fn Child(cx: Scope, state: String) -> Element {
+    cx.render(rsx! {"State: {state}"})
+}
+
+#[server]
+async fn get_server_data() -> Result<String, ServerFnError> {
+    Ok(reqwest::get("https://httpbin.org/ip").await?.text().await?)
+}
+
+fn main() {
+    LaunchBuilder::new(app).launch()
+}


### PR DESCRIPTION
This PR adds support for Islands to dioxus fullstack.

Islands let you only include and hydrate some interactive components in your final binary which can help shrink the bundle size of your final WASM binary. This can be very important for sites that are mostly static like the [docsite](https://dioxuslabs.com/learn)

This is based off of the improved hydration in #1732 