### PR TITLE
fix: no project-name in argument of `dx create`

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,13 +35,13 @@ cargo install --path . --debug
 
 ## Get started
 
-Use `dx create project-name` to initialize a new Dioxus project.
+Use `dx create` to initialize a new Dioxus project.
 It will be cloned from the [dioxus-template](https://github.com/DioxusLabs/dioxus-template) repository.
 
 Alternatively, you can specify the template path:
 
 ```shell
-dx create hello --template gh:dioxuslabs/dioxus-template
+dx create --template gh:dioxuslabs/dioxus-template
 ```
 
 Run `dx --help` for a list of all the available commands.


### PR DESCRIPTION
The CLI tool `dx` doesn't have an argument `project-name`

```sh
$ dx create --help
Init a new project for Dioxus

Usage: dx create [OPTIONS]

Options:
      --template <TEMPLATE>  Template path [default: gh:dioxuslabs/dioxus-template]
      --bin <BIN>            Specify bin target
  -h, --help                 Print help
  ```
  
  ```sh
$ dx create my-project
error: unexpected argument 'my-project' found

Usage: dx create [OPTIONS]

For more information, try '--help'.
```