### PR TITLE
Replace `RwLock::try_read` with `RwLock::read` in `SyncStorage`

### DIFF
--- a/packages/generational-box/src/sync.rs
+++ b/packages/generational-box/src/sync.rs
@@ -112,15 +112,7 @@ impl<T: Sync + Send + 'static> Storage<T> for SyncStorage {
         #[cfg(any(debug_assertions, feature = "debug_ownership"))]
         at: crate::GenerationalRefBorrowInfo,
     ) -> Result<Self::Ref<'static, T>, error::BorrowError> {
-        let read = self.0.try_read();
-
-        #[cfg(any(debug_assertions, feature = "debug_ownership"))]
-        let read = read.ok_or_else(|| at.borrowed_from.borrow_error())?;
-
-        #[cfg(not(any(debug_assertions, feature = "debug_ownership")))]
-        let read = read.ok_or_else(|| {
-            error::BorrowError::AlreadyBorrowedMut(error::AlreadyBorrowedMutError {})
-        })?;
+        let read = self.0.read();
 
         RwLockReadGuard::try_map(read, |any| any.as_ref()?.downcast_ref())
             .map_err(|_| {


### PR DESCRIPTION
## Replace `RwLock::try_read` with `RwLock::read` in `SyncStorage`

This pull request replaces the use of `RwLock::try_read` with `RwLock::read` in the `SyncStorage`. 

This change prioritizes potential deadlocks over panics. Unwrapping a failed `try_read` can lead to unexpected behavior and difficult-to-debug issues. Using `RwLock::read` ensures that the code will always block until a read lock is acquired, preventing potential panics but introducing the possibility of deadlocks.

This change is consistent with the current use of [RwLock::write](https://github.com/DioxusLabs/dioxus/blob/main/packages/generational-box/src/sync.rs#L146) for write operations.

**Changes:**

* Replaces `RwLock::try_read` with `RwLock::read` in `SyncStorage`.

**Rationale:**

* Prioritizes potential deadlocks over panics.
* Ensures consistent API with `RwLock::write` for write operations.

**Potential Issues:**

* This change might introduce the possibility of deadlocks in scenarios where the read lock is consistently blocked, but all test passed. 
