### PR TITLE
Fix empty for loop, if statements and children

### DIFF
--- a/packages/rsx/src/attribute.rs
+++ b/packages/rsx/src/attribute.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use super::*;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::quote;
 use syn::{parse_quote, spanned::Spanned, Expr, ExprIf, Ident, LitStr};
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -11,18 +11,15 @@
 //! - [ ] Keys
 //! - [ ] Properties spreading with with `..` syntax
 
-use self::{location::CallerLocation, renderer::TemplateRenderer};
+use self::location::CallerLocation;
 
 use super::*;
 
 use proc_macro2::TokenStream as TokenStream2;
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::quote;
 use syn::{
-    ext::IdentExt,
-    parse::{Parse, ParseBuffer, ParseStream},
-    spanned::Spanned,
-    token::Brace,
-    AngleBracketedGenericArguments, Error, Expr, Ident, LitStr, PathArguments, Result, Token,
+    ext::IdentExt, parse::ParseBuffer, spanned::Spanned, token::Brace,
+    AngleBracketedGenericArguments, Error, Expr, Ident, LitStr, PathArguments, Token,
 };
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
@@ -184,7 +181,7 @@ impl Component {
         }
         if !self.children.is_empty() {
             let renderer = TemplateRenderer::as_tokens(&self.children, None);
-            toks.append_all(quote! { .children( Some({ #renderer }) ) });
+            toks.append_all(quote! { .children( { #renderer } ) });
         }
         toks.append_all(quote! { .build() });
         toks

--- a/packages/rsx/src/context.rs
+++ b/packages/rsx/src/context.rs
@@ -261,7 +261,7 @@ impl<'a> DynamicContext<'a> {
         }
 
         // And then set the path of this node to the current path (which we're hitting during traversal)
-        self.node_paths[idx] = self.current_path.clone();
+        self.node_paths[idx].clone_from(&self.current_path);
 
         Some(match root {
             BodyNode::Text(_) => TemplateNode::DynamicText { id: idx },
@@ -322,7 +322,7 @@ impl<'a> DynamicContext<'a> {
             self.attr_paths.resize_with(idx + 1, Vec::new);
         }
 
-        self.attr_paths[idx] = self.current_path.clone();
+        self.attr_paths[idx].clone_from(&self.current_path);
 
         Some(idx)
     }

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -3,13 +3,10 @@ use std::fmt::{Display, Formatter};
 use super::*;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::quote;
 use syn::{
-    parse::{Parse, ParseBuffer, ParseStream},
-    punctuated::Punctuated,
-    spanned::Spanned,
-    token::Brace,
-    Expr, Ident, LitStr, Result, Token,
+    parse::ParseBuffer, punctuated::Punctuated, spanned::Spanned, token::Brace, Expr, Ident,
+    LitStr, Token,
 };
 
 // =======================================

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -77,7 +77,7 @@ impl CallBody {
 
         let body = TemplateRenderer::as_tokens(&self.roots, Some(location));
 
-        quote! { Some({ #body }) }
+        quote! { { #body } }
     }
 
     /// This will try to create a new template from the current body and the previous body. This will return None if the
@@ -172,7 +172,7 @@ impl ToTokens for CallBody {
             true => out_tokens.append_all(quote! { None }),
             false => {
                 let body = TemplateRenderer::as_tokens(&self.roots, None);
-                out_tokens.append_all(quote! { Some({ #body }) })
+                out_tokens.append_all(quote! { { #body } })
             }
         }
     }

--- a/packages/rsx/src/node.rs
+++ b/packages/rsx/src/node.rs
@@ -3,13 +3,12 @@ use self::location::CallerLocation;
 use super::*;
 
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::quote;
 use syn::{
     braced,
-    parse::{Parse, ParseStream},
     spanned::Spanned,
     token::{self, Brace},
-    Expr, ExprIf, LitStr, Pat, Result,
+    Expr, ExprIf, LitStr, Pat,
 };
 
 /*
@@ -298,14 +297,14 @@ impl ToTokens for IfChain {
 
             let renderer = TemplateRenderer::as_tokens(then_branch, None);
 
-            body.append_all(quote! { #if_token #cond { Some({#renderer}) } });
+            body.append_all(quote! { #if_token #cond { {#renderer} } });
 
             if let Some(next) = else_if_branch {
                 body.append_all(quote! { else });
                 elif = Some(next);
             } else if let Some(else_branch) = else_branch {
                 let renderer = TemplateRenderer::as_tokens(else_branch, None);
-                body.append_all(quote! { else { Some({#renderer}) } });
+                body.append_all(quote! { else { {#renderer} } });
                 terminated = true;
                 break;
             } else {

--- a/packages/rsx/src/renderer.rs
+++ b/packages/rsx/src/renderer.rs
@@ -16,6 +16,11 @@ impl<'a> TemplateRenderer<'a> {
     }
 
     fn render(mut self) -> TokenStream2 {
+        // If there are no roots, this is an empty template, so just return None
+        if self.roots.is_empty() {
+            return quote! { Option::<dioxus_core::VNode>::None };
+        }
+
         // Create a new dynamic context that tracks the state of all the dynamic nodes
         // We have no old template, to seed it with, so it'll just be used for rendering
         let mut context = DynamicContext::default();
@@ -43,7 +48,7 @@ impl<'a> TemplateRenderer<'a> {
         let node_paths = context.node_paths.iter().map(|it| quote!(&[#(#it),*]));
         let attr_paths = context.attr_paths.iter().map(|it| quote!(&[#(#it),*]));
 
-        quote! {
+        let vnode = quote! {
             static TEMPLATE: dioxus_core::Template = dioxus_core::Template {
                 name: #name,
                 roots: #roots,
@@ -61,7 +66,9 @@ impl<'a> TemplateRenderer<'a> {
                 );
                 __vnodes
             }
-        }
+        };
+
+        quote! { Some({ #vnode }) }
     }
 
     fn get_template_id_tokens(&self) -> TokenStream2 {

--- a/packages/web/src/hot_reload.rs
+++ b/packages/web/src/hot_reload.rs
@@ -30,8 +30,6 @@ pub(crate) fn init() -> UnboundedReceiver<Template> {
 
     // change the rsx when new data is received
     let cl = Closure::wrap(Box::new(move |e: MessageEvent| {
-        console::log_1(&e.clone().into());
-
         if let Ok(text) = e.data().dyn_into::<js_sys::JsString>() {
             let string: String = text.into();
 

--- a/packages/web/src/hot_reload.rs
+++ b/packages/web/src/hot_reload.rs
@@ -3,7 +3,7 @@
 use futures_channel::mpsc::UnboundedReceiver;
 
 use dioxus_core::Template;
-use web_sys::{console, Element};
+use web_sys::{Element};
 
 pub(crate) fn init() -> UnboundedReceiver<Template> {
     use wasm_bindgen::closure::Closure;


### PR DESCRIPTION
We expand empty rsx statements to `None` instead of an empty template so that there is a root node for the template for diffing. This PR expands that behavior to the body of if statements, for loops and children

Fixes #2270