### PR TITLE
Fix hydration for non-bubbling events

### DIFF
--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true, features = ["fs", "io-util"], optional = true }
 rfd = { version = "0.14", optional = true }
 futures-channel = { workspace = true }
 serde_json = { version = "1", optional = true }
+tracing.workspace = true
 
 [dependencies.web-sys]
 optional = true

--- a/packages/html/src/events.rs
+++ b/packages/html/src/events.rs
@@ -348,7 +348,10 @@ pub fn event_bubbles(evt: &str) -> bool {
         "transitionend" => true,
         "toggle" => true,
         "mounted" => false,
-        _ => true,
+        _ => {
+            tracing::warn!("Unknown event name: {evt}");
+            true
+        }
     }
 }
 

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -197,7 +197,7 @@ impl Renderer {
                     // then write any listeners
                     for name in accumulated_listeners.drain(..) {
                         write!(buf, ",{}:", &name[2..])?;
-                        write!(buf, "{}", dioxus_html::event_bubbles(name) as u8)?;
+                        write!(buf, "{}", dioxus_html::event_bubbles(&name[2..]) as u8)?;
                     }
                 }
 


### PR DESCRIPTION
This PR fixes hydration for non-bubbling events like the onmouseenter event in the hackernews guide. We were not correctly trimming the `on` prefix from events before checking if the event was bubbling in SSR which meant the default `true` value was always returned