### PR TITLE
Make EventHandler copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ dependencies = [
  "dioxus-ssr",
  "futures-channel",
  "futures-util",
+ "generational-box",
  "longest-increasing-subsequence",
  "pretty_assertions",
  "rand 0.8.5",

--- a/packages/autofmt/src/component.rs
+++ b/packages/autofmt/src/component.rs
@@ -185,17 +185,6 @@ impl Writer<'_> {
                 ContentField::Shorthand(e) => {
                     write!(self.out, "{}", e.to_token_stream())?;
                 }
-                ContentField::OnHandlerRaw(exp) => {
-                    let out = unparse_expr(exp);
-                    let mut lines = out.split('\n').peekable();
-                    let first = lines.next().unwrap();
-                    write!(self.out, "{name}: {first}")?;
-                    for line in lines {
-                        self.out.new_line()?;
-                        self.out.indented_tab()?;
-                        write!(self.out, "{line}")?;
-                    }
-                }
             }
 
             if field_iter.peek().is_some() || manual_props.is_some() {
@@ -227,7 +216,7 @@ impl Writer<'_> {
             .map(|field| match &field.content {
                 ContentField::Formatted(s) => ifmt_to_string(s).len() ,
                 ContentField::Shorthand(e) => e.to_token_stream().to_string().len(),
-                ContentField::OnHandlerRaw(exp) | ContentField::ManExpr(exp) => {
+                ContentField::ManExpr(exp) => {
                     let formatted = unparse_expr(exp);
                     let len = if formatted.contains('\n') {
                         10000

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -21,6 +21,7 @@ futures-channel = { workspace = true }
 tracing = { workspace = true }
 serde = { version = "1", features = ["derive"], optional = true }
 tracing-subscriber = "0.3.18"
+generational-box = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -167,6 +167,12 @@ pub struct EventHandler<T = ()> {
     pub(super) callback: GenerationalBox<Option<ExternalListenerCallback<T>>>,
 }
 
+impl<F: FnMut(T) + 'static, T: 'static> From<F> for EventHandler<T> {
+    fn from(f: F) -> Self {
+        EventHandler::new(f)
+    }
+}
+
 impl<T> Copy for EventHandler<T> {}
 
 impl<T> Clone for EventHandler<T> {

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -188,7 +188,7 @@ impl<T> Clone for EventHandler<T> {
 }
 
 impl<T: 'static> PartialEq for EventHandler<T> {
-    fn eq(&self, other: &Self) -> bool {
+    fn eq(&self, _: &Self) -> bool {
         true
     }
 }

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -167,6 +167,12 @@ pub struct EventHandler<T = ()> {
     pub(super) callback: GenerationalBox<Option<ExternalListenerCallback<T>>>,
 }
 
+impl<T: 'static> Default for EventHandler<T> {
+    fn default() -> Self {
+        EventHandler::new(|_| {})
+    }
+}
+
 impl<F: FnMut(T) + 'static, T: 'static> From<F> for EventHandler<T> {
     fn from(f: F) -> Self {
         EventHandler::new(f)
@@ -183,7 +189,7 @@ impl<T> Clone for EventHandler<T> {
 
 impl<T: 'static> PartialEq for EventHandler<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.callback.ptr_eq(&other.callback)
+        true
     }
 }
 
@@ -219,5 +225,53 @@ impl<T: 'static> EventHandler<T> {
     /// This will force any future calls to "call" to not doing anything
     pub fn release(&self) {
         self.callback.set(None);
+    }
+
+    #[doc(hidden)]
+    /// This should only be used by the `rsx!` macro.
+    pub fn __set(&mut self, value: impl FnMut(T) + 'static) {
+        self.callback.set(Some(Box::new(value)));
+    }
+
+    #[doc(hidden)]
+    /// This should only be used by the `rsx!` macro.
+    pub fn __take(&self) -> ExternalListenerCallback<T> {
+        self.callback
+            .manually_drop()
+            .expect("Signal has already been dropped")
+            .expect("EventHandler was manually dropped")
+    }
+}
+
+impl<T: 'static> std::ops::Deref for EventHandler<T> {
+    type Target = dyn Fn(T) + 'static;
+
+    fn deref(&self) -> &Self::Target {
+        // https://github.com/dtolnay/case-studies/tree/master/callable-types
+
+        // First we create a closure that captures something with the Same in memory layout as Self (MaybeUninit<Self>).
+        let uninit_callable = std::mem::MaybeUninit::<Self>::uninit();
+        // Then move that value into the closure. We assume that the closure now has a in memory layout of Self.
+        let uninit_closure = move |t| Self::call(unsafe { &*uninit_callable.as_ptr() }, t);
+
+        // Check that the size of the closure is the same as the size of Self in case the compiler changed the layout of the closure.
+        let size_of_closure = std::mem::size_of_val(&uninit_closure);
+        assert_eq!(size_of_closure, std::mem::size_of::<Self>());
+
+        // Then cast the lifetime of the closure to the lifetime of &self.
+        fn cast_lifetime<'a, T>(_a: &T, b: &'a T) -> &'a T {
+            b
+        }
+        let reference_to_closure = cast_lifetime(
+            {
+                // The real closure that we will never use.
+                &uninit_closure
+            },
+            // We transmute self into a reference to the closure. This is safe because we know that the closure has the same memory layout as Self so &Closure == &Self.
+            unsafe { std::mem::transmute(self) },
+        );
+
+        // Cast the closure to a trait object.
+        reference_to_closure as &_
     }
 }

--- a/packages/core/src/generational_box.rs
+++ b/packages/core/src/generational_box.rs
@@ -1,0 +1,102 @@
+//! Integration with the generational-box crate for copy state management.
+//!
+//! Each scope in dioxus has a single [Owner]
+
+use std::{
+    any::{Any, TypeId},
+    cell::RefCell,
+};
+
+use generational_box::{AnyStorage, Owner, SyncStorage, UnsyncStorage};
+
+use crate::{innerlude::current_scope_id, ScopeId};
+
+/// Run a closure with the given owner.
+///
+/// This will override the default owner for the current component.
+pub fn with_owner<S: AnyStorage, F: FnOnce() -> R, R>(owner: Owner<S>, f: F) -> R {
+    let old_owner = set_owner(Some(owner));
+    let result = f();
+    set_owner(old_owner);
+    result
+}
+
+/// Set the owner for the current thread.
+fn set_owner<S: AnyStorage>(owner: Option<Owner<S>>) -> Option<Owner<S>> {
+    let id = TypeId::of::<S>();
+    if id == TypeId::of::<SyncStorage>() {
+        SYNC_OWNER.with(|cell| {
+            std::mem::replace(
+                &mut *cell.borrow_mut(),
+                owner.map(|owner| {
+                    *(Box::new(owner) as Box<dyn Any>)
+                        .downcast::<Owner<SyncStorage>>()
+                        .unwrap()
+                }),
+            )
+            .map(|owner| *(Box::new(owner) as Box<dyn Any>).downcast().unwrap())
+        })
+    } else {
+        UNSYNC_OWNER.with(|cell| {
+            std::mem::replace(
+                &mut *cell.borrow_mut(),
+                owner.map(|owner| {
+                    *(Box::new(owner) as Box<dyn Any>)
+                        .downcast::<Owner<UnsyncStorage>>()
+                        .unwrap()
+                }),
+            )
+            .map(|owner| *(Box::new(owner) as Box<dyn Any>).downcast().unwrap())
+        })
+    }
+}
+
+thread_local! {
+    static SYNC_OWNER: RefCell<Option<Owner<SyncStorage>>> = const { RefCell::new(None) };
+    static UNSYNC_OWNER: RefCell<Option<Owner<UnsyncStorage>>> = const { RefCell::new(None) };
+}
+
+/// Returns the current owner. This owner will be used to drop any `Copy` state that is created by the `generational-box` crate.
+///
+/// If an owner has been set with `with_owner`, that owner will be returned. Otherwise, the owner from the current scope will be returned.
+pub fn current_owner<S: AnyStorage>() -> Owner<S> {
+    let id = TypeId::of::<S>();
+    let override_owner = if id == TypeId::of::<SyncStorage>() {
+        SYNC_OWNER.with(|cell| {
+            let owner = cell.borrow();
+
+            owner.clone().map(|owner| {
+                *(Box::new(owner) as Box<dyn Any>)
+                    .downcast::<Owner<S>>()
+                    .unwrap()
+            })
+        })
+    } else {
+        UNSYNC_OWNER.with(|cell| {
+            cell.borrow().clone().map(|owner| {
+                *(Box::new(owner) as Box<dyn Any>)
+                    .downcast::<Owner<S>>()
+                    .unwrap()
+            })
+        })
+    };
+    if let Some(owner) = override_owner {
+        return owner;
+    }
+
+    // Otherwise get the owner from the current scope
+    current_scope_id().expect("in a virtual dom").owner()
+}
+
+impl ScopeId {
+    /// Get the owner for the current scope.
+    pub fn owner<S: AnyStorage>(self) -> Owner<S> {
+        match self.has_context() {
+            Some(rt) => rt,
+            None => {
+                let owner = S::owner();
+                self.provide_context(owner)
+            }
+        }
+    }
+}

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -10,6 +10,7 @@ mod dirty_scope;
 mod error_boundary;
 mod events;
 mod fragment;
+mod generational_box;
 mod global_context;
 mod mutations;
 mod nodes;
@@ -29,6 +30,7 @@ pub(crate) mod innerlude {
     pub use crate::error_boundary::*;
     pub use crate::events::*;
     pub use crate::fragment::*;
+    pub use crate::generational_box::*;
     pub use crate::global_context::*;
     pub use crate::mutations::*;
     pub use crate::nodes::*;
@@ -88,13 +90,13 @@ pub use crate::innerlude::{
 /// This includes types like [`Element`], and [`Component`].
 pub mod prelude {
     pub use crate::innerlude::{
-        consume_context, consume_context_from_scope, current_scope_id, fc_to_builder, generation,
-        has_context, needs_update, needs_update_any, parent_scope, provide_context,
-        provide_root_context, remove_future, schedule_update, schedule_update_any, spawn,
-        spawn_forever, spawn_isomorphic, suspend, try_consume_context, use_after_render,
+        consume_context, consume_context_from_scope, current_owner, current_scope_id,
+        fc_to_builder, generation, has_context, needs_update, needs_update_any, parent_scope,
+        provide_context, provide_root_context, remove_future, schedule_update, schedule_update_any,
+        spawn, spawn_forever, spawn_isomorphic, suspend, try_consume_context, use_after_render,
         use_before_render, use_drop, use_error_boundary, use_hook, use_hook_with_cleanup,
-        wait_for_next_render, AnyValue, Attribute, Component, ComponentFunction, Element,
-        ErrorBoundary, Event, EventHandler, Fragment, HasAttributes, IntoAttributeValue,
+        wait_for_next_render, with_owner, AnyValue, Attribute, Component, ComponentFunction,
+        Element, ErrorBoundary, Event, EventHandler, Fragment, HasAttributes, IntoAttributeValue,
         IntoDynNode, OptionStringFromMarker, Properties, Runtime, RuntimeGuard, ScopeId,
         ScopeState, SuperFrom, SuperInto, Task, Template, TemplateAttribute, TemplateNode, Throw,
         VNode, VNodeInner, VirtualDom,

--- a/packages/generational-box/src/lib.rs
+++ b/packages/generational-box/src/lib.rs
@@ -51,7 +51,7 @@ pub struct GenerationalBox<T, S: 'static = UnsyncStorage> {
     _marker: PhantomData<T>,
 }
 
-impl<T: 'static, S: AnyStorage> Debug for GenerationalBox<T, S> {
+impl<T, S: AnyStorage> Debug for GenerationalBox<T, S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[cfg(any(debug_assertions, feature = "check_generation"))]
         f.write_fmt(format_args!(
@@ -65,7 +65,7 @@ impl<T: 'static, S: AnyStorage> Debug for GenerationalBox<T, S> {
     }
 }
 
-impl<T: 'static, S: Storage<T>> GenerationalBox<T, S> {
+impl<T, S: Storage<T>> GenerationalBox<T, S> {
     #[inline(always)]
     pub(crate) fn validate(&self) -> bool {
         #[cfg(any(debug_assertions, feature = "check_generation"))]
@@ -196,7 +196,7 @@ impl<T: 'static, S: Storage<T>> GenerationalBox<T, S> {
     }
 }
 
-impl<T, S: 'static> Copy for GenerationalBox<T, S> {}
+impl<T, S> Copy for GenerationalBox<T, S> {}
 
 impl<T, S> Clone for GenerationalBox<T, S> {
     fn clone(&self) -> Self {
@@ -362,7 +362,7 @@ impl<S> MemoryLocation<S> {
         }
     }
 
-    fn replace_with_caller<T: 'static>(
+    fn replace_with_caller<T>(
         &mut self,
         value: T,
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]

--- a/packages/generational-box/src/references.rs
+++ b/packages/generational-box/src/references.rs
@@ -68,7 +68,7 @@ pub struct GenerationalRefMut<W> {
     pub(crate) borrow: GenerationalRefMutBorrowInfo,
 }
 
-impl<T: 'static, R: DerefMut<Target = T>> GenerationalRefMut<R> {
+impl<T, R: DerefMut<Target = T>> GenerationalRefMut<R> {
     pub(crate) fn new(
         inner: R,
         #[cfg(any(debug_assertions, feature = "debug_borrows"))]
@@ -82,7 +82,7 @@ impl<T: 'static, R: DerefMut<Target = T>> GenerationalRefMut<R> {
     }
 }
 
-impl<T: ?Sized + 'static, W: DerefMut<Target = T>> Deref for GenerationalRefMut<W> {
+impl<T: ?Sized, W: DerefMut<Target = T>> Deref for GenerationalRefMut<W> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -90,7 +90,7 @@ impl<T: ?Sized + 'static, W: DerefMut<Target = T>> Deref for GenerationalRefMut<
     }
 }
 
-impl<T: ?Sized + 'static, W: DerefMut<Target = T>> DerefMut for GenerationalRefMut<W> {
+impl<T: ?Sized, W: DerefMut<Target = T>> DerefMut for GenerationalRefMut<W> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner.deref_mut()
     }

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -268,13 +268,13 @@ pub fn Link(props: LinkProps) -> Element {
             router.push_any(router.resolve_into_routable(to.clone()));
         }
 
-        if let Some(handler) = onclick.clone() {
+        if let Some(handler) = onclick {
             handler.call(event);
         }
     };
 
     let onmounted = move |event| {
-        if let Some(handler) = props.onmounted.clone() {
+        if let Some(handler) = props.onmounted {
             handler.call(event);
         }
     };

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -1,106 +1,18 @@
-use generational_box::AnyStorage;
 use generational_box::GenerationalBoxId;
-use generational_box::SyncStorage;
 use generational_box::UnsyncStorage;
-use std::any::Any;
-use std::any::TypeId;
-use std::cell::RefCell;
 use std::ops::Deref;
 
 use dioxus_core::prelude::*;
 use dioxus_core::ScopeId;
 
-use generational_box::{GenerationalBox, Owner, Storage};
+use generational_box::{GenerationalBox, Storage};
 
+use crate::read_impls;
+use crate::Readable;
 use crate::ReadableRef;
 use crate::Writable;
 use crate::WritableRef;
-use crate::{ReactiveContext, Readable};
-
-/// Run a closure with the given owner.
-pub fn with_owner<S: AnyStorage, F: FnOnce() -> R, R>(owner: Owner<S>, f: F) -> R {
-    let old_owner = set_owner(Some(owner));
-    let result = f();
-    set_owner(old_owner);
-    result
-}
-
-/// Set the owner for the current thread.
-fn set_owner<S: AnyStorage>(owner: Option<Owner<S>>) -> Option<Owner<S>> {
-    let id = TypeId::of::<S>();
-    if id == TypeId::of::<SyncStorage>() {
-        SYNC_OWNER.with(|cell| {
-            std::mem::replace(
-                &mut *cell.borrow_mut(),
-                owner.map(|owner| {
-                    *(Box::new(owner) as Box<dyn Any>)
-                        .downcast::<Owner<SyncStorage>>()
-                        .unwrap()
-                }),
-            )
-            .map(|owner| *(Box::new(owner) as Box<dyn Any>).downcast().unwrap())
-        })
-    } else {
-        UNSYNC_OWNER.with(|cell| {
-            std::mem::replace(
-                &mut *cell.borrow_mut(),
-                owner.map(|owner| {
-                    *(Box::new(owner) as Box<dyn Any>)
-                        .downcast::<Owner<UnsyncStorage>>()
-                        .unwrap()
-                }),
-            )
-            .map(|owner| *(Box::new(owner) as Box<dyn Any>).downcast().unwrap())
-        })
-    }
-}
-
-thread_local! {
-    static SYNC_OWNER: RefCell<Option<Owner<SyncStorage>>> = const { RefCell::new(None) };
-    static UNSYNC_OWNER: RefCell<Option<Owner<UnsyncStorage>>> = const { RefCell::new(None) };
-}
-
-fn current_owner<S: Storage<T>, T>() -> Owner<S> {
-    let id = TypeId::of::<S>();
-    let override_owner = if id == TypeId::of::<SyncStorage>() {
-        SYNC_OWNER.with(|cell| {
-            let owner = cell.borrow();
-
-            owner.clone().map(|owner| {
-                *(Box::new(owner) as Box<dyn Any>)
-                    .downcast::<Owner<S>>()
-                    .unwrap()
-            })
-        })
-    } else {
-        UNSYNC_OWNER.with(|cell| {
-            cell.borrow().clone().map(|owner| {
-                *(Box::new(owner) as Box<dyn Any>)
-                    .downcast::<Owner<S>>()
-                    .unwrap()
-            })
-        })
-    };
-    if let Some(owner) = override_owner {
-        return owner;
-    }
-
-    // Otherwise get the owner from the current reactive context.
-    match ReactiveContext::current() {
-        Some(current_reactive_context) => owner_in_scope(current_reactive_context.origin_scope()),
-        None => owner_in_scope(current_scope_id().expect("in a virtual dom")),
-    }
-}
-
-fn owner_in_scope<S: Storage<T>, T>(scope: ScopeId) -> Owner<S> {
-    match scope.has_context() {
-        Some(rt) => rt,
-        None => {
-            let owner = S::owner();
-            scope.provide_context(owner)
-        }
-    }
-}
+use crate::{default_impl, write_impls};
 
 /// CopyValue is a wrapper around a value to make the value mutable and Copy.
 ///
@@ -181,7 +93,7 @@ impl<T: 'static, S: Storage<T>> CopyValue<T, S> {
     /// Create a new CopyValue. The value will be stored in the given scope. When the specified scope is dropped, the value will be dropped.
     #[track_caller]
     pub fn new_maybe_sync_in_scope(value: T, scope: ScopeId) -> Self {
-        let owner = owner_in_scope(scope);
+        let owner = scope.owner();
 
         Self {
             value: owner.insert(value),
@@ -270,3 +182,15 @@ impl<T: Copy, S: Storage<T>> Deref for CopyValue<T, S> {
         Readable::deref_impl(self)
     }
 }
+
+impl<T, S: Storage<T>> Clone for CopyValue<T, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T, S: Storage<T>> Copy for CopyValue<T, S> {}
+
+read_impls!(CopyValue<T, S: Storage<T>>);
+default_impl!(CopyValue<T, S: Storage<T>>);
+write_impls!(CopyValue<T, S: Storage<T>>);

--- a/packages/signals/src/global/memo.rs
+++ b/packages/signals/src/global/memo.rs
@@ -1,3 +1,4 @@
+use crate::read_impls;
 use crate::{read::Readable, Memo, ReadableRef};
 use dioxus_core::prelude::ScopeId;
 use generational_box::UnsyncStorage;
@@ -68,12 +69,6 @@ impl<T: PartialEq + 'static> Readable for GlobalMemo<T> {
     }
 }
 
-impl<T: PartialEq + 'static> PartialEq for GlobalMemo<T> {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self, other)
-    }
-}
-
 /// Allow calling a signal with memo() syntax
 ///
 /// Currently only limited to copy types, though could probably specialize for string/arc/rc
@@ -84,3 +79,5 @@ impl<T: PartialEq + Clone + 'static> Deref for GlobalMemo<T> {
         Readable::deref_impl(self)
     }
 }
