### PR TITLE
Make use_server_future accept FnMut

### DIFF
--- a/packages/fullstack/src/hooks/server_future.rs
+++ b/packages/fullstack/src/hooks/server_future.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 
 /// A future that resolves to a value.
 #[must_use = "Consider using `cx.spawn` to run a future without reading its value"]
-pub fn use_server_future<T, F>(_future: impl Fn() -> F + 'static) -> Option<Resource<T>>
+pub fn use_server_future<T, F>(_future: impl FnMut() -> F + 'static) -> Option<Resource<T>>
 where
     T: Serialize + DeserializeOwned + 'static,
     F: Future<Output = T> + 'static,


### PR DESCRIPTION
This PR changes use_server_future to accept FnMut which makes it possible to use `use_server_future` with `use_reactive`