### PR TITLE
Remove implicit optional dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,8 +195,8 @@ fullstack = ["dioxus/fullstack"]
 axum = ["dioxus/axum"]
 server = ["dioxus/axum"]
 web = ["dioxus/web"]
-collect-assets = ["manganis"]
-http = ["reqwest", "http-range"]
+collect-assets = ["dep:manganis"]
+http = ["dep:reqwest", "dep:http-range"]
 
 [[example]]
 name = "login_form"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,8 @@ tokio = { version = "1.16.1", features = ["full"] }
 # To make most examples faster to compile, we split out assets and http-related stuff
 # This trims off like 270 dependencies, leading to a significant speedup in compilation time
 [features]
-default = ["dioxus/desktop"]
+default = ["desktop"]
+desktop = ["dioxus/desktop"]
 liveview = ["dioxus/liveview"]
 fullstack = ["dioxus/fullstack"]
 axum = ["dioxus/axum"]

--- a/packages/cli-config/Cargo.toml
+++ b/packages/cli-config/Cargo.toml
@@ -23,7 +23,7 @@ tauri-utils = { version = "=1.5.*", optional = true }
 
 [features]
 default = ["read-config"]
-cli = ["tauri-bundler", "tauri-utils", "clap", "toml", "cargo_toml"]
+cli = ["dep:tauri-bundler", "dep:tauri-utils", "dep:clap", "dep:toml", "dep:cargo_toml"]
 read-config = []
 
 [package.metadata.docs.rs]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -109,7 +109,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 
 [features]
 default = []
-plugin = ["mlua"]
+plugin = ["dep:mlua"]
 
 [[bin]]
 path = "src/main.rs"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -43,7 +43,7 @@ features = [
 
 [features]
 default = []
-serialize = ["serde"]
+serialize = ["dep:serde"]
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -71,11 +71,11 @@ objc = "0.2.7"
 
 [features]
 default = ["tokio_runtime", "wry/objc-exception", "hot-reload", "devtools"]
-tokio_runtime = ["tokio"]
+tokio_runtime = ["dep:tokio"]
 fullscreen = ["wry/fullscreen"]
 transparent = ["wry/transparent"]
 devtools = ["wry/devtools"]
-hot-reload = ["dioxus-hot-reload"]
+hot-reload = ["dep:dioxus-hot-reload"]
 gnu = []
 
 [package.metadata.docs.rs]

--- a/packages/desktop/src/launch.rs
+++ b/packages/desktop/src/launch.rs
@@ -67,7 +67,7 @@ pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, desktop_config: Conf
 
 /// Launches the WebView and runs the event loop, with configuration and root props.
 pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) {
-    #[cfg(feature = "tokio")]
+    #[cfg(feature = "tokio_runtime")]
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -76,7 +76,7 @@ pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) {
             launch_virtual_dom_blocking(virtual_dom, desktop_config)
         }));
 
-    #[cfg(not(feature = "tokio"))]
+    #[cfg(not(feature = "tokio_runtime"))]
     launch_virtual_dom_blocking(virtual_dom, desktop_config)
 }
 

--- a/packages/dioxus-lib/Cargo.toml
+++ b/packages/dioxus-lib/Cargo.toml
@@ -24,10 +24,10 @@ dioxus = { workspace = true }
 
 [features]
 default = ["macro", "html", "signals", "hooks"]
-signals = ["dioxus-signals"]
-macro = ["dioxus-core-macro", "dioxus-rsx", "dioxus-config-macro"]
-html = ["dioxus-html"]
-hooks = ["dioxus-hooks"]
+signals = ["dep:dioxus-signals"]
+macro = ["dep:dioxus-core-macro", "dep:dioxus-rsx", "dep:dioxus-config-macro"]
+html = ["dep:dioxus-html"]
+hooks = ["dep:dioxus-hooks"]
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -33,23 +33,23 @@ dioxus-hot-reload = { workspace = true, optional = true }
 
 [features]
 default = ["macro", "html", "hot-reload", "signals", "hooks", "launch"]
-signals = ["dioxus-signals"]
-macro = ["dioxus-core-macro"]
-html = ["dioxus-html"]
-hooks = ["dioxus-hooks"]
-hot-reload = ["dioxus-hot-reload"]
+signals = ["dep:dioxus-signals"]
+macro = ["dep:dioxus-core-macro"]
+html = ["dep:dioxus-html"]
+hooks = ["dep:dioxus-hooks"]
+hot-reload = ["dep:dioxus-hot-reload"]
 
-launch = ["dioxus-config-macro"]
-router = ["dioxus-router"]
+launch = ["dep:dioxus-config-macro"]
+router = ["dep:dioxus-router"]
 
 # Platforms