+
+read_impls!(GlobalMemo<T> where T: PartialEq);

--- a/packages/signals/src/global/signal.rs
+++ b/packages/signals/src/global/signal.rs
@@ -6,6 +6,7 @@ use generational_box::UnsyncStorage;
 use std::ops::Deref;
 
 use super::get_global_context;
+use crate::read_impls;
 use crate::Signal;
 
 /// A signal that can be accessed from anywhere in the application and created in a static
@@ -118,12 +119,6 @@ impl<T: 'static> Writable for GlobalSignal<T> {
     }
 }
 
-impl<T: 'static> PartialEq for GlobalSignal<T> {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self, other)
-    }
-}
-
 /// Allow calling a signal with signal() syntax
 ///
 /// Currently only limited to copy types, though could probably specialize for string/arc/rc
@@ -134,3 +129,5 @@ impl<T: Clone + 'static> Deref for GlobalSignal<T> {
         Readable::deref_impl(self)
     }
 }
+
+read_impls!(GlobalSignal<T>);

--- a/packages/signals/src/impls.rs
+++ b/packages/signals/src/impls.rs
@@ -1,46 +1,265 @@
-use crate::copy_value::CopyValue;
-use crate::memo::Memo;
-use crate::read::Readable;
-use crate::signal::Signal;
-use crate::write::Writable;
-use crate::{GlobalMemo, GlobalSignal, MappedSignal, ReadOnlySignal, SignalData};
-use generational_box::{AnyStorage, Storage};
-
-use std::{
-    fmt::{Debug, Display},
-    ops::{Add, Div, Mul, Sub},
-};
-
+/// This macro is used to generate a `impl Default` block for any type with the function new_maybe_sync that takes a generic `T`
+///
+/// # Example
+/// ```rust
+/// use generational_box::*;
+/// use dioxus::prelude::*;
+///
+/// struct MyCopyValue<T: 'static, S: Storage<T>> {
+///     value: CopyValue<T, S>,
+/// }
+///
+/// impl<T: 'static, S: Storage<T>> MyCopyValue<T, S> {
+///     fn new_maybe_sync(value: T) -> Self {
+///         Self { value: CopyValue::new_maybe_sync(value) }
+///     }
+/// }
+///
+/// impl<T: 'static, S: Storage<T>> Readable for MyCopyValue<T, S> {
+///     type Target = T;
+///     type Storage = S;
+///
+///     fn try_read_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
+///     }
+///
+///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+///         self.value.read_unchecked()
+///     }
+/// }
+///
+/// default_impl!(MyCopyValue<T, S: Storage<T>>);
+/// ```
+#[macro_export]
 macro_rules! default_impl {
-    ($ty:ident $(: $extra_bounds:path)? $(, $bound_ty:ident : $bound:path, $vec_bound_ty:ident : $vec_bound:path)?) => {
+    (
+        $ty:ident
+        // Accept generics
+        < T $(, $gen:ident $(: $gen_bound:path)?)* $(,)?>
+        // Accept extra bounds
         $(
-            impl<T: Default + 'static, $bound_ty: $bound> Default for $ty<T, $bound_ty> {
-                #[track_caller]
-                fn default() -> Self {
-                    Self::new_maybe_sync(Default::default())
-                }
-            }
+            where
+                $(
+                    $extra_bound_ty:ident: $extra_bound:path
+                ),+
         )?
+    ) => {
+        impl<T: Default + 'static
+            $(, $gen $(: $gen_bound)?)*
+        > Default for $ty <T $(, $gen)*>
+        $(
+            where
+                $(
+                    $extra_bound_ty: $extra_bound
+                ),+
+        )?
+        {
+            #[track_caller]
+            fn default() -> Self {
+                Self::new_maybe_sync(Default::default())
+            }
+        }
     }
 }
 
