### PR TITLE
fix(generational-box): polished README.md

### DIFF
--- a/packages/generational-box/README.md
+++ b/packages/generational-box/README.md
@@ -1,12 +1,12 @@
 # Generational Box
 
-Generational Box is a runtime for Rust that allows any static type to implement `Copy`. It can be combined with a global runtime to create an ergonomic state solution like `dioxus-signals`. This crate contains no `unsafe` code.
+Generational Box is a runtime for Rust that allows any static type to implement `Copy`. It can be combined with a global runtime to create an ergonomic state solution like `dioxus-signals`. This crate doesn't have any `unsafe` code.
 
 Three main types manage state in Generational Box:
 
-- Store: Handles recycling generational boxes that have been dropped. Your application should have one store or one store per thread.
-- Owner: Handles dropping generational boxes. The owner acts like a runtime lifetime guard. Any states that you create with an owner will be dropped when that owner is dropped.
-- GenerationalBox: The core Copy state type. The generational box will be dropped when the owner is dropped.
+- `Store`: Handles recycling generational boxes that have been dropped. Your application should have one store or one store per thread.
+- `Owner`: Handles dropping generational boxes. The owner acts like a runtime lifetime guard. Any states that you create with an owner will be dropped when that owner is dropped.
+- `GenerationalBox`: The core Copy state type. The generational box will be dropped when the owner is dropped.
 
 Example:
 
@@ -27,4 +27,4 @@ assert_eq!(*value, "hello world");
 
 ## How it works
 
-Internally, `generational-box` creates an arena of generational `RefCell`'s that are recycled when the owner is dropped. You can think of the cells as something like `&'static RefCell<Box<dyn Any>>` with a generational check to make recycling a cell easier to debug. Then GenerationalBox's are `Copy` because the `&'static` pointer is `Copy`
+Internally, `generational-box` creates an arena of generational `RefCell`s that are recycled when the owner is dropped. You can think of the cells as something like `&'static RefCell<Box<dyn Any>>` with a generational check to make recycling a cell easier to debug. Then `GenerationalBox`es are `Copy` because the `&'static` pointer is `Copy`.


### PR DESCRIPTION
- Formatted a few words with monospace style;
- changed apostrophe to -s/-es;
- added missing period;
- changed "positive negative" phrasing to "negative".
