### PR TITLE
add file size to FileEngine

### DIFF
--- a/packages/html/src/file_data.rs
+++ b/packages/html/src/file_data.rs
@@ -20,6 +20,11 @@ impl FileEngine for SerializedFileEngine {
         self.files.keys().cloned().collect()
     }
 
+    async fn file_size(&self, file: &str) -> Option<u64> {
+        let file = self.files.get(file)?;
+        Some(file.len() as u64)
+    }
+
     async fn read_file(&self, file: &str) -> Option<Vec<u8>> {
         self.files.get(file).cloned()
     }
@@ -41,6 +46,9 @@ impl FileEngine for SerializedFileEngine {
 pub trait FileEngine {
     // get a list of file names
     fn files(&self) -> Vec<String>;
+
+    // get the size of a file
+    async fn file_size(&self, file: &str) -> Option<u64>;
 
     // read a file to bytes
     async fn read_file(&self, file: &str) -> Option<Vec<u8>>;

--- a/packages/html/src/native_bind/native_file_engine.rs
+++ b/packages/html/src/native_bind/native_file_engine.rs
@@ -25,6 +25,11 @@ impl FileEngine for NativeFileEngine {
             .collect()
     }
 
+    async fn file_size(&self, file: &str) -> Option<u64> {
+        let file = File::open(file).await.ok()?;
+        Some(file.metadata().await.ok()?.len())
+    }
+
     async fn read_file(&self, file: &str) -> Option<Vec<u8>> {
         let mut file = File::open(file).await.ok()?;
 

--- a/packages/web/src/file_engine.rs
+++ b/packages/web/src/file_engine.rs
@@ -42,6 +42,11 @@ impl FileEngine for WebFileEngine {
             .collect()
     }
 
+    async fn file_size(&self, file: &str) -> Option<u64> {
+        let file = self.find(file)?;
+        Some(file.size() as u64)
+    }
+
     // read a file to bytes
     async fn read_file(&self, file: &str) -> Option<Vec<u8>> {
         let file = self.find(file)?;


### PR DESCRIPTION
This allows file sizes to be checked *before* loading the entire file into memory (e.g. with `read_file`) when it might be too big. (And without requesting the native file to do this check manually.)