### PR TITLE
fix path of set_server_url

### DIFF
--- a/packages/fullstack/examples/axum-desktop/src/client.rs
+++ b/packages/fullstack/examples/axum-desktop/src/client.rs
@@ -8,7 +8,7 @@ use axum_desktop::*;
 fn main() {
     // Set the url of the server where server functions are hosted.
     #[cfg(not(feature = "server"))]
-    dioxus::fullstack::prelude::server_fn::set_server_url("http://127.0.0.1:8080");
+    dioxus::fullstack::prelude::server_fn::client::set_server_url("http://127.0.0.1:8080");
 
     #[cfg(feature = "desktop")]
     dioxus::prelude::launch_desktop(app)


### PR DESCRIPTION
`set_server_url` is no longer directly under the [prelude](https://github.com/DioxusLabs/dioxus/blob/main/packages/fullstack/src/lib.rs#L40)