### PR TITLE
Use `tracing::warn!` instead of `error!` when the dioxus CLI is not used

### DIFF
--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -50,7 +50,7 @@ pub static CURRENT_CONFIG: once_cell::sync::Lazy<
     CURRENT_CONFIG_JSON
         .and_then(|config| serde_json::from_str(config).ok())
         .ok_or_else(|| {
-            tracing::error!("A library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application.");
+            tracing::warn!("A library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application.");
             DioxusCLINotUsed
     })
 });


### PR DESCRIPTION
Currently, it emits a `tracing::error` when the dioxus CLI was not used to build the application. It should be a warning since `cargo` can also build the application successfully.