### PR TITLE
Fix memo and resource line info

### DIFF
--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -91,6 +91,16 @@ impl<T: PartialEq + 'static> Signal<T> {
     pub fn memo(f: impl FnMut() -> T + 'static) -> Memo<T> {
         Memo::new(f)
     }
+
+    /// Creates a new unsync Selector with an explicit location. The selector will be run immediately and whenever any signal it reads changes.
+    ///
+    /// Selectors can be used to efficiently compute derived data from signals.
+    pub fn memo_with_location(
+        f: impl FnMut() -> T + 'static,
+        location: &'static std::panic::Location<'static>,
+    ) -> Memo<T> {
+        Memo::new_with_location(f, location)
+    }
 }
 
 impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {


### PR DESCRIPTION
This PR fixes the line numbers for tracing logs from the use_memo and use_resource hooks. Before this PR writes on signals that cause use_resource to rerun point to the use_resource hook instead of where that hook was created.

Old:
```
TRACE /dioxus/packages/signals/src/signal.rs:301 Subscribing to the reactive context ReactiveContext created at /dioxus/packages/hooks/src/use_resource.rs:79:29
```
New:
```
TRACE /dioxus/packages/signals/src/signal.rs:301 Subscribing to the reactive context ReactiveContext created at /myapp:line:col
```