### PR TITLE
Fix reclaim element when hot reloading

### DIFF
--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -33,7 +33,8 @@ impl VNode {
                     if template != self.template.get() {
                         let mount_id = self.mount.get();
                         let parent = dom.mounts[mount_id.0].parent;
-                        return self.replace([new], parent, dom, to);
+                        self.replace([new], parent, dom, to);
+                        return;
                     }
                 }
             }
@@ -200,7 +201,7 @@ impl VNode {
 
         // Clean up any attributes that have claimed a static node as dynamic for mount/unmounts
         // Will not generate mutations!
-        self.reclaim_attributes(mount, dom, to);
+        self.reclaim_attributes(mount, dom);
 
         // Remove the nested dynamic nodes
         // We don't generate mutations for these, as they will be removed by the parent (in the next line)
@@ -314,17 +315,8 @@ impl VNode {
         !std::ptr::eq(self_node_name, other_node_name)
     }
 
-    pub(super) fn reclaim_attributes(
-        &self,
-        mount: MountId,
-        dom: &mut VirtualDom,
-        _to: &mut impl WriteMutations,
-    ) {
-        let mut id = None;
-
+    pub(super) fn reclaim_attributes(&self, mount: MountId, dom: &mut VirtualDom) {
         for (idx, path) in self.template.get().attr_paths.iter().enumerate() {
-            let _attr = &self.dynamic_attrs[idx];
-
             // We clean up the roots in the next step, so don't worry about them here
             if path.len() <= 1 {
                 continue;
@@ -333,10 +325,7 @@ impl VNode {
             let next_id = dom.mounts[mount.0].mounted_attributes[idx];
 
             // only reclaim the new element if it's different from the previous one
-            if id != Some(next_id) {
-                dom.reclaim(next_id);
-                id = Some(next_id);
-            }
+            _ = dom.try_reclaim(next_id);
         }
     }
 

--- a/packages/desktop/headless_tests/events.rs
+++ b/packages/desktop/headless_tests/events.rs
@@ -8,6 +8,7 @@ use dioxus_desktop::DesktopContext;
 mod utils;
 
 pub fn main() {
+    #[cfg(not(windows))]
     utils::check_app_exits(app);
 }
 

--- a/packages/desktop/headless_tests/rendering.rs
+++ b/packages/desktop/headless_tests/rendering.rs
@@ -5,6 +5,7 @@ use dioxus_desktop::DesktopContext;
 mod utils;
 
 fn main() {
+    #[cfg(not(windows))]
     utils::check_app_exits(check_html_renders);
 }
 


### PR DESCRIPTION
Part of the code to reclaim ids for elements with dynamic attributes assumed that attr_paths would be in depth first order which may not be true if the template was hot reloaded

Fixes https://github.com/DioxusLabs/dioxus/issues/2238