### PR TITLE
Implement copy for Resource

### DIFF
--- a/packages/hooks/src/use_resource.rs
+++ b/packages/hooks/src/use_resource.rs
@@ -107,6 +107,13 @@ pub struct Resource<T: 'static> {
     callback: UseCallback<Task>,
 }
 
+impl<T> Clone for Resource<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Copy for Resource<T> {}
+
 /// A signal that represents the state of the resource
 // we might add more states (panicked, etc)
 #[derive(Clone, Copy, PartialEq, Hash, Eq, Debug)]

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -244,12 +244,16 @@ impl<'a> ToTokens for TemplateRenderer<'a> {
                 attr_paths: &[ #(#attr_paths),* ],
             };
 
-            dioxus_core::VNode::new(
-                #key_tokens,
-                TEMPLATE,
-                Box::new([ #( #node_printer),* ]),
-                Box::new([ #(#dyn_attr_printer),* ]),
-            )
+            {
+                // NOTE: Allocating a temporary is important to make reads within rsx drop before the value is returned
+                let __vnodes = dioxus_core::VNode::new(
+                    #key_tokens,
+                    TEMPLATE,
+                    Box::new([ #( #node_printer),* ]),
+                    Box::new([ #(#dyn_attr_printer),* ]),
+                );
+                __vnodes
+            }
         });
     }
 }


### PR DESCRIPTION
Implements copy for the resource type and fixes temporary reads in rsx by introducing a block

Fixes #2036