### PR TITLE
Fix: pushroot should actually push the right root on native mutations

### DIFF
--- a/packages/interpreter/src/write_native_mutations.rs
+++ b/packages/interpreter/src/write_native_mutations.rs
@@ -196,7 +196,7 @@ impl WriteMutations for MutationState {
         self.channel.remove(id.0 as u32);
     }
 
-    fn push_root(&mut self, _id: dioxus_core::ElementId) {
-        self.channel.push_root(0);
+    fn push_root(&mut self, id: dioxus_core::ElementId) {
+        self.channel.push_root(id.0 as _);
     }
 }


### PR DESCRIPTION
fix #1970 

Not actually an issue in diffing! Just an issue with a single pushroot command. 