### PR TITLE
Add doc comment on generated inline properties struct

### DIFF
--- a/packages/core-macro/src/component_body_deserializers/component.rs
+++ b/packages/core-macro/src/component_body_deserializers/component.rs
@@ -58,8 +58,11 @@ impl ToTokens for ComponentDeserializerOutput {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         let comp_fn = &self.comp_fn;
         let props_struct = &self.props_struct;
+        let fn_ident = &comp_fn.sig.ident;
 
+        let doc = format!("Properties for the [`{fn_ident}`] component.");
         tokens.append_all(quote! {
+            #[doc = #doc]
             #props_struct
             #[allow(non_snake_case)]
             #comp_fn


### PR DESCRIPTION
Adds a doc comment to the derived properties struct generated from the inline arguments of the component.

This prevents the `missing_docs` lint to trigger if that is setup for a project (for instance, a CI might prevent progress by denying all lint warnings). This could probably be extended to provide custom doc comments to the struct, or use the doc comment of the component function, but I didn't see the need for that, as this PR will include a link to the original component function in the docs for further info.