### PR TITLE
Ignore `#[props(into)]` on Strings

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -213,6 +213,8 @@ mod field_info {
                     || field.ty == parse_quote!(String)
                 {
                     builder_attr.from_displayable = true;
+                    // ToString is both more general and provides a more useful error message than From<String>. If the user tries to use `#[into]`, use ToString instead.
+                    builder_attr.auto_into = false;
                 }
 
                 // extended field is automatically empty


### PR DESCRIPTION
This makes `#[props(into)]` on string properties a no-op. We already coerce any types that implement `Display` into a String without the attribute. It can be confusing that adding the `#[props(into)]` attribute makes the properties accept fewer types

Closes #2497 