### PR TITLE
Fix streaming server functions, and precompress assets in release mode

### DIFF
--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -17,7 +17,8 @@ dioxus_server_macro = { workspace = true }
 
 # axum
 axum = { workspace = true, features = ["ws", "macros"], optional = true }
-tower-http = { workspace = true, optional = true, features = ["fs", "compression-gzip"] }
+tower-http = { workspace = true, optional = true, features = ["fs"] }
+async-compression = { version = "0.4.6", features = ["gzip", "tokio"], optional = true }
 
 dioxus-lib = { workspace = true }
 
@@ -73,7 +74,7 @@ desktop = ["dioxus-desktop"]
 mobile = ["dioxus-mobile"]
 default-tls = ["server_fn/default-tls"]
 rustls = ["server_fn/rustls"]
-axum = ["dep:axum", "tower-http", "server", "server_fn/axum", "dioxus_server_macro/axum"]
+axum = ["dep:axum", "tower-http", "server", "server_fn/axum", "dioxus_server_macro/axum", "async-compression"]
 server = [
     "server_fn/ssr",
     "dioxus_server_macro/server",

--- a/packages/fullstack/examples/axum-auth/src/main.rs
+++ b/packages/fullstack/examples/axum-auth/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
                     .serve_dioxus_application(ServeConfig::builder().build(), || {
                         VirtualDom::new(app)
                     })
+                    .await
                     .layer(
                         axum_session_auth::AuthSessionLayer::<
                             crate::auth::User,

--- a/packages/fullstack/src/assets.rs
+++ b/packages/fullstack/src/assets.rs
@@ -1,0 +1,70 @@
+//! Handles pre-compression for any static assets
+
+use std::{ffi::OsString, path::PathBuf, pin::Pin};
+
+use async_compression::tokio::bufread::GzipEncoder;
+use futures_util::Future;
+use tokio::task::JoinSet;
+
+#[allow(unused)]
+pub async fn pre_compress_files(directory: PathBuf) -> tokio::io::Result<()> {
+    // print to stdin encoded gzip data
+    pre_compress_dir(directory).await?;
+    Ok(())
+}
+
+fn pre_compress_dir(
+    path: PathBuf,
+) -> Pin<Box<dyn Future<Output = tokio::io::Result<()>> + Send + Sync>> {
+    Box::pin(async move {
+        let mut entries = tokio::fs::read_dir(&path).await?;
+        let mut set: JoinSet<tokio::io::Result<()>> = JoinSet::new();
+
+        while let Some(entry) = entries.next_entry().await? {
+            set.spawn(async move {
+                if entry.file_type().await?.is_dir() {
+                    if let Err(err) = pre_compress_dir(entry.path()).await {
+                        tracing::error!(
+                            "Failed to pre-compress directory {}: {}",
+                            entry.path().display(),
+                            err
+                        );
+                    }
+                } else if let Err(err) = pre_compress_file(entry.path()).await {
+                    tracing::error!(
+                        "Failed to pre-compress static assets {}: {}",
+                        entry.path().display(),
+                        err
+                    );
+                }
+
+                Ok(())
+            });
+        }
+        while let Some(res) = set.join_next().await {
+            res??;
+        }
+        Ok(())
+    })
+}
+
+async fn pre_compress_file(path: PathBuf) -> tokio::io::Result<()> {
+    let file = tokio::fs::File::open(&path).await?;
+    let stream = tokio::io::BufReader::new(file);
+    let mut encoder = GzipEncoder::new(stream);
+    let new_extension = match path.extension() {
+        Some(ext) => {
+            if ext.to_string_lossy().to_lowercase().ends_with("gz") {
+                return Ok(());
+            }
+            let mut ext = ext.to_os_string();
+            ext.push(".gz");
+            ext
+        }
+        None => OsString::from("gz"),
+    };
+    let output = path.with_extension(new_extension);
+    let mut buffer = tokio::fs::File::create(&output).await?;
+    tokio::io::copy(&mut encoder, &mut buffer).await?;
+    Ok(())
+}

--- a/packages/fullstack/src/config.rs
+++ b/packages/fullstack/src/config.rs
@@ -133,18 +133,14 @@ impl Config {
             #[cfg(not(any(feature = "desktop", feature = "mobile")))]
             let router = router
                 .serve_static_assets(cfg.assets_path.clone())
+                .await
                 .connect_hot_reload()
                 .fallback(get(render_handler).with_state((
                     cfg,
                     Arc::new(build_virtual_dom),
                     ssr_state,
                 )));
-            let router = router
-                .layer(
-                    ServiceBuilder::new()
-                        .layer(tower_http::compression::CompressionLayer::new().gzip(true)),
-                )
-                .into_make_service();
+            let router = router.into_make_service();
             let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
             axum::serve(listener, router).await.unwrap();
         }

--- a/packages/fullstack/src/lib.rs
+++ b/packages/fullstack/src/lib.rs
@@ -8,6 +8,8 @@ pub use once_cell;
 
 mod html_storage;
 
+#[cfg(feature = "axum")]
+mod assets;
 #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 #[cfg(feature = "axum")]
 mod axum_adapter;

--- a/packages/signals/src/reactive_context.rs
+++ b/packages/signals/src/reactive_context.rs
@@ -5,7 +5,7 @@ use futures_channel::mpsc::UnboundedReceiver;
 use generational_box::SyncStorage;
 use std::{cell::RefCell, hash::Hash};
 
-use crate::{CopyValue, Readable, Writable};
+use crate::{CopyValue, Writable};
 
 /// A context for signal reads and writes to be directed to
 ///
@@ -26,6 +26,7 @@ impl std::fmt::Display for ReactiveContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[cfg(debug_assertions)]
         {
+            use crate::Readable;
             if let Ok(read) = self.inner.try_read() {
                 return write!(f, "ReactiveContext created at {}", read.origin);
             }
@@ -58,7 +59,7 @@ impl ReactiveContext {
     pub fn new_with_callback(
         callback: impl FnMut() + Send + Sync + 'static,
         scope: ScopeId,
-        origin: &'static std::panic::Location<'static>,
+        #[allow(unused)] origin: &'static std::panic::Location<'static>,
     ) -> Self {
         let inner = Inner {
             self_: None,


### PR DESCRIPTION
Our compression layer is breaking streaming server functions. This PR removes the default compression layer and instead only compresses static assets in release mode.

~It also adds a more compelling demo for server functions streaming a chat response for an LLM developed for the blog post.~ The demo is a bit dependency heavy for CI, pulled out into a separate repo

Closes #1947 