### PR TITLE
Improve the base_path story

### DIFF
--- a/packages/cli/src/builder.rs
+++ b/packages/cli/src/builder.rs
@@ -571,7 +571,7 @@ pub fn gen_page(config: &CrateConfig, manifest: Option<&AssetManifest>, serve: b
     }
 
     let base_path = match &config.dioxus_config.web.app.base_path {
-        Some(path) => path,
+        Some(path) => path.trim_matches('/'),
         None => ".",
     };
     let app_name = &config.dioxus_config.application.name;

--- a/packages/cli/src/server/web/mod.rs
+++ b/packages/cli/src/server/web/mod.rs
@@ -132,7 +132,7 @@ async fn start_server(
             None => "http",
         };
         let base_path = match config.dioxus_config.web.app.base_path.as_deref() {
-            Some(base_path) => format!("/{}/", base_path.trim_matches('/')),
+            Some(base_path) => format!("/{}", base_path.trim_matches('/')),
             None => "".to_owned(),
         };
         _ = open::that(format!("{protocol}://localhost:{port}{base_path}"));

--- a/packages/cli/src/server/web/server.rs
+++ b/packages/cli/src/server/web/server.rs
@@ -81,13 +81,6 @@ pub async fn setup_router(
     ));
 
     router = if let Some(base_path) = config.dioxus_config.web.app.base_path.clone() {
-        // NB. The trailing `/` is required for Dioxus Routers to match on root paths. Without it,
-        // navigating to e.g. `/base/path/` results in the below fallback being hit, and users
-        // receiving a message that `/base/path/` is "Outside of the base path: /base/path".
-        // Navigating to e.g. `/base/path` results in the below fallback  _not_ being hit, but a
-        // panic getting thrown from `WebHistory::route_from_location`. Interestingly, the
-        // `RouteParseError` passed into the panic reports that attempts were made to match on no
-        // routes at all.
         let base_path = format!("/{}", base_path.trim_matches('/'));
         Router::new()
             .nest(&base_path, router)

--- a/packages/cli/src/server/web/server.rs
+++ b/packages/cli/src/server/web/server.rs
@@ -88,7 +88,7 @@ pub async fn setup_router(
         // panic getting thrown from `WebHistory::route_from_location`. Interestingly, the
         // `RouteParseError` passed into the panic reports that attempts were made to match on no
         // routes at all.
-        let base_path = format!("/{}/", base_path.trim_matches('/'));
+        let base_path = format!("/{}", base_path.trim_matches('/'));
         Router::new()
             .nest(&base_path, router)
             .fallback(get(move || {

--- a/packages/desktop/headless_tests/eval.rs
+++ b/packages/desktop/headless_tests/eval.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 mod utils;
 
 pub fn main() {
+    #[cfg(not(windows))]
     utils::check_app_exits(app);
 }
 

--- a/packages/interpreter/src/lib.rs
+++ b/packages/interpreter/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::empty_docs)]
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/79236386")]
 #![doc(html_favicon_url = "https://avatars.githubusercontent.com/u/79236386")]

--- a/packages/router/src/history/web.rs
+++ b/packages/router/src/history/web.rs
@@ -132,17 +132,15 @@ where
         let path = location.pathname().unwrap_or_else(|_| "/".into())
             + &location.search().unwrap_or("".into())
             + &location.hash().unwrap_or("".into());
-        let path = match self.prefix {
-            None => path,
-            Some(ref prefix) => {
-                if path.starts_with(prefix) {
-                    path[prefix.len()..].to_string()
-                } else {
-                    path
-                }
-            }
+        let mut path = match self.prefix {
+            None => &path,
+            Some(ref prefix) => path.strip_prefix(prefix).unwrap_or(prefix),
         };
-        R::from_str(&path).unwrap_or_else(|err| panic!("{}", err))
+        // If the path is empty, parse the root route instead
+        if path.is_empty() {
+            path = "/"
+        }
+        R::from_str(path).unwrap_or_else(|err| panic!("{}", err))
     }
 
     fn full_path(&self, state: &R) -> String {

--- a/packages/router/src/history/web.rs
+++ b/packages/router/src/history/web.rs
@@ -74,7 +74,9 @@ impl<R: Routable> WebHistory<R> {
         let myself = Self::new_inner(prefix, do_scroll_restoration);
 
         let current_route = myself.current_route();
-        let current_url = current_route.to_string();
+        let current_route_str = current_route.to_string();
+        let prefix_str = myself.prefix.as_deref().unwrap_or("");
+        let current_url = format!("{prefix_str}{current_route_str}");
         let state = myself.create_state(current_route);
         let _ = replace_state_with_url(&myself.history, &state, Some(&current_url));
 


### PR DESCRIPTION
This PR updates how the the axum router constructed for `dx serve`, the `--open` option, and the dioxus-router `WebHistory` interact with the Dioxus.toml `base_path` field.

Prior to this change, running `dx serve` with a `base_path` set always resulted in my browser displaying the "Outside of the base path: blah" message, even when I was navigating to routes that were very definitely inside of the base path.

Three major changes are included in this PR;
- Setting a `base_path` now causes the `dx serve` router to be nested under the base path, rather than treating the base path as a route that is handled with a `axum::routing::any_service`. 
- The `--open` flag now opens to `localhost:8080/<base_path>` rather than to `localhost:8080`.
- The dioxus router's default web history initializes to a URL that includes the base_path, rather than to the root.  
  This last change is actually what I consider to be the most important, as it impacts dioxus web applications hosted outside of the `dx serve` axum server. Without this change, navigating to e.g. `localhost:8080/base/path/` would cause the browser address bar to resolve to `localhost:8080`, even though following a `Link { to: Route::Home {}, .. }` would push `localhost:8080/base/path/` onto the history stack.