### PR TITLE
Fix: memory leak on listeners for elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "tokio",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -142,6 +142,30 @@ impl Clone for VNode {
     }
 }
 
+impl Drop for VNode {
+    fn drop(&mut self) {
+        // FIXME:
+        // TODO:
+        //
+        // We have to add this drop *here* becase we can't add a drop impl to AttributeValue and
+        // keep semver compatibility. Adding a drop impl means you can't destructure the value, which
+        // we need to do for enums.
+        //
+        // if dropping this will drop the last vnode (rc count is 1), then we need to drop the listeners
+        // in this template
+        if Rc::strong_count(&self.vnode) == 1 {
+            for attrs in self.vnode.dynamic_attrs.iter() {
+                for attr in attrs.iter() {
+                    if let AttributeValue::Listener(listener) = &attr.value {
+                        println!("Dropping listener");
+                        listener.callback.manually_drop();
+                    }
+                }
+            }
+        }
+    }
+}
+
 impl PartialEq for VNode {
     fn eq(&self, other: &Self) -> bool {
         Rc::ptr_eq(&self.vnode, &other.vnode)
@@ -714,15 +738,15 @@ impl AttributeValue {
     ///
     /// The callback must be confined to the lifetime of the ScopeState
     pub fn listener<T: 'static>(mut callback: impl FnMut(Event<T>) + 'static) -> AttributeValue {
-        AttributeValue::Listener(EventHandler::new(move |event: Event<dyn Any>| {
+        let event_handler = EventHandler::new(move |event: Event<dyn Any>| {
             let data = event.data.downcast::<T>().unwrap();
-            // if let Ok(data) = event.data.downcast::<T>() {
             callback(Event {
                 propagates: event.propagates,
                 data,
             });
-            // }
-        }))
+        });
+
+        AttributeValue::Listener(event_handler)
     }
 
     /// Create a new [`AttributeValue`] with a value that implements [`AnyValue`]

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -738,15 +738,15 @@ impl AttributeValue {
     ///
     /// The callback must be confined to the lifetime of the ScopeState
     pub fn listener<T: 'static>(mut callback: impl FnMut(Event<T>) + 'static) -> AttributeValue {
-        let event_handler = EventHandler::new(move |event: Event<dyn Any>| {
+        // TODO: maybe don't use the copy-variant of EventHandler here?
+        // Maybe, create an Owned variant so we are less likely to run into leaks
+        AttributeValue::Listener(EventHandler::new(move |event: Event<dyn Any>| {
             let data = event.data.downcast::<T>().unwrap();
             callback(Event {
                 propagates: event.propagates,
                 data,
             });
-        });
-
-        AttributeValue::Listener(event_handler)
+        }))
     }
 
     /// Create a new [`AttributeValue`] with a value that implements [`AnyValue`]

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -157,7 +157,6 @@ impl Drop for VNode {
             for attrs in self.vnode.dynamic_attrs.iter() {
                 for attr in attrs.iter() {
                     if let AttributeValue::Listener(listener) = &attr.value {
-                        println!("Dropping listener");
                         listener.callback.manually_drop();
                     }
                 }

--- a/packages/generational-box/src/lib.rs
+++ b/packages/generational-box/src/lib.rs
@@ -3,7 +3,6 @@
 
 use parking_lot::Mutex;
 use std::{
-    any::Any,
     fmt::Debug,
     marker::PhantomData,
     ops::{Deref, DerefMut},

--- a/packages/generational-box/src/lib.rs
+++ b/packages/generational-box/src/lib.rs
@@ -3,6 +3,7 @@
 
 use parking_lot::Mutex;
 use std::{
+    any::Any,
     fmt::Debug,
     marker::PhantomData,
     ops::{Deref, DerefMut},
@@ -189,6 +190,7 @@ impl<T, S: Storage<T>> GenerationalBox<T, S> {
     /// Drop the value out of the generational box and invalidate the generational box. This will return the value if the value was taken.
     pub fn manually_drop(&self) -> Option<T> {
         if self.validate() {
+            <S as AnyStorage>::recycle(&self.raw);
             Storage::take(&self.raw.0.data)
         } else {
             None


### PR DESCRIPTION
We switched over to Copy types for EventHandlers on elements which is equivalent to calling Signal::new(). This is not necessary for elements, just for child components, and thus caused a memory leak for long-running components.

This PR adds a drop impl to VNode to manually drop listeners when the last VNodeInner is dropped. We can't add the drop impl anywhere else since VNode is the only struct in the chain that can't be destructured, making it semver compatible.

Fix: #2227