### PR TITLE
Remove unused once-cell in memo

### DIFF
--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -3,7 +3,6 @@ use generational_box::UnsyncStorage;
 use std::ops::Deref;
 
 use dioxus_core::prelude::*;
-use dioxus_core::ScopeId;
 
 use generational_box::{GenerationalBox, Storage};
 

--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -2,7 +2,6 @@ use crate::read_impls;
 use crate::write::Writable;
 use crate::{read::Readable, ReactiveContext, ReadableRef, Signal};
 use crate::{CopyValue, ReadOnlySignal};
-use std::rc::Rc;
 use std::{
     cell::RefCell,
     ops::Deref,
@@ -13,7 +12,6 @@ use std::{
 use dioxus_core::prelude::*;
 use futures_util::StreamExt;
 use generational_box::UnsyncStorage;
-use once_cell::sync::OnceCell;
 
 struct UpdateInformation<T> {
     dirty: Arc<AtomicBool>,
@@ -45,8 +43,6 @@ impl<T: 'static> Memo<T> {
         let dirty = Arc::new(AtomicBool::new(true));
         let (tx, mut rx) = futures_channel::mpsc::unbounded();
 
-        let myself: Rc<OnceCell<Memo<T>>> = Rc::new(OnceCell::new());
-
         let callback = {
             let dirty = dirty.clone();
             move || {
@@ -74,7 +70,6 @@ impl<T: 'static> Memo<T> {
             inner: state,
             update,
         };
-        let _ = myself.set(memo);
 
         spawn_isomorphic(async move {
             while rx.next().await.is_some() {


### PR DESCRIPTION
This PR removes a once cell from the use_memo hook that was set but never used