-fullstack = ["dioxus-fullstack", "dioxus-config-macro/fullstack", "serde", "dioxus-router?/fullstack"]
-desktop = ["dioxus-desktop", "dioxus-fullstack?/desktop", "dioxus-config-macro/desktop"]
-mobile = ["dioxus-mobile", "dioxus-fullstack?/mobile", "dioxus-config-macro/mobile"]
-web = ["dioxus-web", "dioxus-fullstack?/web", "dioxus-static-site-generation?/web", "dioxus-config-macro/web", "dioxus-router?/web"]
-ssr = ["dioxus-ssr", "dioxus-router?/ssr", "dioxus-config-macro/ssr"]
-liveview = ["dioxus-liveview", "dioxus-config-macro/liveview", "dioxus-router?/liveview"]
-static-generation = ["dioxus-static-site-generation", "dioxus-config-macro/static-generation"]
+fullstack = ["dep:dioxus-fullstack", "dioxus-config-macro/fullstack", "dep:serde", "dioxus-router?/fullstack"]
+desktop = ["dep:dioxus-desktop", "dioxus-fullstack?/desktop", "dioxus-config-macro/desktop"]
+mobile = ["dep:dioxus-mobile", "dioxus-fullstack?/mobile", "dioxus-config-macro/mobile"]
+web = ["dep:dioxus-web", "dioxus-fullstack?/web", "dioxus-static-site-generation?/web", "dioxus-config-macro/web", "dioxus-router?/web"]
+ssr = ["dep:dioxus-ssr", "dioxus-router?/ssr", "dioxus-config-macro/ssr"]
+liveview = ["dep:dioxus-liveview", "dioxus-config-macro/liveview", "dioxus-router?/liveview"]
+static-generation = ["dep:dioxus-static-site-generation", "dioxus-config-macro/static-generation"]
 axum = ["dioxus-fullstack?/axum", "dioxus-fullstack?/server", "dioxus-static-site-generation?/server", "ssr", "dioxus-liveview?/axum"]
 
 # This feature just disables the no-renderer-enabled warning

--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -70,31 +70,31 @@ dioxus = { workspace = true, features = ["fullstack"] }
 
 [features]
 default = ["hot-reload"]
-hot-reload = ["serde_json", "dioxus-hot-reload/serve"]
-web = ["dioxus-web", "web-sys"]
-desktop = ["dioxus-desktop", "server_fn/reqwest", "dioxus_server_macro/reqwest"] 
-mobile = ["dioxus-mobile"]
+hot-reload = ["dep:serde_json", "dioxus-hot-reload/serve"]
+web = ["dep:dioxus-web", "dep:web-sys"]
+desktop = ["dep:dioxus-desktop", "server_fn/reqwest", "dioxus_server_macro/reqwest"] 
+mobile = ["dep:dioxus-mobile"]
 default-tls = ["server_fn/default-tls"]
 rustls = ["server_fn/rustls"]
-axum = ["dep:axum", "tower-http", "server", "server_fn/axum", "dioxus_server_macro/axum"]
+axum = ["dep:axum", "dep:tower-http", "server", "server_fn/axum", "dioxus_server_macro/axum"]
 static-site-generation = []
 server = [
     "server_fn/ssr",
     "dioxus_server_macro/server",
-    "tokio",
-    "tokio-util",
-    "tokio-stream",
-    "dioxus-ssr",
+    "dep:tokio",
+    "dep:tokio-util",
+    "dep:tokio-stream",
+    "dep:dioxus-ssr",
     "dioxus-ssr/incremental",
-    "tower",
-    "hyper",
-    "http",
-    "tower-layer",
-    "anymap",
-    "tracing-futures",
-    "pin-project",
-    "thiserror",
-    "dioxus-cli-config"
+    "dep:tower",
+    "dep:hyper",
+    "dep:http",
+    "dep:tower-layer",
+    "dep:anymap",
+    "dep:tracing-futures",
+    "dep:pin-project",
+    "dep:thiserror",
+    "dep:dioxus-cli-config"
 ]
 
 [package.metadata.docs.rs]

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -34,10 +34,10 @@ tracing.workspace = true
 tokio = { workspace = true, features = ["full"] }
 
 [features]
-default = ["dioxus-html"]
-custom_file_watcher = ["ignore", "chrono", "notify", "execute", "once_cell", "ignore"]
+default = ["dep:dioxus-html"]
+custom_file_watcher = ["dep:ignore", "dep:chrono", "dep:notify", "dep:execute", "dep:once_cell", "dep:ignore"]
 file_watcher = ["custom_file_watcher", "dioxus-html/hot-reload-context"]
