### PR TITLE
dioxus-cli: Fix panic when using dev profile

### DIFF
--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -117,8 +117,13 @@ pub fn build(config: &CrateConfig, _: bool, skip_assets: bool) -> Result<BuildRe
     // [2] Establish the output directory structure
     let bindgen_outdir = out_dir.join("assets").join("dioxus");
 
-    let build_profile = if config.custom_profile.is_some() {
-        config.custom_profile.as_ref().unwrap()
+    let build_target = if config.custom_profile.is_some() {
+        let build_profile = config.custom_profile.as_ref().unwrap();
+        if build_profile == "dev" {
+            "debug"
+        } else {
+            build_profile
+        }
     } else if config.release {
         "release"
     } else {
@@ -127,11 +132,11 @@ pub fn build(config: &CrateConfig, _: bool, skip_assets: bool) -> Result<BuildRe
 
     let input_path = match executable {
         ExecutableType::Binary(name) | ExecutableType::Lib(name) => target_dir
-            .join(format!("wasm32-unknown-unknown/{}", build_profile))
+            .join(format!("wasm32-unknown-unknown/{}", build_target))
             .join(format!("{}.wasm", name)),
 
         ExecutableType::Example(name) => target_dir
-            .join(format!("wasm32-unknown-unknown/{}/examples", build_profile))
+            .join(format!("wasm32-unknown-unknown/{}/examples", build_target))
             .join(format!("{}.wasm", name)),
     };
 


### PR DESCRIPTION
When using the dev profile in dioxus-cli (i.e. `dx build --profile dev --platform web`) it will panic saying that path `target/wasm32-unknown-unknown/dev/..` does not exist. This is because the build target for the dev profile is `debug` and not `dev`. This PR fixes that by mapping the build profile to the correct build target.

I tried building dioxus-cli to test that this works, but I am met with the following build error:

```
The following warnings were emitted during compilation:

warning: rav1e@0.7.1: Unable to run nasm: No such file or directory (os error 2)

error: failed to run custom build command for `rav1e v0.7.1`

Caused by:
  process didn't exit successfully: `/Users/lidin/Documents/Projekt/dioxus/target/release/build/rav1e-7f05fd8e16f8cdbd/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-cfg=nasm_x86_64
  cargo:warning=Unable to run nasm: No such file or directory (os error 2)

  --- stderr
  thread 'main' panicked at /Users/lidin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rav1e-0.7.1/build.rs:147:7:
  NASM build failed. Make sure you have nasm installed or disable the "asm" feature.
  You can get NASM from https://nasm.us or your system's package manager.

  error: Unable to run nasm: No such file or directory (os error 2)
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```

Is this a known error?