### PR TITLE
Remove the trailiing slash from a base_path'd router's root URL

### DIFF
--- a/packages/router-macro/src/route.rs
+++ b/packages/router-macro/src/route.rs
@@ -198,7 +198,7 @@ impl Route {
             }
             RouteType::Leaf { .. } => {
                 let write_nests = self.nests.iter().map(|id| nests[id.0].write());
-                let write_segments = self.segments.iter().map(|s| s.write_segment());
+                let write_segments = self.segments.iter().map(|s| s.write_segment_allow_empty());
                 quote! {
                     Self::#name { #(#dynamic_segments,)* } => {
                         #(#write_nests)*

--- a/packages/router-macro/src/segment.rs
+++ b/packages/router-macro/src/segment.rs
@@ -34,6 +34,19 @@ impl RouteSegment {
         }
     }
 
+    pub fn write_segment_allow_empty(&self) -> TokenStream2 {
+        match self {
+            Self::Static(segment) => {
+                if segment.is_empty() {
+                    return quote! {};
+                }
+                quote! { write!(f, "/{}", #segment)?; }
+            }
+            Self::Dynamic(ident, _) => quote! { write!(f, "/{}", #ident)?; },
+            Self::CatchAll(ident, _) => quote! { #ident.display_route_segments(f)?; },
+        }
+    }
+
     pub fn error_name(&self, idx: usize) -> Ident {
         match self {
             Self::Static(_) => static_segment_idx(idx),

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -195,7 +195,7 @@ impl Debug for LinkProps {
 /// # vdom.rebuild_in_place();
 /// # assert_eq!(
 /// #     dioxus_ssr::render(&vdom),
-/// #     r#"<a href="/" dioxus-prevent-default="" class="link_class active" rel="link_rel" target="_blank" id="link_id">A fully configured link</a>"#
+/// #     r#"<a href="" dioxus-prevent-default="" class="link_class active" rel="link_rel" target="_blank" id="link_id">A fully configured link</a>"#
 /// # );
 /// ```
 #[allow(non_snake_case)]

--- a/packages/router/src/history/web.rs
+++ b/packages/router/src/history/web.rs
@@ -145,7 +145,16 @@ where
 
     fn full_path(&self, state: &R) -> String {
         match &self.prefix {
-            None => format!("{state}"),
+            None => {
+                // NB. `state.to_string()` may return `""`, which is a relative path. `full_path`
+                // must be absolute, so special-case that to `"/"`.
+                let state_str = state.to_string();
+                if state_str.is_empty() {
+                    "/".to_string()
+                } else {
+                    state_str
+                }
+            }
             Some(prefix) => format!("{prefix}{state}"),
         }
     }

--- a/packages/router/tests/via_ssr/link.rs
+++ b/packages/router/tests/via_ssr/link.rs
@@ -174,7 +174,7 @@ fn with_active_class_active() {
 
     let expected = format!(
         "<h1>App</h1><a {href} {default} {class}>Link</a>",
-        href = r#"href="/""#,
+        href = r#"href="""#,
         default = r#"dioxus-prevent-default="onclick""#,
         class = r#"class="test_class active_class""#,
     );


### PR DESCRIPTION
Currently, given a Dioxus.toml with `base_path = "base/path"`, navigating to e.g. `localhost:8080/base/path` will result in the router pushing `/base/path/` to the web history API, and therefore rendering `localhost:8080/base/path/` in the browser address bar. This PR attempts to remove the trailing slash from the root url of `base_path`'d routers without breaking the functionality of apps that do not specify a `base_path`.

This isn't a functional bug, but it's a peeve of mine, and I wanted to figure out why this was happening. Additionally, this behavior is inconsistent with
- axum routers that are hosting dioxus router apps; calling `.nest("/base/path", MyDioxusMethodRouter)` will result in browsers rendering e.g. `localhost:8080/base/path/` as the root of the dioxus app, but might cause direct navigations to `localhost:8080/base/path/` to 404. (NB. this is _probably_ an [issue with nested fallbacks in axum][axum-2659], but it was very frustrating for me while I was figuring that out.)
- subroutes in the same dioxus router; adding e.g. `#[route("/not/home/")]` (note the trailing slash) will let both `localhost:8080/base/path/not/home` (note the not trailing slash) and `localhost:8080/base/path/not/home/` to resolve to `localhost:8080/base/path/not/home` (again, note the lack of trailing slash).

[axum-2659]: https://github.com/tokio-rs/axum/issues/2659#issuecomment-2016666385

I'm opening this as a draft because I am _not at all_ confident in the implementation. The fundamental change is displaying the root URL of routers as `""` rather than `"/"`. This might be a bad idea. As you can see from the modified tests, this change requires special-case'ing `Link`s that direct to the root url for non-`base_path`'d apps. Seeing `href=""` in an `<a>` is... kinda weird. Maybe a bit of a red flag. `WebHistory::full_path` does correctly resolve that to `"/"` before pushing to the history API, but I've not tested this behavior with liveview or native apps, nor have I tested this change with routers that use the `#[layout(...)]` or `#[nest(...)]` features.

I'm planning on building some axum experiments with this change in place, so I may update the PR as I find issues. If there's no additional movement on this PR from myself or the dioxus team in, idk, a few weeks I'll probably close this PR to keep it from taking up space.