### PR TITLE
Fix the mobile feature on the dioxus crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-cli"
-version = "0.5.0"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "atty",

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -182,11 +182,15 @@ impl<Cfg: Default + 'static, ContextFn: ?Sized> LaunchBuilder<Cfg, ContextFn> {
 /// - `liveview`
 mod current_platform {
     macro_rules! if_else_cfg {
-        (if $attr:meta { $then:item } else { $else:item }) => {
-            #[cfg($attr)]
-            $then
-            #[cfg(not($attr))]
-            $else
+        (if $attr:meta { $($then:item)* } else { $($else:item)* }) => {
+            $(
+                #[cfg($attr)]
+                $then
+            )*
+            $(
+                #[cfg(not($attr))]
+                $else
+            )*
         };
     }
     use crate::prelude::TryIntoConfig;
@@ -194,7 +198,10 @@ mod current_platform {
     #[cfg(any(feature = "desktop", feature = "mobile"))]
     if_else_cfg! {
         if not(feature = "fullstack") {
+            #[cfg(feature = "desktop")]
             pub use dioxus_desktop::launch::*;
+            #[cfg(not(feature = "desktop"))]
+            pub use dioxus_mobile::launch::*;
         } else {
             impl TryIntoConfig<crate::launch::current_platform::Config> for ::dioxus_desktop::Config {
                 fn into_config(self) -> Option<crate::launch::current_platform::Config> {


### PR DESCRIPTION
When just building with the mobile feature enabled, the dioxus crate fails to compile because `dioxus_desktop` is no longer a direct dependency. This PR fixes that issue by re-exporting `dioxus_mobile` (which re-exports `dioxus_desktop`) when the mobile feature is enabled instead