### PR TITLE
Disable muda until https://github.com/tauri-apps/muda/issues/128 is fixed

### DIFF
--- a/packages/desktop/src/menubar.rs
+++ b/packages/desktop/src/menubar.rs
@@ -1,7 +1,10 @@
+#![allow(unused)]
+
 use tao::window::Window;
 
 #[allow(unused)]
 pub fn build_menu(window: &Window, default_menu_bar: bool) {
+    // TODO: re enable this once https://github.com/tauri-apps/muda/issues/128 is fixed or we find a workaround
     // if default_menu_bar {
     //     #[cfg(not(any(target_os = "ios", target_os = "android")))]
     //     impl_::build_menu_bar(impl_::build_default_menu_bar(), window)

--- a/packages/desktop/src/menubar.rs
+++ b/packages/desktop/src/menubar.rs
@@ -2,10 +2,10 @@ use tao::window::Window;
 
 #[allow(unused)]
 pub fn build_menu(window: &Window, default_menu_bar: bool) {
-    if default_menu_bar {
-        #[cfg(not(any(target_os = "ios", target_os = "android")))]
-        impl_::build_menu_bar(impl_::build_default_menu_bar(), window)
-    }
+    // if default_menu_bar {
+    //     #[cfg(not(any(target_os = "ios", target_os = "android")))]
+    //     impl_::build_menu_bar(impl_::build_default_menu_bar(), window)
+    // }
 }
 
 #[cfg(not(any(target_os = "ios", target_os = "android")))]


### PR DESCRIPTION
This is a very short term fix for https://github.com/tauri-apps/muda/issues/128. It just disables muda for now to fix a crash in dioxus desktop. In the next few days we can find out what in muda is crashing and try to patch it on the dioxus side if possible