### PR TITLE
Fix for Counters sample code in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ fn Counters() -> impl IntoView {
         >
             <li>
                 <button on:click=move |_| counters.update(|n| n[idx] += 1)>
-                    {move |_| counters.with(|n| n[idx])}
+                    {Memo::new(move |_| counters.with(|n| n[idx]))}
                 </button>
                 <button on:click=move |_| counters.update(|n| { n.remove(idx); })>
                     "Remove"

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ fn Counters() -> Element {
 [While in Leptos you would use the `<For>` component.](https://book.leptos.dev/view/04_iteration.html#dynamic-rendering-with-the-for-component):
 
 ```rust
-fn Counters() -> Element {
+fn Counters() -> impl IntoView {
     let counters = RwSignal::new(vec![0; 10]);
 
     view! {
@@ -285,7 +285,7 @@ fn Counters() -> Element {
         >
             <li>
                 <button on:click=move |_| counters.update(|n| n[idx] += 1)>
-                    {Memo::new(move |_| counters.with(|n| n[idx]))}
+                    {move |_| counters.with(|n| n[idx])}
                 </button>
                 <button on:click=move |_| counters.update(|n| { n.remove(idx); })>
                     "Remove"


### PR DESCRIPTION
For leptos code, there is no need for Memorization here. As memorization of the values of the text nodes in the renderer already happens.