### PR TITLE
Updated packages and comments referencing old CLI location

### DIFF
--- a/examples/tailwind/README.md
+++ b/examples/tailwind/README.md
@@ -7,7 +7,7 @@ This example shows how an app might be styled with TailwindCSS.
 1. Install the Dioxus CLI:
 
 ```bash
-cargo install --git https://github.com/DioxusLabs/cli
+cargo install dioxus-cli
 ```
 
 2. Install npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

--- a/packages/cli/src/assets/autoreload.js
+++ b/packages/cli/src/assets/autoreload.js
@@ -1,5 +1,5 @@
 // Dioxus-CLI
-// https://github.com/DioxusLabs/cli
+// https://github.com/DioxusLabs/dioxus/tree/master/packages/cli
 
 (function () {
   var protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';

--- a/packages/hot-reload/README.md
+++ b/packages/hot-reload/README.md
@@ -68,7 +68,7 @@ rsx! {
 
 ## Usage
 
-> This crate implements hot reloading for native compilation targets not WASM. For hot relaoding with the web renderer, see the [dioxus-cli](https://github.com/DioxusLabs/cli) project.
+> This crate implements hot reloading for native compilation targets not WASM. For hot relaoding with the web renderer, see the [dioxus-cli](https://github.com/DioxusLabs/dioxus/tree/master/packages/cli) project.
 
 Add this to the top of your main function on any renderer that supports hot reloading to start the hot reloading server:
 


### PR DESCRIPTION
Fixes #1785 

I also found one more place that looked like it was using the old path:

```
packages/extension/package.json
12:        "url": "https://github.com/DioxusLabs/cli"
```

But as this was a documentation fix I didn't want to touch it in this PR.