-serve = ["axum", "tokio-stream", "futures-util", "tokio", "file_watcher"]
+serve = ["dep:axum", "dep:tokio-stream", "dep:futures-util", "dep:tokio", "file_watcher"]
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -58,9 +58,9 @@ tokio = { workspace = true, features = ["time"] }
 [features]
 default = ["serialize", "mounted", "eval"]
 serialize = [
-    "serde",
-    "serde_json",
-    "serde_repr",
+    "dep:serde",
+    "dep:serde_json",
+    "dep:serde_repr",
     "euclid/serde",
     "keyboard-types/serde",
     "dioxus-core/serialize",
@@ -75,12 +75,12 @@ mounted = [
     "web-sys?/HtmlElement",
 ]
 eval = [
-    "serde",
-    "serde_json"
+    "dep:serde",
+    "dep:serde_json"
 ]
-wasm-bind = ["web-sys", "wasm-bindgen"]
-native-bind = ["tokio"]
-hot-reload-context = ["dioxus-rsx"]
+wasm-bind = ["dep:web-sys", "dep:wasm-bindgen"]
+native-bind = ["dep:tokio"]
+hot-reload-context = ["dep:dioxus-rsx"]
 html-to-rsx = []
 
 [package.metadata.docs.rs]

--- a/packages/interpreter/Cargo.toml
+++ b/packages/interpreter/Cargo.toml
@@ -30,16 +30,16 @@ md5 = "0.7.0"
 
 [features]
 default = []
-serialize = ["serde"]
-sledgehammer = ["sledgehammer_bindgen", "sledgehammer_utils"]
+serialize = ["dep:serde"]
+sledgehammer = ["dep:sledgehammer_bindgen", "dep:sledgehammer_utils"]
 webonly = [
     "sledgehammer",
-    "wasm-bindgen",
-    "wasm-bindgen-futures",
-    "js-sys",
-    "web-sys",
+    "dep:wasm-bindgen",
+    "dep:wasm-bindgen-futures",
+    "dep:js-sys",
+    "dep:web-sys",
     "sledgehammer_bindgen/web",
 ]
-binary-protocol = ["sledgehammer", "dioxus-core", "dioxus-html"]
+binary-protocol = ["sledgehammer", "dep:dioxus-core", "dep:dioxus-html"]
 minimal_bindings = []
 eval = []

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -44,7 +44,7 @@ dioxus = { workspace = true }
 default = ["hot-reload", "multi-thread"]
 axum = ["dep:axum"]
 multi-thread = ["tokio/rt-multi-thread"]
-hot-reload = ["dioxus-hot-reload"]
+hot-reload = ["dep:dioxus-hot-reload"]
 
 [[example]]
 name = "axum"

--- a/packages/router/Cargo.toml
+++ b/packages/router/Cargo.toml
@@ -43,11 +43,11 @@ wasm-bindgen-test = "0.3.33"
 
 [features]
 default = []
-ssr = ["dioxus-ssr/incremental", "tokio", "dioxus-fullstack?/server", "http"]
-liveview = ["dioxus-liveview", "tokio", "dep:serde", "serde_json"]
+ssr = ["dioxus-ssr/incremental", "dep:tokio", "dioxus-fullstack?/server", "dep:http"]
+liveview = ["dep:dioxus-liveview", "dep:tokio", "dep:serde", "dep:serde_json"]
 wasm_test = []
-web = ["gloo", "web-sys", "wasm-bindgen", "gloo-utils", "js-sys", "dioxus-router-macro/web"]
-fullstack = ["dioxus-fullstack"]
+web = ["dep:gloo", "dep:web-sys", "dep:wasm-bindgen", "dep:gloo-utils", "dep:js-sys", "dioxus-router-macro/web"]
+fullstack = ["dep:dioxus-fullstack"]
 
 [dev-dependencies]
 axum = { workspace = true, features = ["ws"] }

--- a/packages/router/src/history/web_scroll.rs
+++ b/packages/router/src/history/web_scroll.rs
@@ -2,7 +2,6 @@ use gloo::render::{request_animation_frame, AnimationFrame};
 use web_sys::Window;
 
 #[derive(Clone, Copy, Debug, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub(crate) struct ScrollPosition {
     pub x: f64,
     pub y: f64,

--- a/packages/router/src/router_cfg.rs
+++ b/packages/router/src/router_cfg.rs
@@ -40,7 +40,6 @@ where
     }
 }
 
-#[cfg(not(feature = "serde"))]
 impl<R: Routable + Clone> RouterConfig<R>
 where
     <R as std::str::FromStr>::Err: std::fmt::Display,

--- a/packages/rsx/Cargo.toml
+++ b/packages/rsx/Cargo.toml
@@ -24,7 +24,7 @@ tracing = { workspace = true }
 
 [features]
 default = ["html", "hot_reload"]
