### PR TITLE
Warn the user if they try to launch without a renderer selected

### DIFF
--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -54,6 +54,8 @@ salvo = ["dioxus-fullstack?/salvo", "ssr", "dioxus-liveview?/salvo"]
 warp = ["dioxus-fullstack?/warp", "ssr", "dioxus-liveview?/warp"]
 rocket = ["dioxus-liveview?/rocket"]
 tui = ["dioxus-tui", "dioxus-config-macro/tui"]
+# This feature just disables the no-renderer-enabled warning
+third-party-renderer = []
 
 # This feature enables some nightly flags that make it more clear what structs/methods are available in each feature
 nightly-doc = []

--- a/packages/dioxus/build.rs
+++ b/packages/dioxus/build.rs
@@ -1,0 +1,47 @@
+fn main() {
+	// Warn the user if they enabled the launch feature without any renderers
+    if feature_enabled("launch") {
+		let liveview_renderers = [
+			"liveview",
+			"axum",
+			"salvo",
+			"warp",
+			"rocket",
+		];
+		let fullstack_renderers = [
+			"axum",
+			"salvo",
+			"warp",
+		];
+		let client_renderers = [
+			"desktop",
+			"mobile",
+			"web",
+			"tui",
+		];
+		let client_renderer_selected = client_renderers.iter().any(|renderer| feature_enabled(renderer));
+		if feature_enabled("fullstack") {
+			let server_fullstack_enabled = fullstack_renderers.iter().any(|renderer| feature_enabled(renderer));
+			if !server_fullstack_enabled && !client_renderer_selected {
+				println!("cargo:warning=You have enabled the launch and fullstack features, but have not enabled any renderers. The application will not be able to launch. Try enabling one of the following renderers: {} for the server or one of the following renderers: {} for the client.", fullstack_renderers.join(", "), client_renderers.join(", "));
+			}
+		}
+
+		if feature_enabled("liveview") {
+			let server_selected = liveview_renderers.iter().any(|renderer| feature_enabled(renderer));
+			if !server_selected {
+				println!("cargo:warning=You have enabled the launch and liveview features, but have not enabled any liveview renderers. The application will not be able to launch. Try enabling one of the following renderers: {}", liveview_renderers.join(", "));
+			}
+		}
+
+		if !client_renderer_selected {
+			println!("cargo:warning=You have enabled the launch feature, but have not enabled any client renderers. The application will not be able to launch. Try enabling one of the following renderers: {}, fullstack or liveview", client_renderers.join(", "));
+		}
+    }
+}
+
+fn feature_enabled(feature: &str) -> bool {
+	let feature = "CARGO_FEATURE_".to_owned() + &feature.to_uppercase().replace("-", "_");
+	println!("cargo:rerun-if-env-changed={}", feature);
+	std::env::var(feature).is_ok()
+}

--- a/packages/dioxus/build.rs
+++ b/packages/dioxus/build.rs
@@ -1,51 +1,42 @@
 fn main() {
-	// Warn the user if they enabled the launch feature without any renderers
+    // Warn the user if they enabled the launch feature without any renderers
     if feature_enabled("launch") {
-		if feature_enabled("third-party-renderer"){
-			return;
-		}
+        if feature_enabled("third-party-renderer") {
+            return;
+        }
 
-		let liveview_renderers = [
-			"liveview",
-			"axum",
-			"salvo",
-			"warp",
-			"rocket",
-		];
-		let fullstack_renderers = [
-			"axum",
-			"salvo",
-			"warp",
-		];
-		let client_renderers = [
-			"desktop",
-			"mobile",
-			"web",
-			"tui",
-		];
-		let client_renderer_selected = client_renderers.iter().any(|renderer| feature_enabled(renderer));
-		if feature_enabled("fullstack") {
-			let server_fullstack_enabled = fullstack_renderers.iter().any(|renderer| feature_enabled(renderer));
-			if !server_fullstack_enabled && !client_renderer_selected {
-				println!("cargo:warning=You have enabled the launch and fullstack features, but have not enabled any renderers. The application will not be able to launch. Try enabling one of the following renderers: {} for the server or one of the following renderers: {} for the client.", fullstack_renderers.join(", "), client_renderers.join(", "));
-			}
-		}
+        let liveview_renderers = ["liveview", "axum", "salvo", "warp", "rocket"];
+        let fullstack_renderers = ["axum", "salvo", "warp"];
+        let client_renderers = ["desktop", "mobile", "web", "tui"];
+        let client_renderer_selected = client_renderers
+            .iter()
+            .any(|renderer| feature_enabled(renderer));
+        if feature_enabled("fullstack") {
+            let server_fullstack_enabled = fullstack_renderers
+                .iter()
+                .any(|renderer| feature_enabled(renderer));
+            if !server_fullstack_enabled && !client_renderer_selected {
+                println!("cargo:warning=You have enabled the launch and fullstack features, but have not enabled any renderers. The application will not be able to launch. Try enabling one of the following renderers: {} for the server or one of the following renderers: {} for the client.", fullstack_renderers.join(", "), client_renderers.join(", "));
+            }
+        }
 
-		if feature_enabled("liveview") {
-			let server_selected = liveview_renderers.iter().any(|renderer| feature_enabled(renderer));
-			if !server_selected {
-				println!("cargo:warning=You have enabled the launch and liveview features, but have not enabled any liveview renderers. The application will not be able to launch. Try enabling one of the following renderers: {}", liveview_renderers.join(", "));
-			}
-		}
+        if feature_enabled("liveview") {
+            let server_selected = liveview_renderers
+                .iter()
+                .any(|renderer| feature_enabled(renderer));
+            if !server_selected {
+                println!("cargo:warning=You have enabled the launch and liveview features, but have not enabled any liveview renderers. The application will not be able to launch. Try enabling one of the following renderers: {}", liveview_renderers.join(", "));
+            }
+        }
 
-		if !client_renderer_selected {
-			println!("cargo:warning=You have enabled the launch feature, but have not enabled any client renderers. The application will not be able to launch. Try enabling one of the following renderers: {}, fullstack or liveview", client_renderers.join(", "));
-		}
+        if !client_renderer_selected {
+            println!("cargo:warning=You have enabled the launch feature, but have not enabled any client renderers. The application will not be able to launch. Try enabling one of the following renderers: {}, fullstack or liveview", client_renderers.join(", "));
+        }
     }
 }
 
 fn feature_enabled(feature: &str) -> bool {
-	let feature = "CARGO_FEATURE_".to_owned() + &feature.to_uppercase().replace("-", "_");
-	println!("cargo:rerun-if-env-changed={}", feature);
-	std::env::var(feature).is_ok()
+    let feature = "CARGO_FEATURE_".to_owned() + &feature.to_uppercase().replace('-', "_");
+    println!("cargo:rerun-if-env-changed={}", feature);
+    std::env::var(feature).is_ok()
 }

