### PR TITLE
fix #1979: generated Owned impl for the props builder was using the wrong generics

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -1276,7 +1276,8 @@ Finally, call `.build()` to create the instance of `{name}`.
             });
             let (impl_generics, _, _) = generics.split_for_impl();
 
-            let (_, ty_generics, where_clause) = self.generics.split_for_impl();
+            let (original_impl_generics, ty_generics, where_clause) =
+                self.generics.split_for_impl();
 
             let modified_ty_generics = modify_types_generics_hack(&ty_generics, |args| {
                 args.insert(
@@ -1344,13 +1345,13 @@ Finally, call `.build()` to create the instance of `{name}`.
                         owner: Owner,
                     }
 
-                    impl #impl_generics PartialEq for #name #ty_generics #where_clause {
+                    impl #original_impl_generics PartialEq for #name #ty_generics #where_clause {
                         fn eq(&self, other: &Self) -> bool {
                             self.inner.eq(&other.inner)
                         }
                     }
 
-                    impl #impl_generics #name #ty_generics #where_clause {
+                    impl #original_impl_generics #name #ty_generics #where_clause {
                         /// Create a component from the props.
                         fn into_vcomponent<M: 'static>(
                             self,
@@ -1362,7 +1363,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                         }
                     }
 
-                    impl #impl_generics dioxus_core::prelude::Properties for #name #ty_generics #where_clause {
+                    impl #original_impl_generics dioxus_core::prelude::Properties for #name #ty_generics #where_clause {
                         type Builder = ();
                         fn builder() -> Self::Builder {
                             unreachable!()

--- a/packages/signals/examples/read_only_degrade.rs
+++ b/packages/signals/examples/read_only_degrade.rs
@@ -1,0 +1,30 @@
+//! Signals can degrade into a ReadOnlySignal variant automatically
+//! This is done thanks to a conversion by the #[component] macro
+
+use dioxus::prelude::*;
+
+fn main() {
+    launch(app);
+}
+
+fn app() -> Element {
+    let mut count = use_signal(|| 0);
+
+    rsx! {
+        h1 { "High-Five counter: {count}" }
+        button { onclick: move |_| count += 1, "Up high!" }
+        button { onclick: move |_| count -= 1, "Down low!" }
+        Child {
+            count,
+            "hiiii"
+        }
+    }
+}
+
+#[component]
+fn Child(count: ReadOnlySignal<i32>, children: Element) -> Element {
+    rsx! {
+        div { "Count: {count}" }
+        {children}
+    }
+}


### PR DESCRIPTION
This commit fixes the owned impl to use the original generics rather than the build generics.

I've also added a little compile test in the form of an example in the signals repo.