### PR TITLE
Make it easier to provide context to fullstack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,12 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
-name = "anymap"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
-
-[[package]]
 name = "anymap2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,6 +2124,7 @@ dependencies = [
 name = "dioxus"
 version = "0.5.2"
 dependencies = [
+ "axum",
  "criterion 0.3.6",
  "dioxus",
  "dioxus-config-macro",
@@ -2416,7 +2411,6 @@ dependencies = [
 name = "dioxus-fullstack"
 version = "0.5.2"
 dependencies = [
- "anymap",
  "async-trait",
  "axum",
  "base64 0.21.7",

--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -27,6 +27,7 @@ dioxus-liveview = { workspace = true, optional = true }
 dioxus-ssr ={ workspace = true, optional = true }
 
 serde = { version = "1.0.136", optional = true }
+axum = { workspace = true, optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "ios", target_os = "android")))'.dependencies]
 dioxus-hot-reload = { workspace = true, optional = true }
@@ -50,7 +51,7 @@ web = ["dioxus-web", "dioxus-fullstack?/web", "dioxus-static-site-generation?/we
 ssr = ["dioxus-ssr", "dioxus-router?/ssr", "dioxus-config-macro/ssr"]
 liveview = ["dioxus-liveview", "dioxus-config-macro/liveview", "dioxus-router?/liveview"]
 static-generation = ["dioxus-static-site-generation", "dioxus-config-macro/static-generation"]
-axum = ["dioxus-fullstack?/axum", "dioxus-fullstack?/server", "dioxus-static-site-generation?/server", "ssr", "dioxus-liveview?/axum"]
+axum = ["dioxus-fullstack?/axum", "dioxus-fullstack?/server", "dioxus-static-site-generation?/server", "ssr", "dioxus-liveview?/axum", "dep:axum"]
 
 # This feature just disables the no-renderer-enabled warning
 third-party-renderer = []

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -31,7 +31,7 @@ type ValidContext = SendContext;
 )))]
 type ValidContext = UnsendContext;
 
-type SendContext = dyn Fn() -> Box<dyn Any> + Send + Sync + 'static;
+type SendContext = dyn Fn() -> Box<dyn Any + Send + Sync> + Send + Sync + 'static;
 
 type UnsendContext = dyn Fn() -> Box<dyn Any> + 'static;
 
