### PR TITLE
dioxus-web: Add `Config::rootelement`

### DIFF
--- a/packages/web/src/cfg.rs
+++ b/packages/web/src/cfg.rs
@@ -10,7 +10,7 @@
 pub struct Config {
     #[cfg(feature = "hydrate")]
     pub(crate) hydrate: bool,
-    pub(crate) rootname: String,
+    pub(crate) root: ConfigRoot,
     pub(crate) cached_strings: Vec<String>,
     pub(crate) default_panic_hook: bool,
 }
@@ -20,7 +20,7 @@ impl Default for Config {
         Self {
             #[cfg(feature = "hydrate")]
             hydrate: false,
-            rootname: "main".to_string(),
+            root: ConfigRoot::RootName("main".to_string()),
             cached_strings: Vec::new(),
             default_panic_hook: true,
         }
@@ -50,8 +50,18 @@ impl Config {
     /// Set the name of the element that Dioxus will use as the root.
     ///
     /// This is akin to calling React.render() on the element with the specified name.
+    /// Note that this only works on the current document, i.e. `window.document`.
+    /// To use a different document (popup, iframe, ...) use [Self::rootelement] instead.
     pub fn rootname(mut self, name: impl Into<String>) -> Self {
-        self.rootname = name.into();
+        self.root = ConfigRoot::RootName(name.into());
+        self
+    }
+
+    /// Set the element that Dioxus will use as root.
+    ///
+    /// This is akin to calling React.render() on the given element.
+    pub fn rootelement(mut self, elem: web_sys::Element) -> Self {
+        self.root = ConfigRoot::RootElement(elem);
         self
     }
 
@@ -71,4 +81,9 @@ impl Config {
         self.default_panic_hook = f;
         self
     }
+}
+
+pub(crate) enum ConfigRoot {
+    RootName(String),
+    RootElement(web_sys::Element),
 }


### PR DESCRIPTION
This PR affects dioxus-web and allows to specify a direct element as dom-root. Before, it was necessary to specify the element by ID. This is annoying, for example if the element was created dynamically.

It is now possible to directly specify the element:
```rust
let doc = web_sys::window().unwrap().document().unwrap();
let elem = doc.get_element_by_id("main").unwrap();

use dioxus_web::Config;
dioxus_web::launch_cfg(App, Config::new().rootelement(elem));
```
This is equivalent to
```rust
use dioxus_web::Config;
dioxus_web::launch_cfg(App, Config::new().rootname("main"));
```

The old approaches still work. This PR just adds the new method `Config::rootelement`. It is necessary for dynamically created elements, for example in shadow roots.

# Open problems
Unfortunately, it still does not work with iframes and popup windows, because of a nice JavaScript detail: JavaScript types like `Object`, `Element`, `Node`, ... are tied to a window. Therefore, JavaScript code like the following will print "false":

```javascript
let iframe = /* ... */;
let elem = iframe.content_document.get_element_by_id("main");
console.log(elem instanceOf Element); // false :(
```

This behaviour obviously transfers to WASM, i.e. the following code panics:

```rust
let iframe: web_sys::HtmlIFrameElement = /* ... */;
let document = iframe.content_document().unwrap(); // ok, but tied to another window
let body = document.body().unwrap(); // ok, HtmlElement
let body: web_sys::Element = body.dyn_into().unwrap(); // panics :(
```

The last line is necessary because we need to cast `HtmlElement` to `Element`. Unfortunately, this does not work, because rust does not support "Runtime types", for example types which are tied to specific windows which are created at runtime.

Note that the problem is only caused by the fact that `dyn_into` uses the `instanceOf` operator to check if the cast is ok. Just using `body.into()` works fine. I adjusted all places in `dioxus-web`, and it worked fine with both iframes and popup windows 🚀🚀🚀

However, this may be a little too risky for this PR. Maybe I'll add another after this one.

# Issues
Closes #1848 