### PR TITLE
Fix the assets head path

### DIFF
--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -81,8 +81,14 @@ fn assets_head() -> Option<String> {
         target_os = "openbsd"
     ))]
     {
-        let head = crate::protocol::get_asset_root_or_default();
-        let head = head.join("dist").join("__assets_head.html");
+        let root = crate::protocol::get_asset_root_or_default();
+        let assets_head_path = "__assets_head.html";
+        let mut head = root.join(assets_head_path);
+        // If we can't find it, add the dist directory and try again
+        // When bundling we currently copy the whole dist directory to the output directory instead of the individual files because of a limitation of cargo bundle2
+        if !head.exists() {
+            head = root.join("dist").join(assets_head_path);
+        }
         match std::fs::read_to_string(&head) {
             Ok(s) => Some(s),
             Err(err) => {


### PR DESCRIPTION
This PR fixes the path to the `__assets_head.html` file the CLI generates for manganis assets. 

In bundled applications the path is `$root/dist/__assets_head.html`, but in applications served by the CLI, the path is `$root/__assets_head.html`. We currently only check for the path that will be available in the bundled application. This PR fixes the issue by checking both paths