### PR TITLE
Add Cargo Arguments and Cross-Architecture Support

### DIFF
--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -93,6 +93,8 @@ pub fn build(config: &CrateConfig, quiet: bool) -> Result<BuildResult> {
         cmd
     };
 
+    let cmd = cmd.args(&config.cargo_args);
+
     let cmd = match executable {
         ExecutableType::Binary(name) => cmd.arg("--bin").arg(name),
         ExecutableType::Lib(name) => cmd.arg("--lib").arg(name),
@@ -285,6 +287,8 @@ pub fn build_desktop(config: &CrateConfig, _is_serve: bool) -> Result<BuildResul
         let features_str = config.features.as_ref().unwrap().join(" ");
         cmd = cmd.arg("--features").arg(features_str);
     }
+
+    let cmd = cmd.args(&config.cargo_args);
 
     let cmd = match &config.executable {
         crate::ExecutableType::Binary(name) => cmd.arg("--bin").arg(name),

--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -288,11 +288,11 @@ pub fn build_desktop(config: &CrateConfig, _is_serve: bool) -> Result<BuildResul
         cmd = cmd.arg("--features").arg(features_str);
     }
 
-    if let Some(platform_triple) = &config.platform_triple {
-        cmd = cmd.arg("--target").arg(platform_triple);
+    if let Some(target) = &config.target {
+        cmd = cmd.arg("--target").arg(target);
     }
 
-    let target_platform = config.platform_triple.as_deref().unwrap_or("");
+    let target_platform = config.target.as_deref().unwrap_or("");
 
     cmd = cmd.args(&config.cargo_args);
 

--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -288,7 +288,13 @@ pub fn build_desktop(config: &CrateConfig, _is_serve: bool) -> Result<BuildResul
         cmd = cmd.arg("--features").arg(features_str);
     }
 
