### PR TITLE
Fix non string layout attributes in rink

### DIFF
--- a/packages/rink/src/layout.rs
+++ b/packages/rink/src/layout.rs
@@ -92,10 +92,10 @@ impl State for TaffyLayout {
                     attribute, value, ..
                 } in attributes
                 {
-                    if let Some(text) = value.as_text() {
+                    if value.as_custom().is_none() {
                         apply_layout_attributes_cfg(
                             &attribute.name,
-                            text,
+                            &value.to_string(),
                             &mut style,
                             &LayoutConfigeration {
                                 border_widths: BorderWidths {


### PR DESCRIPTION
The current rink code only applies layout attributes when they are a string, not a literal `bool`, `f32`, or `i23`. This PR fixes that bug

Fixes #1780