### PR TITLE
impl HasFileData for FormData

### DIFF
--- a/packages/html/src/events/form.rs
+++ b/packages/html/src/events/form.rs
@@ -258,6 +258,12 @@ impl HasFileData for SerializedFormData {
     }
 }
 
+impl HasFileData for FormData {
+    fn files(&self) -> Option<std::sync::Arc<dyn FileEngine>> {
+        self.inner.files()
+    }
+}
+
 #[cfg(feature = "serialize")]
 impl serde::Serialize for FormData {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {


### PR DESCRIPTION
This allows me to write a function that can accept both `Event<DragData>` and `Event<FormData>` as `Event<T: HasFileData>` -- without this PR, `DragData` [has `impl HasFileData`](https://github.com/DioxusLabs/dioxus/blob/a5b4ceed39e2aaa3e517c4f23f466fe2ff67d028/packages/html/src/events/drag.rs#L61) such that I can do `event.files()` but while `FormData` can do `event.files()` it is because that is [explicitly a part of `FormData`](https://github.com/DioxusLabs/dioxus/blob/a5b4ceed39e2aaa3e517c4f23f466fe2ff67d028/packages/html/src/events/form.rs#L109), not with an `impl HasFileData` so each event would need to be handled separately. Now they can be handled together.

I am tempted to remove the `impl FormData ... fn files()` (linked above) and let this new `impl HasFileData` take over, but I am nervous that this might break something somewhere. Please correct me if I am wrong and I will remove the old impl.

Sample fn for purpose:
```
async fn handle_upload<T: HasFileData>(
    evt: Event<T>,
) {
    if let Some(file_engine) = evt.files() {
        for filename in file_engine.files() {
            if let Some(bytes) = file_engine.read_file(&filename).await {
                // ...
            }
        }
    }
}
```