### PR TITLE
Fix fullstack history

### DIFF
--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -9,8 +9,8 @@ use dioxus_ssr::{
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::RwLock;
-use tokio::task::JoinHandle;
 use tokio::task::block_in_place;
+use tokio::task::JoinHandle;
 
 use crate::prelude::*;
 use dioxus_lib::prelude::*;

--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -10,6 +10,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::sync::RwLock;
 use tokio::task::JoinHandle;
+use tokio::task::block_in_place;
 
 use crate::prelude::*;
 use dioxus_lib::prelude::*;
@@ -64,7 +65,7 @@ impl SsrRendererPool {
                     let prev_context = SERVER_CONTEXT.with(|ctx| ctx.replace(server_context));
                     // poll the future, which may call server_context()
                     tracing::info!("Rebuilding vdom");
-                    vdom.rebuild(&mut NoOpMutations);
+                    block_in_place(|| vdom.rebuild(&mut NoOpMutations));
                     vdom.wait_for_suspense().await;
                     tracing::info!("Suspense resolved");
                     // after polling the future, we need to restore the context
@@ -124,7 +125,7 @@ impl SsrRendererPool {
                                         .with(|ctx| ctx.replace(Box::new(server_context)));
                                     // poll the future, which may call server_context()
                                     tracing::info!("Rebuilding vdom");
-                                    vdom.rebuild(&mut NoOpMutations);
+                                    block_in_place(|| vdom.rebuild(&mut NoOpMutations));
                                     vdom.wait_for_suspense().await;
                                     tracing::info!("Suspense resolved");
                                     // after polling the future, we need to restore the context

--- a/packages/fullstack/src/server_context.rs
+++ b/packages/fullstack/src/server_context.rs
@@ -84,14 +84,36 @@ mod server_fn_impl {
         /// Get the request that triggered:
         /// - The initial SSR render if called from a ScopeState or ServerFn
         /// - The server function to be called if called from a server function after the initial render
-        pub fn request_parts(&self) -> tokio::sync::RwLockReadGuard<'_, http::request::Parts> {
+        pub async fn request_parts(
+            &self,
+        ) -> tokio::sync::RwLockReadGuard<'_, http::request::Parts> {
+            self.parts.read().await
+        }
+
+        /// Get the request that triggered:
+        /// - The initial SSR render if called from a ScopeState or ServerFn
+        /// - The server function to be called if called from a server function after the initial render
+        pub fn request_parts_blocking(
+            &self,
+        ) -> tokio::sync::RwLockReadGuard<'_, http::request::Parts> {
             self.parts.blocking_read()
         }
 
         /// Get the request that triggered:
         /// - The initial SSR render if called from a ScopeState or ServerFn
         /// - The server function to be called if called from a server function after the initial render
-        pub fn request_parts_mut(&self) -> tokio::sync::RwLockWriteGuard<'_, http::request::Parts> {
+        pub async fn request_parts_mut(
+            &self,
+        ) -> tokio::sync::RwLockWriteGuard<'_, http::request::Parts> {
+            self.parts.write().await
+        }
+
+        /// Get the request that triggered:
+        /// - The initial SSR render if called from a ScopeState or ServerFn
+        /// - The server function to be called if called from a server function after the initial render
+        pub fn request_parts_mut_blocking(
+            &self,
+        ) -> tokio::sync::RwLockWriteGuard<'_, http::request::Parts> {
             self.parts.blocking_write()
         }
 
@@ -239,6 +261,6 @@ impl<
     type Rejection = R;
 
     async fn from_request(req: &DioxusServerContext) -> Result<Self, Self::Rejection> {
-        Ok(I::from_request_parts(&mut req.request_parts_mut(), &()).await?)
+        Ok(I::from_request_parts(&mut *req.request_parts_mut().await, &()).await?)
     }
 }

--- a/packages/router/src/router_cfg.rs
+++ b/packages/router/src/router_cfg.rs
@@ -134,7 +134,7 @@ where
     return Box::new(AnyHistoryProviderImplWrapper::new(
         MemoryHistory::<R>::with_initial_path(
             dioxus_fullstack::prelude::server_context()
-                .request_parts()
+                .request_parts_blocking()
                 .uri
                 .to_string()
                 .parse()


### PR DESCRIPTION
The fullstack renderer renders on a dedicated thread which should be fine to block in. This PR wraps rebuilding the virtual dom in a wrapper that tells tokio it is ok to block. Rebuilding the virtual dom runs user code which may use blocking tokio operations (like reading the fullstack history)