### PR TITLE
Simplify dioxus-config-macro

### DIFF
--- a/packages/config-macro/src/lib.rs
+++ b/packages/config-macro/src/lib.rs
@@ -6,137 +6,33 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 
-#[proc_macro]
-pub fn server_only(input: TokenStream) -> TokenStream {
-    if cfg!(any(feature = "ssr", feature = "liveview")) {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
+macro_rules! define_config_macro {
+    ($name:ident if $($cfg:tt)+) => {
+        #[proc_macro]
+        pub fn $name(input: TokenStream) -> TokenStream {
+            if cfg!($($cfg)+) {
+                let input = TokenStream2::from(input);
+                quote! {
+                    {
+                        #input
+                    }
+                }
+            } else {
+                quote! {
+                    {}
+                }
+            }
+            .into()
         }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
+    };
 }
 
-#[proc_macro]
-pub fn client(input: TokenStream) -> TokenStream {
-    if cfg!(any(feature = "desktop", feature = "web")) {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
-
-#[proc_macro]
-pub fn web(input: TokenStream) -> TokenStream {
-    if cfg!(feature = "web") {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
-
-#[proc_macro]
-pub fn desktop(input: TokenStream) -> TokenStream {
-    if cfg!(feature = "desktop") {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
-
-#[proc_macro]
-pub fn mobile(input: TokenStream) -> TokenStream {
-    if cfg!(feature = "mobile") {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
-
-#[proc_macro]
-pub fn fullstack(input: TokenStream) -> TokenStream {
-    if cfg!(feature = "fullstack") {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
-
-#[proc_macro]
-pub fn static_generation(input: TokenStream) -> TokenStream {
-    if cfg!(feature = "static-generation") {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
-
-#[proc_macro]
-pub fn ssr(input: TokenStream) -> TokenStream {
-    if cfg!(feature = "ssr") {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
-
-#[proc_macro]
-pub fn liveview(input: TokenStream) -> TokenStream {
-    if cfg!(feature = "liveview") {
-        let input = TokenStream2::from(input);
-        quote! {
-            #input
-        }
-    } else {
-        quote! {
-            {}
-        }
-    }
-    .into()
-}
+define_config_macro!(server_only if any(feature = "ssr", feature = "liveview"));
+define_config_macro!(client if any(feature = "desktop", feature = "web"));
+define_config_macro!(web if feature = "web");
+define_config_macro!(desktop if feature = "desktop");
+define_config_macro!(mobile if feature = "mobile");
+define_config_macro!(fullstack if feature = "fullstack");
+define_config_macro!(static_generation if feature = "static-generation");
+define_config_macro!(ssr if feature = "ssr");
+define_config_macro!(liveview if feature = "liveview");

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -433,8 +433,11 @@ impl<Args: 'static, Ret: 'static> std::ops::Deref for Callback<Args, Ret> {
                 // The real closure that we will never use.
                 &uninit_closure
             },
+            #[allow(clippy::missing_transmute_annotations)]
             // We transmute self into a reference to the closure. This is safe because we know that the closure has the same memory layout as Self so &Closure == &Self.
-            unsafe { std::mem::transmute(self) },
+            unsafe {
+                std::mem::transmute(self)
+            },
         );
 
         // Cast the closure to a trait object.

--- a/packages/hooks/src/use_callback.rs
+++ b/packages/hooks/src/use_callback.rs
@@ -95,8 +95,11 @@ impl<O> std::ops::Deref for UseCallback<O> {
                 // The real closure that we will never use.
                 &uninit_closure
             },
+            #[allow(clippy::missing_transmute_annotations)]
             // We transmute self into a reference to the closure. This is safe because we know that the closure has the same memory layout as Self so &Closure == &Self.
-            unsafe { std::mem::transmute(self) },
+            unsafe {
+                std::mem::transmute(self)
+            },
         );
 
         // Cast the closure to a trait object.

--- a/packages/signals/src/read.rs
+++ b/packages/signals/src/read.rs
@@ -220,8 +220,11 @@ pub trait Readable {
                 // The real closure that we will never use.
                 &uninit_closure
             },
+            #[allow(clippy::missing_transmute_annotations)]
             // We transmute self into a reference to the closure. This is safe because we know that the closure has the same memory layout as Self so &Closure == &Self.
-            unsafe { std::mem::transmute(self) },
+            unsafe {
+                std::mem::transmute(self)
+            },
         );
 
         // Cast the closure to a trait object.


### PR DESCRIPTION
This PR pulls out the code to define each config macro into a macro rules and adds an extra block to the return value. This makes it possible to use the macro with multiple statements like:
```rust
server_only! {
    let value = 0;
    value
}
```