### PR TITLE
Use `tracing::warn!` instead of `error!` when assets not being preloaded

### DIFF
--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -86,7 +86,7 @@ fn assets_head() -> Option<String> {
         match std::fs::read_to_string(&head) {
             Ok(s) => Some(s),
             Err(err) => {
-                tracing::error!("Failed to read {head:?}: {err}");
+                tracing::warn!("Assets cannot be preloaded (failed to read {head:?}): {err}.");
                 None
             }
         }

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -86,7 +86,7 @@ fn assets_head() -> Option<String> {
         match std::fs::read_to_string(&head) {
             Ok(s) => Some(s),
             Err(err) => {
-                tracing::warn!("Assets cannot be preloaded (failed to read {head:?}): {err}.");
+                tracing::warn!("Assets built with manganis cannot be preloaded (failed to read {head:?}). This warning may occur when you build a desktop application without the dioxus CLI. If you do not use manganis, you can ignore this warning: {err}.");
                 None
             }
         }


### PR DESCRIPTION
Currently, it emits a `tracing::error` when assets not being preloaded if the dioxus CLI was not used to build the application. It should be a warning since `cargo` can also build the application successfully.

Fix [#2231](https://github.com/DioxusLabs/dioxus/issues/2231)