### PR TITLE
Mark hot-reload flag incompatible with release

### DIFF
--- a/packages/cli/src/cli/cfg.rs
+++ b/packages/cli/src/cli/cfg.rs
@@ -78,6 +78,7 @@ impl From<ConfigOptsServe> for ConfigOptsBuild {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
+#[command(group = clap::ArgGroup::new("release-incompatible").multiple(true).conflicts_with("release"))]
 pub struct ConfigOptsServe {
     /// Port of dev server
     #[clap(long)]
@@ -116,8 +117,9 @@ pub struct ConfigOptsServe {
     #[clap(long, value_enum)]
     pub platform: Option<Platform>,
 
-    /// Build with hot reloading rsx [default: false]
+    /// Build with hot reloading rsx. Will not work with release builds. [default: false]
     #[clap(long)]
+    #[clap(group = "release-incompatible")]
     #[serde(default)]
     pub hot_reload: bool,
 


### PR DESCRIPTION
- added a new group to `ConfigOptsServe` that conflicts with `release`
- added `hot_reload` to the group
- changed help comment of `hot_reload`

Using `--hot-reload` option with `--release` now shows:

```
error: the argument '--release' cannot be used with '--hot-reload'

Usage: dx.exe serve --release [-- <CARGO_ARGS>...]

For more information, try '--help'.
```

Also reflected on help:
```
--hot-reload
  Build with hot reloading rsx. Will not work with release builds. [default: false]
```

Instead of my approach, the `"release-incompatible"` group could also be refactored into a struct using the '#[group]' macro, moving the incompatible arguments inside and flattening them to the `ConfigOptsServe` struct.

closes #1757