### PR TITLE
Fix routers without an index route

### DIFF
--- a/packages/router/src/router_cfg.rs
+++ b/packages/router/src/router_cfg.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 ///     #[route("/")]
 ///     Index {},
 /// }
-/// let cfg = RouterConfig::default().history(WebHistory::<Route>::default());
+/// let cfg = RouterConfig::default().history(MemoryHistory::<Route>::default());
 /// ```
 pub struct RouterConfig<R: Routable> {
     pub(crate) failure_external_navigation: fn() -> Element,
@@ -46,13 +46,14 @@ where
     <R as std::str::FromStr>::Err: std::fmt::Display,
 {
     pub(crate) fn take_history(&mut self) -> Box<dyn AnyHistoryProvider> {
-        #[allow(unused)]
-        let initial_route = self.initial_route.clone().unwrap_or("/".parse().unwrap_or_else(|err|
-            panic!("index route does not exist:\n{}\n use MemoryHistory::with_initial_path or RouterConfig::initial_route to set a custom path", err)
-        ));
         self.history
             .take()
-            .unwrap_or_else(|| default_history(initial_route))
+            .unwrap_or_else(|| {
+                let initial_route = self.initial_route.clone().unwrap_or_else(|| "/".parse().unwrap_or_else(|err|
+                    panic!("index route does not exist:\n{}\n use MemoryHistory::with_initial_path or RouterConfig::initial_route to set a custom path", err)
+                ));
+                default_history(initial_route)
+    })
     }
 }
 

--- a/packages/router/tests/via_ssr/main.rs
+++ b/packages/router/tests/via_ssr/main.rs
@@ -1,2 +1,3 @@
 mod link;
 mod outlet;
+mod without_index;

--- a/packages/router/tests/via_ssr/without_index.rs
+++ b/packages/router/tests/via_ssr/without_index.rs
@@ -1,0 +1,41 @@
+use dioxus::prelude::*;
+
+// Tests for regressions of <https://github.com/DioxusLabs/dioxus/issues/2468>
+#[test]
+fn router_without_index_route_parses() {
+    let mut vdom = VirtualDom::new_with_props(
+        App,
+        AppProps {
+            path: Route::Test {},
+        },
+    );
+    vdom.rebuild_in_place();
+    let as_string = dioxus_ssr::render(&vdom);
+    assert_eq!(as_string, "<div>router with no index route renders</div>")
+}
+
+#[derive(Routable, Clone, Copy, PartialEq, Debug)]
+enum Route {
+    #[route("/test")]
+    Test {},
+}
+
+#[component]
+fn Test() -> Element {
+    rsx! {
+        div {
+            "router with no index route renders"
+        }
+    }
+}
+
+#[component]
+fn App(path: Route) -> Element {
+    rsx! {
+        Router::<Route> {
+            config: {
+                move || RouterConfig::default().history(MemoryHistory::with_initial_path(path))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes router enmus without an index (`/`) route. We were previously unconditionally parsing the route as an index route and then using the override route if the user provided one. This PR changes the router to only parse the default index route if no override was provided

Fixes https://github.com/DioxusLabs/dioxus/issues/2468