### PR TITLE
check for duplicate event listeners in the rsx macro

### DIFF
--- a/packages/autofmt/tests/samples/attributes.rsx
+++ b/packages/autofmt/tests/samples/attributes.rsx
@@ -12,18 +12,6 @@ rsx! {
             let blah = 120;
             true
         },
-        onclick: move |_| {
-            let blah = 120;
-            true
-        },
-        onclick: move |_| {
-            let blah = 120;
-            true
-        },
-        onclick: move |_| {
-            let blah = 120;
-            true
-        },
         div {
             div { "hi" }
             h2 { class: "asd" }

--- a/packages/autofmt/tests/samples/complex.rsx
+++ b/packages/autofmt/tests/samples/complex.rsx
@@ -6,7 +6,7 @@ rsx! {
             show_user_menu.set(!show_user_menu.get());
             evt.cancel_bubble();
         },
-        onclick: move |evt| show_user_menu.set(!show_user_menu.get()),
+        onmousedown: move |evt| show_user_menu.set(!show_user_menu.get()),
         span { class: "inline-block mr-4", icons::icon_14 {} }
         span { "Settings" }
     }

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -401,13 +401,6 @@ impl VirtualDom {
                                 }
                             }
                         });
-
-                        // Break if this is the exact target element.
-                        // This means we won't call two listeners with the same name on the same element. This should be
-                        // documented, or be rejected from the rsx! macro outright
-                        if target_path == this_path {
-                            break;
-                        }
                     }
                 }
 

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -95,6 +95,27 @@ impl Parse for Element {
                 let span = content.span();
 
                 if name_str.starts_with("on") {
+                    // check for any duplicate event listeners
+                    if attributes.iter().any(|f| {
+                        if let AttributeType::Named(ElementAttrNamed {
+                            attr:
+                                ElementAttr {
+                                    name: ElementAttrName::BuiltIn(n),
+                                    value: ElementAttrValue::EventTokens(_),
+                                },
+                            ..
+                        }) = f
+                        {
+                            n == &name_str
+                        } else {
+                            false
+                        }
+                    }) {
+                        return Err(syn::Error::new(
+                            name.span(),
+                            format!("Duplicate event listener `{}`", name),
+                        ));
+                    }
                     attributes.push(attribute::AttributeType::Named(ElementAttrNamed {
                         el_name: el_name.clone(),
                         attr: ElementAttr {


### PR DESCRIPTION
Our current way of deduplicating event listeners at runtime is flawed. We stop once we reach the first dynamic attribute at the event path instead waiting for the first event listeners. This PR fixes that issue by moving duplicate event listener detection to compile time in the rsx macro

fixes https://github.com/DioxusLabs/dioxus/issues/1811