### PR TITLE
Fix calling server functions on desktop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8088,9 +8088,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfdd051ef905fdb3da20942b0c52d536158d7489a724e14cc2fd47323e7ca91"
+checksum = "064dd9b256e78bf2886774f265cc34d2aefdd05b430c58c78a69eceef21b5e60"
 dependencies = [
  "const_format",
  "convert_case 0.6.0",

--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -73,7 +73,7 @@ dioxus = { workspace = true, features = ["fullstack"] }
 default = ["hot-reload"]
 hot-reload = ["serde_json"]
 web = ["dioxus-web", "web-sys"]
-desktop = ["dioxus-desktop"]
+desktop = ["dioxus-desktop", "server_fn/reqwest", "dioxus_server_macro/reqwest"] 
 mobile = ["dioxus-mobile"]
 default-tls = ["server_fn/default-tls"]
 rustls = ["server_fn/rustls"]

--- a/packages/server-macro/Cargo.toml
+++ b/packages/server-macro/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro2 = "^1.0.63"
 quote = "^1.0.26"
 syn = { workspace = true, features = ["full"] }
 convert_case = "^0.6.0"
-server_fn_macro = "^0.6.5"
+server_fn_macro = "0.6.11"
 
 [lib]
 proc-macro = true
@@ -25,3 +25,4 @@ proc-macro = true
 [features]
 axum = ["server_fn_macro/axum"]
 server = ["server_fn_macro/ssr"]
+reqwest = ["server_fn_macro/reqwest"]


### PR DESCRIPTION
This PR fixes calling server functions on desktop applications. The feature flags were configured incorrectly for the server function macro on desktop which was causing desktop applications to use the request crate for web builds

Closes #2322