### PR TITLE
Add `isComposing` support

### DIFF
--- a/packages/desktop/headless_tests/events.rs
+++ b/packages/desktop/headless_tests/events.rs
@@ -154,7 +154,7 @@ fn app(cx: Scope) -> Element {
         ctrlKey: false,
         metaKey: false,
         shiftKey: false,
-        isComposing: false,
+        isComposing: true,
         which: 65,
         bubbles: true,
         })"#,
@@ -356,6 +356,7 @@ fn app(cx: Scope) -> Element {
                     assert_eq!(event.data.code().to_string(), "KeyA");
                     assert_eq!(event.data.location(), Location::Standard);
                     assert!(event.data.is_auto_repeating());
+                    assert!(event.data.is_composing());
                     received_events.modify(|x| *x + 1)
                 }
             }
@@ -368,6 +369,7 @@ fn app(cx: Scope) -> Element {
                     assert_eq!(event.data.code().to_string(), "KeyA");
                     assert_eq!(event.data.location(), Location::Standard);
                     assert!(!event.data.is_auto_repeating());
+                    assert!(!event.data.is_composing());
                     received_events.modify(|x| *x + 1)
                 }
             }
@@ -380,6 +382,7 @@ fn app(cx: Scope) -> Element {
                     assert_eq!(event.data.code().to_string(), "KeyA");
                     assert_eq!(event.data.location(), Location::Standard);
                     assert!(!event.data.is_auto_repeating());
+                    assert!(!event.data.is_composing());
                     received_events.modify(|x| *x + 1)
                 }
             }

--- a/packages/html/src/web_sys_bind/events.rs
+++ b/packages/html/src/web_sys_bind/events.rs
@@ -78,6 +78,10 @@ impl HasKeyboardData for KeyboardEvent {
         self.repeat()
     }
 
+    fn is_composing(&self) -> bool {
+        self.is_composing()
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/packages/interpreter/src/interpreter.js
+++ b/packages/interpreter/src/interpreter.js
@@ -351,6 +351,7 @@ async function serialize_event(event) {
     case "keyup": {
       let {
         charCode,
+        isComposing,
         key,
         altKey,
         ctrlKey,
@@ -364,6 +365,7 @@ async function serialize_event(event) {
       } = event;
       return {
         char_code: charCode,
+        is_composing: isComposing,
         key: key,
         alt_key: altKey,
         ctrl_key: ctrlKey,

--- a/packages/rink/src/hooks.rs
+++ b/packages/rink/src/hooks.rs
@@ -179,6 +179,7 @@ impl InnerInputState {
                         k.location(),
                         is_repeating,
                         k.modifiers(),
+                        k.is_composing(),
                     );
                 }
 
@@ -779,6 +780,7 @@ fn translate_key_event(event: crossterm::event::KeyEvent) -> Option<EventData> {
         Location::Standard,
         false,
         modifiers,
+        false,
     )))
 }
 


### PR DESCRIPTION
Added isComposing to the js interpreter and updated necessary implementations of keyboard logic.

Since crossterm doesn't seem to have a similar feature to isComposing from the KeyboardEvent web API, I've set the value to be false when translating a crossterm key event.

Also, looks like the code snippet in the docs [here](https://dioxuslabs.com/learn/0.4/cookbook/custom_renderer#event-loop) will need to reflect the changes. I can create a pr for that once this pr is resolved 👍 

closes #1857 