### PR TITLE
Fix #1938, allow explicit props

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,11 +1951,11 @@ dependencies = [
 
 [[package]]
 name = "dioxus"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "criterion 0.3.6",
  "dioxus-config-macro",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-core-macro",
  "dioxus-desktop",
  "dioxus-fullstack",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-autofmt"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "dioxus-rsx",
  "prettier-please",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-check"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "indoc",
  "owo-colors",
@@ -2004,7 +2004,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -2021,7 +2021,7 @@ dependencies = [
  "dioxus-autofmt",
  "dioxus-check",
  "dioxus-cli-config",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-hot-reload",
  "dioxus-html",
  "dioxus-rsx",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli-config"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "cargo_toml 0.18.0",
  "clap 4.4.18",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-config-macro"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2106,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "dioxus",
  "dioxus-ssr",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-core-macro"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "constcat",
  "convert_case 0.6.0",
@@ -2149,13 +2149,13 @@ checksum = "2ea539174bb236e0e7dc9c12b19b88eae3cb574dedbd0252a2d43ea7e6de13e2"
 
 [[package]]
 name = "dioxus-desktop"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "async-trait",
  "core-foundation",
  "dioxus",
  "dioxus-cli-config",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-hooks",
  "dioxus-hot-reload",
  "dioxus-html",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-ext"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "dioxus-autofmt",
  "html_parser",
@@ -2215,7 +2215,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-fullstack"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "anymap",
  "async-trait",
@@ -2253,10 +2253,10 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hooks"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "dioxus",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-debug-cell",
  "dioxus-signals",
  "futures-channel",
@@ -2271,10 +2271,10 @@ dependencies = [
 
 [[package]]
 name = "dioxus-hot-reload"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "chrono",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-html",
  "dioxus-rsx",
  "execute",
@@ -2288,10 +2288,10 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "async-trait",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-html-internal-macro",
  "dioxus-rsx",
  "enumset",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-html-internal-macro"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-interpreter-js"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-html",
  "js-sys",
  "md5",
@@ -2337,10 +2337,10 @@ dependencies = [
 
 [[package]]
 name = "dioxus-lib"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "dioxus-config-macro",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-core-macro",
  "dioxus-hooks",
  "dioxus-html",
@@ -2350,12 +2350,12 @@ dependencies = [
 
 [[package]]
 name = "dioxus-liveview"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "axum",
  "dioxus",
  "dioxus-cli-config",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-hot-reload",
  "dioxus-html",
  "dioxus-interpreter-js",
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-mobile"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "dioxus-desktop",
 ]
@@ -2423,15 +2423,17 @@ dependencies = [
 
 [[package]]
 name = "dioxus-router"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "axum",
+ "console_error_panic_hook",
  "criterion 0.5.1",
  "dioxus",
  "dioxus-cli-config",
  "dioxus-fullstack",
  "dioxus-lib",
  "dioxus-liveview",
+ "dioxus-router",
  "dioxus-router-macro",
  "dioxus-ssr",
  "gloo",
@@ -2444,12 +2446,13 @@ dependencies = [
  "url",
  "urlencoding",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 
 [[package]]
 name = "dioxus-router-macro"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2459,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "dioxus-rsx"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "internment",
  "krates",
  "proc-macro2",
@@ -2473,10 +2476,10 @@ dependencies = [
 
 [[package]]
 name = "dioxus-signals"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "dioxus",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "futures-channel",
  "futures-util",
  "generational-box",
@@ -2492,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-ssr"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "anyhow",
  "argh",
@@ -2500,7 +2503,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dioxus",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-html",
  "dioxus-signals",
  "fern",
@@ -2526,12 +2529,12 @@ dependencies = [
 
 [[package]]
 name = "dioxus-web"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "async-trait",
  "console_error_panic_hook",
  "dioxus",
- "dioxus-core 0.5.0-alpha.1",
+ "dioxus-core 0.5.0-alpha.2",
  "dioxus-html",
  "dioxus-interpreter-js",
  "dioxus-ssr",
@@ -2556,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus_server_macro"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3348,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "generational-box"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "criterion 0.3.6",
  "parking_lot",
@@ -7319,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "rsx-rosetta"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "convert_case 0.5.0",
  "dioxus-autofmt",

--- a/examples/spread.rs
+++ b/examples/spread.rs
@@ -14,7 +14,7 @@ fn main() {
 
 fn app() -> Element {
     rsx! {
-        spreadable_component {
+        SpreadableComponent {
             width: "10px",
             extra_data: "hello{1}",
             extra_data2: "hello{2}",
@@ -34,7 +34,8 @@ struct Props {
     extra_data2: String,
 }
 
-fn spreadable_component(props: Props) -> Element {
+#[component]
+fn SpreadableComponent(props: Props) -> Element {
     rsx! {
         audio { ..props.attributes, "1: {props.extra_data}\n2: {props.extra_data2}" }
     }

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -29,7 +29,7 @@ dioxus = { workspace = true }
 pretty_assertions = "1.3.0"
 rand = "0.8.5"
 dioxus-ssr = { workspace = true }
-reqwest.workspace = true
+reqwest = { workspace = true}
 
 [features]
 default = []


### PR DESCRIPTION
- [x] Fix #1938 

Allows users to specify `props: SomeProps` and skip the generation of the props struct.