### PR TITLE
Create use_muda_event_handler hook

### DIFF
--- a/examples/custom_menu.rs
+++ b/examples/custom_menu.rs
@@ -1,7 +1,7 @@
 //! This example shows how to use a custom menu bar with Dioxus desktop.
 //! This example is not supported on the mobile or web renderers.
 
-use dioxus::desktop::muda::*;
+use dioxus::desktop::{muda::*, use_muda_event_handler};
 use dioxus::prelude::*;
 
 fn main() {
@@ -18,6 +18,7 @@ fn main() {
             &PredefinedMenuItem::copy(None),
             &PredefinedMenuItem::paste(None),
             &PredefinedMenuItem::select_all(None),
+            &MenuItem::with_id("switch-text", "Switch text", true, None),
         ])
         .unwrap();
 
@@ -31,5 +32,18 @@ fn main() {
 }
 
 fn app() -> Element {
-    rsx! {"Hello World!"}
+    let mut text = use_signal(String::new);
+    // You can use the `use_muda_event_handler` hook to run code when a menu event is triggered.
+    use_muda_event_handler(move |muda_event| {
+        if muda_event.id() == "switch-text" {
+            text.set("Switched to text".to_string());
+        }
+    });
+
+    rsx! {
+        div {
+            h1 { "Custom Menu" }
+            p { "Text: {text}" }
+        }
+    }
 }

--- a/packages/desktop/src/hooks.rs
+++ b/packages/desktop/src/hooks.rs
@@ -18,7 +18,7 @@ pub fn use_window() -> DesktopContext {
     use_hook(consume_context::<DesktopContext>)
 }
 
-/// Get a closure that executes any JavaScript in the WebView context.
+/// Register an event handler that runs when a wry event is processed.
 pub fn use_wry_event_handler(
     handler: impl FnMut(&Event<UserWindowEvent>, &EventLoopWindowTarget<UserWindowEvent>) + 'static,
 ) -> WryEventHandler {
@@ -26,6 +26,22 @@ pub fn use_wry_event_handler(
         move || window().create_wry_event_handler(handler),
         move |handler| handler.remove(),
     )
+}
+
+/// Register an event handler that runs when a muda event is processed.
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(target_os = "windows", target_os = "linux", target_os = "macos")))
+)]
+#[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+pub fn use_muda_event_handler(
+    mut handler: impl FnMut(&muda::MenuEvent) + 'static,
+) -> WryEventHandler {
+    use_wry_event_handler(move |event, _| {
+        if let Event::UserEvent(UserWindowEvent::MudaMenuEvent(event)) = event {
+            handler(event);
+        }
+    })
 }
 
 /// Provide a callback to handle asset loading yourself.

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -44,6 +44,9 @@ pub use assets::AssetRequest;
 pub use config::{Config, WindowCloseBehaviour};
 pub use desktop_context::{window, DesktopContext, DesktopService};
 pub use event_handlers::WryEventHandler;
-pub use hooks::{use_asset_handler, use_global_shortcut, use_window, use_wry_event_handler};
+pub use hooks::{
+    use_asset_handler, use_global_shortcut, use_muda_event_handler, use_window,
+    use_wry_event_handler,
+};
 pub use shortcut::{ShortcutHandle, ShortcutRegistryError};
 pub use wry::RequestAsyncResponder;

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -44,9 +44,6 @@ pub use assets::AssetRequest;
 pub use config::{Config, WindowCloseBehaviour};
 pub use desktop_context::{window, DesktopContext, DesktopService};
 pub use event_handlers::WryEventHandler;
-pub use hooks::{
-    use_asset_handler, use_global_shortcut, use_muda_event_handler, use_window,
-    use_wry_event_handler,
-};
+pub use hooks::*;
 pub use shortcut::{ShortcutHandle, ShortcutRegistryError};
 pub use wry::RequestAsyncResponder;


### PR DESCRIPTION
This PR creates a new hook to listen for muda events. This makes it possible to respond to clicking on a menu item in dioxus. This data is also exposed in the `UserEvent` dioxus uses but that enum is currently private and contains some internal information including what futures have been polled