### PR TITLE
Converted `out_dir` and `asset_dir` fields to methods in `CrateConfig` (cli-config refactor)

### DIFF
--- a/packages/cli-config/src/config.rs
+++ b/packages/cli-config/src/config.rs
@@ -338,11 +338,9 @@ pub struct WebHttpsConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CrateConfig {
-    pub out_dir: PathBuf,
     pub crate_dir: PathBuf,
     pub workspace_dir: PathBuf,
     pub target_dir: PathBuf,
-    pub asset_dir: PathBuf,
     #[cfg(feature = "cli")]
     pub manifest: cargo_toml::Manifest<cargo_toml::Value>,
     pub executable: ExecutableType,
@@ -383,11 +381,7 @@ impl CrateConfig {
         let workspace_dir = meta.workspace_root;
         let target_dir = meta.target_directory;
 
-        let out_dir = crate_dir.join(&dioxus_config.application.out_dir);
-
         let cargo_def = &crate_dir.join("Cargo.toml");
-
-        let asset_dir = crate_dir.join(&dioxus_config.application.asset_dir);
 
         let manifest = cargo_toml::Manifest::from_path(cargo_def).unwrap();
 
@@ -414,6 +408,7 @@ impl CrateConfig {
 
         let release = false;
         let hot_reload = false;
+        let cross_origin_policy = false;
         let verbose = false;
         let custom_profile = None;
         let features = None;
@@ -421,24 +416,36 @@ impl CrateConfig {
         let cargo_args = vec![];
 
         Ok(Self {
-            out_dir,
             crate_dir,
             workspace_dir,
             target_dir,
-            asset_dir,
             #[cfg(feature = "cli")]
             manifest,
             executable,
-            release,
             dioxus_config,
+            release,
             hot_reload,
-            cross_origin_policy: false,
+            cross_origin_policy,
+            verbose,
             custom_profile,
             features,
-            verbose,
             target,
             cargo_args,
         })
+    }
+
+    /// Compose an asset directory. Represents the typical "public" directory
+    /// with publicly available resources (configurable in the `Dioxus.toml`).
+    pub fn asset_dir(&self) -> PathBuf {
+        self.crate_dir
+            .join(&self.dioxus_config.application.asset_dir)
+    }
+
+    /// Compose an out directory. Represents the typical "dist" directory that
+    /// is "distributed" after building an application (configurable in the
+    /// `Dioxus.toml`).
+    pub fn out_dir(&self) -> PathBuf {
+        self.crate_dir.join(&self.dioxus_config.application.out_dir)
     }
 
     pub fn as_example(&mut self, example_name: String) -> &mut Self {

--- a/packages/cli/src/assets.rs
+++ b/packages/cli/src/assets.rs
@@ -13,7 +13,7 @@ pub fn asset_manifest(crate_config: &CrateConfig) -> AssetManifest {
 
 /// Create a head file that contains all of the imports for assets that the user project uses
 pub fn create_assets_head(config: &CrateConfig, manifest: &AssetManifest) -> Result<()> {
-    let mut file = File::create(config.out_dir.join("__assets_head.html"))?;
+    let mut file = File::create(config.out_dir().join("__assets_head.html"))?;
     file.write_all(manifest.head().as_bytes())?;
     Ok(())
 }
@@ -29,7 +29,7 @@ pub(crate) fn process_assets(config: &CrateConfig, manifest: &AssetManifest) -> 
             .clone()
             .unwrap_or_default(),
     );
-    let static_asset_output_dir = config.out_dir.join(static_asset_output_dir);
+    let static_asset_output_dir = config.out_dir().join(static_asset_output_dir);
 
     manifest.copy_static_assets_to(static_asset_output_dir)?;
 

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -87,7 +87,7 @@ impl Bundle {
         build_desktop(&crate_config, false, false)?;
 
         // copy the binary to the out dir
-        let package = crate_config.manifest.package.unwrap();
+        let package = crate_config.manifest.package.as_ref().unwrap();
 
         let mut name: PathBuf = match &crate_config.executable {
             ExecutableType::Binary(name)
@@ -149,7 +149,7 @@ impl Bundle {
         }
 
         let mut settings = SettingsBuilder::new()
-            .project_out_directory(crate_config.out_dir)
+            .project_out_directory(crate_config.out_dir())
             .package_settings(PackageSettings {
                 product_name: crate_config.dioxus_config.application.name.clone(),
                 version: package.version().to_string(),

--- a/packages/cli/src/plugin/mod.rs
+++ b/packages/cli/src/plugin/mod.rs
@@ -184,8 +184,8 @@ impl PluginManager {
         let args = lua.create_table()?;
         args.set("name", crate_config.dioxus_config.application.name.clone())?;
         args.set("platform", platform)?;
-        args.set("out_dir", crate_config.out_dir.to_str().unwrap())?;
-        args.set("asset_dir", crate_config.asset_dir.to_str().unwrap())?;
+        args.set("out_dir", crate_config.out_dir().to_str().unwrap())?;
+        args.set("asset_dir", crate_config.asset_dir().to_str().unwrap())?;
 
         for i in 1..(manager.len()? as i32 + 1) {
             let info = manager.get::<i32, PluginInfo>(i)?;
@@ -208,8 +208,8 @@ impl PluginManager {
         let args = lua.create_table()?;
         args.set("name", crate_config.dioxus_config.application.name.clone())?;
         args.set("platform", platform)?;
-        args.set("out_dir", crate_config.out_dir.to_str().unwrap())?;
-        args.set("asset_dir", crate_config.asset_dir.to_str().unwrap())?;
+        args.set("out_dir", crate_config.out_dir().to_str().unwrap())?;
+        args.set("asset_dir", crate_config.asset_dir().to_str().unwrap())?;
 
         for i in 1..(manager.len()? as i32 + 1) {
             let info = manager.get::<i32, PluginInfo>(i)?;

--- a/packages/cli/src/server/desktop/mod.rs
+++ b/packages/cli/src/server/desktop/mod.rs
@@ -221,7 +221,7 @@ fn start_desktop(config: &CrateConfig, skip_assets: bool) -> Result<(RAIIChild, 
         ExecutableType::Binary(name)
         | ExecutableType::Lib(name)
         | ExecutableType::Example(name) => {
-            let mut file = config.out_dir.join(name);
+            let mut file = config.out_dir().join(name);
             if cfg!(windows) {
                 file.set_extension("exe");
             }

--- a/packages/cli/src/server/web/mod.rs
+++ b/packages/cli/src/server/web/mod.rs
@@ -290,7 +290,7 @@ async fn setup_router(
                         std::fs::read_to_string(
                             file_service_config
                                 .crate_dir
-                                .join(file_service_config.out_dir)
+                                .join(file_service_config.out_dir())
                                 .join("index.html"),
                         )
                         .ok()
@@ -315,7 +315,7 @@ async fn setup_router(
                 Ok(response)
             },
         )
-        .service(ServeDir::new(config.crate_dir.join(&config.out_dir)));
+        .service(ServeDir::new(config.crate_dir.join(config.out_dir())));
 
     // Setup websocket
     let mut router = Router::new().route("/_dioxus/ws", get(ws_handler));


### PR DESCRIPTION
`out_dir` and `asset_dir` are now methods, because they derive from `crate_dir` and `dioxus_config`. As a result a few other files had to be updated as well.
