### PR TITLE
Make some enums non-exhaustive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "av1-grain"
@@ -5457,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "manganis"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42db80aa639f70d6bf1d2ef93612d2ffbb33f6ea17d473b91bfeb3f67bc24bc"
+checksum = "c211cfb4529c79b32307b606e83a1bb15d491b3b4a1ab97159b161d7af9d1b72"
 dependencies = [
  "dioxus-core 0.5.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "manganis-macro",
@@ -5467,9 +5467,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-cli-support"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0db7983cc200c1c378b25c90c84383eafc5baacbafce70e9f2417ff971fd752"
+checksum = "6d502b0db0ef8c880fecff174903815efedfacbcd5ea9a8bef96752f1e0d7eb6"
 dependencies = [
  "anyhow",
  "cargo-lock",
@@ -5495,9 +5495,9 @@ dependencies = [
 
 [[package]]
 name = "manganis-common"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86627eb778d7ba12272e8b80228559b04dec41af3bb0a7e76e438cbb5f85e961"
+checksum = "542300f1e7d9313de5b7e5b92d273ba42ab547c068d773559d616aa14987de43"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5506,19 +5506,21 @@ dependencies = [
  "reqwest",
  "serde",
  "toml 0.7.8",
+ "tracing",
  "url",
 ]
 
 [[package]]
 name = "manganis-macro"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2c2e11190c2f3d6133cffda5c955b463a7e90b7ba866e71e7dfa65fa97ddfc"
+checksum = "704a0123ac90fa630b21a04fde56c29dfd5a7665c5e8f3639567989daa2d29d1"
 dependencies = [
  "manganis-common",
  "proc-macro2",
  "quote",
  "syn 2.0.55",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/packages/check/src/issues.rs
+++ b/packages/check/src/issues.rs
@@ -155,6 +155,7 @@ impl Display for IssueReport {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 #[allow(clippy::enum_variant_names)] // we'll add non-hook ones in the future
 /// Issues that might be found via static analysis of a Dioxus file.
 pub enum Issue {

--- a/packages/cli-config/src/config.rs
+++ b/packages/cli-config/src/config.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Debug)]
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+#[non_exhaustive]
 pub enum Platform {
     /// Targeting the web platform using WASM
     #[cfg_attr(feature = "cli", clap(name = "web"))]
@@ -57,6 +58,7 @@ impl std::fmt::Display for LoadDioxusConfigError {
 impl std::error::Error for LoadDioxusConfigError {}
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum CrateConfigError {
     Cargo(CargoError),
     Io(std::io::Error),

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -105,6 +105,7 @@ impl Build {
                     )?
                 }
             }
+            _ => unreachable!(),
         };
 
         let temp = gen_page(&crate_config, build_result.assets.as_ref(), false);

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -68,6 +68,7 @@ impl Serve {
             Platform::Web => web::startup(crate_config.clone(), &serve_cfg).await?,
             Platform::Desktop => desktop::startup(crate_config.clone(), &serve_cfg).await?,
             Platform::Fullstack => fullstack::startup(crate_config.clone(), &serve_cfg).await?,
+            _ => unreachable!(),
         }
 
         Ok(())

--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -7,6 +7,7 @@ use crate::menubar::{default_menu_bar, DioxusMenu};
 
 /// The behaviour of the application when the last window is closed.
 #[derive(Copy, Clone, Eq, PartialEq)]
+#[non_exhaustive]
 pub enum WindowCloseBehaviour {
     /// Default behaviour, closing the last window exits the app
     LastWindowExitsApp,

--- a/packages/desktop/src/query.rs
+++ b/packages/desktop/src/query.rs
@@ -254,6 +254,7 @@ impl<V: DeserializeOwned> Drop for Query<V> {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum QueryError {
     #[error("Error receiving query result.")]
     Recv,

--- a/packages/fullstack/src/server_fn/collection.rs
+++ b/packages/fullstack/src/server_fn/collection.rs
@@ -163,6 +163,7 @@ impl server_fn::ServerFunctionRegistry<()> for DioxusServerFnRegistry {
 #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
 /// Errors that can occur when registering a server function.
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum ServerRegistrationFnError {
     /// The server function is already registered.
     #[error("The server function {0} is already registered")]

--- a/packages/html/src/eval.rs
+++ b/packages/html/src/eval.rs
@@ -131,6 +131,7 @@ impl IntoFuture for UseEval {
 
 /// Represents an error when evaluating JavaScript
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum EvalError {
     /// The platform does not support evaluating JavaScript.
     Unsupported,

--- a/packages/html/src/events/mounted.rs
+++ b/packages/html/src/events/mounted.rs
@@ -114,6 +114,7 @@ pub type MountedResult<T> = Result<T, MountedError>;
 
 #[derive(Debug)]
 /// The error type for the MountedData
+#[non_exhaustive]
 pub enum MountedError {
     /// The renderer does not support the requested operation
     NotSupported,

--- a/packages/liveview/src/lib.rs
+++ b/packages/liveview/src/lib.rs
@@ -26,6 +26,7 @@ pub trait WebsocketRx: StreamExt<Item = Result<String, LiveViewError>> {}
 impl<T> WebsocketRx for T where T: StreamExt<Item = Result<String, LiveViewError>> {}
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum LiveViewError {
     #[error("Sending to client error")]
     SendingFailed,

--- a/packages/liveview/src/query.rs
+++ b/packages/liveview/src/query.rs
@@ -260,6 +260,7 @@ impl<V: DeserializeOwned> Drop for Query<V> {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum QueryError {
     #[error("Error receiving query result: {0}")]
     Recv(RecvError),

--- a/packages/router/src/routable.rs
+++ b/packages/router/src/routable.rs
@@ -343,6 +343,7 @@ impl SiteMapSegment {
 
 /// The type of a route segment.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum SegmentType {
     /// A static route segment.
     Static(&'static str),

--- a/packages/ssr/src/cache.rs
+++ b/packages/ssr/src/cache.rs
@@ -15,7 +15,7 @@ pub struct StringChain {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub enum Segment {
+pub(crate) enum Segment {
     Attr(usize),
     Node(usize),
     PreRendered(String),

--- a/packages/ssr/src/incremental.rs
+++ b/packages/ssr/src/incremental.rs
@@ -272,6 +272,7 @@ impl DerefMut for WriteBuffer {
 
 /// An error that can occur while rendering a route or retrieving a cached route.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum IncrementalRendererError {
     /// An formatting error occurred while rendering a route.
     #[error("RenderError: {0}")]

--- a/packages/web/src/rehydrate.rs
+++ b/packages/web/src/rehydrate.rs
@@ -5,6 +5,7 @@ use dioxus_core::WriteMutations;
 use dioxus_core::{DynamicNode, ElementId, ScopeState, TemplateNode, VNode, VirtualDom};
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum RehydrationError {
     VNodeNotInitialized,
 }


### PR DESCRIPTION
Make some error enums and other enums dioxus may want to change in a minor release exhaustive to avoid semvar breaking changes in 0.5.1