### PR TITLE
Replace `AttributeValue::Text` with `Cow<'static, str>`

### DIFF
--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -953,6 +953,12 @@ impl IntoAttributeValue for AttributeValue {
     }
 }
 
+impl IntoAttributeValue for Cow<'static, str> {
+    fn into_value(self) -> AttributeValue {
+        AttributeValue::Text(self)
+    }
+}
+
 impl IntoAttributeValue for &'static str {
     fn into_value(self) -> AttributeValue {
         AttributeValue::Text(self.into())

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use crate::{Properties, VirtualDom};
 use core::panic;
+use std::borrow::Cow;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::vec;
@@ -711,7 +712,7 @@ impl Attribute {
 /// variant.
 pub enum AttributeValue {
     /// Text attribute
-    Text(String),
+    Text(Cow<'static, str>),
 
     /// A float
     Float(f64),
@@ -952,15 +953,15 @@ impl IntoAttributeValue for AttributeValue {
     }
 }
 
-impl IntoAttributeValue for &str {
+impl IntoAttributeValue for &'static str {
     fn into_value(self) -> AttributeValue {
-        AttributeValue::Text(self.to_string())
+        AttributeValue::Text(self.into())
     }
 }
 
 impl IntoAttributeValue for String {
     fn into_value(self) -> AttributeValue {
-        AttributeValue::Text(self)
+        AttributeValue::Text(self.into())
     }
 }
 
@@ -984,7 +985,7 @@ impl IntoAttributeValue for bool {
 
 impl IntoAttributeValue for Arguments<'_> {
     fn into_value(self) -> AttributeValue {
-        AttributeValue::Text(self.to_string())
+        AttributeValue::Text(self.to_string().into())
     }
 }
 

--- a/packages/core/tests/attr_cleanup.rs
+++ b/packages/core/tests/attr_cleanup.rs
@@ -55,13 +55,13 @@ fn attrs_cycle() {
             AssignId { path: &[0], id: ElementId(3) },
             SetAttribute {
                 name: "class",
-                value: dioxus_core::AttributeValue::Text("3".to_string()),
+                value: dioxus_core::AttributeValue::Text("3".into()),
                 id: ElementId(3),
                 ns: None
             },
             SetAttribute {
                 name: "id",
-                value: dioxus_core::AttributeValue::Text("3".to_string()),
+                value: dioxus_core::AttributeValue::Text("3".into()),
                 id: ElementId(3),
                 ns: None
             },

--- a/packages/core/tests/fuzzing.rs
+++ b/packages/core/tests/fuzzing.rs
@@ -202,7 +202,7 @@ fn create_random_dynamic_node(depth: usize) -> DynamicNode {
 
 fn create_random_dynamic_attr() -> Attribute {
     let value = match rand::random::<u8>() % 7 {
-        0 => AttributeValue::Text(format!("{}", rand::random::<usize>())),
+        0 => format!("{}", rand::random::<usize>()).into_value(),
         1 => AttributeValue::Float(rand::random()),
         2 => AttributeValue::Int(rand::random()),
         3 => AttributeValue::Bool(rand::random()),


### PR DESCRIPTION
```rust
pub enum AttributeValue {
    Text(Cow<'static, str>),
    ...
}
```

This would allow for less clones when using text nodes.

However this does introduce the tradeoff of not automatically converting `&str` to `String`, only `&'static str` is permitted to reduce cloning.

Definitely open to changing any of this! 😄 