### PR TITLE
Fix child routers with the web history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli"
-version = "0.5.0"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "atty",

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -462,14 +462,25 @@ impl RouteEnum {
             }
         }
         for route in &self.routes {
-            for segment in &route.segments {
-                if segment.name().as_ref() == Some(field) {
-                    from_route = true
+            match &route.ty {
+                RouteType::Child(child) => {
+                    if let Some(child) = child.ident.as_ref() {
+                        if child == "child" {
+                            from_route = true
+                        }
+                    }
                 }
-            }
-            if let Some(query) = &route.query {
-                if query.contains_ident(field) {
-                    from_route = true
+                RouteType::Leaf { .. } => {
+                    for segment in &route.segments {
+                        if segment.name().as_ref() == Some(field) {
+                            from_route = true
+                        }
+                    }
+                    if let Some(query) = &route.query {
+                        if query.contains_ident(field) {
+                            from_route = true
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Followup to #2159

This PR fixes an error that happens when a child field is used with the web router in the docsite. It currently triggers an unused field error even though the `child` field is used

(NOTE: the child attribute is not currently a public API and is intentionally undocumented)