### PR TITLE
Fix memorization for the fragment component

### DIFF
--- a/packages/core/src/error_boundary.rs
+++ b/packages/core/src/error_boundary.rs
@@ -344,7 +344,8 @@ impl Properties for ErrorBoundaryProps {
     fn builder() -> Self::Builder {
         ErrorBoundaryProps::builder()
     }
-    fn memoize(&mut self, _: &Self) -> bool {
+    fn memoize(&mut self, other: &Self) -> bool {
+        *self = other.clone();
         false
     }
 }

--- a/packages/core/src/fragment.rs
+++ b/packages/core/src/fragment.rs
@@ -27,7 +27,7 @@ use crate::innerlude::*;
 /// You want to use this free-function when your fragment needs a key and simply returning multiple nodes from rsx! won't cut it.
 #[allow(non_upper_case_globals, non_snake_case)]
 pub fn Fragment(cx: FragmentProps) -> Element {
-    cx.0.clone()
+    cx.0
 }
 
 #[derive(Clone, PartialEq)]
@@ -90,7 +90,12 @@ impl Properties for FragmentProps {
     fn builder() -> Self::Builder {
         FragmentBuilder(None)
     }
-    fn memoize(&mut self, _other: &Self) -> bool {
-        false
+    fn memoize(&mut self, new: &Self) -> bool {
+        let equal = self == new;
+        if !equal {
+            let new_clone = new.clone();
+            self.0 = new_clone.0;
+        }
+        equal
     }
 }


### PR DESCRIPTION
Memorize no longer just compares props. It also moves over props if they are different.

Fragment was not updated when `memorize` changed from comparing to comparing and reconciling props which caused diffing issues. This PR updates the manual prop implementation of Fragment and ErrorBoundary to fix those diffing issues

Fixes #2359 