### PR TITLE
switch from slab to slotmap for tasks to fix the ABA problem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,6 +2253,7 @@ dependencies = [
  "rustversion",
  "serde",
  "slab",
+ "slotmap",
  "tokio",
  "tracing",
  "tracing-fluent-assertions",
@@ -8341,6 +8342,16 @@ dependencies = [
  "lru",
  "once_cell",
  "rustc-hash",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "serde",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ tracing-futures = "0.2.5"
 toml = "0.8"
 tokio = "1.28"
 slab = "0.4.2"
+slotmap = { version = "1.0.7", features = ["serde"] }
 futures-channel = "0.3.21"
 futures-util = { version = "0.3", default-features = false }
 rustc-hash = "1.1.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -17,6 +17,7 @@ futures-util = { workspace = true, default-features = false, features = [
     "std",
 ] }
 slab = { workspace = true }
+slotmap = { workspace = true }
 futures-channel = { workspace = true }
 tracing = { workspace = true }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -1,3 +1,5 @@
+use slotmap::DefaultKey;
+
 use crate::innerlude::Effect;
 use crate::{
     innerlude::{LocalTask, SchedulerMsg},
@@ -27,7 +29,7 @@ pub struct Runtime {
     pub(crate) current_task: Cell<Option<Task>>,
 
     /// Tasks created with cx.spawn
-    pub(crate) tasks: RefCell<slab::Slab<Rc<LocalTask>>>,
+    pub(crate) tasks: RefCell<slotmap::SlotMap<DefaultKey, Rc<LocalTask>>>,
 
     // Currently suspended tasks
     pub(crate) suspended_tasks: Cell<usize>,


### PR DESCRIPTION
This is an alternate solution to #2440 that addresses the wider [ABA problem](https://en.wikipedia.org/wiki/ABA_problem) with tasks by introducing generationals to tasks.

This PR is non-breaking so it can be backported to 0.5. `ElementId` and `ScopeId` have similar problems, but they are intentionally not changed in this PR because the inner `usize` type is public, and too small for generations on wasm where `usize` is `u32`