### PR TITLE
fix: initialize linux wry webview

### DIFF
--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -91,7 +91,28 @@ impl WebviewInstance {
             }
         };
 
-        let mut webview = WebViewBuilder::new(&window)
+        #[cfg(any(
+            target_os = "windows",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "android"
+        ))]
+        let mut webview = WebViewBuilder::new(&window);
+
+        #[cfg(not(any(
+            target_os = "windows",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "android"
+        )))]
+        let mut webview = {
+            use tao::platform::unix::WindowExtUnix;
+            use wry::WebViewBuilderExtUnix;
+            let vbox = window.default_vbox().unwrap();
+            WebViewBuilder::new_gtk(vbox)
+        };
+
+        webview = webview
             .with_transparent(cfg.window.window.transparent)
             .with_url("dioxus://index.html/")
             .unwrap()


### PR DESCRIPTION
In the wry 0.32 examples the linux webviews are initialized in a different way to render properly using
tao::platform::unix::WindowExtUnix. Tested with Gnome 45.3 and Wayland.

The changes was taken from the wry example files like https://github.com/tauri-apps/wry/blob/7234b2b99a8efc59484c96b767f3be8b52127816/examples/simple.rs#L16