### PR TITLE
Don't move over event handler fields when diffing props

### DIFF
--- a/packages/core-macro/tests/values_memoize_in_place.rs
+++ b/packages/core-macro/tests/values_memoize_in_place.rs
@@ -44,6 +44,12 @@ fn app() -> Element {
             },
             children: count() / 2
         }
+        TakesEventHandler {
+            click: move |num| {
+                println!("num2 is {num}");
+            },
+            children: count()
+        }
         TakesSignal { sig: count(), children: count() / 2 }
     }
 }

--- a/packages/core-macro/tests/values_memoize_in_place.rs
+++ b/packages/core-macro/tests/values_memoize_in_place.rs
@@ -1,4 +1,6 @@
 use dioxus::prelude::*;
+use dioxus_core::ElementId;
+use std::rc::Rc;
 
 thread_local! {
     static DROP_COUNT: std::cell::RefCell<usize> = const { std::cell::RefCell::new(0) };
@@ -6,11 +8,19 @@ thread_local! {
 
 #[test]
 fn values_memoize_in_place() {
+    set_event_converter(Box::new(dioxus::html::SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
 
-    dom.rebuild_in_place();
+    let mutations = dom.rebuild_to_vec();
+    println!("{:#?}", mutations);
     dom.mark_dirty(ScopeId::ROOT);
     for _ in 0..20 {
+        dom.handle_event(
+            "click",
+            Rc::new(PlatformEventData::new(Box::<SerializedMouseData>::default())),
+            ElementId(1),
+            true,
+        );
         dom.render_immediate(&mut dioxus_core::NoOpMutations);
     }
     dom.render_immediate(&mut dioxus_core::NoOpMutations);
@@ -44,12 +54,6 @@ fn app() -> Element {
             },
             children: count() / 2
         }
-        TakesEventHandler {
-            click: move |num| {
-                println!("num2 is {num}");
-            },
-            children: count()
-        }
         TakesSignal { sig: count(), children: count() / 2 }
     }
 }
@@ -63,7 +67,10 @@ fn TakesEventHandler(click: EventHandler<usize>, children: usize) -> Element {
     }
 
     rsx! {
-        button { "{children}" }
+        button {
+            onclick: move |_| click(children),
+            "{children}"
+        }
     }
 }
 


### PR DESCRIPTION
Follow up to #2126 to fix this test case:
```rust
fn app() -> Element {
    let mut enabled = use_signal(|| false);

    rsx!(
        ScrollThumb {
            clicking_scrollbar: enabled(),
            onmousedown: move |_| enabled.toggle(),
        }
    )
}

#[allow(non_snake_case)]
#[component]
pub fn ScrollThumb(
    clicking_scrollbar: bool,
    onmousedown: EventHandler<MouseEvent>,
) -> Element {
    rsx!(
        rect {
            onmousedown: move |e| {
                onmousedown.call(e);
            },
            width: "100%",
            height: "100%",
            background: "black",
        }
    )
}
```

We were manually updating event handlers in place *and* moving over the event handlers from the old to new props. This PR only updates the event handlers in place which fixes the issue 