### PR TITLE
Now fullstack client uses correct config via `dx build`

### DIFF
--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -71,7 +71,7 @@ impl Build {
                         }
                         None => web_config.features = Some(vec![web_feature]),
                     };
-                    crate::builder::build(&crate_config, false, self.build.skip_assets)?;
+                    crate::builder::build(&web_config, false, self.build.skip_assets)?;
                 }
                 {
                     let mut desktop_config = crate_config.clone();


### PR DESCRIPTION
The server already uses the correct config. Now the `./dist/binary` works as expected — all the buttons work.
