### PR TITLE
Fix signals leaking memory

### DIFF
--- a/packages/signals/README.md
+++ b/packages/signals/README.md
@@ -36,18 +36,18 @@ use dioxus_signals::*;
 #[component]
 fn App() -> Element {
     // Because signal is never read in this component, this component will not rerun when the signal changes
-    let signal = use_signal(|| 0);
+    let mut signal = use_signal(|| 0);
 
     rsx! {
         button {
             onclick: move |_| {
-                *signal.write() += 1;
+                signal += 1;
             },
             "Increase"
         }
         for id in 0..10 {
             Child {
-                signal: signal,
+                signal,
             }
         }
     }
@@ -58,11 +58,10 @@ struct ChildProps {
     signal: Signal<usize>,
 }
 
-#[component]
-fn Child(cx: Scope<ChildProps>) -> Element {
+fn Child(props: ChildProps) -> Element {
     // This component does read from the signal, so when the signal changes it will rerun
     rsx! {
-        "{cx.props.signal}"
+        "{props.signal}"
     }
 }
 ```
@@ -85,7 +84,7 @@ fn App() -> Element {
 
 #[component]
 fn Child() -> Element {
-    let signal: Signal<i32> = *use_context(cx).unwrap();
+    let signal: Signal<i32> = use_context();
     // This component does read from the signal, so when the signal changes it will rerun
     rsx! {
         "{signal}"
@@ -105,12 +104,12 @@ use dioxus_signals::*;
 
 #[component]
 fn App() -> Element {
-    let signal = use_signal(|| 0);
-    let doubled = use_memo(|| signal * 2);
+    let mut signal = use_signal(|| 0);
+    let doubled = use_memo(move || signal * 2);
 
     rsx! {
         button {
-            onclick: move |_| *signal.write() += 1,
+            onclick: move |_| signal += 1,
             "Increase"
         }
         Child {

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -93,7 +93,7 @@ fn current_owner<S: Storage<T>, T>() -> Owner<S> {
 }
 
 fn owner_in_scope<S: Storage<T>, T>(scope: ScopeId) -> Owner<S> {
-    match consume_context_from_scope(scope) {
+    match scope.has_context() {
         Some(rt) => rt,
         None => {
             let owner = S::owner();

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -30,17 +30,15 @@ use std::{
 /// }
 ///
 /// #[component]
-/// fn Child(state: Signal<u32>) -> Element {
-///     let state = *state;
-///
-///     use_future( |()| async move {
+/// fn Child(mut state: Signal<u32>) -> Element {
+///     use_future(move || async move {
 ///         // Because the signal is a Copy type, we can use it in an async block without cloning it.
-///         *state.write() += 1;
+///         state += 1;
 ///     });
 ///
 ///     rsx! {
 ///         button {
-///             onclick: move |_| *state.write() += 1,
+///             onclick: move |_| state += 1,
 ///             "{state}"
 ///         }
 ///     }


### PR DESCRIPTION
Signals should be owned by the scope they were created in. They use an owner which lives in the context API. Dioxus signals had a bug that caused child scopes to use the parent scope's owner and only drop when that parent is dropped. This PR fixes the leak by only looking for the signal owner in the current scope instead of looking through all parent scopes (including the root scope). 

Closes #1999 