### PR TITLE
Fix #2088 - rethink proxy logic

### DIFF
--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -71,9 +71,6 @@ pub fn connect(mut callback: impl FnMut(HotReloadMsg) + Send + 'static) {
             }
 
             let Ok(template) = serde_json::from_str(Box::leak(buf.into_boxed_str())) else {
-                eprintln!(
-                    "Could not parse hot reloading message - make sure your client is up to date"
-                );
                 continue;
             };
 

--- a/packages/web/src/eval.rs
+++ b/packages/web/src/eval.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use dioxus_html::prelude::{EvalError, EvalProvider, Evaluator};
 use futures_util::StreamExt;
 use generational_box::{AnyStorage, GenerationalBox, UnsyncStorage};


### PR DESCRIPTION
Fixes the catchall route used by the proxy which was broken during the hyper upgrade.
Also prevents infinite loops when the api is set to the same port as the dev server.

- [x] Fix #2088