### PR TITLE
Extend the subscriber list instead of overriding it; fixes subscribers added in mark_dirty

### DIFF
--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -155,7 +155,8 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
             // We cannot hold the subscribers lock while calling mark_dirty, because mark_dirty can run user code which may cause a new subscriber to be added. If we hold the lock, we will deadlock.
             let mut subscribers = std::mem::take(&mut *inner.subscribers.lock().unwrap());
             subscribers.retain(|reactive_context| reactive_context.mark_dirty());
-            *inner.subscribers.lock().unwrap() = subscribers;
+            // Extend the subscribers list instead of overwriting it in case a subscriber is added while reactive contexts are marked dirty
+            inner.subscribers.lock().unwrap().extend(subscribers);
         }
     }
 


### PR DESCRIPTION
We have slightly wrong behavior when writing to a signal. If any subscriptions are added while marking a signal as dirty, they will currently be ignored. This PR changes behavior to add those subscriptions.

In practice, this edge case is very difficult to hit. You would need to read a signal in a memo then write to the signal and read the memo in the same render

Closes #2306