### PR TITLE
Fix: autofmt shouldn't eat keys

### DIFF
--- a/packages/autofmt/src/component.rs
+++ b/packages/autofmt/src/component.rs
@@ -28,6 +28,7 @@ impl Writer<'_> {
             children,
             manual_props,
             prop_gen_args,
+            key,
             ..
         }: &Component,
     ) -> Result {
@@ -38,7 +39,7 @@ impl Writer<'_> {
         let mut opt_level = ShortOptimization::NoOpt;
 
         // check if we have a lot of attributes
-        let attr_len = self.field_len(fields, manual_props);
+        let attr_len = self.field_len(fields, manual_props) + self.key_len(key.as_ref());
         let is_short_attr_list = attr_len < 80;
         let is_small_children = self.is_short_children(children).is_some();
 
@@ -62,7 +63,7 @@ impl Writer<'_> {
         }
 
         // If there's nothing at all, empty optimization
-        if fields.is_empty() && children.is_empty() && manual_props.is_none() {
+        if fields.is_empty() && children.is_empty() && manual_props.is_none() && key.is_none() {
             opt_level = ShortOptimization::Empty;
         }
 
@@ -85,7 +86,7 @@ impl Writer<'_> {
             ShortOptimization::Oneliner => {
                 write!(self.out, " ")?;
 
-                self.write_component_fields(fields, manual_props, true)?;
+                self.write_component_fields(fields, key.as_ref(), manual_props, true)?;
 
                 if !children.is_empty() && !fields.is_empty() {
                     write!(self.out, ", ")?;
@@ -103,7 +104,7 @@ impl Writer<'_> {
 
             ShortOptimization::PropsOnTop => {
                 write!(self.out, " ")?;
-                self.write_component_fields(fields, manual_props, true)?;
+                self.write_component_fields(fields, key.as_ref(), manual_props, true)?;
 
                 if !children.is_empty() && !fields.is_empty() {
                     write!(self.out, ",")?;
@@ -114,7 +115,7 @@ impl Writer<'_> {
             }
 
             ShortOptimization::NoOpt => {
-                self.write_component_fields(fields, manual_props, false)?;
+                self.write_component_fields(fields, key.as_ref(), manual_props, false)?;
 
                 if !children.is_empty() && !fields.is_empty() {
                     write!(self.out, ",")?;
@@ -154,10 +155,22 @@ impl Writer<'_> {
     fn write_component_fields(
         &mut self,
         fields: &[ComponentField],
+        key: Option<&IfmtInput>,
         manual_props: &Option<syn::Expr>,
         sameline: bool,
     ) -> Result {
         let mut field_iter = fields.iter().peekable();
+
+        // write the key
+        if let Some(key) = key {
+            write!(self.out, "key: {}", ifmt_to_string(key))?;
+            if !fields.is_empty() {
+                write!(self.out, ",")?;
+                if sameline {
+                    write!(self.out, " ")?;
+                }
+            }
+        }
 
         while let Some(field) = field_iter.next() {
             if !sameline {

--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -1,4 +1,4 @@
-use dioxus_rsx::{AttributeType, BodyNode, ElementAttrValue, ForLoop, IfChain};
+use dioxus_rsx::{AttributeType, BodyNode, ElementAttrValue, ForLoop, IfChain, IfmtInput};
 use proc_macro2::{LineColumn, Span};
 use quote::ToTokens;
 use std::{
@@ -328,6 +328,13 @@ impl<'a> Writer<'a> {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn key_len(&self, key: Option<&IfmtInput>) -> usize {
+        match key {
+            Some(key) => ifmt_to_string(key).len() + 5,
+            None => 0,
+        }
     }
 }
 

--- a/packages/autofmt/tests/samples/complex.rsx
+++ b/packages/autofmt/tests/samples/complex.rsx
@@ -48,6 +48,21 @@ rsx! {
         }
     }
 
+    for i in 0..10 {
+        Component { key: "{i}", blah: 120 }
+    }
+    for i in 0..10 {
+        Component { key: "{i}" }
+    }
+
+    for i in 0..10 {
+        div { key: "{i}", blah: 120 }
+    }
+
+    for i in 0..10 {
+        div { key: "{i}" }
+    }
+
     div {
         "asdbascasdbasd"
         "asbdasbdabsd"


### PR DESCRIPTION
I guess we never printed keys on components! This fixes that.

Fix #2252 