### PR TITLE
Enable serde dependency in the html crate even if eval is disabled

### DIFF
--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -52,6 +52,8 @@ serde_json = "1"
 [features]
 default = ["serialize", "mounted", "eval"]
 serialize = [
+    "serde",
+    "serde_json",
     "serde_repr",
     "euclid/serde",
     "keyboard-types/serde",


### PR DESCRIPTION
This fixes the dioxus tui renderer. The HTML crate uses serde if the `serialize` feature is enabled but it only enables the serde dependency if the `eval` feature is enabled. This PR changes the features so that serde is enabled if either `eval` or `serialize` is enabled