### PR TITLE
Fix the ondouble click event

### DIFF
--- a/packages/html/src/events.rs
+++ b/packages/html/src/events.rs
@@ -6,7 +6,7 @@ macro_rules! impl_event {
         $data:ty;
         $(
             $( #[$attr:meta] )*
-            $name:ident
+            $name:ident $(: $js_name:literal)?
         )*
     ) => {
         $(
@@ -14,7 +14,7 @@ macro_rules! impl_event {
             #[inline]
             pub fn $name<'a, E: crate::EventReturn<T>, T>(_cx: &'a ::dioxus_core::ScopeState, mut _f: impl FnMut(::dioxus_core::Event<$data>) -> E + 'a) -> ::dioxus_core::Attribute<'a> {
                 ::dioxus_core::Attribute::new(
-                    stringify!($name),
+                    impl_event!(@name $name $($js_name)?),
                     _cx.listener(move |e: ::dioxus_core::Event<crate::PlatformEventData>| {
                         _f(e.map(|e|e.into())).spawn(_cx);
                     }),
@@ -23,6 +23,13 @@ macro_rules! impl_event {
                 )
             }
         )*
+    };
+
+    (@name $name:ident $js_name:literal) => {
+        $js_name
+    };
+    (@name $name:ident) => {
+        stringify!($name)
     };
 }
 

--- a/packages/html/src/events/mouse.rs
+++ b/packages/html/src/events/mouse.rs
@@ -78,6 +78,8 @@ impl_event! {
     #[deprecated(since = "0.5.0", note = "use ondoubleclick instead")]
     ondblclick
 
+    ondoubleclick: "ondblclick"
+
     /// onmousedown
     onmousedown
 
@@ -102,21 +104,6 @@ impl_event! {
     onmouseup
 }
 
-/// ondoubleclick
-#[inline]
-pub fn ondoubleclick<'a, E: crate::EventReturn<T>, T>(
-    _cx: &'a ::dioxus_core::ScopeState,
-    mut _f: impl FnMut(::dioxus_core::Event<MouseData>) -> E + 'a,
-) -> ::dioxus_core::Attribute<'a> {
-    ::dioxus_core::Attribute::new(
-        "ondblclick",
-        _cx.listener(move |e: ::dioxus_core::Event<MouseData>| {
-            _f(e).spawn(_cx);
-        }),
-        None,
-        false,
-    )
-}
 
 impl MouseData {
     /// Create a new instance of MouseData


### PR DESCRIPTION
Some merge issues between the new event system and the ondouble click fix caused the event to break again. This PR fixes it and includes an option to rename the event in the event macro