@@ -137,7 +137,7 @@ impl<Cfg> LaunchBuilder<Cfg, SendContext> {
     /// Inject state into the root component's context that is created on the thread that the app is launched on.
     pub fn with_context_provider(
         mut self,
-        state: impl Fn() -> Box<dyn Any> + Send + Sync + 'static,
+        state: impl Fn() -> Box<dyn Any + Send + Sync> + Send + Sync + 'static,
     ) -> Self {
         self.contexts.push(Box::new(state) as Box<SendContext>);
         self

--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -110,6 +110,10 @@ pub mod prelude {
     #[cfg(feature = "router")]
     #[cfg_attr(docsrs, doc(cfg(feature = "router")))]
     pub use dioxus_router::prelude::*;
+
+    #[cfg(feature = "axum")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
+    pub use axum;
 }
 
 #[cfg(feature = "web")]

--- a/packages/fullstack/Cargo.toml
+++ b/packages/fullstack/Cargo.toml
@@ -39,7 +39,6 @@ tracing = { workspace = true }
 tracing-futures = { workspace = true, optional = true }
 once_cell = "1.17.1"
 tokio-util = { version = "0.7.8", features = ["rt"], optional = true }
-anymap = { version = "0.12.1", optional = true }
 
 serde = "1.0.159"
 serde_json = { version = "1.0.95", optional = true }
@@ -90,7 +89,6 @@ server = [
     "hyper",
     "http",
     "tower-layer",
-    "anymap",
     "tracing-futures",
     "pin-project",
     "thiserror",

--- a/packages/fullstack/examples/axum-auth/src/main.rs
+++ b/packages/fullstack/examples/axum-auth/src/main.rs
@@ -49,9 +49,7 @@ fn main() {
                 // build our application with some routes
                 let app = Router::new()
                     // Server side render the application, serve static assets, and register server functions
-                    .serve_dioxus_application(ServeConfig::builder().build(), || {
-                        VirtualDom::new(app)
-                    })
+                    .serve_dioxus_application(ServeConfig::default(), app)
                     .await
                     .layer(
                         axum_session_auth::AuthSessionLayer::<

--- a/packages/fullstack/examples/axum-desktop/src/server.rs
+++ b/packages/fullstack/examples/axum-desktop/src/server.rs
@@ -19,7 +19,7 @@ async fn main() {
     axum::serve(
         listener,
         axum::Router::new()
-            .register_server_fns()
+            .register_server_functions()
             .into_make_service(),
     )
     .await

--- a/packages/fullstack/src/axum_adapter.rs
+++ b/packages/fullstack/src/axum_adapter.rs
@@ -356,7 +356,7 @@ type AxumHandler<F> = (
 ///         .serve(
 ///             axum::Router::new()
 ///                 // Register server functions, etc.
-///                 // Note you probably want to use `register_server_fns_with_handler`
+///                 // Note you can use `register_server_functions_with_context`
 ///                 // to inject the context into server functions running outside
 ///                 // of an SSR render context.
 ///                 .fallback(get(render_handler_with_context).with_state((

--- a/packages/fullstack/src/axum_adapter.rs
+++ b/packages/fullstack/src/axum_adapter.rs
@@ -66,11 +66,8 @@ use http::header::*;
 
 use std::sync::Arc;
 
+use crate::launch::ContextProviders;
 use crate::prelude::*;
-
-pub(crate) type ContextProviders = Arc<
-    Vec<Box<dyn Fn() -> Box<dyn std::any::Any + Send + Sync + 'static> + Send + Sync + 'static>>,
->;
 
 /// A extension trait with utilities for integrating Dioxus with your Axum router.
 pub trait DioxusRouterExt<S> {

--- a/packages/fullstack/src/config.rs
+++ b/packages/fullstack/src/config.rs
@@ -116,9 +116,12 @@ impl Config {
     pub async fn launch_server(
         self,
         build_virtual_dom: impl Fn() -> VirtualDom + Send + Sync + 'static,
+        context_providers: ContextProviders,
     ) {
+        use std::any::Any;
+
         let addr = self.addr;
-        println!("Listening on {}", addr);
+        println!("Listening on http://{}", addr);
         let cfg = self.server_cfg.build();
         let server_fn_route = self.server_fn_route;
 
@@ -129,7 +132,7 @@ impl Config {
             use tower::ServiceBuilder;
 
             let ssr_state = SSRState::new(&cfg);
-            let router = axum::Router::new().register_server_fns();
+            let router = axum::Router::new().register_server_fns(context_providers);
             #[cfg(not(any(feature = "desktop", feature = "mobile")))]
             let router = {
                 let mut router = router.serve_static_assets(cfg.assets_path.clone()).await;

--- a/packages/fullstack/src/config.rs
+++ b/packages/fullstack/src/config.rs
@@ -116,7 +116,7 @@ impl Config {
     pub async fn launch_server(
         self,
         build_virtual_dom: impl Fn() -> VirtualDom + Send + Sync + 'static,
-        context_providers: ContextProviders,
+        context_providers: crate::launch::ContextProviders,
     ) {
         use std::any::Any;
 

--- a/packages/fullstack/src/config.rs
+++ b/packages/fullstack/src/config.rs
@@ -132,7 +132,8 @@ impl Config {
             use tower::ServiceBuilder;
 
             let ssr_state = SSRState::new(&cfg);
-            let router = axum::Router::new().register_server_fns(context_providers);
+            let router =
+                axum::Router::new().register_server_functions_with_context(context_providers);
             #[cfg(not(any(feature = "desktop", feature = "mobile")))]
             let router = {
                 let mut router = router.serve_static_assets(cfg.assets_path.clone()).await;

--- a/packages/fullstack/src/launch.rs
+++ b/packages/fullstack/src/launch.rs
@@ -4,15 +4,16 @@ use std::{any::Any, sync::Arc};
 
 use dioxus_lib::prelude::{Element, VirtualDom};
 
+use crate::prelude::ContextProviders;
 pub use crate::Config;
 
 fn virtual_dom_factory(
     root: fn() -> Element,
-    contexts: Arc<Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>>,
+    contexts: ContextProviders,
 ) -> impl Fn() -> VirtualDom + 'static {
     move || {
         let mut vdom = VirtualDom::new(root);
-        for context in &contexts {
+        for context in &*contexts {
             vdom.insert_any_root_context(context());
         }
         vdom
@@ -24,7 +25,7 @@ fn virtual_dom_factory(
 #[allow(unused)]
 pub fn launch(
     root: fn() -> Element,
-    contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
+    contexts: Vec<Box<dyn Fn() -> Box<dyn Any + Send + Sync> + Send + Sync>>,
     platform_config: Config,
 ) -> ! {
     let contexts = Arc::new(contexts);

--- a/packages/fullstack/src/launch.rs
+++ b/packages/fullstack/src/launch.rs
@@ -4,8 +4,10 @@ use std::{any::Any, sync::Arc};
 
 use dioxus_lib::prelude::{Element, VirtualDom};
 
-use crate::prelude::ContextProviders;
 pub use crate::Config;
+pub(crate) type ContextProviders = Arc<
+    Vec<Box<dyn Fn() -> Box<dyn std::any::Any + Send + Sync + 'static> + Send + Sync + 'static>>,
+>;
 
 fn virtual_dom_factory(
     root: fn() -> Element,

--- a/packages/fullstack/src/lib.rs
+++ b/packages/fullstack/src/lib.rs
@@ -55,8 +55,8 @@ pub mod prelude {
     #[cfg(feature = "server")]
     #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
     pub use crate::server_context::{
-        extract, server_context, with_server_context, DioxusServerContext, FromServerContext,
-        ProvideServerContext,
+        extract, server_context, with_server_context, DioxusServerContext, FromContext,
+        FromServerContext, ProvideServerContext,
     };
 
     #[cfg(feature = "server")]

--- a/packages/fullstack/src/server_context.rs
+++ b/packages/fullstack/src/server_context.rs
@@ -65,7 +65,7 @@ mod server_fn_impl {
 
         /// Insert a value into the shared server context
         pub fn insert<T: Any + Send + Sync + 'static>(
-            &mut self,
+            &self,
             value: T,
         ) -> Result<(), PoisonError<RwLockWriteGuard<'_, SendSyncAnyMap>>> {
             self.shared_context
@@ -76,7 +76,7 @@ mod server_fn_impl {
 
         /// Insert a Boxed `Any` value into the shared server context
         pub fn insert_any(
-            &mut self,
+            &self,
             value: Box<dyn Any + Send + Sync>,
         ) -> Result<(), PoisonError<RwLockWriteGuard<'_, SendSyncAnyMap>>> {
             self.shared_context

--- a/packages/fullstack/src/server_context.rs
+++ b/packages/fullstack/src/server_context.rs
@@ -248,7 +248,34 @@ impl<T: 'static> std::fmt::Display for NotFoundInServerContext<T> {
 
 impl<T: 'static> std::error::Error for NotFoundInServerContext<T> {}
 
-pub struct FromContext<T: std::marker::Send + std::marker::Sync + Clone + 'static>(pub(crate) T);
+/// Extract a value from the server context provided through the launch builder context or [`DioxusServerContext::insert`]
+///
+/// Example:
+/// ```rust, no_run
+/// use dioxus::prelude::*;
+///
+/// LaunchBuilder::new()
+///     // You can provide context to your whole app (including server functions) with the `with_context` method on the launch builder
+///     .with_context(server_only! {
+///         1234567890u32
+///     })
+///     .launch(app);
+///
+/// #[server]
+/// async fn read_context() -> Result<u32, ServerFnError> {
+///     // You can extract values from the server context with the `extract` function
+///     let FromContext(value) = extract().await?;
+///     Ok(value)
+/// }
+///
+/// fn app() -> Element {
+///     let future = use_resource(read_context);
+///     rsx! {
+///         h1 { "{future:?}" }
+///     }
+/// }
+/// ```
+pub struct FromContext<T: std::marker::Send + std::marker::Sync + Clone + 'static>(pub T);
 
 #[async_trait::async_trait]
 impl<T: Send + Sync + Clone + 'static> FromServerContext for FromContext<T> {

--- a/packages/fullstack/src/server_context.rs
+++ b/packages/fullstack/src/server_context.rs
@@ -1,6 +1,11 @@
 use crate::html_storage::HTMLData;
+use std::any::Any;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::RwLock;
+
+type SendSyncAnyMap =
+    std::collections::HashMap<std::any::TypeId, Box<dyn Any + Send + Sync + 'static>>;
 
 /// A shared context for server functions that contains information about the request and middleware state.
 /// This allows you to pass data between your server framework and the server functions. This can be used to pass request information or information about the state of the server. For example, you could pass authentication data though this context to your server functions.
@@ -8,9 +13,7 @@ use std::sync::RwLock;
 /// You should not construct this directly inside components. Instead use the `HasServerContext` trait to get the server context from the scope.
 #[derive(Clone)]
 pub struct DioxusServerContext {
-    shared_context: std::sync::Arc<
-        std::sync::RwLock<anymap::Map<dyn anymap::any::Any + Send + Sync + 'static>>,
-    >,
+    shared_context: std::sync::Arc<std::sync::RwLock<SendSyncAnyMap>>,
     response_parts: std::sync::Arc<std::sync::RwLock<http::response::Parts>>,
     pub(crate) parts: Arc<tokio::sync::RwLock<http::request::Parts>>,
     html_data: Arc<RwLock<HTMLData>>,
@@ -20,7 +23,7 @@ pub struct DioxusServerContext {
 impl Default for DioxusServerContext {
     fn default() -> Self {
         Self {
-            shared_context: std::sync::Arc::new(std::sync::RwLock::new(anymap::Map::new())),
+            shared_context: std::sync::Arc::new(std::sync::RwLock::new(HashMap::new())),
             response_parts: std::sync::Arc::new(RwLock::new(
                 http::response::Response::new(()).into_parts().0,
             )),
@@ -34,11 +37,9 @@ impl Default for DioxusServerContext {
 
 mod server_fn_impl {
     use super::*;
+    use std::any::{Any, TypeId};
     use std::sync::LockResult;
     use std::sync::{PoisonError, RwLockReadGuard, RwLockWriteGuard};
-
-    use anymap::{any::Any, Map};
-    type SendSyncAnyMap = Map<dyn Any + Send + Sync + 'static>;
 
     impl DioxusServerContext {
         /// Create a new server context from a request
@@ -55,7 +56,11 @@ mod server_fn_impl {
 
         /// Clone a value from the shared server context
         pub fn get<T: Any + Send + Sync + Clone + 'static>(&self) -> Option<T> {
-            self.shared_context.read().ok()?.get::<T>().cloned()
+            self.shared_context
+                .read()
+                .ok()?
+                .get(&TypeId::of::<T>())
+                .map(|v| v.downcast_ref::<T>().unwrap().clone())
         }
 
         /// Insert a value into the shared server context
@@ -65,7 +70,18 @@ mod server_fn_impl {
         ) -> Result<(), PoisonError<RwLockWriteGuard<'_, SendSyncAnyMap>>> {
             self.shared_context
                 .write()
-                .map(|mut map| map.insert(value))
+                .map(|mut map| map.insert(TypeId::of::<T>(), Box::new(value)))
+                .map(|_| ())
+        }
+
+        /// Insert a Boxed `Any` value into the shared server context
+        pub fn insert_any(
+            &mut self,
+            value: Box<dyn Any + Send + Sync>,
+        ) -> Result<(), PoisonError<RwLockWriteGuard<'_, SendSyncAnyMap>>> {
+            self.shared_context
+                .write()
+                .map(|mut map| map.insert((*value).type_id(), value))
                 .map(|_| ())
         }
 
@@ -239,7 +255,7 @@ impl<T: Send + Sync + Clone + 'static> FromServerContext for FromContext<T> {
     type Rejection = NotFoundInServerContext<T>;
 
     async fn from_request(req: &DioxusServerContext) -> Result<Self, Self::Rejection> {
-        Ok(Self(req.clone().get::<T>().ok_or({
+        Ok(Self(req.get::<T>().ok_or({
             NotFoundInServerContext::<T>(std::marker::PhantomData::<T>)
         })?))
     }


### PR DESCRIPTION
This PR changes the context function in the launch builder to provide context throughout the fullstack application including in server functions. You can now consume context in server functions with an extractor:
```rust
LaunchBuilder::new().with_context(1234567890u32).launch(app);

#[server]
async fn get_server_data() -> Result<String, ServerFnError> {
    let FromContext(context): FromContext<u32> = extract().await?;
    let text = reqwest::get("https://httpbin.org/ip").await?.text().await?;
    Ok(format!("context {context} Your IP address is: {text} 🌎"))
}
```

Closes #2131
Closes #1688