### PR TITLE
Fix rendering aborted nodes in SSR

### DIFF
--- a/packages/ssr/src/cache.rs
+++ b/packages/ssr/src/cache.rs
@@ -4,9 +4,8 @@ use std::fmt::Write;
 use crate::renderer::{str_truthy, BOOL_ATTRS};
 
 #[derive(Debug)]
-pub struct StringCache {
+pub(crate) struct StringCache {
     pub segments: Vec<Segment>,
-    pub template: Template,
 }
 
 #[derive(Default)]
@@ -56,7 +55,6 @@ impl StringCache {
 
         Ok(Self {
             segments: chain.segments,
-            template: template.template.get(),
         })
     }
 

--- a/packages/ssr/src/fs_cache.rs
+++ b/packages/ssr/src/fs_cache.rs
@@ -1,10 +1,6 @@
 #![allow(non_snake_case)]
 
-use std::{
-    ops::{Deref, DerefMut},
-    path::PathBuf,
-    time::Duration,
-};
+use std::{path::PathBuf, time::Duration};
 
 /// Information about the freshness of a rendered response
 #[derive(Debug, Clone, Copy)]
@@ -57,31 +53,6 @@ impl RenderFreshness {
                 http::HeaderValue::from_str(&format!("max-age={}", max_age)).unwrap(),
             );
         }
-    }
-}
-
-struct WriteBuffer {
-    buffer: Vec<u8>,
-}
-
-impl std::fmt::Write for WriteBuffer {
-    fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.buffer.extend_from_slice(s.as_bytes());
-        Ok(())
-    }
-}
-
-impl Deref for WriteBuffer {
-    type Target = Vec<u8>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.buffer
-    }
-}
-
-impl DerefMut for WriteBuffer {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.buffer
     }
 }
 

--- a/packages/ssr/src/incremental.rs
+++ b/packages/ssr/src/incremental.rs
@@ -2,7 +2,6 @@
 
 #![allow(non_snake_case)]
 
-use crate::fs_cache::ValidCachedPath;
 use chrono::offset::Utc;
 use chrono::DateTime;
 use dioxus_core::VirtualDom;

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -1,8 +1,6 @@
 use super::cache::Segment;
 use crate::cache::StringCache;
-use dioxus_core::RenderReturn;
 
-use dioxus_core::Attribute;
 use dioxus_core::{prelude::*, AttributeValue, DynamicNode};
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -55,12 +53,9 @@ impl Renderer {
         dom: &VirtualDom,
         scope: ScopeId,
     ) -> std::fmt::Result {
-        // We should never ever run into async or errored nodes in SSR
-        // Error boundaries and suspense boundaries will convert these to sync
-        if let RenderReturn::Ready(node) = dom.get_scope(scope).unwrap().root_node() {
-            self.dynamic_node_id = 0;
-            self.render_template(buf, dom, node)?
-        };
+        let node = dom.get_scope(scope).unwrap().root_node();
+        self.dynamic_node_id = 0;
+        self.render_template(buf, dom, node)?;
 
         Ok(())
     }
@@ -122,14 +117,7 @@ impl Renderer {
                         } else {
                             let scope = node.mounted_scope(*idx, template, dom).unwrap();
                             let node = scope.root_node();
-                            match node {
-                                RenderReturn::Ready(node) => {
-                                    self.render_template(buf, dom, node)?
-                                }
-                                _ => todo!(
-                                    "generally, scopes should be sync, only if being traversed"
-                                ),
-                            }
+                            self.render_template(buf, dom, node)?
                         }
                     }
                     DynamicNode::Text(text) => {


### PR DESCRIPTION
This PR fixes rendering aborted nodes in the SSR renderer by first converting nodes to VNodes and then rendering the VNode. It also cleans up a few unused items in the SSR renderer

Fixes #2190