-hot_reload = ["krates", "internment", "dioxus-core"]
+hot_reload = ["dep:krates", "dep:internment", "dep:dioxus-core"]
 serde = ["dep:serde"]
 html = []
 

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -33,7 +33,7 @@ rand = "0.8"
 
 [features]
 default = []
-serialize = ["serde"]
+serialize = ["dep:serde"]
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -21,7 +21,7 @@ pub struct CopyValue<T: 'static, S: Storage<T> = UnsyncStorage> {
     origin_scope: ScopeId,
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 impl<T: 'static, Store: Storage<T>> serde::Serialize for CopyValue<T, Store>
 where
     T: serde::Serialize,
@@ -31,7 +31,7 @@ where
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 impl<'de, T: 'static, Store: Storage<T>> serde::Deserialize<'de> for CopyValue<T, Store>
 where
     T: serde::Deserialize<'de>,

--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -78,7 +78,7 @@ impl<T, S: Storage<SignalData<T>>> Readable for ReadOnlySignal<T, S> {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 impl<T: serde::Serialize + 'static, Store: Storage<SignalData<T>>> serde::Serialize
     for ReadOnlySignal<T, Store>
 {
@@ -87,7 +87,7 @@ impl<T: serde::Serialize + 'static, Store: Storage<SignalData<T>>> serde::Serial
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 impl<'de, T: serde::Deserialize<'de> + 'static, Store: Storage<SignalData<T>>>
     serde::Deserialize<'de> for ReadOnlySignal<T, Store>
 {

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -455,7 +455,7 @@ impl<T: Clone, S: Storage<SignalData<T>> + 'static> Deref for Signal<T, S> {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 impl<T: serde::Serialize + 'static, Store: Storage<SignalData<T>>> serde::Serialize
     for Signal<T, Store>
 {
@@ -464,7 +464,7 @@ impl<T: serde::Serialize + 'static, Store: Storage<SignalData<T>>> serde::Serial
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialize")]
 impl<'de, T: serde::Deserialize<'de> + 'static, Store: Storage<SignalData<T>>>
     serde::Deserialize<'de> for Signal<T, Store>
 {

--- a/packages/ssr/Cargo.toml
+++ b/packages/ssr/Cargo.toml
@@ -43,7 +43,7 @@ fs_extra = "1.2.0"
 
 [features]
 default = []
-incremental = ["dep:tokio", "chrono", "dioxus-cli-config"]
+incremental = ["dep:tokio", "dep:chrono", "dep:dioxus-cli-config"]
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/static-generation/Cargo.toml
+++ b/packages/static-generation/Cargo.toml
@@ -30,8 +30,8 @@ dioxus = { workspace = true }
 
 [features]
 default = []
-server = ["dioxus-fullstack/server", "dioxus-router/ssr", "dioxus-ssr", "tokio", "http", "dep:axum", "tower-http", "dioxus-hot-reload", "dioxus-cli-config", "tower"]
-web = ["dioxus-fullstack/web", "dioxus-router/web", "dioxus-web"]
+server = ["dioxus-fullstack/server", "dioxus-router/ssr", "dep:dioxus-ssr", "dep:tokio", "dep:http", "dep:axum", "dep:tower-http", "dep:dioxus-hot-reload", "dep:dioxus-cli-config", "dep:tower"]
+web = ["dioxus-fullstack/web", "dioxus-router/web", "dep:dioxus-web"]
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -53,17 +53,17 @@ features = [
 
 [features]
 default = ["panic_hook", "mounted", "file_engine", "hot_reload", "eval"]
-panic_hook = ["console_error_panic_hook"]
+panic_hook = ["dep:console_error_panic_hook"]
 hydrate = ["web-sys/Comment"]
 mounted = ["web-sys/Element", "dioxus-html/mounted"]
 file_engine = [
     "web-sys/File",
     "web-sys/FileList",
     "web-sys/FileReader",
-    "async-trait",
+    "dep:async-trait",
 ]
 hot_reload = ["web-sys/MessageEvent", "web-sys/WebSocket", "web-sys/Location"]
-eval = ["dioxus-html/eval", "dioxus-interpreter-js/eval", "serde-wasm-bindgen", "async-trait"]
+eval = ["dioxus-html/eval", "dioxus-interpreter-js/eval", "dep:serde-wasm-bindgen", "dep:async-trait"]
 
 [dev-dependencies]
 dioxus = { workspace = true }


### PR DESCRIPTION
Optional dependencies add implicit features to crates if they are never used with `dep:`. This PR switches all of our optional dependencies to use `dep:` to remove those useless features

Closes #2513