### PR TITLE
Fix features not passed from dx bundle to cargo

### DIFF
--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -86,6 +86,10 @@ impl Bundle {
             crate_config.extend_with_platform(platform);
         }
 
+        if let Some(features) = self.build.features {
+            crate_config.set_features(features);
+        }
+
         // build the desktop app
         // Since the `bundle()` function is only run for the desktop platform,
         // the `rust_flags` argument is set to `None`.


### PR DESCRIPTION
Playing around with [Publishing](https://dioxuslabs.com/learn/0.5/cookbook/publishing), the docs recommended to use a feature to disable the console on Windows when bundling. That worked with `dx build` but not `dx bundle`.

This PR fixes that by passing features to `cargo` when using `dx bundle`, which is the same behaviour as `dx build`