### PR TITLE
Fix Manganis assets overlapping between examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,7 +2201,7 @@ version = "0.5.0-alpha.0"
 dependencies = [
  "criterion 0.3.6",
  "dioxus-config-macro",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-core-macro",
  "dioxus-desktop",
  "dioxus-fullstack",
@@ -2268,7 +2268,7 @@ dependencies = [
  "dioxus-autofmt",
  "dioxus-check",
  "dioxus-cli-config",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-hot-reload",
  "dioxus-html",
  "dioxus-rsx",
@@ -2357,6 +2357,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-core"
+version = "0.5.0-alpha.0"
+source = "git+https://github.com/DioxusLabs/dioxus#44d09fcd2de4af32c8a3a107cabdd3e6860baeeb"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "longest-increasing-subsequence",
+ "rustc-hash",
+ "slab",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "dioxus-core-macro"
 version = "0.5.0-alpha.0"
 dependencies = [
@@ -2386,7 +2400,7 @@ dependencies = [
  "core-foundation",
  "dioxus",
  "dioxus-cli-config",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-hooks",
  "dioxus-hot-reload",
  "dioxus-html",
@@ -2487,7 +2501,7 @@ name = "dioxus-hooks"
 version = "0.5.0-alpha.0"
 dependencies = [
  "dioxus",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-debug-cell",
  "dioxus-signals",
  "futures-channel",
@@ -2505,7 +2519,7 @@ name = "dioxus-hot-reload"
 version = "0.5.0-alpha.0"
 dependencies = [
  "chrono",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-html",
  "dioxus-rsx",
  "execute",
@@ -2522,7 +2536,7 @@ name = "dioxus-html"
 version = "0.5.0-alpha.0"
 dependencies = [
  "async-trait",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-html-internal-macro",
  "dioxus-rsx",
  "enumset",
@@ -2555,7 +2569,7 @@ dependencies = [
 name = "dioxus-interpreter-js"
 version = "0.5.0-alpha.0"
 dependencies = [
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-html",
  "js-sys",
  "md5",
@@ -2571,7 +2585,7 @@ name = "dioxus-lib"
 version = "0.5.0-alpha.0"
 dependencies = [
  "dioxus-config-macro",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-core-macro",
  "dioxus-hooks",
  "dioxus-html",
@@ -2586,7 +2600,7 @@ dependencies = [
  "axum",
  "dioxus",
  "dioxus-cli-config",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-hot-reload",
  "dioxus-html",
  "dioxus-interpreter-js",
@@ -2620,7 +2634,7 @@ dependencies = [
  "anymap 1.0.0-beta.2",
  "dashmap",
  "dioxus",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-native-core",
  "dioxus-native-core-macro",
  "keyboard-types",
@@ -2729,7 +2743,7 @@ dependencies = [
 name = "dioxus-rsx"
 version = "0.5.0-alpha.0"
 dependencies = [
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "internment",
  "krates",
  "proc-macro2",
@@ -2744,7 +2758,7 @@ name = "dioxus-signals"
 version = "0.5.0-alpha.0"
 dependencies = [
  "dioxus",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "futures-channel",
  "futures-util",
  "generational-box",
@@ -2768,7 +2782,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dioxus",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-html",
  "dioxus-signals",
  "fern",
@@ -2799,7 +2813,7 @@ dependencies = [
  "criterion 0.3.6",
  "crossterm 0.26.1",
  "dioxus",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-hot-reload",
  "dioxus-html",
  "dioxus-native-core",
@@ -2817,7 +2831,7 @@ dependencies = [
  "async-trait",
  "console_error_panic_hook",
  "dioxus",
- "dioxus-core",
+ "dioxus-core 0.5.0-alpha.0",
  "dioxus-html",
  "dioxus-interpreter-js",
  "dioxus-ssr",
@@ -5701,17 +5715,14 @@ dependencies = [
 [[package]]
 name = "manganis"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11b87b5222a0eb4c7b1e7a49cc78922aa82a7fa5aa614e07ace55ed74fcdf67"
 dependencies = [
+ "dioxus-core 0.5.0-alpha.0 (git+https://github.com/DioxusLabs/dioxus)",
  "manganis-macro",
 ]
 
 [[package]]
 name = "manganis-cli-support"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9c40a20048742dfbb793fb93498640e128543bcf92588b4c3b25451957522d"
 dependencies = [
  "anyhow",
  "cargo-lock 9.0.0",
@@ -5737,8 +5748,6 @@ dependencies = [
 [[package]]
 name = "manganis-common"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84166560d60366c4b4fe12e204f2fca78fe594382e13c02d75fab6e0d8f40184"
 dependencies = [
  "anyhow",
  "base64",
@@ -5753,8 +5762,6 @@ dependencies = [
 [[package]]
 name = "manganis-macro"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b78150e016312c51841521a9dc7fb5ae994c163a325eb4c2aa0186efce9532e"
 dependencies = [
  "manganis-common",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,11 +100,11 @@ thiserror = "1.0.40"
 prettyplease = { package = "prettier-please", version = "0.2", features = [
     "verbatim",
 ] }
-manganis-cli-support = { version = "0.1.0", features = [
+manganis-cli-support = { version = "0.2.0", features = [
     "webp",
     "html",
 ] }
-manganis = { version = "0.1.0" }
+manganis = { version = "0.2.0" }
 
 lru = "0.12.2"
 async-trait = "0.1.77"

--- a/packages/cli-config/src/config.rs
+++ b/packages/cli-config/src/config.rs
@@ -370,6 +370,16 @@ pub enum ExecutableType {
     Example(String),
 }
 
+impl ExecutableType {
+    /// Get the name of the executable if it is a binary or an example.
+    pub fn executable(&self) -> Option<&str> {
+        match self {
+            Self::Binary(bin) | Self::Example(bin) => Some(bin),
+            _ => None,
+        }
+    }
+}
+
 impl CrateConfig {
     #[cfg(feature = "cli")]
     pub fn new(bin: Option<PathBuf>) -> Result<Self, CrateConfigError> {

--- a/packages/cli/src/assets.rs
+++ b/packages/cli/src/assets.rs
@@ -4,8 +4,9 @@ use crate::Result;
 use dioxus_cli_config::CrateConfig;
 use manganis_cli_support::{AssetManifest, AssetManifestExt};
 
-pub fn asset_manifest(crate_config: &CrateConfig) -> AssetManifest {
+pub fn asset_manifest(bin: Option<&str>, crate_config: &CrateConfig) -> AssetManifest {
     AssetManifest::load_from_path(
+        bin,
         crate_config.crate_dir.join("Cargo.toml"),
         crate_config.workspace_dir.join("Cargo.lock"),
     )

--- a/packages/cli/src/server/mod.rs
+++ b/packages/cli/src/server/mod.rs
@@ -137,7 +137,7 @@ async fn setup_file_watcher<F: Fn() -> Result<BuildResult> + Send + 'static>(
             &config.crate_dir.join(sub_path),
             notify::RecursiveMode::Recursive,
         ) {
-            log::error!("Failed to watch path: {}", err);
+            log::warn!("Failed to watch path: {}", err);
         }
     }
     Ok(watcher)

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -204,7 +204,7 @@ fn module_loader(root_id: &str, headless: bool) -> String {
 /// Defaults to the current directory if no asset directory is found, which is useful for development when the app
 /// isn't bundled.
 fn get_asset_root_or_default() -> PathBuf {
-    get_asset_root().unwrap_or_else(|| Path::new(".").to_path_buf())
+    get_asset_root().unwrap_or_else(|| std::env::current_dir().unwrap())
 }
 
 /// Get the asset directory, following tauri/cargo-bundles directory discovery approach


### PR DESCRIPTION
This PR bumps Manganis which fixes assets built for one example carrying over to other examples. It also cleans up some of the logic to find the path to output binary for cargo builds.