### PR TITLE
fix the relative paths issue in the fullstack crates.io build

### DIFF
--- a/packages/cli/src/assets/autoreload.js
+++ b/packages/cli/src/assets/autoreload.js
@@ -1,5 +1,7 @@
 // Dioxus-CLI
 // https://github.com/DioxusLabs/dioxus/tree/master/packages/cli
+// NOTE: This is also used in the fullstack package at ../packages/fullstack/src/render.rs, if you make changes here, make sure to update the version in there as well
+// TODO: Extract hot reloading with axum into a separate crate or use the fullstack hot reloading Axum extension trait here
 
 (function () {
   var protocol = window.location.protocol === "https:" ? "wss:" : "ws:";


### PR DESCRIPTION
This just copies the dioxus-cli's script back into fullstack inline. In the future, we should try to pull out the hot reloading code into a separate package that both the CLI and fullstack can use to serve the websocket