### PR TITLE
Fix Clippy warning in `Routable` macro

### DIFF
--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -559,7 +559,8 @@ impl RouteEnum {
             #(#type_defs)*
 
             #[allow(non_camel_case_types)]
-            #[derive(Debug, PartialEq, Eq)]
+            #[allow(clippy::derive_partial_eq_without_eq)]
+            #[derive(Debug, PartialEq)]
             pub enum #match_error_name {
                 #(#error_variants),*
             }

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -559,7 +559,7 @@ impl RouteEnum {
             #(#type_defs)*
 
             #[allow(non_camel_case_types)]
-            #[derive(Debug, PartialEq)]
+            #[derive(Debug, PartialEq, Eq)]
             pub enum #match_error_name {
                 #(#error_variants),*
             }

--- a/packages/router-macro/src/segment.rs
+++ b/packages/router-macro/src/segment.rs
@@ -309,7 +309,8 @@ pub(crate) fn create_error_type(
 
     quote! {
         #[allow(non_camel_case_types)]
-        #[derive(Debug, PartialEq, Eq)]
+        #[allow(clippy::derive_partial_eq_without_eq)]
+        #[derive(Debug, PartialEq)]
         pub enum #error_name {
             ExtraSegments(String),
             #(#child_type_variant,)*

--- a/packages/router-macro/src/segment.rs
+++ b/packages/router-macro/src/segment.rs
@@ -309,7 +309,7 @@ pub(crate) fn create_error_type(
 
     quote! {
         #[allow(non_camel_case_types)]
-        #[derive(Debug, PartialEq)]
+        #[derive(Debug, PartialEq, Eq)]
         pub enum #error_name {
             ExtraSegments(String),
             #(#child_type_variant,)*


### PR DESCRIPTION
`Routable` creates types which derive `PartialEq`, but can also derive `Eq`. Clippy complains about this. This PR makes them derive `Eq` as well. If deriving only `PartialEq` is intentional let me know and I'll add an `#[allow]` instead.