### PR TITLE
Remove value attribute instead of resetting it

### DIFF
--- a/packages/interpreter/src/unified_bindings.rs
+++ b/packages/interpreter/src/unified_bindings.rs
@@ -98,6 +98,7 @@ mod js {
                 switch (field) {
                     case "value":
                         node.value = "";
+                        node.removeAttribute("value");
                         break;
                     case "checked":
                         node.checked = false;


### PR DESCRIPTION
This changes the logic for `None` values for the `value` attribute. We were previously just resetting the value which causes issues if the attribute is actually an attribute instead of a property. This PR changes `None` to both remove the attribute and reset the property

Fixes #2478