### PR TITLE
Make use of `#[doc]` field attributes in `Props` derive macro

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -271,7 +271,7 @@ mod field_info {
     #[derive(Debug, Default, Clone)]
     pub struct FieldBuilderAttr {
         pub default: Option<syn::Expr>,
-        pub doc: Option<syn::Expr>,
+        pub docs: Vec<String>,
         pub skip: bool,
         pub auto_into: bool,
         pub from_displayable: bool,
@@ -284,6 +284,11 @@ mod field_info {
         pub fn with(mut self, attrs: &[syn::Attribute]) -> Result<Self, Error> {
             let mut skip_tokens = None;
             for attr in attrs {
+                if attr.path().is_ident("doc") {
+                    self.apply_doc_meta(&attr.meta)?;
+                    continue;
+                }
+
                 if path_to_single_string(attr.path()).as_deref() != Some("props") {
                     continue;
                 }
@@ -343,10 +348,6 @@ mod field_info {
                         }
                         "default" => {
                             self.default = Some(*assign.right);
-                            Ok(())
-                        }
-                        "doc" => {
-                            self.doc = Some(*assign.right);
                             Ok(())
                         }
                         "default_code" => {
@@ -444,10 +445,6 @@ mod field_info {
                                 self.default = None;
                                 Ok(())
                             }
-                            "doc" => {
-                                self.doc = None;
-                                Ok(())
-                            }
                             "skip" => {
                                 self.skip = false;
                                 Ok(())
@@ -476,6 +473,33 @@ mod field_info {
                 }
                 _ => Err(Error::new_spanned(expr, "Expected (<...>=<...>)")),
             }
+        }
+
+        fn apply_doc_meta(&mut self, meta: &syn::Meta) -> Result<(), Error> {
+            match meta {
+                syn::Meta::NameValue(meta) => {
+                    match &meta.value {
+                        syn::Expr::Lit(expr) => {
+                            match &expr.lit {
+                                syn::Lit::Str(lit) => {
+                                    self.docs.push(lit.value());
+                                }
+                                _ => {
+                                    return Err(Error::new_spanned(&meta.value, "Expected string"));
+                                }
+                            }
+                        }
+                        _ => {
+                            return Err(Error::new_spanned(&meta.value, "Expected string"));
+                        }
+                    }
+                }
+                _ => {
+                    // Ignore other doc attributes
+                }
+            }
+
+            Ok(())
         }
     }
 }
@@ -1105,10 +1129,7 @@ Finally, call `.build()` to create the instance of `{name}`.
             );
 
             let (impl_generics, _, where_clause) = generics.split_for_impl();
-            let doc = match field.builder_attr.doc {
-                Some(ref doc) => quote!(#[doc = #doc]),
-                None => quote!(),
-            };
+            let docs = field.builder_attr.docs.iter().map(|doc| quote!(#[doc = #doc]));
 
             let arg_type = field_type;
             // If the field is auto_into, we need to add a generic parameter to the builder for specialization
@@ -1161,7 +1182,7 @@ Finally, call `.build()` to create the instance of `{name}`.
             Ok(quote! {
                 #[allow(dead_code, non_camel_case_types, missing_docs)]
                 impl #impl_generics #builder_name < #( #ty_generics ),* > #where_clause {
-                    #doc
+                    #( #docs )*
                     #[allow(clippy::type_complexity)]
                     pub fn #field_name < #marker > (self, #field_name: #arg_type) -> #builder_name < #( #target_generics ),* > {
                         let #field_name = (#arg_expr,);


### PR DESCRIPTION
## Objective

Currently, it doesn't seem like you can pass the docs from a prop field to its method generated via the `Props` derive. The only way to achieve this is to duplicate the doc into a dedicated `#[props(doc = "My doc comment")]` attribute.

This, however, is both inconvenient and error-prone since users will need to handle the formatting manually and all in a single attribute.

## Solution

Pass along all `#[doc]` attributes on a prop field to the respective function. This allows the documentation to be shared by that method and show up on hover when using the component.

Here's a before/after comparison in Rust Rover:

| Before | After |
| ------ | ----- |
| <img width="100%" alt="dioxus_prop_docs--before" src="https://github.com/DioxusLabs/dioxus/assets/49806985/6dd7ef19-6eb7-4c33-b7ae-1af5c177e42b"> | <img width="100%" alt="dioxus_prop_docs--after" src="https://github.com/DioxusLabs/dioxus/assets/49806985/246eb648-9800-4992-b7b9-83668545af2f"> |

---

## Changelog

- Removed `#[props(doc)]` attribute
- Documentation on prop fields should now be visible from within `rsx!` invocations