--- a/packages/dioxus/build.rs
+++ b/packages/dioxus/build.rs
@@ -1,6 +1,10 @@
 fn main() {
 	// Warn the user if they enabled the launch feature without any renderers
     if feature_enabled("launch") {
+		if feature_enabled("third-party-renderer"){
+			return;
+		}
+
 		let liveview_renderers = [
 			"liveview",
 			"axum",

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -211,6 +211,9 @@ mod current_platform {
         contexts: Vec<Box<super::ValidContext>>,
         platform_config: (),
     ) {
+        #[cfg(feature = "third-party-renderer")]
+        panic!("No first party renderer feature enabled. It looks like you are trying to use a third party renderer. You will need to use the launch function from the third party renderer crate.");
+
         panic!("No platform feature enabled. Please enable one of the following features: liveview, desktop, mobile, web, tui, fullstack to use the launch API.");
     }
 }

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -167,12 +167,20 @@ mod current_platform {
     #[cfg(feature = "fullstack")]
     pub use dioxus_fullstack::launch::*;
 
-    #[cfg(all(feature = "web", not(any(feature = "desktop", feature = "mobile", feature = "fullstack"))))]
+    #[cfg(all(
+        feature = "web",
+        not(any(feature = "desktop", feature = "mobile", feature = "fullstack"))
+    ))]
     pub use dioxus_web::launch::*;
 
     #[cfg(all(
         feature = "liveview",
-        not(any(feature = "web", feature = "desktop", feature = "mobile", feature = "fullstack"))
+        not(any(
+            feature = "web",
+            feature = "desktop",
+            feature = "mobile",
+            feature = "fullstack"
+        ))
     ))]
     pub use dioxus_liveview::launch::*;
 

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -161,15 +161,18 @@ mod current_platform {
     #[cfg(all(feature = "desktop", not(feature = "fullstack")))]
     pub use dioxus_desktop::launch::*;
 
+    #[cfg(all(feature = "mobile", not(feature = "fullstack")))]
+    pub use dioxus_desktop::launch::*;
+
     #[cfg(feature = "fullstack")]
     pub use dioxus_fullstack::launch::*;
 
-    #[cfg(all(feature = "web", not(any(feature = "desktop", feature = "fullstack"))))]
+    #[cfg(all(feature = "web", not(any(feature = "desktop", feature = "mobile", feature = "fullstack"))))]
     pub use dioxus_web::launch::*;
 
     #[cfg(all(
         feature = "liveview",
-        not(any(feature = "web", feature = "desktop", feature = "fullstack"))
+        not(any(feature = "web", feature = "desktop", feature = "mobile", feature = "fullstack"))
     ))]
     pub use dioxus_liveview::launch::*;
 
@@ -179,6 +182,7 @@ mod current_platform {
             feature = "liveview",
             feature = "web",
             feature = "desktop",
+            feature = "mobile",
             feature = "fullstack"
         ))
     ))]
@@ -187,6 +191,7 @@ mod current_platform {
     #[cfg(not(any(
         feature = "liveview",
         feature = "desktop",
+        feature = "mobile",
         feature = "web",
         feature = "tui",
         feature = "fullstack"
@@ -196,6 +201,7 @@ mod current_platform {
     #[cfg(not(any(
         feature = "liveview",
         feature = "desktop",
+        feature = "mobile",
         feature = "web",
         feature = "tui",
         feature = "fullstack"
@@ -205,6 +211,7 @@ mod current_platform {
         contexts: Vec<Box<super::ValidContext>>,
         platform_config: (),
     ) {
+        panic!("No platform feature enabled. Please enable one of the following features: liveview, desktop, mobile, web, tui, fullstack to use the launch API.");
     }
 }
 

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
-rust-version = "1.60.0"
+rust-version = "1.64.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
I have seen a few people try to launch a app without any features and running into a blank screen with no errors. This PR adds a compile time warning and panics if you try to call launch builder without any renderers enabled