### PR TITLE
Only poll suspended futures, lazy memos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,7 +2754,6 @@ version = "0.5.0-alpha.0"
 dependencies = [
  "dioxus",
  "dioxus-core",
- "flume",
  "futures-channel",
  "futures-util",
  "generational-box",

--- a/examples/memo_chain.rs
+++ b/examples/memo_chain.rs
@@ -26,11 +26,7 @@ fn app() -> Element {
 }
 
 #[component]
-fn Child(
-    state: ReadOnlySignal<isize>,
-    items: ReadOnlySignal<Vec<isize>>,
-    depth: ReadOnlySignal<usize>,
-) -> Element {
+fn Child(state: Memo<isize>, items: Memo<Vec<isize>>, depth: ReadOnlySignal<usize>) -> Element {
     if depth() == 0 {
         return None;
     }

--- a/examples/memo_chain.rs
+++ b/examples/memo_chain.rs
@@ -21,25 +21,25 @@ fn app() -> Element {
         button { onclick: move |_| value += 1, "Increment" }
         button { onclick: move |_| depth += 1, "Add depth" }
         button { onclick: move |_| depth -= 1, "Remove depth" }
-        Child { depth, items, state }
+        if depth() > 0 {
+            Child { depth, items, state }
+        }
     }
 }
 
 #[component]
 fn Child(state: Memo<isize>, items: Memo<Vec<isize>>, depth: ReadOnlySignal<usize>) -> Element {
-    if depth() == 0 {
-        return None;
-    }
-
     // These memos don't get re-computed when early returns happen
     let state = use_memo(move || state() + 1);
-    let item = use_memo(move || items()[depth()]);
+    let item = use_memo(move || items()[depth() - 1]);
     let depth = use_memo(move || depth() - 1);
 
     println!("rendering child: {}", depth());
 
     rsx! {
         h3 { "Depth({depth})-Item({item}): {state}"}
-        Child { depth, state, items }
+        if depth() > 0 {
+            Child { depth, state, items }
+        }
     }
 }

--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -50,9 +50,9 @@ pub fn provide_root_context<T: 'static + Clone>(value: T) -> T {
         .expect("to be in a dioxus runtime")
 }
 
-/// Suspends the current component
-pub fn suspend() -> Option<Element> {
-    Runtime::with_current_scope(|cx| cx.suspend());
+/// Suspended the current component on a specific task and then return None
+pub fn suspend(task: Task) -> Element {
+    Runtime::with_current_scope(|cx| cx.suspend(task));
     None
 }
 

--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -1,3 +1,5 @@
+use rustc_hash::FxHashSet;
+
 use crate::{
     innerlude::{LocalTask, SchedulerMsg},
     render_signal::RenderSignal,
@@ -24,10 +26,13 @@ pub struct Runtime {
     // We use this to track the current task
     pub(crate) current_task: Cell<Option<Task>>,
 
-    pub(crate) rendering: Cell<bool>,
-
     /// Tasks created with cx.spawn
     pub(crate) tasks: RefCell<slab::Slab<Rc<LocalTask>>>,
+
+    // Currently suspended tasks
+    pub(crate) suspended_tasks: RefCell<FxHashSet<Task>>,
+
+    pub(crate) rendering: Cell<bool>,
 
     pub(crate) sender: futures_channel::mpsc::UnboundedSender<SchedulerMsg>,
 
@@ -45,6 +50,7 @@ impl Runtime {
             scope_stack: Default::default(),
             current_task: Default::default(),
             tasks: Default::default(),
+            suspended_tasks: Default::default(),
         })
     }
 

--- a/packages/core/src/tasks.rs
+++ b/packages/core/src/tasks.rs
@@ -171,11 +171,7 @@ impl Runtime {
                 .borrow_mut()
                 .remove(&id);
 
-            // Remove it from the scheduler
-            self.tasks.borrow_mut().try_remove(id.0);
-
-            // Remove it from the suspended tasks
-            self.suspended_tasks.borrow_mut().remove(&id);
+            self.remove_task(id);
         }
 
         // Remove the scope from the stack

--- a/packages/core/src/tasks.rs
+++ b/packages/core/src/tasks.rs
@@ -173,6 +173,9 @@ impl Runtime {
 
             // Remove it from the scheduler
             self.tasks.borrow_mut().try_remove(id.0);
+
+            // Remove it from the suspended tasks
+            self.suspended_tasks.borrow_mut().remove(&id);
         }
 
         // Remove the scope from the stack
@@ -187,6 +190,7 @@ impl Runtime {
     ///
     /// This does not abort the task, so you'll want to wrap it in an abort handle if that's important to you
     pub(crate) fn remove_task(&self, id: Task) -> Option<Rc<LocalTask>> {
+        self.suspended_tasks.borrow_mut().remove(&id);
         self.tasks.borrow_mut().try_remove(id.0)
     }
 }

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -661,7 +661,6 @@ impl VirtualDom {
 
                 // Now that we have collected all queued work, we should check if we have any dirty scopes. If there are not, then we can poll any queued futures
                 if self.dirty_scopes.has_dirty_scopes() {
-                    println!("dirty scopes");
                     break;
                 }
 

--- a/packages/core/tests/suspense.rs
+++ b/packages/core/tests/suspense.rs
@@ -37,9 +37,9 @@ fn suspended_child() -> Element {
         panic!("Non-suspended task was polled");
     });
 
-    // // Memos should still work like normal
-    // let memo = use_memo(move || val * 2);
-    // assert_eq!(memo, val * 2);
+    // Memos should still work like normal
+    let memo = use_memo(move || val * 2);
+    assert_eq!(memo, val * 2);
 
     if val() < 3 {
         let task = spawn(async move {

--- a/packages/core/tests/suspense.rs
+++ b/packages/core/tests/suspense.rs
@@ -1,9 +1,10 @@
 use dioxus::prelude::*;
+use std::future::poll_fn;
+use std::task::Poll;
 
 #[test]
 fn suspense_resolves() {
     // wait just a moment, not enough time for the boundary to resolve
-
     tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap()
@@ -31,11 +32,35 @@ fn app() -> Element {
 fn suspended_child() -> Element {
     let mut val = use_signal(|| 0);
 
+    // Tasks that are not suspended should never be polled
+    spawn(async move {
+        panic!("Non-suspended task was polled");
+    });
+
+    // // Memos should still work like normal
+    // let memo = use_memo(move || val * 2);
+    // assert_eq!(memo, val * 2);
+
     if val() < 3 {
-        spawn(async move {
+        let task = spawn(async move {
+            // Poll each task 3 times
+            let mut count = 0;
+            poll_fn(|cx| {
+                println!("polling... {}", count);
+                if count < 3 {
+                    count += 1;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            })
+            .await;
+
+            println!("waiting... {}", val);
             val += 1;
         });
-        suspend()?;
+        suspend(task)?;
     }
 
     rsx!("child")

--- a/packages/core/tests/task.rs
+++ b/packages/core/tests/task.rs
@@ -53,7 +53,7 @@ async fn running_async() {
 #[tokio::test]
 async fn yield_now_works() {
     thread_local! {
-        static SEQUENCE: std::cell::RefCell<Vec<usize>> = std::cell::RefCell::new(Vec::new());
+        static SEQUENCE: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
     }
 
     fn app() -> Element {
@@ -88,7 +88,7 @@ async fn yield_now_works() {
 #[tokio::test]
 async fn flushing() {
     thread_local! {
-        static SEQUENCE: std::cell::RefCell<Vec<usize>> = std::cell::RefCell::new(Vec::new());
+        static SEQUENCE: std::cell::RefCell<Vec<usize>> = const { std::cell::RefCell::new(Vec::new()) };
         static BROADCAST: (tokio::sync::broadcast::Sender<()>, tokio::sync::broadcast::Receiver<()>) = tokio::sync::broadcast::channel(1);
     }
 

--- a/packages/fullstack/examples/static-hydrated/src/main.rs
+++ b/packages/fullstack/examples/static-hydrated/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
 }
 
 // Hydrate the page
-#[cfg(all(feature = "web", not(feature = "server")))]
+#[cfg(not(feature = "server"))]
 fn main() {
     dioxus_web::launch_with_props(
         dioxus_fullstack::router::RouteWithCfg::<Route>,

--- a/packages/fullstack/examples/static-hydrated/src/main.rs
+++ b/packages/fullstack/examples/static-hydrated/src/main.rs
@@ -36,7 +36,7 @@ async fn main() {
 }
 
 // Hydrate the page
-#[cfg(not(feature = "server"))]
+#[cfg(all(feature = "web", not(feature = "server")))]
 fn main() {
     dioxus_web::launch_with_props(
         dioxus_fullstack::router::RouteWithCfg::<Route>,

--- a/packages/fullstack/src/hooks/server_future.rs
+++ b/packages/fullstack/src/hooks/server_future.rs
@@ -54,7 +54,7 @@ where
     // Suspend if the value isn't ready
     match resource.state().cloned() {
         UseResourceState::Pending => {
-            suspend();
+            suspend(resource.task());
             None
         }
         _ => Some(resource),

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -22,7 +22,6 @@ once_cell = "1.18.0"
 rustc-hash = { workspace = true }
 futures-channel = { workspace = true }
 futures-util = { workspace = true }
-flume = { version = "0.11.0", default-features = false, features = ["async"] }
 
 [dev-dependencies]
 dioxus = { workspace = true }

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -237,14 +237,17 @@ impl<T: 'static, S: Storage<T>> Writable for CopyValue<T, S> {
         S::try_map_mut(mut_, f)
     }
 
+    #[track_caller]
     fn try_write(&mut self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
         self.value.try_write()
     }
 
+    #[track_caller]
     fn write(&mut self) -> Self::Mut<T> {
         self.value.write()
     }
 
+    #[track_caller]
     fn set(&mut self, value: T) {
         self.value.set(value);
     }

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -237,7 +237,7 @@ impl<T: 'static, S: Storage<T>> Writable for CopyValue<T, S> {
         S::try_map_mut(mut_, f)
     }
 
-    fn try_write(&self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
+    fn try_write(&mut self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
         self.value.try_write()
     }
 

--- a/packages/signals/src/global/signal.rs
+++ b/packages/signals/src/global/signal.rs
@@ -103,7 +103,7 @@ impl<T: 'static> Writable for GlobalSignal<T> {
     }
 
     #[track_caller]
-    fn try_write(&self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
+    fn try_write(&mut self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
         self.signal().try_write()
     }
 }

--- a/packages/signals/src/impls.rs
+++ b/packages/signals/src/impls.rs
@@ -1,4 +1,5 @@
 use crate::copy_value::CopyValue;
+use crate::memo::Memo;
 use crate::read::Readable;
 use crate::signal::Signal;
 use crate::write::Writable;
@@ -158,6 +159,16 @@ impl<T: 'static, S: Storage<SignalData<T>>> Clone for ReadOnlySignal<T, S> {
 }
 
 impl<T: 'static, S: Storage<SignalData<T>>> Copy for ReadOnlySignal<T, S> {}
+
+read_impls!(Memo: PartialEq);
+
+impl<T: 'static> Clone for Memo<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: 'static> Copy for Memo<T> {}
 
 read_impls!(GlobalSignal);
 default_impl!(GlobalSignal);

--- a/packages/signals/src/lib.rs
+++ b/packages/signals/src/lib.rs
@@ -19,6 +19,9 @@ pub use map::*;
 // mod comparer;
 // pub use comparer::*;
 
+mod memo;
+pub use memo::*;
+
 mod global;
 pub use global::*;
 

--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -1,0 +1,173 @@
+use crate::write::Writable;
+use crate::{read::Readable, ReactiveContext, ReadableRef, Signal};
+use crate::{CopyValue, ReadOnlySignal};
+use std::{
+    cell::RefCell,
+    ops::Deref,
+    panic::Location,
+    sync::{atomic::AtomicBool, Arc},
+};
+
+use dioxus_core::prelude::*;
+use futures_util::StreamExt;
+use generational_box::UnsyncStorage;
+struct UpdateInformation<T> {
+    dirty: Arc<AtomicBool>,
+    callback: RefCell<Box<dyn FnMut() -> T>>,
+}
+
+/// A value that is memoized. This is useful for caching the result of a computation.
+pub struct Memo<T: 'static> {
+    inner: Signal<T>,
+    update: CopyValue<UpdateInformation<T>>,
+}
+
+impl<T> From<Memo<T>> for ReadOnlySignal<T>
+where
+    T: PartialEq,
+{
+    fn from(val: Memo<T>) -> Self {
+        ReadOnlySignal::new(val.inner)
+    }
+}
+
+impl<T: 'static> Memo<T> {
+    /// Create a new memo
+    #[track_caller]
+    pub fn new(mut f: impl FnMut() -> T + 'static) -> Self
+    where
+        T: PartialEq,
+    {
+        let dirty = Arc::new(AtomicBool::new(true));
+        let (tx, mut rx) = futures_channel::mpsc::unbounded();
+
+        let callback = {
+            let dirty = dirty.clone();
+            move || {
+                dirty.store(true, std::sync::atomic::Ordering::Relaxed);
+                tx.unbounded_send(()).unwrap();
+            }
+        };
+        let rc = ReactiveContext::new_with_callback(
+            callback,
+            current_scope_id().unwrap(),
+            Location::caller(),
+        );
+
+        // Create a new signal in that context, wiring up its dependencies and subscribers
+        let value = rc.run_in(&mut f);
+        let recompute = RefCell::new(Box::new(f) as Box<dyn FnMut() -> T>);
+        let update = CopyValue::new(UpdateInformation {
+            dirty,
+            callback: recompute,
+        });
+        let state: Signal<T> = Signal::new(value);
+
+        let memo = Memo {
+            inner: state,
+            update,
+        };
+
+        spawn(async move {
+            while rx.next().await.is_some() {
+                memo.recompute();
+            }
+        });
+
+        memo
+    }
+
+    /// Rerun the computation and update the value of the memo if the result has changed.
+    fn recompute(&self)
+    where
+        T: PartialEq,
+    {
+        let mut update_copy = self.update;
+        let update_write = update_copy.write();
+        let peak = self.inner.peek();
+        let new_value = (update_write.callback.borrow_mut())();
+        if new_value != *peak {
+            drop(peak);
+            let mut copy = self.inner;
+            let mut write = copy.write();
+            *write = new_value;
+            update_write
+                .dirty
+                .store(false, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    /// Get the scope that the signal was created in.
+    pub fn origin_scope(&self) -> ScopeId {
+        self.inner.origin_scope()
+    }
+
+    /// Get the id of the signal.
+    pub fn id(&self) -> generational_box::GenerationalBoxId {
+        self.inner.id()
+    }
+}
+
+impl<T> Readable for Memo<T>
+where
+    T: PartialEq,
+{
+    type Target = T;
+    type Storage = UnsyncStorage;
+
+    #[track_caller]
+    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
+        let read = self.inner.try_read();
+        match read {
+            Ok(r) => {
+                let needs_update = self
+                    .update
+                    .read()
+                    .dirty
+                    .swap(false, std::sync::atomic::Ordering::Relaxed);
+                if needs_update {
+                    drop(r);
+                    self.recompute();
+                    self.inner.try_read()
+                } else {
+                    Ok(r)
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Get the current value of the signal. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
+    ///
+    /// If the signal has been dropped, this will panic.
+    #[track_caller]
+    fn peek(&self) -> ReadableRef<Self> {
+        self.inner.peek()
+    }
+}
+
+impl<T> IntoAttributeValue for Memo<T>
+where
+    T: Clone + IntoAttributeValue + PartialEq,
+{
+    fn into_value(self) -> dioxus_core::AttributeValue {
+        self.with(|f| f.clone().into_value())
+    }
+}
+
+impl<T: 'static> PartialEq for Memo<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl<T: Clone> Deref for Memo<T>
+where
+    T: PartialEq,
+{
+    type Target = dyn Fn() -> T;
+
+    fn deref(&self) -> &Self::Target {
+        Readable::deref_impl(self)
+    }
+}

--- a/packages/signals/src/reactive_context.rs
+++ b/packages/signals/src/reactive_context.rs
@@ -1,9 +1,9 @@
 use dioxus_core::prelude::{
     current_scope_id, has_context, provide_context, schedule_update_any, ScopeId,
 };
+use futures_channel::mpsc::UnboundedReceiver;
 use generational_box::SyncStorage;
-use rustc_hash::FxHashSet;
-use std::{cell::RefCell, hash::Hash, sync::Arc};
+use std::{cell::RefCell, hash::Hash};
 
 use crate::{CopyValue, Readable, Writable};
 
@@ -25,66 +25,48 @@ thread_local! {
 impl std::fmt::Display for ReactiveContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let read = self.inner.read();
-        match read.scope_subscriber {
-            Some(scope) => write!(f, "ReactiveContext for scope {:?}", scope),
-            None => {
-                #[cfg(debug_assertions)]
-                return write!(f, "ReactiveContext created at {}", read.origin);
-                #[cfg(not(debug_assertions))]
-                write!(f, "ReactiveContext")
-            }
-        }
-    }
-}
-
-impl Default for ReactiveContext {
-    #[track_caller]
-    fn default() -> Self {
-        Self::new_for_scope(None, std::panic::Location::caller())
+        #[cfg(debug_assertions)]
+        return write!(f, "ReactiveContext created at {}", read.origin);
+        #[cfg(not(debug_assertions))]
+        write!(f, "ReactiveContext")
     }
 }
 
 impl ReactiveContext {
     /// Create a new reactive context
     #[track_caller]
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new() -> (Self, UnboundedReceiver<()>) {
+        Self::new_with_origin(std::panic::Location::caller())
     }
 
     /// Create a new reactive context with a location for debugging purposes
     /// This is useful for reactive contexts created within closures
-    pub fn new_with_origin(origin: &'static std::panic::Location<'static>) -> Self {
-        Self::new_for_scope(None, origin)
+    pub fn new_with_origin(
+        origin: &'static std::panic::Location<'static>,
+    ) -> (Self, UnboundedReceiver<()>) {
+        let (tx, rx) = futures_channel::mpsc::unbounded();
+        let callback = move || {
+            let _ = tx.unbounded_send(());
+        };
+        let _self = Self::new_with_callback(callback, current_scope_id().unwrap(), origin);
+        (_self, rx)
     }
 
-    /// Create a new reactive context that may update a scope
-    #[allow(unused)]
-    pub(crate) fn new_for_scope(
-        scope: Option<ScopeId>,
+    /// Create a new reactive context that may update a scope. When any signal that this context subscribes to changes, the callback will be run
+    pub fn new_with_callback(
+        callback: impl FnMut() + Send + Sync + 'static,
+        scope: ScopeId,
         origin: &'static std::panic::Location<'static>,
     ) -> Self {
-        let (tx, rx) = flume::unbounded();
-
-        let mut scope_subscribers = FxHashSet::default();
-        if let Some(scope) = scope {
-            scope_subscribers.insert(scope);
-        }
-
         let inner = Inner {
-            scope_subscriber: scope,
-            sender: tx,
             self_: None,
-            update_any: schedule_update_any(),
-            receiver: rx,
+            update: Box::new(callback),
             #[cfg(debug_assertions)]
             origin,
         };
 
         let mut self_ = Self {
-            inner: CopyValue::new_maybe_sync_in_scope(
-                inner,
-                scope.or_else(current_scope_id).unwrap(),
-            ),
+            inner: CopyValue::new_maybe_sync_in_scope(inner, scope),
         };
 
         self_.inner.write().self_ = Some(self_);
@@ -112,10 +94,17 @@ impl ReactiveContext {
         if let Some(cx) = has_context() {
             return Some(cx);
         }
+        let update_any = schedule_update_any();
+        let scope_id = current_scope_id().unwrap();
+        let update_scope = move || {
+            tracing::trace!("Marking scope {:?} as dirty", scope_id);
+            update_any(scope_id)
+        };
 
         // Otherwise, create a new context at the current scope
-        Some(provide_context(ReactiveContext::new_for_scope(
-            current_scope_id(),
+        Some(provide_context(ReactiveContext::new_with_callback(
+            update_scope,
+            scope_id,
             std::panic::Location::caller(),
         )))
     }
@@ -137,25 +126,18 @@ impl ReactiveContext {
     ///
     /// Returns true if the context was marked as dirty, or false if the context has been dropped
     pub fn mark_dirty(&self) -> bool {
-        if let Ok(self_read) = self.inner.try_read() {
+        let mut copy = self.inner;
+        if let Ok(mut self_write) = copy.try_write() {
             #[cfg(debug_assertions)]
             {
-                if let Some(scope) = self_read.scope_subscriber {
-                    tracing::trace!("Marking reactive context for scope {:?} as dirty", scope);
-                } else {
-                    tracing::trace!(
-                        "Marking reactive context created at {} as dirty",
-                        self_read.origin
-                    );
-                }
-            }
-            if let Some(scope) = self_read.scope_subscriber {
-                (self_read.update_any)(scope);
+                tracing::trace!(
+                    "Marking reactive context created at {} as dirty",
+                    self_write.origin
+                );
             }
 
-            // mark the listeners as dirty
-            // If the channel is full it means that the receivers have already been marked as dirty
-            _ = self_read.sender.try_send(());
+            (self_write.update)();
+
             true
         } else {
             false
@@ -166,12 +148,6 @@ impl ReactiveContext {
     pub fn origin_scope(&self) -> ScopeId {
         self.inner.origin_scope()
     }
-
-    /// Wait for this reactive context to change
-    pub async fn changed(&self) {
-        let rx = self.inner.read().receiver.clone();
-        _ = rx.recv_async().await;
-    }
 }
 
 impl Hash for ReactiveContext {
@@ -181,14 +157,10 @@ impl Hash for ReactiveContext {
 }
 
 struct Inner {
-    // A scope we mark as dirty when this context is written to
-    scope_subscriber: Option<ScopeId>,
     self_: Option<ReactiveContext>,
-    update_any: Arc<dyn Fn(ScopeId) + Send + Sync>,
 
     // Futures will call .changed().await
-    sender: flume::Sender<()>,
-    receiver: flume::Receiver<()>,
+    update: Box<dyn FnMut() + Send + Sync>,
 
     // Debug information for signal subscriptions
     #[cfg(debug_assertions)]

--- a/packages/signals/src/reactive_context.rs
+++ b/packages/signals/src/reactive_context.rs
@@ -24,10 +24,12 @@ thread_local! {
 
 impl std::fmt::Display for ReactiveContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let read = self.inner.read();
         #[cfg(debug_assertions)]
-        return write!(f, "ReactiveContext created at {}", read.origin);
-        #[cfg(not(debug_assertions))]
+        {
+            if let Ok(read) = self.inner.try_read() {
+                return write!(f, "ReactiveContext created at {}", read.origin);
+            }
+        }
         write!(f, "ReactiveContext")
     }
 }

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -1,11 +1,9 @@
+use crate::Memo;
 use crate::{
     read::Readable, write::Writable, CopyValue, GlobalMemo, GlobalSignal, ReactiveContext,
-    ReadOnlySignal, ReadableRef,
+    ReadableRef,
 };
-use dioxus_core::{
-    prelude::{spawn, IntoAttributeValue},
-    ScopeId,
-};
+use dioxus_core::{prelude::IntoAttributeValue, ScopeId};
 use generational_box::{AnyStorage, Storage, SyncStorage, UnsyncStorage};
 use std::{
     any::Any,
@@ -88,35 +86,8 @@ impl<T: PartialEq + 'static> Signal<T> {
     ///
     /// Selectors can be used to efficiently compute derived data from signals.
     #[track_caller]
-    pub fn memo(f: impl FnMut() -> T + 'static) -> ReadOnlySignal<T> {
-        Self::use_maybe_sync_memo(f)
-    }
-
-    /// Creates a new Selector that may be Sync + Send. The selector will be run immediately and whenever any signal it reads changes.
-    ///
-    /// Selectors can be used to efficiently compute derived data from signals.
-    #[track_caller]
-    pub fn use_maybe_sync_memo<S: Storage<SignalData<T>>>(
-        mut f: impl FnMut() -> T + 'static,
-    ) -> ReadOnlySignal<T, S> {
-        // Get the current reactive context
-        let rc = ReactiveContext::new();
-
-        // Create a new signal in that context, wiring up its dependencies and subscribers
-        let mut state: Signal<T, S> = rc.run_in(|| Signal::new_maybe_sync(f()));
-
-        spawn(async move {
-            loop {
-                rc.changed().await;
-                let new = f();
-                if new != *state.peek() {
-                    *state.write() = new;
-                }
-            }
-        });
-
-        // And just return the readonly variant of that signal
-        ReadOnlySignal::new_maybe_sync(state)
+    pub fn memo(f: impl FnMut() -> T + 'static) -> Memo<T> {
+        Memo::new(f)
     }
 }
 
@@ -237,7 +208,7 @@ impl<T: 'static, S: Storage<SignalData<T>>> Writable for Signal<T, S> {
     }
 
     #[track_caller]
-    fn try_write(&self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
+    fn try_write(&mut self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
         self.inner.try_write().map(|inner| {
             let borrow = S::map_mut(inner, |v| &mut v.value);
             Write {

--- a/packages/signals/src/write.rs
+++ b/packages/signals/src/write.rs
@@ -27,7 +27,7 @@ pub trait Writable: Readable {
     }
 
     /// Try to get a mutable reference to the value. If the value has been dropped, this will panic.
-    fn try_write(&self) -> Result<Self::Mut<Self::Target>, generational_box::BorrowMutError>;
+    fn try_write(&mut self) -> Result<Self::Mut<Self::Target>, generational_box::BorrowMutError>;
 
     /// Run a function with a mutable reference to the value. If the value has been dropped, this will panic.
     #[track_caller]


### PR DESCRIPTION
This PR fixes suspense polling futures that are unrelated to suspense. This will fix some hydration errors including https://github.com/DioxusLabs/dioxus/issues/1804.

Currently during suspense, all futures that have been spawned will be polled until suspense is finished. This causes hydration issues if a future finishes on the server but not the client and renders different content.

Fixes #2003
Fixes #1935