### PR TITLE
Fix hydration for static text nodes at the root of the template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dioxus
 /target
 /packages/playwright-tests/web/dist
 /packages/playwright-tests/fullstack/dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli"
-version = "0.5.0"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "atty",

--- a/packages/ssr/src/cache.rs
+++ b/packages/ssr/src/cache.rs
@@ -156,11 +156,20 @@ impl StringCache {
                 cur_path.pop();
             }
             TemplateNode::Text { text } => {
+                // write the id if we are prerendering and this is a root node that may need to be removed in the future
+                if prerender && is_root {
+                    write!(chain, "<!--node-id")?;
+                    chain.segments.push(Segment::RootNodeMarker);
+                    write!(chain, "-->")?;
+                }
                 write!(
                     chain,
                     "{}",
                     askama_escape::escape(text, askama_escape::Html)
                 )?;
+                if prerender && is_root {
+                    write!(chain, "<!--#-->")?;
+                }
             }
             TemplateNode::Dynamic { id: idx } | TemplateNode::DynamicText { id: idx } => {
                 chain.segments.push(Segment::Node(*idx))

--- a/packages/web/src/rehydrate.rs
+++ b/packages/web/src/rehydrate.rs
@@ -118,7 +118,6 @@ impl WebsysDom {
                     ids.push(id.0 as u32);
                 }
             }
-            _ => {}
         }
         Ok(())
     }

--- a/packages/web/src/rehydrate.rs
+++ b/packages/web/src/rehydrate.rs
@@ -113,6 +113,11 @@ impl WebsysDom {
                     ids,
                     to_mount,
                 )?,
+            TemplateNode::Text { .. } => {
+                if let Some(id) = root_id {
+                    ids.push(id.0 as u32);
+                }
+            }
             _ => {}
         }
         Ok(())


### PR DESCRIPTION
This PR fixes hydration for static text nodes at the root of templates. Here is a small example that works on this branch, but is broken in the published version of dioxus:

```rust
use dioxus::prelude::*;

fn main() {
    launch(app);
}

fn app() -> Element {
    let mut count = use_signal(|| 0);

    rsx! {
        h1 { "High-Five counter: {count}" }
        button { onclick: move |_| count += 1, "Up high!" }
        button { onclick: move |_| count -= 1, "Down low!" }
        if count() > 10 {
            "Big number!"
        }
        else {
            "Small number!"
        }
    }
}
```

Fixes https://github.com/DioxusLabs/docsite/issues/234