### PR TITLE
Fix volatile attributes

### DIFF
--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -367,7 +367,9 @@ impl VNode {
                             std::cmp::Ordering::Equal => {
                                 let old = old_attributes_iter.next().unwrap();
                                 let new = new_attributes_iter.next().unwrap();
-                                if old.value != new.value {
+                                // Volatile attributes are attributes that the browser may override so we always update them
+                                let volatile = old.volatile;
+                                if volatile || old.value != new.value {
                                     self.write_attribute(
                                         path,
                                         new,


### PR DESCRIPTION
This PR fixes diffing volatile attributes. Any volatile attributes should always be written even if the value appears not to have changed because the browser may have changed the attribute. This fixes this example:
```rust
use dioxus::prelude::*;

fn main() {
    launch(app);
}

fn app() -> Element {
    let mut count = use_signal(|| 0);

    rsx! {
        input {
            value: count,
            r#type: "number",
            oninput: move |evt| {
                if let Ok(value) = evt.value().parse::<i64>() {
                    if value < 0 {
                        count.set(0);
                    }
                    else {
                        count.set(value);
                    }
                }
            },
        }
    }
}
```