### PR TITLE
feat(cli): init cmd can now skip user interaction

### DIFF
--- a/packages/cli/src/cli/create.rs
+++ b/packages/cli/src/cli/create.rs
@@ -1,7 +1,7 @@
 use super::*;
 use cargo_generate::{GenerateArgs, TemplatePath};
 
-static DEFAULT_TEMPLATE: &str = "gh:dioxuslabs/dioxus-template";
+pub(crate) static DEFAULT_TEMPLATE: &str = "gh:dioxuslabs/dioxus-template";
 
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 #[clap(name = "new")]
@@ -34,6 +34,7 @@ impl Create {
                 subfolder: self.subtemplate,
                 ..Default::default()
             },
+            define: self.option,
             ..Default::default()
         };
         if self.yes {
@@ -43,9 +44,8 @@ impl Create {
                 );
             }
             args.silent = true;
-        };
+        }
         args.name = self.name;
-        args.define = self.option;
         let path = cargo_generate::generate(args)?;
         post_create(&path)
     }

--- a/packages/cli/src/cli/init.rs
+++ b/packages/cli/src/cli/init.rs
@@ -1,33 +1,49 @@
 use super::*;
+use crate::cli::create::DEFAULT_TEMPLATE;
 use cargo_generate::{GenerateArgs, TemplatePath};
 
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 #[clap(name = "init")]
 pub struct Init {
     /// Template path
-    #[clap(default_value = "gh:dioxuslabs/dioxus-template", long)]
+    #[clap(default_value = DEFAULT_TEMPLATE, short, long)]
     template: String,
+    /// Pass <option>=<value> for the used template (e.g., `foo=bar`)
+    #[clap(short, long)]
+    option: Vec<String>,
+    /// Specify a sub-template within the template repository to be used as the actual template
+    #[clap(long)]
+    subtemplate: Option<String>,
+    /// Skip user interaction by using the default values for the used template.
+    /// Default values can be overridden with `--option`
+    #[clap(short, long)]
+    yes: bool,
+    // TODO: turn on/off cargo-generate's output (now is invisible)
+    // #[clap(default_value = "false", short, long)]
+    // silent: bool,
 }
 
 impl Init {
     pub fn init(self) -> Result<()> {
-        // get dir name
+        // Get directory name.
         let name = std::env::current_dir()?
             .file_name()
             .map(|f| f.to_str().unwrap().to_string());
-
-        let args = GenerateArgs {
+        let mut args = GenerateArgs {
             template_path: TemplatePath {
                 auto_path: Some(self.template),
+                subfolder: self.subtemplate,
                 ..Default::default()
             },
             name,
             init: true,
+            define: self.option,
             ..Default::default()
         };
-
+        if self.yes {
+            args.silent = true;
+        }
         let path = cargo_generate::generate(args)?;
-
         create::post_create(&path)
     }
 }


### PR DESCRIPTION
Previously only `dx new` had this ability, now `dx init` has it, too.