+/// This macro is used to generate `impl Display`, `impl Debug`, `impl PartialEq`, and `impl Eq` blocks for any Readable type that takes a generic `T`
+///
+/// # Example
+/// ```rust
+/// use generational_box::*;
+/// use dioxus::prelude::*;
+///
+/// struct MyCopyValue<T: 'static, S: Storage<T>> {
+///     value: CopyValue<T, S>,
+/// }
+///
+/// impl<T: 'static, S: Storage<T>> Readable for MyCopyValue<T, S> {
+///     type Target = T;
+///     type Storage = S;
+///
+///     fn try_read_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
+///     }
+///
+///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+///         self.value.read_unchecked()
+///     }
+/// }
+///
+/// read_impls!(MyCopyValue<T, S: Storage<T>>);
+/// ```
+#[macro_export]
 macro_rules! read_impls {
-    ($ty:ident $(: $extra_bounds:path)? $(, $bound_ty:ident : $bound:path, $vec_bound_ty:ident : $vec_bound:path)?) => {
-        impl<T: $($extra_bounds + )? Display + 'static $(,$bound_ty: $bound)?> Display for $ty<T $(, $bound_ty)?> {
-            #[track_caller]
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                self.with(|v| Display::fmt(v, f))
-            }
+    (
+        $ty:ident
+        // Accept generics
+        < T $(, $gen:ident $(: $gen_bound:path)?)* $(,)?>
+        // Accept extra bounds
+        $(
+            where
+                $(
+                    $extra_bound_ty:ident: $extra_bound:path
+                ),+
+        )?
+    ) => {
+        $crate::fmt_impls!{
+            $ty<
+                T
+                $(
+                    , $gen
+                    $(: $gen_bound)?
+                )*
+            >
+            $(
+                where
+                    $($extra_bound_ty: $extra_bound),*
+            )?
         }
-
-        impl<T: $($extra_bounds + )? Debug + 'static $(,$bound_ty: $bound)?> Debug for $ty<T $(, $bound_ty)?> {
-            #[track_caller]
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                self.with(|v| Debug::fmt(v, f))
-            }
+        $crate::eq_impls!{
+            $ty<
+                T
+                $(
+                    , $gen
+                    $(: $gen_bound)?
+                )*
+            >
+            $(
+                where
+                    $($extra_bound_ty: $extra_bound),*
+            )?
         }
+    };
+}
 
