### PR TITLE
feat(cli): added short `release` build option

### DIFF
--- a/packages/cli/src/cli/cfg.rs
+++ b/packages/cli/src/cli/cfg.rs
@@ -6,7 +6,7 @@ use super::*;
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 pub struct ConfigOptsBuild {
     /// Build in release mode [default: false]
-    #[clap(long)]
+    #[clap(long, short)]
     #[serde(default)]
     pub release: bool,
 
@@ -159,7 +159,7 @@ pub struct ConfigOptsServe {
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 pub struct ConfigOptsBundle {
     /// Build in release mode [default: false]
-    #[clap(long)]
+    #[clap(long, short)]
     #[serde(default)]
     pub release: bool,
 


### PR DESCRIPTION
Same as `cargo build` has `-r` now `dx build` and `dx bundle` also have it. Since user probably wants to use these commands for production-ready artifacts, the `--release` option is probably used often, same as with `cargo build`. This allow users to use the same `build -r` "pattern".
