### PR TITLE
Implemented From<Signal<T>> for ReadOnlySignal<T>

### DIFF
--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -495,3 +495,9 @@ impl<T> Deref for ReadOnlySignal<T> {
         reference_to_closure as &Self::Target
     }
 }
+
+impl<T> From<Signal<T>> for ReadOnlySignal<T> {
+    fn from(signal: Signal<T>) -> Self {
+        Self::new(signal)
+    }
+}


### PR DESCRIPTION
I noticed I couldn't convert a Signal into a ReadOnlySignal with .into()

This implements the trait that enables that.