### PR TITLE
fix typo varient -> variant

### DIFF
--- a/packages/native-core/src/real_dom.rs
+++ b/packages/native-core/src/real_dom.rs
@@ -108,7 +108,7 @@ type AttributeWatchers<V> = Arc<RwLock<Vec<Box<dyn AttributeWatcher<V> + Send + 
 /// 4) Call [RealDom::update_state] to update the state of incrementally computed values on each node
 ///
 /// # Custom attribute values
-/// To allow custom values to be passed into attributes implement FromAnyValue on a type that can represent your custom value and specify the V generic to be that type. If you have many different custom values, it can be useful to use a enum type to represent the varients.
+/// To allow custom values to be passed into attributes implement FromAnyValue on a type that can represent your custom value and specify the V generic to be that type. If you have many different custom values, it can be useful to use a enum type to represent the variants.
 pub struct RealDom<V: FromAnyValue + Send + Sync = ()> {
     pub(crate) world: World,
     nodes_listening: FxHashMap<String, FxHashSet<NodeId>>,

--- a/packages/router-macro/src/route_tree.rs
+++ b/packages/router-macro/src/route_tree.rs
@@ -153,8 +153,8 @@ impl<'a> RouteTree<'a> {
                                 segment,
                                 children: Vec::new(),
                                 error_variant: StaticErrorVariant {
-                                    varient_parse_error: nest.error_ident(),
-                                    enum_varient: nest.error_variant(),
+                                    variant_parse_error: nest.error_ident(),
+                                    enum_variant: nest.error_variant(),
                                 },
                                 index,
                             };
@@ -254,8 +254,8 @@ impl<'a> RouteTree<'a> {
 
 #[derive(Debug, Clone)]
 pub struct StaticErrorVariant {
-    varient_parse_error: Ident,
-    enum_varient: Ident,
+    variant_parse_error: Ident,
+    enum_variant: Ident,
 }
 
 // First deduplicate the routes by the static part of the route
@@ -290,8 +290,8 @@ impl<'a> RouteTreeSegmentData<'a> {
                 index,
                 error_variant:
                     StaticErrorVariant {
-                        varient_parse_error,
-                        enum_varient,
+                        variant_parse_error,
+                        enum_variant,
                     },
             } => {
                 let children = children.iter().map(|child| {
@@ -318,7 +318,7 @@ impl<'a> RouteTreeSegmentData<'a> {
                                 #(#children)*
                             }
                             else {
-                                errors.push(#error_enum_name::#enum_varient(#varient_parse_error::#error_ident(segment.to_string())))
+                                errors.push(#error_enum_name::#enum_variant(#variant_parse_error::#error_ident(segment.to_string())))
                             }
                         }
                     }
@@ -326,8 +326,8 @@ impl<'a> RouteTreeSegmentData<'a> {
             }
             RouteTreeSegmentData::Route(route) => {
                 // At this point, we have matched all static segments, so we can just check if the remaining segments match the route
-                let varient_parse_error = route.error_ident();
-                let enum_varient = &route.route_name;
+                let variant_parse_error = route.error_ident();
+                let enum_variant = &route.route_name;
 
                 let route_segments = route
                     .segments
@@ -353,13 +353,13 @@ impl<'a> RouteTreeSegmentData<'a> {
                         insure_not_trailing,
                         construct_variant,
                         &error_enum_name,
-                        enum_varient,
-                        &varient_parse_error,
+                        enum_variant,
+                        &variant_parse_error,
                         parse_query,
                     ),
                     &error_enum_name,
-                    enum_varient,
-                    &varient_parse_error,
+                    enum_variant,
+                    &variant_parse_error,
                 );
 
                 match &route.ty {
@@ -374,7 +374,7 @@ impl<'a> RouteTreeSegmentData<'a> {
                                 trailing += "/";
                             }
                             trailing.pop();
-                            match #ty::from_str(&trailing).map_err(|err| #error_enum_name::#enum_varient(#varient_parse_error::ChildRoute(err))) {
+                            match #ty::from_str(&trailing).map_err(|err| #error_enum_name::#enum_variant(#variant_parse_error::ChildRoute(err))) {
                                 Ok(#child_name) => {
                                     #print_route_segment
                                 }
@@ -389,8 +389,8 @@ impl<'a> RouteTreeSegmentData<'a> {
             }
             Self::Nest { nest, children } => {
                 // At this point, we have matched all static segments, so we can just check if the remaining segments match the route
-                let varient_parse_error: Ident = nest.error_ident();
-                let enum_varient = nest.error_variant();
+                let variant_parse_error: Ident = nest.error_ident();
+                let enum_variant = nest.error_variant();
 
                 let route_segments = nest
                     .segments
@@ -410,14 +410,14 @@ impl<'a> RouteTreeSegmentData<'a> {
                     route_segments.peekable(),
                     parse_children,
                     &error_enum_name,
-                    &enum_varient,
-                    &varient_parse_error,
+                    &enum_variant,
+                    &variant_parse_error,
                 )
             }
             Self::Redirect(redirect) => {
                 // At this point, we have matched all static segments, so we can just check if the remaining segments match the route
-                let varient_parse_error = redirect.error_ident();
-                let enum_varient = &redirect.error_variant();
+                let variant_parse_error = redirect.error_ident();
+                let enum_variant = &redirect.error_variant();
 
                 let route_segments = redirect
                     .segments
@@ -451,13 +451,13 @@ impl<'a> RouteTreeSegmentData<'a> {
                         insure_not_trailing,
                         return_redirect,
                         &error_enum_name,
-                        enum_varient,
-                        &varient_parse_error,
+                        enum_variant,
+                        &variant_parse_error,
                         parse_query,
                     ),
                     &error_enum_name,
-                    enum_varient,
-                    &varient_parse_error,
+                    enum_variant,
+                    &variant_parse_error,
                 )
             }
         }
@@ -468,23 +468,23 @@ fn print_route_segment<'a, I: Iterator<Item = (usize, &'a RouteSegment)>>(
     mut s: std::iter::Peekable<I>,
     sucess_tokens: TokenStream,
     error_enum_name: &Ident,
-    enum_varient: &Ident,
-    varient_parse_error: &Ident,
+    enum_variant: &Ident,
+    variant_parse_error: &Ident,
 ) -> TokenStream {
     if let Some((i, route)) = s.next() {
         let children = print_route_segment(
             s,
             sucess_tokens,
             error_enum_name,
-            enum_varient,
-            varient_parse_error,
+            enum_variant,
+            variant_parse_error,
         );
 
         route.try_parse(
             i,
             error_enum_name,
-            enum_varient,
-            varient_parse_error,
+            enum_variant,
+            variant_parse_error,
             children,
         )
     } else {
@@ -498,8 +498,8 @@ fn return_constructed(
     insure_not_trailing: bool,
     construct_variant: TokenStream,
     error_enum_name: &Ident,
-    enum_varient: &Ident,
-    varient_parse_error: &Ident,
+    enum_variant: &Ident,
+    variant_parse_error: &Ident,
     parse_query: TokenStream,
 ) -> TokenStream {
     if insure_not_trailing {
@@ -523,7 +523,7 @@ fn return_constructed(
                         trailing += "/";
                     }
                     trailing.pop();
-                    errors.push(#error_enum_name::#enum_varient(#varient_parse_error::ExtraSegments(trailing)))
+                    errors.push(#error_enum_name::#enum_variant(#variant_parse_error::ExtraSegments(trailing)))
                 }
             }
         }
@@ -595,8 +595,8 @@ impl<'a> PathIter<'a> {
 
     fn error_variant(&self) -> StaticErrorVariant {
         StaticErrorVariant {
-            varient_parse_error: self.error_ident.clone(),
-            enum_varient: self.error_variant.clone(),
+            variant_parse_error: self.error_ident.clone(),
+            enum_variant: self.error_variant.clone(),
         }
     }
 }

--- a/packages/router-macro/src/segment.rs
+++ b/packages/router-macro/src/segment.rs
@@ -48,7 +48,7 @@ impl RouteSegment {
         &self,
         idx: usize,
         error_enum_name: &Ident,
-        error_enum_varient: &Ident,
+        error_enum_variant: &Ident,
         inner_parse_enum: &Ident,
         parse_children: TokenStream2,
     ) -> TokenStream2 {
@@ -63,7 +63,7 @@ impl RouteSegment {
                         let parsed = if let Some(#segment) = segment {
                             Ok(())
                         } else {
-                            Err(#error_enum_name::#error_enum_varient(#inner_parse_enum::#error_name(segment.map(|s|s.to_string()).unwrap_or_default())))
+                            Err(#error_enum_name::#error_enum_variant(#inner_parse_enum::#error_name(segment.map(|s|s.to_string()).unwrap_or_default())))
                         };
                         match parsed {
                             Ok(_) => {
@@ -83,9 +83,9 @@ impl RouteSegment {
                         let mut segments = segments.clone();
                         let segment = segments.next();
                         let parsed = if let Some(segment) = segment.as_deref() {
-                            <#ty as dioxus_router::routable::FromRouteSegment>::from_route_segment(segment).map_err(|err| #error_enum_name::#error_enum_varient(#inner_parse_enum::#error_name(err)))
+                            <#ty as dioxus_router::routable::FromRouteSegment>::from_route_segment(segment).map_err(|err| #error_enum_name::#error_enum_variant(#inner_parse_enum::#error_name(err)))
                         } else {
-                            Err(#error_enum_name::#error_enum_varient(#inner_parse_enum::#missing_error_name))
+                            Err(#error_enum_name::#error_enum_variant(#inner_parse_enum::#missing_error_name))
                         };
                         match parsed {
                             Ok(#name) => {
@@ -107,7 +107,7 @@ impl RouteSegment {
                             for segment in &remaining_segments {
                                 new_segments.push(&*segment);
                             }
-                            <#ty as dioxus_router::routable::FromRouteSegments>::from_route_segments(&new_segments).map_err(|err| #error_enum_name::#error_enum_varient(#inner_parse_enum::#error_name(err)))
+                            <#ty as dioxus_router::routable::FromRouteSegments>::from_route_segments(&new_segments).map_err(|err| #error_enum_name::#error_enum_variant(#inner_parse_enum::#error_name(err)))
                         };
                         match parsed {
                             Ok(#name) => {

--- a/packages/rsx/src/hot_reload/hot_reload_diff.rs
+++ b/packages/rsx/src/hot_reload/hot_reload_diff.rs
@@ -59,9 +59,9 @@ fn find_rsx_item(
             if new_item.variants.len() != old_item.variants.len() {
                 return true;
             }
-            for (new_varient, old_varient) in new_item.variants.iter().zip(old_item.variants.iter())
+            for (new_variant, old_variant) in new_item.variants.iter().zip(old_item.variants.iter())
             {
-                match (&new_varient.discriminant, &old_varient.discriminant) {
+                match (&new_variant.discriminant, &old_variant.discriminant) {
                     (Some((new_eq, new_expr)), Some((old_eq, old_expr))) => {
                         if find_rsx_expr(new_expr, old_expr, rsx_calls) || new_eq != old_eq {
                             return true;
@@ -70,9 +70,9 @@ fn find_rsx_item(
                     (None, None) => (),
                     _ => return true,
                 }
-                if new_varient.attrs != old_varient.attrs
-                    || new_varient.ident != old_varient.ident
-                    || new_varient.fields != old_varient.fields
+                if new_variant.attrs != old_variant.attrs
+                    || new_variant.ident != old_variant.ident
+                    || new_variant.fields != old_variant.fields
                 {
                     return true;
                 }


### PR DESCRIPTION
this PR fixes typo `varient` -> `variant`