### PR TITLE
Restore signal lifetimes; rename take to manually drop

### DIFF
--- a/examples/dog_app.rs
+++ b/examples/dog_app.rs
@@ -80,7 +80,7 @@ fn BreedPic(breed: Signal<String>) -> Element {
             .await
     });
 
-    match fut.read().as_ref() {
+    match fut.read_unchecked().as_ref() {
         Some(Ok(resp)) => rsx! {
             button { onclick: move |_| fut.restart(), "Click to fetch another doggo" }
             img { max_width: "500px", max_height: "500px", src: "{resp.message}" }

--- a/examples/suspense.rs
+++ b/examples/suspense.rs
@@ -62,7 +62,7 @@ fn Doggo() -> Element {
             .await
     });
 
-    match fut.read().as_ref() {
+    match fut.read_unchecked().as_ref() {
         Some(Ok(resp)) => rsx! {
             button { onclick: move |_| fut.restart(), "Click to fetch another doggo" }
             div { img { max_width: "500px", max_height: "500px", src: "{resp.message}" } }

--- a/packages/desktop/headless_tests/rendering.rs
+++ b/packages/desktop/headless_tests/rendering.rs
@@ -25,14 +25,13 @@ fn use_inner_html(id: &'static str) -> Option<String> {
             .unwrap();
 
             if let Some(html) = res.as_str() {
-                // serde_json::Value::String(html)
                 println!("html: {}", html);
                 value.set(Some(html.to_string()));
             }
         });
     });
 
-    value.read().clone()
+    value()
 }
 
 const EXPECTED_HTML: &str = r#"<div style="width: 100px; height: 100px; color: rgb(0, 0, 0);" id="5"><input type="checkbox"><h1>text</h1><div><p>hello world</p></div></div>"#;

--- a/packages/generational-box/src/lib.rs
+++ b/packages/generational-box/src/lib.rs
@@ -234,13 +234,17 @@ pub trait AnyStorage: Default {
 
     /// Downcast a reference in a Ref to a more specific lifetime
     ///
-    /// This function enforces the variance of the lifetime parameter `'a` in Ref.
-    fn downcast_ref<'a: 'b, 'b, T: ?Sized + 'static>(ref_: Self::Ref<'a, T>) -> Self::Ref<'b, T>;
+    /// This function enforces the variance of the lifetime parameter `'a` in Ref. Rust will typically infer this cast with a concrete type, but it cannot with a generic type.
+    fn downcast_lifetime_ref<'a: 'b, 'b, T: ?Sized + 'static>(
+        ref_: Self::Ref<'a, T>,
+    ) -> Self::Ref<'b, T>;
 
     /// Downcast a mutable reference in a RefMut to a more specific lifetime
     ///
-    /// This function enforces the variance of the lifetime parameter `'a` in Ref.
-    fn downcast_mut<'a: 'b, 'b, T: ?Sized + 'static>(mut_: Self::Mut<'a, T>) -> Self::Mut<'b, T>;
+    /// This function enforces the variance of the lifetime parameter `'a` in Mut.  Rust will typically infer this cast with a concrete type, but it cannot with a generic type.
+    fn downcast_lifetime_mut<'a: 'b, 'b, T: ?Sized + 'static>(
+        mut_: Self::Mut<'a, T>,
+    ) -> Self::Mut<'b, T>;
 
     /// Try to map the mutable ref.
     fn try_map_mut<T: ?Sized + 'static, U: ?Sized + 'static>(

--- a/packages/generational-box/src/lib.rs
+++ b/packages/generational-box/src/lib.rs
@@ -186,8 +186,8 @@ impl<T: 'static, S: Storage<T>> GenerationalBox<T, S> {
         }
     }
 
-    /// Take the value out of the generational box and invalidate the generational box. This will return the value if the value was taken.
-    pub fn take(&self) -> Option<T> {
+    /// Drop the value out of the generational box and invalidate the generational box. This will return the value if the value was taken.
+    pub fn manually_drop(&self) -> Option<T> {
         if self.validate() {
             Storage::take(&self.raw.0.data)
         } else {

--- a/packages/generational-box/src/sync.rs
+++ b/packages/generational-box/src/sync.rs
@@ -23,11 +23,15 @@ impl AnyStorage for SyncStorage {
     type Ref<'a, R: ?Sized + 'static> = GenerationalRef<MappedRwLockReadGuard<'a, R>>;
     type Mut<'a, W: ?Sized + 'static> = GenerationalRefMut<MappedRwLockWriteGuard<'a, W>>;
 
-    fn downcast_ref<'a: 'b, 'b, T: ?Sized + 'static>(ref_: Self::Ref<'a, T>) -> Self::Ref<'b, T> {
+    fn downcast_lifetime_ref<'a: 'b, 'b, T: ?Sized + 'static>(
+        ref_: Self::Ref<'a, T>,
+    ) -> Self::Ref<'b, T> {
         ref_
     }
 
-    fn downcast_mut<'a: 'b, 'b, T: ?Sized + 'static>(mut_: Self::Mut<'a, T>) -> Self::Mut<'b, T> {
+    fn downcast_lifetime_mut<'a: 'b, 'b, T: ?Sized + 'static>(
+        mut_: Self::Mut<'a, T>,
+    ) -> Self::Mut<'b, T> {
         mut_
     }
 

--- a/packages/generational-box/src/sync.rs
+++ b/packages/generational-box/src/sync.rs
@@ -20,13 +20,21 @@ fn sync_runtime() -> &'static Arc<Mutex<Vec<MemoryLocation<SyncStorage>>>> {
 }
 
 impl AnyStorage for SyncStorage {
-    type Ref<R: ?Sized + 'static> = GenerationalRef<MappedRwLockReadGuard<'static, R>>;
-    type Mut<W: ?Sized + 'static> = GenerationalRefMut<MappedRwLockWriteGuard<'static, W>>;
+    type Ref<'a, R: ?Sized + 'static> = GenerationalRef<MappedRwLockReadGuard<'a, R>>;
+    type Mut<'a, W: ?Sized + 'static> = GenerationalRefMut<MappedRwLockWriteGuard<'a, W>>;
 
-    fn try_map<I: ?Sized, U: ?Sized + 'static>(
-        ref_: Self::Ref<I>,
+    fn downcast_ref<'a: 'b, 'b, T: ?Sized + 'static>(ref_: Self::Ref<'a, T>) -> Self::Ref<'b, T> {
+        ref_
+    }
+
+    fn downcast_mut<'a: 'b, 'b, T: ?Sized + 'static>(mut_: Self::Mut<'a, T>) -> Self::Mut<'b, T> {
+        mut_
+    }
+
+    fn try_map<I: ?Sized + 'static, U: ?Sized + 'static>(
+        ref_: Self::Ref<'_, I>,
         f: impl FnOnce(&I) -> Option<&U>,
-    ) -> Option<Self::Ref<U>> {
+    ) -> Option<Self::Ref<'_, U>> {
         let GenerationalRef {
             inner,
             #[cfg(any(debug_assertions, feature = "debug_borrows"))]
@@ -46,10 +54,10 @@ impl AnyStorage for SyncStorage {
             })
     }
 
-    fn try_map_mut<I: ?Sized, U: ?Sized + 'static>(
-        mut_ref: Self::Mut<I>,
+    fn try_map_mut<I: ?Sized + 'static, U: ?Sized + 'static>(
+        mut_ref: Self::Mut<'_, I>,
         f: impl FnOnce(&mut I) -> Option<&mut U>,
-    ) -> Option<Self::Mut<U>> {
+    ) -> Option<Self::Mut<'_, U>> {
         let GenerationalRefMut {
             inner,
             #[cfg(any(debug_assertions, feature = "debug_borrows"))]
@@ -101,7 +109,7 @@ impl<T: Sync + Send + 'static> Storage<T> for SyncStorage {
         &'static self,
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
         at: crate::GenerationalRefBorrowInfo,
-    ) -> Result<Self::Ref<T>, error::BorrowError> {
+    ) -> Result<Self::Ref<'static, T>, error::BorrowError> {
         let read = self.0.try_read();
 
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
@@ -132,7 +140,7 @@ impl<T: Sync + Send + 'static> Storage<T> for SyncStorage {
         &'static self,
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
         at: crate::GenerationalRefMutBorrowInfo,
-    ) -> Result<Self::Mut<T>, error::BorrowMutError> {
+    ) -> Result<Self::Mut<'static, T>, error::BorrowMutError> {
         let write = self.0.try_write();
 
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]

--- a/packages/generational-box/src/unsync.rs
+++ b/packages/generational-box/src/unsync.rs
@@ -15,7 +15,7 @@ impl<T: 'static> Storage<T> for UnsyncStorage {
 
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
         at: crate::GenerationalRefBorrowInfo,
-    ) -> Result<Self::Ref<T>, error::BorrowError> {
+    ) -> Result<Self::Ref<'static, T>, error::BorrowError> {
         let borrow = self.0.try_borrow();
 
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
@@ -46,7 +46,7 @@ impl<T: 'static> Storage<T> for UnsyncStorage {
         &'static self,
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
         at: crate::GenerationalRefMutBorrowInfo,
-    ) -> Result<Self::Mut<T>, error::BorrowMutError> {
+    ) -> Result<Self::Mut<'static, T>, error::BorrowMutError> {
         let borrow = self.0.try_borrow_mut();
 
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
@@ -89,13 +89,21 @@ thread_local! {
 }
 
 impl AnyStorage for UnsyncStorage {
-    type Ref<R: ?Sized + 'static> = GenerationalRef<Ref<'static, R>>;
-    type Mut<W: ?Sized + 'static> = GenerationalRefMut<RefMut<'static, W>>;
+    type Ref<'a, R: ?Sized + 'static> = GenerationalRef<Ref<'a, R>>;
+    type Mut<'a, W: ?Sized + 'static> = GenerationalRefMut<RefMut<'a, W>>;
 
-    fn try_map<I: ?Sized, U: ?Sized + 'static>(
-        _self: Self::Ref<I>,
+    fn downcast_ref<'a: 'b, 'b, T: ?Sized + 'static>(ref_: Self::Ref<'a, T>) -> Self::Ref<'b, T> {
+        ref_
+    }
+
+    fn downcast_mut<'a: 'b, 'b, T: ?Sized + 'static>(mut_: Self::Mut<'a, T>) -> Self::Mut<'b, T> {
+        mut_
+    }
+
+    fn try_map<I: ?Sized + 'static, U: ?Sized + 'static>(
+        _self: Self::Ref<'_, I>,
         f: impl FnOnce(&I) -> Option<&U>,
-    ) -> Option<Self::Ref<U>> {
+    ) -> Option<Self::Ref<'_, U>> {
         let GenerationalRef {
             inner,
             #[cfg(any(debug_assertions, feature = "debug_borrows"))]
@@ -109,10 +117,10 @@ impl AnyStorage for UnsyncStorage {
         })
     }
 
-    fn try_map_mut<I: ?Sized, U: ?Sized + 'static>(
-        mut_ref: Self::Mut<I>,
+    fn try_map_mut<I: ?Sized + 'static, U: ?Sized + 'static>(
+        mut_ref: Self::Mut<'_, I>,
         f: impl FnOnce(&mut I) -> Option<&mut U>,
-    ) -> Option<Self::Mut<U>> {
+    ) -> Option<Self::Mut<'_, U>> {
         let GenerationalRefMut {
             inner,
             #[cfg(any(debug_assertions, feature = "debug_borrows"))]

--- a/packages/generational-box/src/unsync.rs
+++ b/packages/generational-box/src/unsync.rs
@@ -92,11 +92,15 @@ impl AnyStorage for UnsyncStorage {
     type Ref<'a, R: ?Sized + 'static> = GenerationalRef<Ref<'a, R>>;
     type Mut<'a, W: ?Sized + 'static> = GenerationalRefMut<RefMut<'a, W>>;
 
-    fn downcast_ref<'a: 'b, 'b, T: ?Sized + 'static>(ref_: Self::Ref<'a, T>) -> Self::Ref<'b, T> {
+    fn downcast_lifetime_ref<'a: 'b, 'b, T: ?Sized + 'static>(
+        ref_: Self::Ref<'a, T>,
+    ) -> Self::Ref<'b, T> {
         ref_
     }
 
-    fn downcast_mut<'a: 'b, 'b, T: ?Sized + 'static>(mut_: Self::Mut<'a, T>) -> Self::Mut<'b, T> {
+    fn downcast_lifetime_mut<'a: 'b, 'b, T: ?Sized + 'static>(
+        mut_: Self::Mut<'a, T>,
+    ) -> Self::Mut<'b, T> {
         mut_
     }
 

--- a/packages/router/examples/simple_routes.rs
+++ b/packages/router/examples/simple_routes.rs
@@ -123,7 +123,7 @@ fn Route3(dynamic: String) -> Element {
             oninput: move |evt| {
                 *current_route_str.write() = evt.value();
             },
-            value: "{current_route_str.read()}"
+            value: "{current_route_str}"
         }
         "dynamic: {dynamic}"
         Link { to: Route::Route2 { user_id: 8888 }, "hello world link" }

--- a/packages/router/src/contexts/router.rs
+++ b/packages/router/src/contexts/router.rs
@@ -157,7 +157,7 @@ impl RouterContext {
     /// Will fail silently if there is no previous location to go to.
     pub fn go_back(&self) {
         {
-            self.inner.clone().write().history.go_back();
+            self.inner.write_unchecked().history.go_back();
         }
 
         self.change_route();
@@ -168,7 +168,7 @@ impl RouterContext {
     /// Will fail silently if there is no next location to go to.
     pub fn go_forward(&self) {
         {
-            self.inner.clone().write().history.go_forward();
+            self.inner.write_unchecked().history.go_forward();
         }
 
         self.change_route();
@@ -179,7 +179,7 @@ impl RouterContext {
         target: NavigationTarget<Rc<dyn Any>>,
     ) -> Option<ExternalNavigationFailure> {
         {
-            let mut write = self.inner.clone().write();
+            let mut write = self.inner.write_unchecked();
             match target {
                 NavigationTarget::Internal(p) => write.history.push(p),
                 NavigationTarget::External(e) => return write.external(e),
@@ -195,7 +195,7 @@ impl RouterContext {
     pub fn push(&self, target: impl Into<IntoRoutable>) -> Option<ExternalNavigationFailure> {
         let target = self.resolve_into_routable(target.into());
         {
-            let mut write = self.inner.clone().write();
+            let mut write = self.inner.write_unchecked();
             match target {
                 NavigationTarget::Internal(p) => write.history.push(p),
                 NavigationTarget::External(e) => return write.external(e),
@@ -212,7 +212,7 @@ impl RouterContext {
         let target = self.resolve_into_routable(target.into());
 
         {
-            let mut state = self.inner.clone().write();
+            let mut state = self.inner.write_unchecked();
             match target {
                 NavigationTarget::Internal(p) => state.history.replace(p),
                 NavigationTarget::External(e) => return state.external(e),
@@ -276,14 +276,14 @@ impl RouterContext {
 
     /// Clear any unresolved errors
     pub fn clear_error(&self) {
-        let mut write_inner = self.inner.clone().write();
+        let mut write_inner = self.inner.write_unchecked();
         write_inner.unresolved_error = None;
 
         write_inner.update_subscribers();
     }
 
     pub(crate) fn render_error(&self) -> Element {
-        let inner_read = self.inner.clone().write();
+        let inner_read = self.inner.write_unchecked();
         inner_read
             .unresolved_error
             .as_ref()
@@ -297,7 +297,7 @@ impl RouterContext {
             let callback = callback.clone();
             drop(self_read);
             if let Some(new) = callback(myself) {
-                let mut self_write = self.inner.clone().write();
+                let mut self_write = self.inner.write_unchecked();
                 match new {
                     NavigationTarget::Internal(p) => self_write.history.replace(p),
                     NavigationTarget::External(e) => return self_write.external(e),

--- a/packages/signals/examples/errors.rs
+++ b/packages/signals/examples/errors.rs
@@ -30,9 +30,9 @@ fn app() -> Element {
 
 #[component]
 fn Read() -> Element {
-    let mut signal = use_signal_sync(|| 0);
+    let signal = use_signal_sync(|| 0);
 
-    let _write = signal.write();
+    let _write = signal.write_unchecked();
     let _read = signal.read();
 
     unreachable!()
@@ -40,10 +40,10 @@ fn Read() -> Element {
 
 #[component]
 fn ReadMut() -> Element {
-    let mut signal = use_signal_sync(|| 0);
+    let signal = use_signal_sync(|| 0);
 
     let _read = signal.read();
-    let _write = signal.write();
+    let _write = signal.write_unchecked();
 
     unreachable!()
 }

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -238,8 +238,10 @@ impl<T: 'static, S: Storage<T>> Writable for CopyValue<T, S> {
         S::try_map_mut(mut_, f)
     }
 
-    fn downcast_mut<'a: 'b, 'b, R: ?Sized + 'static>(mut_: Self::Mut<'a, R>) -> Self::Mut<'b, R> {
-        S::downcast_mut(mut_)
+    fn downcast_lifetime_mut<'a: 'b, 'b, R: ?Sized + 'static>(
+        mut_: Self::Mut<'a, R>,
+    ) -> Self::Mut<'b, R> {
+        S::downcast_lifetime_mut(mut_)
     }
 
     #[track_caller]

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -190,11 +190,9 @@ impl<T: 'static, S: Storage<T>> CopyValue<T, S> {
         }
     }
 
-    /// Take the value out of the CopyValue, invalidating the value in the process.
-    pub fn take(&self) -> T {
-        self.value
-            .take()
-            .expect("value is already dropped or borrowed")
+    /// Manually drop the value in the CopyValue, invalidating the value in the process.
+    pub fn manually_drop(&self) -> Option<T> {
+        self.value.manually_drop()
     }
 
     /// Get the scope this value was created in.

--- a/packages/signals/src/global/memo.rs
+++ b/packages/signals/src/global/memo.rs
@@ -56,13 +56,15 @@ impl<T: PartialEq + 'static> Readable for GlobalMemo<T> {
     type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
-        self.memo().try_read()
+    fn try_read_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+        self.memo().try_read_unchecked()
     }
 
     #[track_caller]
-    fn peek(&self) -> ReadableRef<Self> {
-        self.memo().peek()
+    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+        self.memo().peek_unchecked()
     }
 }
 

--- a/packages/signals/src/global/signal.rs
+++ b/packages/signals/src/global/signal.rs
@@ -104,7 +104,9 @@ impl<T: 'static> Writable for GlobalSignal<T> {
         Write::filter_map(ref_, f)
     }
 
-    fn downcast_mut<'a: 'b, 'b, R: ?Sized + 'static>(mut_: Self::Mut<'a, R>) -> Self::Mut<'b, R> {
+    fn downcast_lifetime_mut<'a: 'b, 'b, R: ?Sized + 'static>(
+        mut_: Self::Mut<'a, R>,
+    ) -> Self::Mut<'b, R> {
         Write::downcast_lifetime(mut_)
     }
 

--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -163,8 +163,10 @@ where
     type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
-        let read = self.inner.try_read();
+    fn try_read_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+        let read = self.inner.try_read_unchecked();
         match read {
             Ok(r) => {
                 let needs_update = self
@@ -175,7 +177,7 @@ where
                 if needs_update {
                     drop(r);
                     self.recompute();
-                    self.inner.try_read()
+                    self.inner.try_read_unchecked()
                 } else {
                     Ok(r)
                 }
@@ -188,8 +190,8 @@ where
     ///
     /// If the signal has been dropped, this will panic.
     #[track_caller]
-    fn peek(&self) -> ReadableRef<Self> {
-        self.inner.peek()
+    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+        self.inner.peek_unchecked()
     }
 }
 

--- a/packages/signals/src/reactive_context.rs
+++ b/packages/signals/src/reactive_context.rs
@@ -128,8 +128,7 @@ impl ReactiveContext {
     ///
     /// Returns true if the context was marked as dirty, or false if the context has been dropped
     pub fn mark_dirty(&self) -> bool {
-        let mut copy = self.inner;
-        if let Ok(mut self_write) = copy.try_write() {
+        if let Ok(mut self_write) = self.inner.try_write_unchecked() {
             #[cfg(debug_assertions)]
             {
                 tracing::trace!(

--- a/packages/signals/src/read.rs
+++ b/packages/signals/src/read.rs
@@ -6,7 +6,8 @@ use crate::MappedSignal;
 
 /// A reference to a value that can be read from.
 #[allow(type_alias_bounds)]
-pub type ReadableRef<T: Readable, O = <T as Readable>::Target> = <T::Storage as AnyStorage>::Ref<O>;
+pub type ReadableRef<'a, T: Readable, O = <T as Readable>::Target> =
+    <T::Storage as AnyStorage>::Ref<'a, O>;
 
 /// A trait for states that can be read from like [`crate::Signal`], [`crate::GlobalSignal`], or [`crate::ReadOnlySignal`]. You may choose to accept this trait as a parameter instead of the concrete type to allow for more flexibility in your API. For example, instead of creating two functions, one that accepts a [`crate::Signal`] and one that accepts a [`crate::GlobalSignal`], you can create one function that accepts a [`Readable`] type.
 pub trait Readable {
@@ -27,15 +28,17 @@ pub trait Readable {
             let mapping = mapping.clone();
             move || {
                 self_
-                    .try_read()
+                    .try_read_unchecked()
                     .map(|ref_| <Self::Storage as AnyStorage>::map(ref_, |r| mapping(r)))
             }
         })
             as Rc<
-                dyn Fn() -> Result<ReadableRef<Self, O>, generational_box::BorrowError> + 'static,
+                dyn Fn() -> Result<ReadableRef<'static, Self, O>, generational_box::BorrowError>
+                    + 'static,
             >;
-        let peek = Rc::new(move || <Self::Storage as AnyStorage>::map(self.peek(), |r| mapping(r)))
-            as Rc<dyn Fn() -> ReadableRef<Self, O> + 'static>;
+        let peek = Rc::new(move || {
+            <Self::Storage as AnyStorage>::map(self.peek_unchecked(), |r| mapping(r))
+        }) as Rc<dyn Fn() -> ReadableRef<'static, Self, O> + 'static>;
         MappedSignal::new(try_read, peek)
     }
 
@@ -47,12 +50,38 @@ pub trait Readable {
         self.try_read().unwrap()
     }
 
-    /// Try to get the current value of the state. If this is a signal, this will subscribe the current scope to the signal. If the value has been dropped, this will panic.
+    /// Try to get the current value of the state. If this is a signal, this will subscribe the current scope to the signal.
     #[track_caller]
-    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError>;
+    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
+        self.try_read_unchecked().map(Self::Storage::downcast_ref)
+    }
+
+    /// Try to get a reference to the value without checking the lifetime.
+    ///
+    /// NOTE: This method is completely safe because borrow checking is done at runtime.
+    fn try_read_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>;
+
+    /// Tet a reference to the value without checking the lifetime.
+    ///
+    /// NOTE: This method is completely safe because borrow checking is done at runtime.
+    fn read_unchecked(&self) -> ReadableRef<'static, Self> {
+        self.try_read_unchecked().unwrap()
+    }
+
+    /// Get the current value of the signal without checking the lifetime. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
+    ///
+    /// If the signal has been dropped, this will panic.
+    ///
+    /// NOTE: This method is completely safe because borrow checking is done at runtime.
+    fn peek_unchecked(&self) -> ReadableRef<'static, Self>;
 
     /// Get the current value of the state without subscribing to updates. If the value has been dropped, this will panic.
-    fn peek(&self) -> ReadableRef<Self>;
+    #[track_caller]
+    fn peek(&self) -> ReadableRef<Self> {
+        Self::Storage::downcast_ref(self.peek_unchecked())
+    }
 
     /// Clone the inner value and return it. If the value has been dropped, this will panic.
     #[track_caller]
@@ -171,7 +200,7 @@ pub struct ReadableValueIterator<'a, R> {
 }
 
 impl<'a, T: 'static, R: Readable<Target = Vec<T>>> Iterator for ReadableValueIterator<'a, R> {
-    type Item = ReadableRef<R, T>;
+    type Item = ReadableRef<'a, R, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let index = self.index;

--- a/packages/signals/src/read.rs
+++ b/packages/signals/src/read.rs
@@ -53,7 +53,8 @@ pub trait Readable {
     /// Try to get the current value of the state. If this is a signal, this will subscribe the current scope to the signal.
     #[track_caller]
     fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
-        self.try_read_unchecked().map(Self::Storage::downcast_ref)
+        self.try_read_unchecked()
+            .map(Self::Storage::downcast_lifetime_ref)
     }
 
     /// Try to get a reference to the value without checking the lifetime.
@@ -80,7 +81,7 @@ pub trait Readable {
     /// Get the current value of the state without subscribing to updates. If the value has been dropped, this will panic.
     #[track_caller]
     fn peek(&self) -> ReadableRef<Self> {
-        Self::Storage::downcast_ref(self.peek_unchecked())
+        Self::Storage::downcast_lifetime_ref(self.peek_unchecked())
     }
 
     /// Clone the inner value and return it. If the value has been dropped, this will panic.

--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -59,16 +59,18 @@ impl<T, S: Storage<SignalData<T>>> Readable for ReadOnlySignal<T, S> {
     type Storage = S;
 
     #[track_caller]
-    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
-        self.inner.try_read()
+    fn try_read_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+        self.inner.try_read_unchecked()
     }
 
     /// Get the current value of the signal. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
     ///
     /// If the signal has been dropped, this will panic.
     #[track_caller]
-    fn peek(&self) -> S::Ref<T> {
-        self.inner.peek()
+    fn peek_unchecked(&self) -> S::Ref<'static, T> {
+        self.inner.peek_unchecked()
     }
 }
 

--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -50,7 +50,9 @@ impl<T: 'static, S: Storage<SignalData<T>>> ReadOnlySignal<T, S> {
     #[doc(hidden)]
     /// This should only be used by the `rsx!` macro.
     pub fn __take(&self) -> T {
-        self.inner.take()
+        self.inner
+            .manually_drop()
+            .expect("Signal has already been dropped")
     }
 }
 

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -136,9 +136,9 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
         }
     }
 
-    /// Take the value out of the signal, invalidating the signal in the process.
-    pub fn take(&self) -> T {
-        self.inner.take().value
+    /// Drop the value out of the signal, invalidating the signal in the process.
+    pub fn manually_drop(&self) -> Option<T> {
+        self.inner.manually_drop().map(|i| i.value)
     }
 
     /// Get the scope the signal was created in.

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -1,8 +1,8 @@
-use crate::Memo;
 use crate::{
     read::Readable, write::Writable, CopyValue, GlobalMemo, GlobalSignal, ReactiveContext,
     ReadableRef,
 };
+use crate::{Memo, WritableRef};
 use dioxus_core::{prelude::IntoAttributeValue, ScopeId};
 use generational_box::{AnyStorage, Storage, SyncStorage, UnsyncStorage};
 use std::{
@@ -168,8 +168,10 @@ impl<T, S: Storage<SignalData<T>>> Readable for Signal<T, S> {
     type Storage = S;
 
     #[track_caller]
-    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
-        let inner = self.inner.try_read()?;
+    fn try_read_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+        let inner = self.inner.try_read_unchecked()?;
 
         if let Some(reactive_context) = ReactiveContext::current() {
             tracing::trace!("Subscribing to the reactive context {}", reactive_context);
@@ -182,19 +184,20 @@ impl<T, S: Storage<SignalData<T>>> Readable for Signal<T, S> {
     /// Get the current value of the signal. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
     ///
     /// If the signal has been dropped, this will panic.
-    fn peek(&self) -> ReadableRef<Self> {
-        let inner = self.inner.read();
+    #[track_caller]
+    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+        let inner = self.inner.try_read_unchecked().unwrap();
         S::map(inner, |v| &v.value)
     }
 }
 
 impl<T: 'static, S: Storage<SignalData<T>>> Writable for Signal<T, S> {
-    type Mut<R: ?Sized + 'static> = Write<R, S>;
+    type Mut<'a, R: ?Sized + 'static> = Write<'a, R, S>;
 
     fn map_mut<I: ?Sized, U: ?Sized + 'static, F: FnOnce(&mut I) -> &mut U>(
-        ref_: Self::Mut<I>,
+        ref_: Self::Mut<'_, I>,
         f: F,
-    ) -> Self::Mut<U> {
+    ) -> Self::Mut<'_, U> {
         Write::map(ref_, f)
     }
 
@@ -203,15 +206,21 @@ impl<T: 'static, S: Storage<SignalData<T>>> Writable for Signal<T, S> {
         U: ?Sized + 'static,
         F: FnOnce(&mut I) -> Option<&mut U>,
     >(
-        ref_: Self::Mut<I>,
+        ref_: Self::Mut<'_, I>,
         f: F,
-    ) -> Option<Self::Mut<U>> {
+    ) -> Option<Self::Mut<'_, U>> {
         Write::filter_map(ref_, f)
     }
 
+    fn downcast_mut<'a: 'b, 'b, R: ?Sized + 'static>(mut_: Self::Mut<'a, R>) -> Self::Mut<'b, R> {
+        Write::downcast_lifetime(mut_)
+    }
+
     #[track_caller]
-    fn try_write(&mut self) -> Result<Self::Mut<T>, generational_box::BorrowMutError> {
-        self.inner.try_write().map(|inner| {
+    fn try_write_unchecked(
+        &self,
+    ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError> {
+        self.inner.try_write_unchecked().map(|inner| {
             let borrow = S::map_mut(inner, |v| &mut v.value);
             Write {
                 write: borrow,
@@ -273,14 +282,14 @@ impl<'de, T: serde::Deserialize<'de> + 'static, Store: Storage<SignalData<T>>>
 ///
 /// T is the current type of the write
 /// S is the storage type of the signal
-pub struct Write<T: ?Sized + 'static, S: AnyStorage = UnsyncStorage> {
-    write: S::Mut<T>,
+pub struct Write<'a, T: ?Sized + 'static, S: AnyStorage = UnsyncStorage> {
+    write: S::Mut<'a, T>,
     drop_signal: Box<dyn Any>,
 }
 
-impl<T: ?Sized + 'static, S: AnyStorage> Write<T, S> {
+impl<'a, T: ?Sized + 'static, S: AnyStorage> Write<'a, T, S> {
     /// Map the mutable reference to the signal's value to a new type.
-    pub fn map<O: ?Sized>(myself: Self, f: impl FnOnce(&mut T) -> &mut O) -> Write<O, S> {
+    pub fn map<O: ?Sized>(myself: Self, f: impl FnOnce(&mut T) -> &mut O) -> Write<'a, O, S> {
         let Self {
             write, drop_signal, ..
         } = myself;
@@ -294,16 +303,27 @@ impl<T: ?Sized + 'static, S: AnyStorage> Write<T, S> {
     pub fn filter_map<O: ?Sized>(
         myself: Self,
         f: impl FnOnce(&mut T) -> Option<&mut O>,
-    ) -> Option<Write<O, S>> {
+    ) -> Option<Write<'a, O, S>> {
         let Self {
             write, drop_signal, ..
         } = myself;
         let write = S::try_map_mut(write, f);
         write.map(|write| Write { write, drop_signal })
     }
+
+    /// Downcast the lifetime of the mutable reference to the signal's value.
+    pub fn downcast_lifetime<'b>(mut_: Self) -> Write<'b, T, S>
+    where
+        'a: 'b,
+    {
+        Write {
+            write: S::downcast_mut(mut_.write),
+            drop_signal: mut_.drop_signal,
+        }
+    }
 }
 
-impl<T: ?Sized + 'static, S: AnyStorage> Deref for Write<T, S> {
+impl<T: ?Sized + 'static, S: AnyStorage> Deref for Write<'_, T, S> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -311,7 +331,7 @@ impl<T: ?Sized + 'static, S: AnyStorage> Deref for Write<T, S> {
     }
 }
 
-impl<T: ?Sized, S: AnyStorage> DerefMut for Write<T, S> {
+impl<T: ?Sized, S: AnyStorage> DerefMut for Write<'_, T, S> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.write
     }

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -212,7 +212,9 @@ impl<T: 'static, S: Storage<SignalData<T>>> Writable for Signal<T, S> {
         Write::filter_map(ref_, f)
     }
 
-    fn downcast_mut<'a: 'b, 'b, R: ?Sized + 'static>(mut_: Self::Mut<'a, R>) -> Self::Mut<'b, R> {
+    fn downcast_lifetime_mut<'a: 'b, 'b, R: ?Sized + 'static>(
+        mut_: Self::Mut<'a, R>,
+    ) -> Self::Mut<'b, R> {
         Write::downcast_lifetime(mut_)
     }
 
@@ -312,12 +314,14 @@ impl<'a, T: ?Sized + 'static, S: AnyStorage> Write<'a, T, S> {
     }
 
     /// Downcast the lifetime of the mutable reference to the signal's value.
+    ///
+    /// This function enforces the variance of the lifetime parameter `'a` in Mut.  Rust will typically infer this cast with a concrete type, but it cannot with a generic type.
     pub fn downcast_lifetime<'b>(mut_: Self) -> Write<'b, T, S>
     where
         'a: 'b,
     {
         Write {
-            write: S::downcast_mut(mut_.write),
+            write: S::downcast_lifetime_mut(mut_.write),
             drop_signal: mut_.drop_signal,
         }
     }

--- a/packages/signals/src/write.rs
+++ b/packages/signals/src/write.rs
@@ -26,7 +26,9 @@ pub trait Writable: Readable {
     /// Downcast a mutable reference in a RefMut to a more specific lifetime
     ///
     /// This function enforces the variance of the lifetime parameter `'a` in Ref.
-    fn downcast_mut<'a: 'b, 'b, T: ?Sized + 'static>(mut_: Self::Mut<'a, T>) -> Self::Mut<'b, T>;
+    fn downcast_lifetime_mut<'a: 'b, 'b, T: ?Sized + 'static>(
+        mut_: Self::Mut<'a, T>,
+    ) -> Self::Mut<'b, T>;
 
     /// Get a mutable reference to the value. If the value has been dropped, this will panic.
     #[track_caller]
@@ -37,7 +39,7 @@ pub trait Writable: Readable {
     /// Try to get a mutable reference to the value.
     #[track_caller]
     fn try_write(&mut self) -> Result<WritableRef<'_, Self>, generational_box::BorrowMutError> {
-        self.try_write_unchecked().map(Self::downcast_mut)
+        self.try_write_unchecked().map(Self::downcast_lifetime_mut)
     }
 
     /// Try to get a mutable reference to the value without checking the lifetime.
@@ -238,7 +240,7 @@ impl<'a, T: 'static, R: Writable<Target = Vec<T>>> Iterator for WritableValueIte
             self.value.try_write_unchecked().unwrap(),
             |v: &mut Vec<T>| v.get_mut(index),
         )
-        .map(R::downcast_mut)
+        .map(R::downcast_lifetime_mut)
     }
 }
 

--- a/packages/signals/src/write.rs
+++ b/packages/signals/src/write.rs
@@ -1,33 +1,58 @@
-use std::ops::DerefMut;
-use std::ops::IndexMut;
+use std::ops::{DerefMut, IndexMut};
 
 use crate::read::Readable;
+
+/// A reference to a value that can be read from.
+#[allow(type_alias_bounds)]
+pub type WritableRef<'a, T: Writable, O = <T as Readable>::Target> = T::Mut<'a, O>;
 
 /// A trait for states that can be read from like [`crate::Signal`], or [`crate::GlobalSignal`]. You may choose to accept this trait as a parameter instead of the concrete type to allow for more flexibility in your API. For example, instead of creating two functions, one that accepts a [`crate::Signal`] and one that accepts a [`crate::GlobalSignal`], you can create one function that accepts a [`Writable`] type.
 pub trait Writable: Readable {
     /// The type of the reference.
-    type Mut<R: ?Sized + 'static>: DerefMut<Target = R> + 'static;
+    type Mut<'a, R: ?Sized + 'static>: DerefMut<Target = R>;
 
     /// Map the reference to a new type.
     fn map_mut<I: ?Sized, U: ?Sized, F: FnOnce(&mut I) -> &mut U>(
-        ref_: Self::Mut<I>,
+        ref_: Self::Mut<'_, I>,
         f: F,
-    ) -> Self::Mut<U>;
+    ) -> Self::Mut<'_, U>;
 
     /// Try to map the reference to a new type.
     fn try_map_mut<I: ?Sized, U: ?Sized, F: FnOnce(&mut I) -> Option<&mut U>>(
-        ref_: Self::Mut<I>,
+        ref_: Self::Mut<'_, I>,
         f: F,
-    ) -> Option<Self::Mut<U>>;
+    ) -> Option<Self::Mut<'_, U>>;
+
+    /// Downcast a mutable reference in a RefMut to a more specific lifetime
+    ///
+    /// This function enforces the variance of the lifetime parameter `'a` in Ref.
+    fn downcast_mut<'a: 'b, 'b, T: ?Sized + 'static>(mut_: Self::Mut<'a, T>) -> Self::Mut<'b, T>;
 
     /// Get a mutable reference to the value. If the value has been dropped, this will panic.
     #[track_caller]
-    fn write(&mut self) -> Self::Mut<Self::Target> {
+    fn write(&mut self) -> WritableRef<'_, Self> {
         self.try_write().unwrap()
     }
 
-    /// Try to get a mutable reference to the value. If the value has been dropped, this will panic.
-    fn try_write(&mut self) -> Result<Self::Mut<Self::Target>, generational_box::BorrowMutError>;
+    /// Try to get a mutable reference to the value.
+    #[track_caller]
+    fn try_write(&mut self) -> Result<WritableRef<'_, Self>, generational_box::BorrowMutError> {
+        self.try_write_unchecked().map(Self::downcast_mut)
+    }
+
+    /// Try to get a mutable reference to the value without checking the lifetime.
+    ///
+    /// NOTE: This method is completely safe because borrow checking is done at runtime.
+    fn try_write_unchecked(
+        &self,
+    ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError>;
+
+    /// Tet a mutable reference to the value without checking the lifetime.
+    ///
+    /// NOTE: This method is completely safe because borrow checking is done at runtime.
+    fn write_unchecked(&self) -> WritableRef<'static, Self> {
+        self.try_write_unchecked().unwrap()
+    }
 
     /// Run a function with a mutable reference to the value. If the value has been dropped, this will panic.
     #[track_caller]
@@ -55,7 +80,10 @@ pub trait Writable: Readable {
 
     /// Index into the inner value and return a reference to the result.
     #[track_caller]
-    fn index_mut<I>(&mut self, index: I) -> Self::Mut<<Self::Target as std::ops::Index<I>>::Output>
+    fn index_mut<I>(
+        &mut self,
+        index: I,
+    ) -> WritableRef<'_, Self, <Self::Target as std::ops::Index<I>>::Output>
     where
         Self::Target: std::ops::IndexMut<I>,
     {
@@ -84,15 +112,14 @@ pub trait Writable: Readable {
 /// An extension trait for Writable<Option<T>> that provides some convenience methods.
 pub trait WritableOptionExt<T: 'static>: Writable<Target = Option<T>> {
     /// Gets the value out of the Option, or inserts the given value if the Option is empty.
-    fn get_or_insert(&mut self, default: T) -> Self::Mut<T> {
+    fn get_or_insert(&mut self, default: T) -> WritableRef<'_, Self, T> {
         self.get_or_insert_with(|| default)
     }
 
     /// Gets the value out of the Option, or inserts the value returned by the given function if the Option is empty.
-    fn get_or_insert_with(&mut self, default: impl FnOnce() -> T) -> Self::Mut<T> {
-        let borrow = self.read();
-        if borrow.is_none() {
-            drop(borrow);
+    fn get_or_insert_with(&mut self, default: impl FnOnce() -> T) -> WritableRef<'_, Self, T> {
+        let is_none = self.read().is_none();
+        if is_none {
             self.with_mut(|v| *v = Some(default()));
             Self::map_mut(self.write(), |v| v.as_mut().unwrap())
         } else {
@@ -102,7 +129,7 @@ pub trait WritableOptionExt<T: 'static>: Writable<Target = Option<T>> {
 
     /// Attempts to write the inner value of the Option.
     #[track_caller]
-    fn as_mut(&mut self) -> Option<Self::Mut<T>> {
+    fn as_mut(&mut self) -> Option<WritableRef<'_, Self, T>> {
         Self::try_map_mut(self.write(), |v: &mut Option<T>| v.as_mut())
     }
 }
@@ -178,36 +205,40 @@ pub trait WritableVecExt<T: 'static>: Writable<Target = Vec<T>> {
 
     /// Try to mutably get an element from the vector.
     #[track_caller]
-    fn get_mut(&mut self, index: usize) -> Option<Self::Mut<T>> {
+    fn get_mut(&mut self, index: usize) -> Option<WritableRef<'_, Self, T>> {
         Self::try_map_mut(self.write(), |v: &mut Vec<T>| v.get_mut(index))
     }
 
     /// Gets an iterator over the values of the vector.
     #[track_caller]
-    fn iter_mut(&self) -> WritableValueIterator<Self>
+    fn iter_mut(&mut self) -> WritableValueIterator<'_, Self>
     where
         Self: Sized + Clone,
     {
         WritableValueIterator {
             index: 0,
-            value: self.clone(),
+            value: self,
         }
     }
 }
 
 /// An iterator over the values of a `Writable<Vec<T>>`.
-pub struct WritableValueIterator<R> {
+pub struct WritableValueIterator<'a, R> {
     index: usize,
-    value: R,
+    value: &'a mut R,
 }
 
-impl<T: 'static, R: Writable<Target = Vec<T>>> Iterator for WritableValueIterator<R> {
-    type Item = R::Mut<T>;
+impl<'a, T: 'static, R: Writable<Target = Vec<T>>> Iterator for WritableValueIterator<'a, R> {
+    type Item = WritableRef<'a, R, T>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let index = self.index;
         self.index += 1;
-        self.value.get_mut(index)
+        R::try_map_mut(
+            self.value.try_write_unchecked().unwrap(),
+            |v: &mut Vec<T>| v.get_mut(index),
+        )
+        .map(R::downcast_mut)
     }
 }
 


### PR DESCRIPTION
This PR renames the `take` method on signals to `manually_drop` to make it easier to find and restore local lifetime tracking for signals.

Note while local lifetime tracking can help prevent some bugs at compile time, it can make some common situations less ergonomic including [matching the value of a resource](https://github.com/ealmloff/dioxus/blob/5f9e5f607b94aa92cd90584a97bb1c1b28198963/examples/dog_app.rs#L83):

```rust
// fut.read() now causes an error
match fut.read_unchecked().as_ref() {
    Some(Ok(resp)) => rsx! {
        button { onclick: move |_| fut.restart(), "Click to fetch another doggo" }
        div { img { max_width: "500px", max_height: "500px", src: "{resp.message}" } }
    },
    Some(Err(_)) => rsx! { div { "loading dogs failed" } },
    None => rsx! { div { "loading dogs..." } },
}
```

Closes https://github.com/DioxusLabs/dioxus/issues/2011
Closes https://github.com/DioxusLabs/dioxus/issues/2009