### PR TITLE
Add CI step to test packages with debug assertions off

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,30 @@ jobs:
           swap-storage: false
       - run: cargo make tests
 
+  release-test:
+    if: github.event.pull_request.draft == false
+    name: Test Suite with Optimizations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update
+      - run: sudo apt install libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev libxdo-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - uses: davidB/rust-cargo-make@v1
+      - uses: browser-actions/setup-firefox@latest
+      - uses: jetli/wasm-pack-action@v0.4.0
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with: # speed things up a bit
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+      - run: cargo test --profile release-unoptimized --lib --bins --tests --examples --workspace --exclude dioxus-desktop --exclude dioxus-mobile
+
   fmt:
     if: github.event.pull_request.draft == false
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,10 @@ opt-level = 1
 [profile.cli-dev.package."*"]
 opt-level = 3
 
+# Disable debug assertions to check the released path of core and other packages, but build without optimizations to keep build times quick
+[profile.release-unoptimized]
+inherits = "dev"
+debug-assertions = false
 
 # This is a "virtual package"
 # It is not meant to be published, but is used so "cargo run --example XYZ" works properly

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -88,7 +88,7 @@ command = "cargo"
 args = ["build"]
 
 [tasks.test-flow]
-dependencies = ["test", "docs"]
+dependencies = ["test", "docs", "release"]
 private = true
 
 [tasks.test]
@@ -116,6 +116,26 @@ args = [
   "test",
   "--doc",
   "--workspace",
+]
+private = true
+
+[tasks.release]
+dependencies = ["build"]
+command = "cargo"
+args = [
+  "test",
+  "--profile",
+  "release-unoptimized",
+  "--lib",
+  "--bins",
+  "--tests",
+  "--examples",
+  "--workspace",
+  # These tests run on Ubuntu without a screen. Desktop tests that require a screen fail, so we skip them
+  "--exclude",
+  "dioxus-desktop",
+  "--exclude",
+  "dioxus-mobile",
 ]
 private = true
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -88,7 +88,7 @@ command = "cargo"
 args = ["build"]
 
 [tasks.test-flow]
-dependencies = ["test", "docs", "release"]
+dependencies = ["test", "docs"]
 private = true
 
 [tasks.test]
@@ -116,26 +116,6 @@ args = [
   "test",
   "--doc",
   "--workspace",
-]
-private = true
-
-[tasks.release]
-dependencies = ["build"]
-command = "cargo"
-args = [
-  "test",
-  "--profile",
-  "release-unoptimized",
-  "--lib",
-  "--bins",
-  "--tests",
-  "--examples",
-  "--workspace",
-  # These tests run on Ubuntu without a screen. Desktop tests that require a screen fail, so we skip them
-  "--exclude",
-  "dioxus-desktop",
-  "--exclude",
-  "dioxus-mobile",
 ]
 private = true
 

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -18,7 +18,6 @@ use std::{
     sync::Arc,
 };
 use tao::{
-    dpi::PhysicalSize,
     event::Event,
     event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopProxy, EventLoopWindowTarget},
     window::WindowId,
@@ -481,7 +480,7 @@ impl App {
                     window.set_outer_position(tao::dpi::PhysicalPosition::new(
                         position.0, position.1,
                     ));
-                    window.set_inner_size(PhysicalSize::new(size.0, size.1));
+                    window.set_inner_size(tao::dpi::PhysicalSize::new(size.0, size.1));
                 }
             }
         }

--- a/packages/generational-box/tests/errors.rs
+++ b/packages/generational-box/tests/errors.rs
@@ -70,14 +70,19 @@ fn write_while_writing_error() {
     let owner = UnsyncStorage::owner();
     let value = owner.insert(1);
 
+    #[allow(unused)]
     let (write, location) = write_at_location(value);
 
+    let write_result = value.try_write();
+    assert!(write_result.is_err());
+    #[cfg(debug_assertions)]
     assert_eq!(
-        value.try_write().err(),
+        write_result.err(),
         Some(BorrowMutError::AlreadyBorrowedMut(
             AlreadyBorrowedMutError::new(location)
         ))
     );
+
     drop(write);
 }
 


### PR DESCRIPTION
This adds an extra step that tests packages with debug assertions off (but without optimizations) to test the faster paths in core and other packages. This should prevent regressions like https://github.com/DioxusLabs/dioxus/commit/79e18c2d62166f388641cd6e20a82bef2506535a