### PR TITLE
Add test for using `use_memo` with `use_effect`

### DIFF
--- a/packages/hooks/tests/memo.rs
+++ b/packages/hooks/tests/memo.rs
@@ -68,3 +68,111 @@ async fn memo_updates() {
         println!("Signal: {signal:?}");
     }
 }
+
+#[tokio::test]
+async fn use_memo_with_use_effect() {
+    use dioxus::prelude::*;
+    use futures_util::future::select;
+    use std::{cell::RefCell, collections::VecDeque, pin::pin, rc::Rc};
+    use tokio::sync::mpsc;
+
+    let (action_sender, mut action_receiver) = mpsc::unbounded_channel::<Action>();
+
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    enum Action {
+        Write(Option<usize>, Option<usize>),
+        Read(usize, usize),
+    }
+
+    #[derive(Clone)]
+    struct ActionSender(Rc<RefCell<mpsc::UnboundedSender<Action>>>);
+
+    #[component]
+    fn App() -> Element {
+        let action_sender = use_context::<ActionSender>();
+        let mut a = use_signal(|| 0);
+        let mut b = use_signal(|| 0);
+        let mut counter = use_signal(|| 0);
+
+        use_effect({
+            let action_sender = action_sender.clone();
+            move || {
+                let count = counter();
+                let action = match count {
+                    0 => Action::Write(Some(0), None),
+                    1 => Action::Write(None, Some(0)),
+                    2 => Action::Write(Some(0), Some(0)),
+                    3 => Action::Write(Some(1), None),
+                    4 => Action::Write(None, Some(1)),
+                    5 => Action::Write(Some(1), Some(1)),
+                    6 => Action::Write(Some(2), Some(2)),
+                    7 => Action::Write(Some(0), Some(0)),
+                    _ => return,
+                };
+                action_sender.0.borrow_mut().send(action).unwrap();
+                if let Action::Write(Some(n), _) = action {
+                    *a.write() = n;
+                }
+                if let Action::Write(_, Some(n)) = action {
+                    *b.write() = n;
+                }
+                *counter.write() = count + 1;
+            }
+        });
+
+        let tuple = use_memo(move || (a(), b()));
+
+        use_effect(move || {
+            let (a, b) = tuple();
+            action_sender
+                .0
+                .borrow_mut()
+                .send(Action::Read(a, b))
+                .unwrap();
+        });
+
+        None
+    }
+
+    let mut dom =
+        VirtualDom::new(App).with_root_context(ActionSender(Rc::new(RefCell::new(action_sender))));
+    dom.rebuild_in_place();
+
+    let update_dom = async {
+        loop {
+            dom.wait_for_work().await;
+            dom.render_immediate(&mut dioxus::dioxus_core::NoOpMutations);
+        }
+    };
+
+    let mut reads = VecDeque::new();
+    let mut writes = VecDeque::new();
+    let recv_actions = async {
+        while let Some(action) = action_receiver.recv().await {
+            println!("{action:?}");
+            match action {
+                read @ Action::Read(_, _) => reads.push_back(read),
+                write @ Action::Write(_, _) => writes.push_back(write),
+            }
+            if reads.len() == 5 && writes.len() == 8 {
+                break;
+            }
+        }
+    };
+
+    select(pin!(update_dom), pin!(recv_actions)).await;
+
+    assert_eq!(reads.pop_front(), Some(Action::Read(0, 0)));
+    assert_eq!(writes.pop_front(), Some(Action::Write(Some(0), None)));
+    assert_eq!(writes.pop_front(), Some(Action::Write(None, Some(0))));
+    assert_eq!(writes.pop_front(), Some(Action::Write(Some(0), Some(0))));
+    assert_eq!(writes.pop_front(), Some(Action::Write(Some(1), None)));
+    assert_eq!(reads.pop_front(), Some(Action::Read(1, 0)));
+    assert_eq!(writes.pop_front(), Some(Action::Write(None, Some(1))));
+    assert_eq!(reads.pop_front(), Some(Action::Read(1, 1)));
+    assert_eq!(writes.pop_front(), Some(Action::Write(Some(1), Some(1))));
+    assert_eq!(writes.pop_front(), Some(Action::Write(Some(2), Some(2))));
+    assert_eq!(reads.pop_front(), Some(Action::Read(2, 2)));
+    assert_eq!(writes.pop_front(), Some(Action::Write(Some(0), Some(0))));
+    assert_eq!(reads.pop_front(), Some(Action::Read(0, 0)));
+}


### PR DESCRIPTION
This PR is a reproduction test case for #2416.

Currently, when starting with `(0, 0)` and writing

```
Write(Some(0), None)
Write(None, Some(0))
Write(Some(0), Some(0))
Write(Some(1), None)
Write(None, Some(1))
Write(Some(1), Some(1))
Write(Some(2), Some(2))
Write(Some(0), Some(0))
```

this test results in the following reads:

```
Read(0, 0)
Read(1, 1)
Read(1, 1)
Read(0, 0)
Read(0, 0)
```

However, the expected result is

```
Read(0, 0)
Read(1, 0)
Read(1, 1)
Read(2, 2)
Read(0, 0)
```