### PR TITLE
Fix external links in dioxus desktop

### DIFF
--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -74,7 +74,7 @@ fn handle_edits_code() -> String {
         interpreter.replace_range(import_start..import_end, "");
     }
 
-    format!("{interpreter}\nconst config = new InterpreterConfig(false);")
+    format!("{interpreter}\nconst config = new InterpreterConfig(true);")
 }
 
 static DEFAULT_INDEX: &str = include_str!("./index.html");


### PR DESCRIPTION
Changes the config desktop uses to open links in the system browser instead of the current app to match the documented behavior

Closes https://github.com/DioxusLabs/dioxus/issues/1904