-        impl<T: $($extra_bounds + )? PartialEq + 'static $(,$bound_ty: $bound)?> PartialEq<T> for $ty<T $(, $bound_ty)?> {
+/// This macro is used to generate `impl Display`, and `impl Debug` blocks for any Readable type that takes a generic `T`
+///
+/// # Example
+/// ```rust
+/// use generational_box::*;
+/// use dioxus::prelude::*;
+///
+/// struct MyCopyValue<T: 'static, S: Storage<T>> {
+///     value: CopyValue<T, S>,
+/// }
+///
+/// impl<T: 'static, S: Storage<T>> Readable for MyCopyValue<T, S> {
+///     type Target = T;
+///     type Storage = S;
+///
+///     fn try_read_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
+///     }
+///
+///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+///         self.value.read_unchecked()
+///     }
+/// }
+///
+/// fmt_impls!(MyCopyValue<T, S: Storage<T>>);
+/// ```
+#[macro_export]
+macro_rules! fmt_impls {
+    (
+        $ty:ident
+        // Accept generics
+        < T $(, $gen:ident $(: $gen_bound:path)?)* $(,)?>
+        // Accept extra bounds
+        $(
+            where
+                $(
+                    $extra_bound_ty:ident: $extra_bound:path
+                ),+
+        )?
+    ) => {
+    impl<
+        T: std::fmt::Display + 'static
+        $(, $gen $(: $gen_bound)?)*
+    > std::fmt::Display for $ty<T $(, $gen)*>
+        $(
+            where
+                $($extra_bound_ty: $extra_bound,)*
+        )?
+    {
+        #[track_caller]
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.with(|v| std::fmt::Display::fmt(v, f))
+        }
+    }
+
+    impl<
+        T: std::fmt::Debug + 'static
+        $(, $gen $(: $gen_bound)?)*
+    > std::fmt::Debug for $ty<T $(, $gen)*>
+        $(
+            where
+                $($extra_bound_ty: $extra_bound,)*
+        )?
+    {
+        #[track_caller]
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            self.with(|v| std::fmt::Debug::fmt(v, f))
+        }
+    }
+};
+    }
+
+/// This macro is used to generate `impl PartialEq` blocks for any Readable type that takes a generic `T`
+///
+/// # Example
+/// ```rust
+/// use generational_box::*;
+/// use dioxus::prelude::*;
+///
+/// struct MyCopyValue<T: 'static, S: Storage<T>> {
+///     value: CopyValue<T, S>,
+/// }
+///
+/// impl<T: 'static, S: Storage<T>> Readable for MyCopyValue<T, S> {
+///     type Target = T;
+///     type Storage = S;
+///
+///     fn try_read_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
+///     }
+///
+///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+///         self.value.read_unchecked()
+///     }
+/// }
+///
+/// eq_impls!(MyCopyValue<T, S: Storage<T>>);
+/// ```
+#[macro_export]
+macro_rules! eq_impls {
+    (
+        $ty:ident
+        // Accept generics
+        < T $(, $gen:ident $(: $gen_bound:path)?)* $(,)?>
+        // Accept extra bounds
+        $(
+            where
+                $(
+                    $extra_bound_ty:ident: $extra_bound:path
+                ),+
+        )?
+    ) => {
+        impl<
+            T: PartialEq + 'static
+            $(, $gen $(: $gen_bound)?)*
+        > PartialEq<T> for $ty<T $(, $gen)*>
+            $(
+                where
+                    $($extra_bound_ty: $extra_bound,)*
+            )?
+        {
             #[track_caller]
             fn eq(&self, other: &T) -> bool {
                 self.with(|v| *v == *other)
@@ -49,9 +268,63 @@ macro_rules! read_impls {
     };
 }
 
+/// This macro is used to generate `impl Add`, `impl AddAssign`, `impl Sub`, `impl SubAssign`, `impl Mul`, `impl MulAssign`, `impl Div`, and `impl DivAssign` blocks for any Writable type that takes a generic `T`
+///
+/// # Example
+/// ```rust, ignore
+/// use generational_box::*;
+/// use dioxus::prelude::*;
+///
+/// struct MyCopyValue<T: 'static, S: Storage<T>> {
+///     value: CopyValue<T, S>,
+/// }
+///
+/// impl<T: 'static, S: Storage<T>> Readable for MyCopyValue<T, S> {
+///     type Target = T;
+///     type Storage = S;
+///
+///     fn try_read_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
+///     }
+///
+///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+///         self.value.read_unchecked()
+///     }
+/// }
+///
+/// impl<T: 'static, S: Storage<T>> Writable for MyCopyValue<T, S> {
+///     fn try_write_unchecked(
+///         &self,
+///     ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError> {
+///         self.value.try_write_unchecked()
+///
+///      }
+///
+///     //...
+/// }
+///
+/// write_impls!(MyCopyValue<T, S: Storage<T>>);
+/// ```
+#[macro_export]
 macro_rules! write_impls {
-    ($ty:ident, $bound:path, $vec_bound:path) => {
-        impl<T: Add<Output = T> + Copy + 'static, S: $bound> std::ops::Add<T> for $ty<T, S> {
+    (
+        $ty:ident
+        // Accept generics
+        < T $(, $gen:ident $(: $gen_bound:path)?)* $(,)?>
+        // Accept extra bounds
+        $(
+            where
+                $(
+                    $extra_bound_ty:ident: $extra_bound:path
+                ),+
+        )?) => {
+        impl<T: std::ops::Add<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::Add<T>
+            for $ty<T $(, $gen)*>
+        {
             type Output = T;
 
             #[track_caller]
@@ -60,21 +333,33 @@ macro_rules! write_impls {
             }
         }
 
-        impl<T: Add<Output = T> + Copy + 'static, S: $bound> std::ops::AddAssign<T> for $ty<T, S> {
+        impl<T: std::ops::Add<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::AddAssign<T>
+            for $ty<T $(, $gen)*>
+        {
             #[track_caller]
             fn add_assign(&mut self, rhs: T) {
                 self.with_mut(|v| *v = *v + rhs)
             }
         }
 
-        impl<T: Sub<Output = T> + Copy + 'static, S: $bound> std::ops::SubAssign<T> for $ty<T, S> {
+        impl<T: std::ops::Sub<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::SubAssign<T>
+            for $ty<T $(, $gen)*>
+        {
             #[track_caller]
             fn sub_assign(&mut self, rhs: T) {
                 self.with_mut(|v| *v = *v - rhs)
             }
         }
 
-        impl<T: Sub<Output = T> + Copy + 'static, S: $bound> std::ops::Sub<T> for $ty<T, S> {
+        impl<T: std::ops::Sub<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::Sub<T>
+            for $ty<T $(, $gen)*>
+        {
             type Output = T;
 
             #[track_caller]
@@ -83,14 +368,22 @@ macro_rules! write_impls {
             }
         }
 
-        impl<T: Mul<Output = T> + Copy + 'static, S: $bound> std::ops::MulAssign<T> for $ty<T, S> {
+        impl<T: std::ops::Mul<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::MulAssign<T>
+            for $ty<T $(, $gen)*>
+        {
             #[track_caller]
             fn mul_assign(&mut self, rhs: T) {
                 self.with_mut(|v| *v = *v * rhs)
             }
         }
 
-        impl<T: Mul<Output = T> + Copy + 'static, S: $bound> std::ops::Mul<T> for $ty<T, S> {
+        impl<T: std::ops::Mul<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::Mul<T>
+            for $ty<T $(, $gen)*>
+        {
             type Output = T;
 
             #[track_caller]
@@ -99,14 +392,22 @@ macro_rules! write_impls {
             }
         }
 
-        impl<T: Div<Output = T> + Copy + 'static, S: $bound> std::ops::DivAssign<T> for $ty<T, S> {
+        impl<T: std::ops::Div<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::DivAssign<T>
+            for $ty<T $(, $gen)*>
+        {
             #[track_caller]
             fn div_assign(&mut self, rhs: T) {
                 self.with_mut(|v| *v = *v / rhs)
             }
         }
 
-        impl<T: Div<Output = T> + Copy + 'static, S: $bound> std::ops::Div<T> for $ty<T, S> {
+        impl<T: std::ops::Div<Output = T> + Copy + 'static
+        $(, $gen $(: $gen_bound)?)*
+        > std::ops::Div<T>
+            for $ty<T $(, $gen)*>
+        {
             type Output = T;
 
             #[track_caller]
@@ -116,63 +417,3 @@ macro_rules! write_impls {
         }
     };
 }
-
-read_impls!(CopyValue, S: Storage<T>, S: Storage<Vec<T>>);
-default_impl!(CopyValue, S: Storage<T>, S: Storage<Vec<T>>);
-write_impls!(CopyValue, Storage<T>, Storage<Vec<T>>);
-
-impl<T: 'static, S: Storage<T>> Clone for CopyValue<T, S> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T: 'static, S: Storage<T>> Copy for CopyValue<T, S> {}
-
-read_impls!(Signal, S: Storage<SignalData<T>>, S: Storage<SignalData<Vec<T>>>);
-default_impl!(Signal, S: Storage<SignalData<T>>, S: Storage<SignalData<Vec<T>>>);
-write_impls!(Signal, Storage<SignalData<T>>, Storage<SignalData<Vec<T>>>);
-
-impl<T: 'static, S: Storage<SignalData<T>>> Clone for Signal<T, S> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T: 'static, S: Storage<SignalData<T>>> Copy for Signal<T, S> {}
-
-read_impls!(
-    ReadOnlySignal,
-    S: Storage<SignalData<T>>,
-    S: Storage<SignalData<Vec<T>>>
-);
-default_impl!(
-    ReadOnlySignal,
-    S: Storage<SignalData<T>>,
-    S: Storage<SignalData<Vec<T>>>
-);
-
-impl<T: 'static, S: Storage<SignalData<T>>> Clone for ReadOnlySignal<T, S> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T: 'static, S: Storage<SignalData<T>>> Copy for ReadOnlySignal<T, S> {}
-
-read_impls!(Memo: PartialEq);
-
-impl<T: 'static> Clone for Memo<T> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-
-impl<T: 'static> Copy for Memo<T> {}
-
-read_impls!(GlobalSignal);
-default_impl!(GlobalSignal);
-
-read_impls!(GlobalMemo: PartialEq);
-
-read_impls!(MappedSignal, S: AnyStorage, S: AnyStorage);

--- a/packages/signals/src/map.rs
+++ b/packages/signals/src/map.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, rc::Rc};
 
-use crate::{read::Readable, ReadableRef};
+use crate::{read::Readable, read_impls, ReadableRef};
 use dioxus_core::prelude::*;
 use generational_box::{AnyStorage, UnsyncStorage};
 
@@ -88,3 +88,5 @@ where
         Readable::deref_impl(self)
     }
 }
+
+read_impls!(MappedSignal<T, S: AnyStorage>);

--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -1,3 +1,4 @@
+use crate::read_impls;
 use crate::write::Writable;
 use crate::{read::Readable, ReactiveContext, ReadableRef, Signal};
 use crate::{CopyValue, ReadOnlySignal};
@@ -191,3 +192,13 @@ where
         Readable::deref_impl(self)
     }
 }
