### PR TITLE
Bump sledgehammer bindgen to a stable release

### DIFF
--- a/packages/interpreter/Cargo.toml
+++ b/packages/interpreter/Cargo.toml
@@ -17,7 +17,7 @@ web-sys = { version = "0.3.56", optional = true, features = [
     "Element",
     "Node",
 ] }
-sledgehammer_bindgen = { git = "https://github.com/ealmloff/sledgehammer_bindgen", default-features = false, optional = true }
+sledgehammer_bindgen = { version = "0.5.0", default-features = false, optional = true }
 sledgehammer_utils = { version = "0.2", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 


### PR DESCRIPTION
This moves from the git version of sledgehammer bindgen to the crates.io `0.5.0` version before we publish dioxus `0.5.0-alpha.1`