### PR TITLE
Poll tasks in the same order they are queued

### DIFF
--- a/packages/core/src/dirty_scope.rs
+++ b/packages/core/src/dirty_scope.rs
@@ -32,6 +32,7 @@ use crate::Task;
 use crate::VirtualDom;
 use std::borrow::Borrow;
 use std::cell::RefCell;
+use std::collections::VecDeque;
 use std::hash::Hash;
 
 #[derive(Debug, Clone, Copy, Eq)]
@@ -138,7 +139,7 @@ impl VirtualDom {
                         Some(Work {
                             scope,
                             rerun_scope: true,
-                            tasks: Vec::new(),
+                            tasks: Default::default(),
                         })
                     }
                     std::cmp::Ordering::Greater => {
@@ -165,7 +166,7 @@ impl VirtualDom {
                 Some(Work {
                     scope,
                     rerun_scope: true,
-                    tasks: Vec::new(),
+                    tasks: Default::default(),
                 })
             }
             (None, Some(_)) => {
@@ -185,27 +186,27 @@ impl VirtualDom {
 pub struct Work {
     pub scope: ScopeOrder,
     pub rerun_scope: bool,
-    pub tasks: Vec<Task>,
+    pub tasks: VecDeque<Task>,
 }
 
 #[derive(Debug, Clone, Eq)]
 pub(crate) struct DirtyTasks {
     pub order: ScopeOrder,
-    pub tasks_queued: RefCell<Vec<Task>>,
+    pub tasks_queued: RefCell<VecDeque<Task>>,
 }
 
 impl From<ScopeOrder> for DirtyTasks {
     fn from(order: ScopeOrder) -> Self {
         Self {
             order,
-            tasks_queued: Vec::new().into(),
+            tasks_queued: VecDeque::new().into(),
         }
     }
 }
 
 impl DirtyTasks {
     pub fn queue_task(&self, task: Task) {
-        self.tasks_queued.borrow_mut().push(task);
+        self.tasks_queued.borrow_mut().push_back(task);
     }
 }
 

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -518,7 +518,7 @@ impl VirtualDom {
         while let Some(task) = self.pop_task() {
             // Then poll any tasks that might be pending
             let mut tasks = task.tasks_queued.into_inner();
-            while let Some(task) = tasks.pop() {
+            while let Some(task) = tasks.pop_front() {
                 let _ = self.runtime.handle_task_wakeup(task);
 
                 // Running that task, may mark a scope higher up as dirty. If it does, return from the function early
@@ -702,7 +702,7 @@ impl VirtualDom {
                     while let Some(task) = self.pop_task() {
                         // Then poll any tasks that might be pending
                         let mut tasks = task.tasks_queued.into_inner();
-                        while let Some(task) = tasks.pop() {
+                        while let Some(task) = tasks.pop_front() {
                             if self.runtime.task_runs_during_suspense(task) {
                                 let _ = self.runtime.handle_task_wakeup(task);
                                 // Running that task, may mark a scope higher up as dirty. If it does, return from the function early


### PR DESCRIPTION
This changes the task queue for each scope from a Vec to a VecDeque to preserve the order we poll tasks in a single scope. This fixes effect ordering which uses futures internally

Fixes https://github.com/DioxusLabs/dioxus/issues/2262