### PR TITLE
Fix asset bundling in the CLI

### DIFF
--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -1,12 +1,11 @@
 use core::panic;
 use dioxus_cli_config::ExecutableType;
-use manganis_cli_support::AssetManifestExt;
 use std::{fs::create_dir_all, str::FromStr};
 
 use tauri_bundler::{BundleSettings, PackageSettings, SettingsBuilder};
 
 use super::*;
-use crate::{assets::asset_manifest, build_desktop, cfg::ConfigOptsBundle};
+use crate::{build_desktop, cfg::ConfigOptsBundle};
 
 /// Bundle the Rust desktop app and all of its assets
 #[derive(Clone, Debug, Parser)]


### PR DESCRIPTION
This copies the asset in the dist directory when bundling applications with the CLI and adds code to dioxus desktop to look in the dist directory even when the application is run without cargo

Fixes https://github.com/DioxusLabs/dioxus/issues/2144