### PR TITLE
Fix client side suspense

### DIFF
--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -439,7 +439,7 @@ impl VirtualDom {
             self.process_events();
 
             // Now that we have collected all queued work, we should check if we have any dirty scopes. If there are not, then we can poll any queued futures
-            if !self.dirty_scopes.is_empty() || !self.suspended_scopes.is_empty() {
+            if !self.dirty_scopes.is_empty() {
                 return;
             }
 

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -162,9 +162,9 @@ pub async fn run(virtual_dom: VirtualDom, web_config: Config) {
             {
                 let mut hot_reload_next = hotreload_rx.select_next_some();
                 select! {
-                        _ = work => (None, None),
-                        new_template = hot_reload_next => (None, Some(new_template)),
-                        evt = rx_next => (Some(evt), None),
+                    _ = work => (None, None),
+                    new_template = hot_reload_next => (None, Some(new_template)),
+                    evt = rx_next => (Some(evt), None),
                 }
             }
             #[cfg(not(all(feature = "hot_reload", debug_assertions)))]

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -61,10 +61,7 @@ pub use crate::cfg::Config;
 #[cfg(feature = "file_engine")]
 pub use crate::file_engine::WebFileEngineExt;
 use dioxus_core::VirtualDom;
-use futures_util::{
-    future::{select, Either},
-    pin_mut, FutureExt, StreamExt,
-};
+use futures_util::{pin_mut, select, FutureExt, StreamExt};
 
 mod cfg;
 mod dom;
@@ -159,17 +156,21 @@ pub async fn run(virtual_dom: VirtualDom, web_config: Config) {
         let (mut res, template) = {
             let work = dom.wait_for_work().fuse();
             pin_mut!(work);
+            let mut rx_next = rx.select_next_some();
 
             #[cfg(all(feature = "hot_reload", debug_assertions))]
-            match select(work, select(hotreload_rx.next(), rx.next())).await {
-                Either::Left((_, _)) => (None, None),
-                Either::Right((Either::Left((new_template, _)), _)) => (None, new_template),
-                Either::Right((Either::Right((evt, _)), _)) => (evt, None),
+            {
+                let mut hot_reload_next = hotreload_rx.select_next_some();
+                select! {
+                        _ = work => (None, None),
+                        new_template = hot_reload_next => (None, Some(new_template)),
+                        evt = rx_next => (Some(evt), None),
+                }
             }
             #[cfg(not(all(feature = "hot_reload", debug_assertions)))]
-            match select(work, rx.next()).await {
-                Either::Left((_, _)) => (None, None),
-                Either::Right((evt, _)) => (evt, None),
+            select! {
+                _ = work => (None, None),
+                evt = rx_next => (Some(evt), None),
             }
         };
 


### PR DESCRIPTION
This PR fixes an infinite loop that happens when suspense starts on the client. Currently suspense causes tasks to stop being polled which makes suspense never resolve and causes an infinite loop. Stacked on #1925.

This example does not work on the git version of dioxus but does work in this PR:
```rust
use dioxus::prelude::*;
use serde::{Deserialize, Serialize};

fn app() -> Element {
    let mut count = use_signal(|| 1);

    rsx! {
        button { onclick: move |_| count += 1, "Up high!" }
        for i in 0..count() {
            Child {}
        }
    }
}

fn Child() -> Element {
    let server_future = use_server_future(get_server_data)?;
    rsx! {
        h1 { "Hello, World!" }
        "{server_future.state():?}"
    }
}

#[server]
async fn get_server_data() -> Result<String, ServerFnError> {
    Ok(reqwest::get("https://httpbin.org/ip").await?.text().await?)
}

fn main() {
    launch(app);
}
```