-    let cmd = cmd.args(&config.cargo_args);
+    if let Some(platform_triple) = &config.platform_triple {
+        cmd = cmd.arg("--target").arg(platform_triple);
+    }
+
+    let target_platform = config.platform_triple.as_deref().unwrap_or("");
+
+    cmd = cmd.args(&config.cargo_args);
 
     let cmd = match &config.executable {
         crate::ExecutableType::Binary(name) => cmd.arg("--bin").arg(name),
@@ -307,12 +313,17 @@ pub fn build_desktop(config: &CrateConfig, _is_serve: bool) -> Result<BuildResul
     let mut res_path = match &config.executable {
         crate::ExecutableType::Binary(name) | crate::ExecutableType::Lib(name) => {
             file_name = name.clone();
-            config.target_dir.join(release_type).join(name)
+            config
+                .target_dir
+                .join(target_platform)
+                .join(release_type)
+                .join(name)
         }
         crate::ExecutableType::Example(name) => {
             file_name = name.clone();
             config
                 .target_dir
+                .join(target_platform)
                 .join(release_type)
                 .join("examples")
                 .join(name)

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -37,8 +37,8 @@ impl Build {
             .platform
             .unwrap_or(crate_config.dioxus_config.application.default_platform);
 
-        if let Some(platform_triple) = self.build.platform_triple {
-            crate_config.set_platform_triple(platform_triple);
+        if let Some(target) = self.build.target {
+            crate_config.set_target(target);
         }
 
         crate_config.set_cargo_args(self.build.cargo_args);

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -37,6 +37,10 @@ impl Build {
             .platform
             .unwrap_or(crate_config.dioxus_config.application.default_platform);
 
+        if let Some(platform_triple) = self.build.platform_triple {
+            crate_config.set_platform_triple(platform_triple);
+        }
+
         crate_config.set_cargo_args(self.build.cargo_args);
 
         // #[cfg(feature = "plugin")]

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -37,6 +37,8 @@ impl Build {
             .platform
             .unwrap_or(crate_config.dioxus_config.application.default_platform);
 
+        crate_config.set_cargo_args(self.build.cargo_args);
+
         // #[cfg(feature = "plugin")]
         // let _ = PluginManager::on_build_start(&crate_config, &platform);
 

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -76,6 +76,12 @@ impl Bundle {
             crate_config.set_profile(self.build.profile.unwrap());
         }
 
+        if let Some(platform_triple) = self.build.platform_triple {
+            crate_config.set_platform_triple(platform_triple);
+        }
+
+        crate_config.set_cargo_args(self.build.cargo_args);
+
         // build the desktop app
         build_desktop(&crate_config, false)?;
 

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -154,6 +154,7 @@ impl Bundle {
                     .collect(),
             );
         }
+
         let settings = settings.build();
 
         // on macos we need to set CI=true (https://github.com/tauri-apps/tauri/issues/2567)
@@ -162,9 +163,9 @@ impl Bundle {
 
         tauri_bundler::bundle::bundle_project(settings.unwrap()).unwrap_or_else(|err|{
             #[cfg(target_os = "macos")]
-            panic!("Failed to bundle project: {}\nMake sure you have automation enabled in your terminal (https://github.com/tauri-apps/tauri/issues/3055#issuecomment-1624389208) and full disk access enabled for your terminal (https://github.com/tauri-apps/tauri/issues/3055#issuecomment-1624389208)", err);
+            panic!("Failed to bundle project: {:#?}\nMake sure you have automation enabled in your terminal (https://github.com/tauri-apps/tauri/issues/3055#issuecomment-1624389208) and full disk access enabled for your terminal (https://github.com/tauri-apps/tauri/issues/3055#issuecomment-1624389208)", err);
             #[cfg(not(target_os = "macos"))]
-            panic!("Failed to bundle project: {}", err);
+            panic!("Failed to bundle project: {:#?}", err);
         });
 
         Ok(())

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -76,8 +76,8 @@ impl Bundle {
             crate_config.set_profile(self.build.profile.unwrap());
         }
 
-        if let Some(platform_triple) = &self.build.platform_triple {
-            crate_config.set_platform_triple(platform_triple.to_string());
+        if let Some(target) = &self.build.target {
+            crate_config.set_target(target.to_string());
         }
 
         crate_config.set_cargo_args(self.build.cargo_args);
@@ -155,8 +155,8 @@ impl Bundle {
             );
         }
 
-        if let Some(platform_triple) = &self.build.platform_triple {
-            settings = settings.target(platform_triple.to_string());
+        if let Some(target) = &self.build.target {
+            settings = settings.target(target.to_string());
         }
 
         let settings = settings.build();

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -76,8 +76,8 @@ impl Bundle {
             crate_config.set_profile(self.build.profile.unwrap());
         }
 
-        if let Some(platform_triple) = self.build.platform_triple {
-            crate_config.set_platform_triple(platform_triple);
+        if let Some(platform_triple) = &self.build.platform_triple {
+            crate_config.set_platform_triple(platform_triple.to_string());
         }
 
         crate_config.set_cargo_args(self.build.cargo_args);
@@ -153,6 +153,10 @@ impl Bundle {
                     .map(|p| p.parse::<PackageType>().unwrap().into())
                     .collect(),
             );
+        }
+
+        if let Some(platform_triple) = &self.build.platform_triple {
+            settings = settings.target(platform_triple.to_string());
         }
 
         let settings = settings.build();

--- a/packages/cli/src/cli/cfg.rs
+++ b/packages/cli/src/cli/cfg.rs
@@ -6,11 +6,6 @@ use super::*;
 /// Config options for the build system.
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 pub struct ConfigOptsBuild {
-    /// The index HTML file to drive the bundling process [default: index.html]
-    #[arg(long)]
-    pub target: Option<PathBuf>,
-
-    /// Build in release mode [default: false]
     #[clap(long)]
     #[serde(default)]
     pub release: bool,
@@ -36,9 +31,9 @@ pub struct ConfigOptsBuild {
     #[clap(long)]
     pub features: Option<Vec<String>>,
 
-    /// Rustc platform triple (equivalent to cargo build --target)
+    /// Rustc platform triple
     #[clap(long)]
-    pub platform_triple: Option<String>,
+    pub target: Option<String>,
 
     /// Extra arguments passed to cargo build
     #[clap(last = true)]
@@ -47,11 +42,6 @@ pub struct ConfigOptsBuild {
 
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 pub struct ConfigOptsServe {
-    /// The index HTML file to drive the bundling process [default: index.html]
-    #[arg(short, long)]
-    pub target: Option<PathBuf>,
-
-    /// Port of dev server
     #[clap(long)]
     #[clap(default_value_t = 8080)]
     pub port: u16,
@@ -98,9 +88,9 @@ pub struct ConfigOptsServe {
     #[clap(long)]
     pub features: Option<Vec<String>>,
 
-    /// Rustc platform triple (equivalent to cargo build --target)
+    /// Rustc platform triple
     #[clap(long)]
-    pub platform_triple: Option<String>,
+    pub target: Option<String>,
 
     /// Extra arguments passed to cargo build
     #[clap(last = true)]
@@ -146,9 +136,9 @@ pub struct ConfigOptsBundle {
     #[clap(long)]
     pub features: Option<Vec<String>>,
 
-    /// Rustc platform triple (equivalent to cargo build --target)
+    /// Rustc platform triple
     #[clap(long)]
-    pub platform_triple: Option<String>,
+    pub target: Option<String>,
 
     /// Extra arguments passed to cargo build
     #[clap(last = true)]

--- a/packages/cli/src/cli/cfg.rs
+++ b/packages/cli/src/cli/cfg.rs
@@ -35,6 +35,10 @@ pub struct ConfigOptsBuild {
     /// Space separated list of features to activate
     #[clap(long)]
     pub features: Option<Vec<String>>,
+
+    /// Extra arguments passed to cargo build
+    #[clap(last = true)]
+    pub cargo_args: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
@@ -89,6 +93,10 @@ pub struct ConfigOptsServe {
     /// Space separated list of features to activate
     #[clap(long)]
     pub features: Option<Vec<String>>,
+
+    /// Extra arguments passed to cargo build
+    #[clap(last = true)]
+    pub cargo_args: Vec<String>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Serialize, Deserialize, Debug)]
@@ -129,4 +137,8 @@ pub struct ConfigOptsBundle {
     /// Space separated list of features to activate
     #[clap(long)]
     pub features: Option<Vec<String>>,
+
+    /// Extra arguments passed to cargo build
+    #[clap(last = true)]
+    pub cargo_args: Vec<String>,
 }

--- a/packages/cli/src/cli/cfg.rs
+++ b/packages/cli/src/cli/cfg.rs
@@ -36,6 +36,10 @@ pub struct ConfigOptsBuild {
     #[clap(long)]
     pub features: Option<Vec<String>>,
 
+    /// Rustc platform triple (equivalent to cargo build --target)
+    #[clap(long)]
+    pub platform_triple: Option<String>,
+
     /// Extra arguments passed to cargo build
     #[clap(last = true)]
     pub cargo_args: Vec<String>,
@@ -94,6 +98,10 @@ pub struct ConfigOptsServe {
     #[clap(long)]
     pub features: Option<Vec<String>>,
 
+    /// Rustc platform triple (equivalent to cargo build --target)
+    #[clap(long)]
+    pub platform_triple: Option<String>,
+
     /// Extra arguments passed to cargo build
     #[clap(last = true)]
     pub cargo_args: Vec<String>,
@@ -137,6 +145,10 @@ pub struct ConfigOptsBundle {
     /// Space separated list of features to activate
     #[clap(long)]
     pub features: Option<Vec<String>>,
+
+    /// Rustc platform triple (equivalent to cargo build --target)
+    #[clap(long)]
+    pub platform_triple: Option<String>,
 
     /// Extra arguments passed to cargo build
     #[clap(last = true)]

--- a/packages/cli/src/cli/cfg.rs
+++ b/packages/cli/src/cli/cfg.rs
@@ -6,6 +6,7 @@ use super::*;
 /// Config options for the build system.
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 pub struct ConfigOptsBuild {
+    /// Build in release mode [default: false]
     #[clap(long)]
     #[serde(default)]
     pub release: bool,
@@ -42,6 +43,7 @@ pub struct ConfigOptsBuild {
 
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 pub struct ConfigOptsServe {
+    /// Port of dev server
     #[clap(long)]
     #[clap(default_value_t = 8080)]
     pub port: u16,

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -34,8 +34,8 @@ impl Serve {
         // Subdirectories don't work with the server
         crate_config.dioxus_config.web.app.base_path = None;
 
-        if let Some(platform_triple) = self.serve.platform_triple {
-            crate_config.set_platform_triple(platform_triple);
+        if let Some(target) = self.serve.target {
+            crate_config.set_target(target);
         }
 
         crate_config.set_cargo_args(self.serve.cargo_args);

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -34,6 +34,12 @@ impl Serve {
         // Subdirectories don't work with the server
         crate_config.dioxus_config.web.app.base_path = None;
 
+        if let Some(platform_triple) = self.serve.platform_triple {
+            crate_config.set_platform_triple(platform_triple);
+        }
+
+        crate_config.set_cargo_args(self.serve.cargo_args);
+
         let platform = self
             .serve
             .platform

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -211,7 +211,7 @@ pub struct CrateConfig {
     pub verbose: bool,
     pub custom_profile: Option<String>,
     pub features: Option<Vec<String>>,
-    pub platform_triple: Option<String>,
+    pub target: Option<String>,
     pub cargo_args: Vec<String>,
 }
 
@@ -280,7 +280,7 @@ impl CrateConfig {
         let verbose = false;
         let custom_profile = None;
         let features = None;
-        let platform_triple = None;
+        let target = None;
         let cargo_args = vec![];
 
         Ok(Self {
@@ -298,7 +298,7 @@ impl CrateConfig {
             custom_profile,
             features,
             verbose,
-            platform_triple,
+            target,
             cargo_args,
         })
     }
@@ -338,8 +338,8 @@ impl CrateConfig {
         self
     }
 
-    pub fn set_platform_triple(&mut self, platform_triple: String) -> &mut Self {
-        self.platform_triple = Some(platform_triple);
+    pub fn set_target(&mut self, target: String) -> &mut Self {
+        self.target = Some(target);
         self
     }
 

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -211,6 +211,7 @@ pub struct CrateConfig {
     pub verbose: bool,
     pub custom_profile: Option<String>,
     pub features: Option<Vec<String>>,
+    pub cargo_args: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -278,6 +279,7 @@ impl CrateConfig {
         let verbose = false;
         let custom_profile = None;
         let features = None;
+        let cargo_args = vec![];
 
         Ok(Self {
             out_dir,
@@ -294,6 +296,7 @@ impl CrateConfig {
             custom_profile,
             features,
             verbose,
+            cargo_args,
         })
     }
 
@@ -329,6 +332,11 @@ impl CrateConfig {
 
     pub fn set_features(&mut self, features: Vec<String>) -> &mut Self {
         self.features = Some(features);
+        self
+    }
+
+    pub fn set_cargo_args(&mut self, cargo_args: Vec<String>) -> &mut Self {
+        self.cargo_args = cargo_args;
         self
     }
 }

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -211,6 +211,7 @@ pub struct CrateConfig {
     pub verbose: bool,
     pub custom_profile: Option<String>,
     pub features: Option<Vec<String>>,
+    pub platform_triple: Option<String>,
     pub cargo_args: Vec<String>,
 }
 
@@ -279,6 +280,7 @@ impl CrateConfig {
         let verbose = false;
         let custom_profile = None;
         let features = None;
+        let platform_triple = None;
         let cargo_args = vec![];
 
         Ok(Self {
@@ -296,6 +298,7 @@ impl CrateConfig {
             custom_profile,
             features,
             verbose,
+            platform_triple,
             cargo_args,
         })
     }
@@ -332,6 +335,11 @@ impl CrateConfig {
 
     pub fn set_features(&mut self, features: Vec<String>) -> &mut Self {
         self.features = Some(features);
+        self
+    }
+
+    pub fn set_platform_triple(&mut self, platform_triple: String) -> &mut Self {
+        self.platform_triple = Some(platform_triple);
         self
     }
 


### PR DESCRIPTION
Changes apply for the CLI actions `build`, `bundle`, and `serve`. Adds `-- [CARGO_FLAGS]` and `--platform-triple`.

Cargo arguments can now be passed through after `--` (e.g. `dx build -- --timings`)  via escaped conditionals. This does lock out that space for any later usage without a breaking change to the CLI, but I can't think of any other necessary use for post-argument parsing on this tool.

Since the `--target` flag is currently taken, a `--platform-triple` flag allows alternative values for `cargo build --target`. This can't be done directly in passthrough, since dioxus-cli needs to know the output folder. If reasonable, the existing `--target` flag should probably be renamed so we can be 1:1 with cargo naming.

If the codebase has any other instances where bundled anyhow errors are flattened by "{}" they should probably be replaced with "{:?}" or "{:#?}" -- this caused a lot of confusion trying to bundle my first Dioxus project.

Closes #1693, closes #1347