### PR TITLE
Fetch relative assets from `base_path` instead of root when `base_path` is set

### DIFF
--- a/packages/cli/src/server/web/server.rs
+++ b/packages/cli/src/server/web/server.rs
@@ -81,7 +81,7 @@ pub async fn setup_router(
     ));
 
     router = if let Some(base_path) = config.dioxus_config.web.app.base_path.clone() {
-        let base_path = format!("/{}", base_path.trim_matches('/'));
+        let base_path = format!("/{}/", base_path.trim_matches('/'));
         Router::new()
             .nest(&base_path, router)
             .fallback(get(move || {


### PR DESCRIPTION
I also ran into #2285, and went ahead and had a look. Turns out #2381 fixed most of it, but I believe it needs a trailing `/` in order to serve assets correctly. Without a trailing `/`, assets that are relatively addressed will search in the root path instead of relative to the `base_path`, causing 404s as assets are (correctly) served from the `base_path`.

This seems as if it was the intended use of `Router::nest` as requests to `/<base_path>` are redirected to `/<base_path>/` automatically.

The alternative would be to hardcode the `base_path` in the assets but I don't think this is a very intuitive approach.

