### PR TITLE
fix: Avoid cloning a provided context unnecessarily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2572,7 +2572,6 @@ version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "dioxus",
- "dioxus-web",
  "log",
  "wasm-logger",
 ]

--- a/packages/hooks/src/use_context.rs
+++ b/packages/hooks/src/use_context.rs
@@ -57,7 +57,5 @@ pub fn use_context<T: 'static + Clone>() -> T {
 ///}
 /// ```
 pub fn use_context_provider<T: 'static + Clone>(f: impl FnOnce() -> T) -> T {
-    use_hook(|| {
-        provide_context(f())
-    })
+    use_hook(|| provide_context(f()))
 }

--- a/packages/hooks/src/use_context.rs
+++ b/packages/hooks/src/use_context.rs
@@ -58,7 +58,6 @@ pub fn use_context<T: 'static + Clone>() -> T {
 /// ```
 pub fn use_context_provider<T: 'static + Clone>(f: impl FnOnce() -> T) -> T {
     use_hook(|| {
-        let val = f();
-        provide_context(val.clone())
+        provide_context(f())
     })
 }

--- a/packages/hooks/src/use_context.rs
+++ b/packages/hooks/src/use_context.rs
@@ -59,7 +59,6 @@ pub fn use_context<T: 'static + Clone>() -> T {
 pub fn use_context_provider<T: 'static + Clone>(f: impl FnOnce() -> T) -> T {
     use_hook(|| {
         let val = f();
-        provide_context(val.clone());
-        val
+        provide_context(val.clone())
     })
 }


### PR DESCRIPTION
`provide_context` already clones the context internally