+
+read_impls!(Memo<T> where T: PartialEq);
+
+impl<T: 'static> Clone for Memo<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: 'static> Copy for Memo<T> {}

--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -2,6 +2,7 @@ use crate::{read::Readable, ReadableRef, Signal, SignalData};
 use dioxus_core::IntoDynNode;
 use std::ops::Deref;
 
+use crate::{default_impl, read_impls};
 use dioxus_core::{prelude::IntoAttributeValue, ScopeId};
 use generational_box::{Storage, UnsyncStorage};
 
@@ -128,3 +129,20 @@ impl<T: Clone, S: Storage<SignalData<T>> + 'static> Deref for ReadOnlySignal<T, 
         Readable::deref_impl(self)
     }
 }
+
+read_impls!(
+    ReadOnlySignal<T, S> where
+        S: Storage<SignalData<T>>
+);
+default_impl!(
+    ReadOnlySignal<T, S> where
+    S: Storage<SignalData<T>>
+);
+
+impl<T: 'static, S: Storage<SignalData<T>>> Clone for ReadOnlySignal<T, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: 'static, S: Storage<SignalData<T>>> Copy for ReadOnlySignal<T, S> {}

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -1,3 +1,4 @@
+use crate::{default_impl, fmt_impls, write_impls};
 use crate::{
     read::Readable, write::Writable, CopyValue, GlobalMemo, GlobalSignal, ReactiveContext,
     ReadableRef,
@@ -382,6 +383,8 @@ impl<T: 'static, S: Storage<SignalData<T>>> PartialEq for Signal<T, S> {
     }
 }
 
+impl<T: 'static, S: Storage<SignalData<T>>> Eq for Signal<T, S> {}
+
 /// Allow calling a signal with signal() syntax
 ///
 /// Currently only limited to copy types, though could probably specialize for string/arc/rc
@@ -488,3 +491,15 @@ impl<T: 'static, S: Storage<SignalData<T>>> Drop for SignalSubscriberDrop<T, S> 
         self.signal.update_subscribers();
     }
 }
+
+fmt_impls!(Signal<T, S: Storage<SignalData<T>>>);
+default_impl!(Signal<T, S: Storage<SignalData<T>>>);
+write_impls!(Signal<T, S: Storage<SignalData<T>>>);
+
+impl<T: 'static, S: Storage<SignalData<T>>> Clone for Signal<T, S> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: 'static, S: Storage<SignalData<T>>> Copy for Signal<T, S> {}


### PR DESCRIPTION
- Makes EventHandler Copy
- Removes the special `on` prefix for event handlers. Instead EventHandler just implements `From<impl FnMut>`
- Cleans up and exposes the `impl` macros for Readable and Writable types

Closes #2100 