### PR TITLE
Implement Readable for mapped signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -422,7 +422,7 @@ dependencies = [
  "futures-io",
  "futures-lite 2.2.0",
  "parking",
- "polling 3.3.2",
+ "polling 3.4.0",
  "rustix 0.38.31",
  "slab",
  "tracing",
@@ -909,16 +909,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
-dependencies = [
- "byteorder",
- "safemem",
-]
-
-[[package]]
-name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -1158,9 +1148,9 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -1169,9 +1159,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1180,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.14.1"
+version = "1.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2490600f404f2b94c167e31d3ed1d5f3c225a0f3b80230053b3e0b7b962bd9"
+checksum = "ea31d69bda4949c1c1562c1e6f042a1caefac98cdc8a298260a2ff41c1e2d42b"
 
 [[package]]
 name = "byteorder"
@@ -1287,7 +1277,7 @@ dependencies = [
  "serde",
  "tempfile",
  "thiserror",
- "toml 0.8.9",
+ "toml 0.8.10",
  "walkdir",
 ]
 
@@ -1374,7 +1364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3f9629bc6c4388ea699781dc988c2b99766d7679b151c81990b4fa1208fafd3"
 dependencies = [
  "serde",
- "toml 0.8.9",
+ "toml 0.8.10",
 ]
 
 [[package]]
@@ -1384,7 +1374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "802b755090e39835a4b0440fb0bbee0df7495a8b337f63db21e616f7821c7e8c"
 dependencies = [
  "serde",
- "toml 0.8.9",
+ "toml 0.8.10",
 ]
 
 [[package]]
@@ -2438,7 +2428,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.8.9",
+ "toml 0.8.10",
  "toml_edit 0.21.1",
  "tower",
  "tower-http 0.2.5",
@@ -2885,7 +2875,7 @@ version = "0.4.3"
 dependencies = [
  "dioxus",
  "dioxus-core",
- "flume 0.11.0",
+ "flume",
  "futures-channel",
  "futures-util",
  "generational-box",
@@ -3299,12 +3289,12 @@ checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "exr"
-version = "1.6.4"
+version = "1.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279d3efcc55e19917fff7ab3ddd6c14afb6a90881a0078465196fe2f99d08c56"
+checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
 dependencies = [
  "bit_field",
- "flume 0.10.14",
+ "flume",
  "half 2.3.1",
  "lebe",
  "miniz_oxide",
@@ -3381,7 +3371,7 @@ dependencies = [
  "atomic 0.6.0",
  "pear",
  "serde",
- "toml 0.8.9",
+ "toml 0.8.10",
  "uncased",
  "version_check",
 ]
@@ -3418,19 +3408,6 @@ checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin 0.9.8",
 ]
 
 [[package]]
@@ -3927,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
  "bitflags 2.4.2",
  "libc",
@@ -4687,9 +4664,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
 
 [[package]]
 name = "hex"
@@ -4954,9 +4931,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5225,7 +5202,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi 0.3.5",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -5281,7 +5258,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi 0.3.5",
  "rustix 0.38.31",
  "windows-sys 0.52.0",
 ]
@@ -5298,9 +5275,9 @@ dependencies = [
 
 [[package]]
 name = "is_ci"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "itertools"
@@ -5406,9 +5383,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5561,9 +5538,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
@@ -6120,9 +6097,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
  "simd-adler32",
@@ -6271,15 +6248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
  "rand 0.8.5",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.12",
 ]
 
 [[package]]
@@ -6487,9 +6455,9 @@ dependencies = [
 
 [[package]]
 name = "num-derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6545,7 +6513,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.4",
+ "hermit-abi 0.3.5",
  "libc",
 ]
 
@@ -6968,9 +6936,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
 dependencies = [
  "memchr",
  "thiserror",
@@ -6979,9 +6947,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6989,9 +6957,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -7002,9 +6970,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.6"
+version = "2.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
 dependencies = [
  "once_cell",
  "pest",
@@ -7320,9 +7288,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
+checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -7754,7 +7722,7 @@ dependencies = [
  "nasm-rs",
  "new_debug_unreachable",
  "noop_proc_macro",
- "num-derive 0.4.1",
+ "num-derive 0.4.2",
  "num-traits",
  "once_cell",
  "paste",
@@ -7917,9 +7885,9 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
@@ -8071,9 +8039,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -8089,9 +8057,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9440,7 +9408,7 @@ checksum = "210976b7d948c7ba9fced8ca835b11cbb2d677c59c79de41ac0d397e14547490"
 dependencies = [
  "atoi",
  "chrono",
- "flume 0.11.0",
+ "flume",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -9667,7 +9635,7 @@ dependencies = [
  "cfg-expr 0.15.6",
  "heck 0.4.1",
  "pkg-config",
- "toml 0.8.9",
+ "toml 0.8.10",
  "version-compare",
 ]
 
@@ -9939,9 +9907,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe80ced77cbfb4cb91a94bf72b378b4b6791a0d9b7f09d0be747d1bdff4e68bd"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
  "itoa 1.0.10",
@@ -10158,15 +10126,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.1",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]
@@ -10207,6 +10175,17 @@ name = "toml_edit"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.2",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
  "indexmap 2.2.2",
  "serde",
@@ -10403,9 +10382,9 @@ dependencies = [
 
 [[package]]
 name = "treediff"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52984d277bdf2a751072b5df30ec0377febdb02f7696d64c2d7d54630bac4303"
+checksum = "4d127780145176e2b5d16611cc25a900150e86e9fd79d3bde6ff3a37359c9cb5"
 dependencies = [
  "serde_json",
 ]
@@ -10564,9 +10543,9 @@ dependencies = [
 
 [[package]]
 name = "ulid"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3c3b4dcec1e4729aab50688a1a0631483d79e65b194851425e7748287715a6"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
 dependencies = [
  "getrandom 0.2.12",
  "rand 0.8.5",
@@ -10621,9 +10600,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -10730,7 +10709,7 @@ checksum = "c372e4e6fad129795fb86fda6021b258948560b39883b80ed00510a7d19846b0"
 dependencies = [
  "cfg-if",
  "noop_proc_macro",
- "num-derive 0.4.1",
+ "num-derive 0.4.2",
  "num-traits",
  "profiling",
 ]
@@ -10882,9 +10861,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -10892,9 +10871,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
 dependencies = [
  "bumpalo",
  "log",
@@ -10907,12 +10886,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a875870b7b39024cbca8f61a0e1fc8edfe7ac02b484e5a9bcea64374050a850e"
+checksum = "806a045c4ec4ef7c3ad86dc27bcb641b84d9eeb3846200f56d7ab0885241d654"
 dependencies = [
  "anyhow",
- "base64 0.9.3",
+ "base64 0.21.7",
  "log",
  "rustc-demangle",
  "serde_json",
@@ -10929,9 +10908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-externref-xform"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c5d468dc79cfd824d181c386f34c2e7ea521ea5855ddd95af8f4cf3fa676f4"
+checksum = "12b6ac5fca1d0992d2328147488169ea166bfe899c88f8ad06cf583f4c492fcf"
 dependencies = [
  "anyhow",
  "walrus",
@@ -10939,9 +10918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -10951,9 +10930,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10961,9 +10940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10974,9 +10953,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-multi-value-xform"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f10c037dad45759d53b598d4737acdced90a0945023c8c6cd8d67b4b3e4eaf"
+checksum = "d1e019acde479e2f090fb7f14a51fa0077ec3a7bb12a56e0e888a82be7b5bd3f"
 dependencies = [
  "anyhow",
  "walrus",
@@ -10984,15 +10963,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139bd73305d50e1c1c4333210c0db43d989395b64a237bd35c10ef3832a7f70c"
+checksum = "143ddeb4f833e2ed0d252e618986e18bfc7b0e52f2d28d77d05b2f045dd8eb61"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -11004,9 +10983,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70072aebfe5da66d2716002c729a14e4aec4da0e23cc2ea66323dac541c93928"
+checksum = "a5211b7550606857312bba1d978a8ec75692eae187becc5e680444fffc5e6f89"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11015,9 +10994,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-threads-xform"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ddf1a4beb1bceb2b73c2325581901ca2cd92af628f24389a678854dcd65b24"
+checksum = "90a2e577034352f9aa9352730fcf2562c68957f2e9b9ee70ab6379510e49e2fe"
 dependencies = [
  "anyhow",
  "walrus",
@@ -11026,9 +11005,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-wasm-conventions"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f13ed8ccdac31eadcfd4c9b2ec7bd43e77454b14acb1f43189f2875a9b0391"
+checksum = "4e6b653f6820409609bda0f176e6949302307af7a7b9479cd4d4b1bdc31eb9cd"
 dependencies = [
  "anyhow",
  "walrus",
@@ -11036,9 +11015,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-wasm-interpreter"
-version = "0.2.90"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4282a271772a3063d4057c1144e118254f207fbbc1381b8d50b23c25585d893"
+checksum = "682940195a701dbf887f20017418b8cac916a37b3f91ededec33226619e973c1"
 dependencies = [
  "anyhow",
  "log",
@@ -11087,9 +11066,9 @@ checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11549,9 +11528,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "5389a154b01683d28c77f8f68f49dea75f0a4da32557a58f68ee51ebba472d29"
 dependencies = [
  "memchr",
 ]
@@ -11654,11 +11633,11 @@ dependencies = [
 
 [[package]]
 name = "xdg-home"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2769203cd13a0c6015d515be729c526d041e9cf2c0cc478d57faee85f40c6dcd"
+checksum = "21e5a325c3cb8398ad6cf859c1135b25dd29e186679cf2da7581d9679f63b38e"
 dependencies = [
- "nix 0.26.4",
+ "libc",
  "winapi",
 ]
 
@@ -11691,9 +11670,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "3.14.1"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31de390a2d872e4cd04edd71b425e29853f786dc99317ed72d73d6fcf5ebb948"
+checksum = "c45d06ae3b0f9ba1fb2671268b975557d8f5a84bb5ec6e43964f87e763d8bca8"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -11732,9 +11711,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "3.14.1"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d1794a946878c0e807f55a397187c11fc7a038ba5d868e7db4f3bd7760bc9d"
+checksum = "b4a1ba45ed0ad344b85a2bb5a1fe9830aed23d67812ea39a586e7d0136439c7d"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ reqwest = { version = "0.11.9", features = ["json"], optional = true}
 http-range = {version = "0.1.5", optional = true }
 
 [dev-dependencies]
-dioxus = { workspace = true, features = ["router"]}
+dioxus = { workspace = true, features = ["router"] }
 dioxus-ssr = { workspace = true }
 futures-util = "0.3.21"
 separator = "0.4.1"

--- a/packages/generational-box/src/lib.rs
+++ b/packages/generational-box/src/lib.rs
@@ -228,9 +228,9 @@ pub trait Storage<Data = ()>: AnyStorage + 'static {
 /// A trait for any storage backing type.
 pub trait AnyStorage: Default {
     /// The reference this storage type returns.
-    type Ref<T: ?Sized + 'static>: Deref<Target = T>;
+    type Ref<T: ?Sized + 'static>: Deref<Target = T> + 'static;
     /// The mutable reference this storage type returns.
-    type Mut<T: ?Sized + 'static>: DerefMut<Target = T>;
+    type Mut<T: ?Sized + 'static>: DerefMut<Target = T> + 'static;
 
     /// Try to map the mutable ref.
     fn try_map_mut<T: ?Sized, U: ?Sized + 'static>(
@@ -247,13 +247,16 @@ pub trait AnyStorage: Default {
     }
 
     /// Try to map the ref.
-    fn try_map<T, U: ?Sized + 'static>(
+    fn try_map<T: ?Sized, U: ?Sized + 'static>(
         ref_: Self::Ref<T>,
         f: impl FnOnce(&T) -> Option<&U>,
     ) -> Option<Self::Ref<U>>;
 
     /// Map the ref.
-    fn map<T, U: ?Sized + 'static>(ref_: Self::Ref<T>, f: impl FnOnce(&T) -> &U) -> Self::Ref<U> {
+    fn map<T: ?Sized, U: ?Sized + 'static>(
+        ref_: Self::Ref<T>,
+        f: impl FnOnce(&T) -> &U,
+    ) -> Self::Ref<U> {
         Self::try_map(ref_, |v| Some(f(v))).unwrap()
     }
 

--- a/packages/generational-box/src/sync.rs
+++ b/packages/generational-box/src/sync.rs
@@ -23,7 +23,7 @@ impl AnyStorage for SyncStorage {
     type Ref<R: ?Sized + 'static> = GenerationalRef<MappedRwLockReadGuard<'static, R>>;
     type Mut<W: ?Sized + 'static> = GenerationalRefMut<MappedRwLockWriteGuard<'static, W>>;
 
-    fn try_map<I, U: ?Sized + 'static>(
+    fn try_map<I: ?Sized, U: ?Sized + 'static>(
         ref_: Self::Ref<I>,
         f: impl FnOnce(&I) -> Option<&U>,
     ) -> Option<Self::Ref<U>> {

--- a/packages/generational-box/src/unsync.rs
+++ b/packages/generational-box/src/unsync.rs
@@ -92,7 +92,7 @@ impl AnyStorage for UnsyncStorage {
     type Ref<R: ?Sized + 'static> = GenerationalRef<Ref<'static, R>>;
     type Mut<W: ?Sized + 'static> = GenerationalRefMut<RefMut<'static, W>>;
 
-    fn try_map<I, U: ?Sized + 'static>(
+    fn try_map<I: ?Sized, U: ?Sized + 'static>(
         _self: Self::Ref<I>,
         f: impl FnOnce(&I) -> Option<&U>,
     ) -> Option<Self::Ref<U>> {

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -25,7 +25,7 @@ futures-util = { workspace = true }
 flume = { version = "0.11.0", default-features = false, features = ["async"] }
 
 [dev-dependencies]
-dioxus = { workspace = true }
+dioxus = { workspace = true, features = ["desktop"]}
 # dioxus-desktop = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.3.17"

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -25,8 +25,7 @@ futures-util = { workspace = true }
 flume = { version = "0.11.0", default-features = false, features = ["async"] }
 
 [dev-dependencies]
-dioxus = { workspace = true, features = ["desktop"]}
-# dioxus-desktop = { workspace = true }
+dioxus = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.3.17"
 simple_logger = "4.2.0"

--- a/packages/signals/examples/map_signal.rs
+++ b/packages/signals/examples/map_signal.rs
@@ -1,0 +1,51 @@
+#![allow(non_snake_case)]
+
+use dioxus::prelude::*;
+use dioxus_signals::Signal;
+
+fn main() {
+    launch(app);
+}
+
+fn app() -> Element {
+    let mut vec = use_signal(|| vec![0]);
+
+    rsx! {
+        button {
+            onclick: move |_| {
+                let mut write = vec.write();
+                let len = write.len() as i32;
+                write.push(len);
+            },
+            "Create"
+        }
+
+        button {
+            onclick: move |_| {
+                vec.write().pop();
+            },
+            "Destroy"
+        }
+
+        for i in 0..vec.len() {
+            Child { count: vec.map(move |v| &v[i]) }
+        }
+    }
+}
+
+#[component]
+fn Child(count: MappedSignal<i32, Signal<Vec<i32>>>) -> Element {
+    use_memo({
+        to_owned![count];
+        move || {
+            let value = count.read();
+            print!("Child value: {value}");
+        }
+    });
+
+    rsx! {
+        div {
+            "Child: {count}"
+        }
+    }
+}

--- a/packages/signals/examples/map_signal.rs
+++ b/packages/signals/examples/map_signal.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 
 use dioxus::prelude::*;
-use dioxus_signals::Signal;
 
 fn main() {
     launch(app);
@@ -34,12 +33,12 @@ fn app() -> Element {
 }
 
 #[component]
-fn Child(count: MappedSignal<i32, Signal<Vec<i32>>>) -> Element {
+fn Child(count: MappedSignal<i32>) -> Element {
     use_memo({
         to_owned![count];
         move || {
             let value = count.read();
-            print!("Child value: {value}");
+            println!("Child value: {value}");
         }
     });
 

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -13,6 +13,7 @@ use dioxus_core::ScopeId;
 
 use generational_box::{GenerationalBox, Owner, Storage};
 
+use crate::ReadableRef;
 use crate::Writable;
 use crate::{ReactiveContext, Readable};
 
@@ -206,27 +207,13 @@ impl<T: 'static, S: Storage<T>> CopyValue<T, S> {
 
 impl<T: 'static, S: Storage<T>> Readable for CopyValue<T, S> {
     type Target = T;
-    type Ref<R: ?Sized + 'static> = S::Ref<R>;
+    type Storage = S;
 
-    fn map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> &U>(
-        ref_: Self::Ref<I>,
-        f: F,
-    ) -> Self::Ref<U> {
-        S::map(ref_, f)
-    }
-
-    fn try_map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
-        ref_: Self::Ref<I>,
-        f: F,
-    ) -> Option<Self::Ref<U>> {
-        S::try_map(ref_, f)
-    }
-
-    fn try_read(&self) -> Result<S::Ref<T>, generational_box::BorrowError> {
+    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
         self.value.try_read()
     }
 
-    fn peek(&self) -> Self::Ref<T> {
+    fn peek(&self) -> ReadableRef<Self> {
         self.value.read()
     }
 }

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -204,14 +204,18 @@ impl<T: 'static, S: Storage<T>> CopyValue<T, S> {
     }
 }
 
-impl<T: 'static, S: Storage<T>> Readable<T> for CopyValue<T, S> {
+impl<T: 'static, S: Storage<T>> Readable for CopyValue<T, S> {
+    type Target = T;
     type Ref<R: ?Sized + 'static> = S::Ref<R>;
 
-    fn map_ref<I, U: ?Sized, F: FnOnce(&I) -> &U>(ref_: Self::Ref<I>, f: F) -> Self::Ref<U> {
+    fn map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> &U>(
+        ref_: Self::Ref<I>,
+        f: F,
+    ) -> Self::Ref<U> {
         S::map(ref_, f)
     }
 
-    fn try_map_ref<I, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
+    fn try_map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
         ref_: Self::Ref<I>,
         f: F,
     ) -> Option<Self::Ref<U>> {
@@ -227,17 +231,17 @@ impl<T: 'static, S: Storage<T>> Readable<T> for CopyValue<T, S> {
     }
 }
 
-impl<T: 'static, S: Storage<T>> Writable<T> for CopyValue<T, S> {
+impl<T: 'static, S: Storage<T>> Writable for CopyValue<T, S> {
     type Mut<R: ?Sized + 'static> = S::Mut<R>;
 
-    fn map_mut<I, U: ?Sized, F: FnOnce(&mut I) -> &mut U>(
+    fn map_mut<I: ?Sized, U: ?Sized, F: FnOnce(&mut I) -> &mut U>(
         mut_: Self::Mut<I>,
         f: F,
     ) -> Self::Mut<U> {
         S::map_mut(mut_, f)
     }
 
-    fn try_map_mut<I, U: ?Sized, F: FnOnce(&mut I) -> Option<&mut U>>(
+    fn try_map_mut<I: ?Sized, U: ?Sized, F: FnOnce(&mut I) -> Option<&mut U>>(
         mut_: Self::Mut<I>,
         f: F,
     ) -> Option<Self::Mut<U>> {

--- a/packages/signals/src/global/memo.rs
+++ b/packages/signals/src/global/memo.rs
@@ -51,14 +51,18 @@ impl<T: PartialEq + 'static> GlobalMemo<T> {
     }
 }
 
-impl<T: PartialEq + 'static> Readable<T> for GlobalMemo<T> {
+impl<T: PartialEq + 'static> Readable for GlobalMemo<T> {
+    type Target = T;
     type Ref<R: ?Sized + 'static> = generational_box::GenerationalRef<std::cell::Ref<'static, R>>;
 
-    fn map_ref<I, U: ?Sized, F: FnOnce(&I) -> &U>(ref_: Self::Ref<I>, f: F) -> Self::Ref<U> {
+    fn map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> &U>(
+        ref_: Self::Ref<I>,
+        f: F,
+    ) -> Self::Ref<U> {
         <UnsyncStorage as AnyStorage>::map(ref_, f)
     }
 
-    fn try_map_ref<I, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
+    fn try_map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
         ref_: Self::Ref<I>,
         f: F,
     ) -> Option<Self::Ref<U>> {

--- a/packages/signals/src/global/signal.rs
+++ b/packages/signals/src/global/signal.rs
@@ -2,11 +2,11 @@ use crate::read::Readable;
 use crate::write::Writable;
 use crate::Write;
 use dioxus_core::prelude::{IntoAttributeValue, ScopeId};
-use generational_box::{AnyStorage, GenerationalRef, UnsyncStorage};
-use std::{cell::Ref, mem::MaybeUninit, ops::Deref};
+use generational_box::{AnyStorage, UnsyncStorage};
+use std::{mem::MaybeUninit, ops::Deref};
 
 use super::get_global_context;
-use crate::{MappedSignal, Signal};
+use crate::Signal;
 
 /// A signal that can be accessed from anywhere in the application and created in a static
 pub struct GlobalSignal<T> {
@@ -58,15 +58,6 @@ impl<T: 'static> GlobalSignal<T> {
     #[track_caller]
     pub fn with_mut<O>(&self, f: impl FnOnce(&mut T) -> O) -> O {
         self.signal().with_mut(f)
-    }
-
-    /// Map the signal to a new type.
-    pub fn map<O>(
-        &self,
-        f: impl Fn(&T) -> &O + 'static,
-    ) -> MappedSignal<GenerationalRef<Ref<'static, O>>> {
-        // MappedSignal::new(self.signal(), f)
-        todo!()
     }
 
     /// Get the generational id of the signal.

--- a/packages/signals/src/global/signal.rs
+++ b/packages/signals/src/global/signal.rs
@@ -1,8 +1,8 @@
-use crate::read::Readable;
 use crate::write::Writable;
 use crate::Write;
+use crate::{read::Readable, ReadableRef};
 use dioxus_core::prelude::{IntoAttributeValue, ScopeId};
-use generational_box::{AnyStorage, UnsyncStorage};
+use generational_box::UnsyncStorage;
 use std::{mem::MaybeUninit, ops::Deref};
 
 use super::get_global_context;
@@ -68,29 +68,15 @@ impl<T: 'static> GlobalSignal<T> {
 
 impl<T: 'static> Readable for GlobalSignal<T> {
     type Target = T;
-    type Ref<R: ?Sized + 'static> = generational_box::GenerationalRef<std::cell::Ref<'static, R>>;
-
-    fn map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> &U>(
-        ref_: Self::Ref<I>,
-        f: F,
-    ) -> Self::Ref<U> {
-        <UnsyncStorage as AnyStorage>::map(ref_, f)
-    }
-
-    fn try_map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
-        ref_: Self::Ref<I>,
-        f: F,
-    ) -> Option<Self::Ref<U>> {
-        <UnsyncStorage as AnyStorage>::try_map(ref_, f)
-    }
+    type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read(&self) -> Result<Self::Ref<T>, generational_box::BorrowError> {
+    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
         self.signal().try_read()
     }
 
     #[track_caller]
-    fn peek(&self) -> Self::Ref<T> {
+    fn peek(&self) -> ReadableRef<Self> {
         self.signal().peek()
     }
 }

--- a/packages/signals/src/impls.rs
+++ b/packages/signals/src/impls.rs
@@ -3,7 +3,7 @@ use crate::read::Readable;
 use crate::signal::Signal;
 use crate::write::Writable;
 use crate::{GlobalMemo, GlobalSignal, MappedSignal, ReadOnlySignal, SignalData};
-use generational_box::Storage;
+use generational_box::{AnyStorage, Storage};
 
 use std::{
     fmt::{Debug, Display},
@@ -164,4 +164,4 @@ default_impl!(GlobalSignal);
 
 read_impls!(GlobalMemo: PartialEq);
 
-read_impls!(MappedSignal, S: Readable, S: Readable);
+read_impls!(MappedSignal, S: AnyStorage, S: AnyStorage);

--- a/packages/signals/src/map.rs
+++ b/packages/signals/src/map.rs
@@ -3,112 +3,105 @@ use crate::CopyValue;
 use crate::Signal;
 use crate::SignalData;
 use dioxus_core::ScopeId;
+use generational_box::AnyStorage;
 use generational_box::Storage;
+use generational_box::UnsyncStorage;
 use std::fmt::Debug;
 use std::fmt::Display;
 
 /// A read only signal that has been mapped to a new type.
-pub struct MappedSignal<U: 'static + ?Sized> {
-    origin_scope: ScopeId,
-    mapping: CopyValue<Box<dyn Fn() -> U>>,
+pub struct MappedSignal<U: ?Sized + 'static, S: AnyStorage = UnsyncStorage> {
+    mapping: CopyValue<Box<dyn Fn() -> S::Ref<U>>>,
 }
 
 impl MappedSignal<()> {
     /// Create a new mapped signal.
-    pub fn new<T, S, U>(
-        signal: Signal<T, S>,
-        mapping: impl Fn(&T) -> &U + 'static,
-    ) -> MappedSignal<S::Ref<U>>
+    pub fn new<R, T, S, U>(readable: R, mapping: impl Fn(&T) -> &U + 'static) -> MappedSignal<U, S>
     where
         S: Storage<SignalData<T>>,
         U: ?Sized,
     {
-        MappedSignal {
-            origin_scope: signal.origin_scope(),
-            mapping: CopyValue::new(Box::new(move || S::map(signal.read(), &mapping))),
-        }
+        todo!()
+        // MappedSignal {
+        //     mapping: CopyValue::new(Box::new(move || S::map(signal.read(), &mapping))),
+        // }
     }
 }
 
-impl<U> MappedSignal<U> {
-    /// Get the scope that the signal was created in.
-    pub fn origin_scope(&self) -> ScopeId {
-        self.origin_scope
-    }
+// impl<U: ?Sized> MappedSignal<U> {
+//     /// Get the current value of the signal. This will subscribe the current scope to the signal.
+//     pub fn read(&self) -> U {
+//         (self.mapping.read())()
+//     }
 
-    /// Get the current value of the signal. This will subscribe the current scope to the signal.
-    pub fn read(&self) -> U {
-        (self.mapping.read())()
-    }
+//     /// Run a closure with a reference to the signal's value.
+//     pub fn with<O>(&self, f: impl FnOnce(U) -> O) -> O {
+//         f(self.read())
+//     }
+// }
 
-    /// Run a closure with a reference to the signal's value.
-    pub fn with<O>(&self, f: impl FnOnce(U) -> O) -> O {
-        f(self.read())
-    }
-}
+// impl<U: ?Sized + Clone> MappedSignal<U> {
+//     /// Get the current value of the signal. This will subscribe the current scope to the signal.
+//     pub fn value(&self) -> U {
+//         self.read().clone()
+//     }
+// }
 
-impl<U: ?Sized + Clone> MappedSignal<U> {
-    /// Get the current value of the signal. This will subscribe the current scope to the signal.
-    pub fn value(&self) -> U {
-        self.read().clone()
-    }
-}
+// impl<U: ?Sized> PartialEq for MappedSignal<U> {
+//     fn eq(&self, other: &Self) -> bool {
+//         self.mapping == other.mapping
+//     }
+// }
 
-impl<U: ?Sized> PartialEq for MappedSignal<U> {
-    fn eq(&self, other: &Self) -> bool {
-        self.mapping == other.mapping
-    }
-}
+// impl<U> std::clone::Clone for MappedSignal<U> {
+//     fn clone(&self) -> Self {
+//         *self
+//     }
+// }
 
-impl<U> std::clone::Clone for MappedSignal<U> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
+// impl<U> Copy for MappedSignal<U> {}
 
-impl<U> Copy for MappedSignal<U> {}
+// impl<U: Display> Display for MappedSignal<U> {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         self.with(|v| Display::fmt(&v, f))
+//     }
+// }
 
-impl<U: Display> Display for MappedSignal<U> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.with(|v| Display::fmt(&v, f))
-    }
-}
+// impl<U: Debug> Debug for MappedSignal<U> {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         self.with(|v| Debug::fmt(&v, f))
+//     }
+// }
 
-impl<U: Debug> Debug for MappedSignal<U> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.with(|v| Debug::fmt(&v, f))
-    }
-}
+// impl<T> std::ops::Deref for MappedSignal<T> {
+//     type Target = dyn Fn() -> T;
 
-impl<T> std::ops::Deref for MappedSignal<T> {
-    type Target = dyn Fn() -> T;
+//     fn deref(&self) -> &Self::Target {
+//         // https://github.com/dtolnay/case-studies/tree/master/callable-types
 
-    fn deref(&self) -> &Self::Target {
-        // https://github.com/dtolnay/case-studies/tree/master/callable-types
+//         // First we create a closure that captures something with the Same in memory layout as Self (MaybeUninit<Self>).
+//         let uninit_callable = std::mem::MaybeUninit::<Self>::uninit();
+//         // Then move that value into the closure. We assume that the closure now has a in memory layout of Self.
+//         let uninit_closure = move || Self::read(unsafe { &*uninit_callable.as_ptr() });
 
-        // First we create a closure that captures something with the Same in memory layout as Self (MaybeUninit<Self>).
-        let uninit_callable = std::mem::MaybeUninit::<Self>::uninit();
-        // Then move that value into the closure. We assume that the closure now has a in memory layout of Self.
-        let uninit_closure = move || Self::read(unsafe { &*uninit_callable.as_ptr() });
+//         // Check that the size of the closure is the same as the size of Self in case the compiler changed the layout of the closure.
+//         let size_of_closure = std::mem::size_of_val(&uninit_closure);
+//         assert_eq!(size_of_closure, std::mem::size_of::<Self>());
 
-        // Check that the size of the closure is the same as the size of Self in case the compiler changed the layout of the closure.
-        let size_of_closure = std::mem::size_of_val(&uninit_closure);
-        assert_eq!(size_of_closure, std::mem::size_of::<Self>());
+//         // Then cast the lifetime of the closure to the lifetime of &self.
+//         fn cast_lifetime<'a, T>(_a: &T, b: &'a T) -> &'a T {
+//             b
+//         }
+//         let reference_to_closure = cast_lifetime(
+//             {
+//                 // The real closure that we will never use.
+//                 &uninit_closure
+//             },
+//             // We transmute self into a reference to the closure. This is safe because we know that the closure has the same memory layout as Self so &Closure == &Self.
+//             unsafe { std::mem::transmute(self) },
+//         );
 
-        // Then cast the lifetime of the closure to the lifetime of &self.
-        fn cast_lifetime<'a, T>(_a: &T, b: &'a T) -> &'a T {
-            b
-        }
-        let reference_to_closure = cast_lifetime(
-            {
-                // The real closure that we will never use.
-                &uninit_closure
-            },
-            // We transmute self into a reference to the closure. This is safe because we know that the closure has the same memory layout as Self so &Closure == &Self.
-            unsafe { std::mem::transmute(self) },
-        );
-
-        // Cast the closure to a trait object.
-        reference_to_closure as &Self::Target
-    }
-}
+//         // Cast the closure to a trait object.
+//         reference_to_closure as &Self::Target
+//     }
+// }

--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -54,14 +54,18 @@ impl<T: 'static, S: Storage<SignalData<T>>> ReadOnlySignal<T, S> {
     }
 }
 
-impl<T, S: Storage<SignalData<T>>> Readable<T> for ReadOnlySignal<T, S> {
+impl<T, S: Storage<SignalData<T>>> Readable for ReadOnlySignal<T, S> {
+    type Target = T;
     type Ref<R: ?Sized + 'static> = S::Ref<R>;
 
-    fn map_ref<I, U: ?Sized, F: FnOnce(&I) -> &U>(ref_: Self::Ref<I>, f: F) -> Self::Ref<U> {
+    fn map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> &U>(
+        ref_: Self::Ref<I>,
+        f: F,
+    ) -> Self::Ref<U> {
         S::map(ref_, f)
     }
 
-    fn try_map_ref<I, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
+    fn try_map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
         ref_: Self::Ref<I>,
         f: F,
     ) -> Option<Self::Ref<U>> {

--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -1,4 +1,4 @@
-use crate::{read::Readable, Signal, SignalData};
+use crate::{read::Readable, ReadableRef, Signal, SignalData};
 use std::ops::Deref;
 
 use dioxus_core::{prelude::IntoAttributeValue, ScopeId};
@@ -56,24 +56,10 @@ impl<T: 'static, S: Storage<SignalData<T>>> ReadOnlySignal<T, S> {
 
 impl<T, S: Storage<SignalData<T>>> Readable for ReadOnlySignal<T, S> {
     type Target = T;
-    type Ref<R: ?Sized + 'static> = S::Ref<R>;
-
-    fn map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> &U>(
-        ref_: Self::Ref<I>,
-        f: F,
-    ) -> Self::Ref<U> {
-        S::map(ref_, f)
-    }
-
-    fn try_map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
-        ref_: Self::Ref<I>,
-        f: F,
-    ) -> Option<Self::Ref<U>> {
-        S::try_map(ref_, f)
-    }
+    type Storage = S;
 
     #[track_caller]
-    fn try_read(&self) -> Result<Self::Ref<T>, generational_box::BorrowError> {
+    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
         self.inner.try_read()
     }
 

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -189,7 +189,8 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
 
     /// Map the signal to a new type.
     pub fn map<O>(self, f: impl Fn(&T) -> &O + 'static) -> MappedSignal<S::Ref<O>> {
-        MappedSignal::new(self, f)
+        // MappedSignal::new(self, f)
+        todo!()
     }
 
     /// Get the generational id of the signal.
@@ -198,14 +199,18 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
     }
 }
 
-impl<T, S: Storage<SignalData<T>>> Readable<T> for Signal<T, S> {
+impl<T, S: Storage<SignalData<T>>> Readable for Signal<T, S> {
+    type Target = T;
     type Ref<R: ?Sized + 'static> = S::Ref<R>;
 
-    fn map_ref<I, U: ?Sized, F: FnOnce(&I) -> &U>(ref_: Self::Ref<I>, f: F) -> Self::Ref<U> {
+    fn map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> &U>(
+        ref_: Self::Ref<I>,
+        f: F,
+    ) -> Self::Ref<U> {
         S::map(ref_, f)
     }
 
-    fn try_map_ref<I, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
+    fn try_map_ref<I: ?Sized, U: ?Sized, F: FnOnce(&I) -> Option<&U>>(
         ref_: Self::Ref<I>,
         f: F,
     ) -> Option<Self::Ref<U>> {
@@ -231,17 +236,21 @@ impl<T, S: Storage<SignalData<T>>> Readable<T> for Signal<T, S> {
     }
 }
 
-impl<T: 'static, S: Storage<SignalData<T>>> Writable<T> for Signal<T, S> {
+impl<T: 'static, S: Storage<SignalData<T>>> Writable for Signal<T, S> {
     type Mut<R: ?Sized + 'static> = Write<R, S>;
 
-    fn map_mut<I, U: ?Sized + 'static, F: FnOnce(&mut I) -> &mut U>(
+    fn map_mut<I: ?Sized, U: ?Sized + 'static, F: FnOnce(&mut I) -> &mut U>(
         ref_: Self::Mut<I>,
         f: F,
     ) -> Self::Mut<U> {
         Write::map(ref_, f)
     }
 
-    fn try_map_mut<I: 'static, U: ?Sized + 'static, F: FnOnce(&mut I) -> Option<&mut U>>(
+    fn try_map_mut<
+        I: ?Sized + 'static,
+        U: ?Sized + 'static,
+        F: FnOnce(&mut I) -> Option<&mut U>,
+    >(
         ref_: Self::Mut<I>,
         f: F,
     ) -> Option<Self::Mut<U>> {

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -1,6 +1,6 @@
 use crate::{
-    read::Readable, write::Writable, CopyValue, GlobalMemo, GlobalSignal, MappedSignal,
-    ReactiveContext, ReadOnlySignal,
+    read::Readable, write::Writable, CopyValue, GlobalMemo, GlobalSignal, ReactiveContext,
+    ReadOnlySignal,
 };
 use dioxus_core::{
     prelude::{flush_sync, spawn, IntoAttributeValue},
@@ -185,12 +185,6 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
             let mut subscribers = inner.subscribers.lock().unwrap();
             subscribers.retain(|reactive_context| reactive_context.mark_dirty())
         }
-    }
-
-    /// Map the signal to a new type.
-    pub fn map<O>(self, f: impl Fn(&T) -> &O + 'static) -> MappedSignal<S::Ref<O>> {
-        // MappedSignal::new(self, f)
-        todo!()
     }
 
     /// Get the generational id of the signal.


### PR DESCRIPTION
This PR makes mapped signals implement readable. It also restructures the readable and writable traits to make the target and storage types associated types which lets us remove generics and boilerplate in a few places.

The new version of Mapped signals also now works with any readable type including user types