### PR TITLE
Assert that launch never returns for better compiler errors

### DIFF
--- a/packages/desktop/src/launch.rs
+++ b/packages/desktop/src/launch.rs
@@ -11,7 +11,7 @@ use tao::event::{Event, StartCause, WindowEvent};
 ///
 /// This will block the main thread, and *must* be spawned on the main thread. This function does not assume any runtime
 /// and is equivalent to calling launch_with_props with the tokio feature disabled.
-pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, desktop_config: Config) {
+pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, desktop_config: Config) -> ! {
     let (event_loop, mut app) = App::new(desktop_config, virtual_dom);
 
     event_loop.run(move |window_event, _, control_flow| {
@@ -66,7 +66,7 @@ pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, desktop_config: Conf
 }
 
 /// Launches the WebView and runs the event loop, with configuration and root props.
-pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) {
+pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) -> ! {
     #[cfg(feature = "tokio")]
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -77,7 +77,9 @@ pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) {
         }));
 
     #[cfg(not(feature = "tokio"))]
-    launch_virtual_dom_blocking(virtual_dom, desktop_config)
+    launch_virtual_dom_blocking(virtual_dom, desktop_config);
+
+    unreachable!("The desktop launch function will never exit")
 }
 
 /// Launches the WebView and runs the event loop, with configuration and root props.
@@ -85,7 +87,7 @@ pub fn launch(
     root: fn() -> Element,
     contexts: Vec<Box<dyn Fn() -> Box<dyn Any>>>,
     platform_config: Config,
-) {
+) -> ! {
     let mut virtual_dom = VirtualDom::new(root);
 
     for context in contexts {

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -15,7 +15,7 @@ pub struct LaunchBuilder<Cfg: 'static = (), ContextFn: ?Sized = ValidContext> {
     platform_config: Option<Cfg>,
 }
 
-pub type LaunchFn<Cfg, Context> = fn(fn() -> Element, Vec<Box<Context>>, Cfg);
+pub type LaunchFn<Cfg, Context> = fn(fn() -> Element, Vec<Box<Context>>, Cfg) -> !;
 
 #[cfg(any(
     feature = "fullstack",
@@ -189,7 +189,7 @@ impl<Cfg: Default + 'static, ContextFn: ?Sized> LaunchBuilder<Cfg, ContextFn> {
     }
 
     /// Launch your application.
-    pub fn launch(self, app: fn() -> Element) {
+    pub fn launch(self, app: fn() -> Element) -> ! {
         let cfg = self.platform_config.unwrap_or_default();
 
         (self.launch_fn)(app, self.contexts, cfg)
@@ -333,7 +333,7 @@ mod current_platform {
         note = "No renderer is enabled. You must enable a renderer feature on the dioxus crate before calling the launch function.\nAdd `web`, `desktop`, `mobile`, `fullstack`, or `static-generation` to the `features` of dioxus field in your Cargo.toml.\n# Example\n```toml\n# ...\n[dependencies]\ndioxus = { version = \"0.5.0\", features = [\"web\"] }\n# ...\n```"
     )
 )]
-pub fn launch(app: fn() -> Element) {
+pub fn launch(app: fn() -> Element) -> ! {
     #[allow(deprecated)]
     LaunchBuilder::new().launch(app)
 }

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -15,7 +15,7 @@ pub struct LaunchBuilder<Cfg: 'static = (), ContextFn: ?Sized = ValidContext> {
     platform_config: Option<Cfg>,
 }
 
-pub type LaunchFn<Cfg, Context> = fn(fn() -> Element, Vec<Box<Context>>, Cfg) -> !;
+pub type LaunchFn<Cfg, Context> = fn(fn() -> Element, Vec<Box<Context>>, Cfg);
 
 #[cfg(any(
     feature = "fullstack",
@@ -55,7 +55,7 @@ impl LaunchBuilder {
     )]
     pub fn new() -> LaunchBuilder<current_platform::Config, ValidContext> {
         LaunchBuilder {
-            launch_fn: current_platform::launch,
+            launch_fn: |root, contexts, cfg| current_platform::launch(root, contexts, cfg),
             contexts: Vec::new(),
             platform_config: None,
         }
@@ -66,7 +66,7 @@ impl LaunchBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "web")))]
     pub fn web() -> LaunchBuilder<dioxus_web::Config, UnsendContext> {
         LaunchBuilder {
-            launch_fn: dioxus_web::launch::launch,
+            launch_fn: |root, contexts, cfg| dioxus_web::launch::launch(root, contexts, cfg),
             contexts: Vec::new(),
             platform_config: None,
         }
@@ -77,7 +77,7 @@ impl LaunchBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "desktop")))]
     pub fn desktop() -> LaunchBuilder<dioxus_desktop::Config, UnsendContext> {
         LaunchBuilder {
-            launch_fn: dioxus_desktop::launch::launch,
+            launch_fn: |root, contexts, cfg| dioxus_desktop::launch::launch(root, contexts, cfg),
             contexts: Vec::new(),
             platform_config: None,
         }
@@ -88,7 +88,7 @@ impl LaunchBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "fullstack")))]
     pub fn fullstack() -> LaunchBuilder<dioxus_fullstack::Config, SendContext> {
         LaunchBuilder {
-            launch_fn: dioxus_fullstack::launch::launch,
+            launch_fn: |root, contexts, cfg| dioxus_fullstack::launch::launch(root, contexts, cfg),
             contexts: Vec::new(),
             platform_config: None,
         }
@@ -99,7 +99,7 @@ impl LaunchBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "mobile")))]
     pub fn mobile() -> LaunchBuilder<dioxus_mobile::Config, UnsendContext> {
         LaunchBuilder {
-            launch_fn: dioxus_mobile::launch::launch,
+            launch_fn: |root, contexts, cfg| dioxus_mobile::launch::launch(root, contexts, cfg),
             contexts: Vec::new(),
             platform_config: None,
         }
@@ -188,11 +188,22 @@ impl<Cfg: Default + 'static, ContextFn: ?Sized> LaunchBuilder<Cfg, ContextFn> {
         self
     }
 
+    // Static generation is the only platform that may exit. We can't use the `!` type here
+    #[cfg(feature = "static-generation")]
+    /// Launch your application.
+    pub fn launch(self, app: fn() -> Element) {
+        let cfg = self.platform_config.unwrap_or_default();
+
+        (self.launch_fn)(app, self.contexts, cfg)
+    }
+
+    #[cfg(not(feature = "static-generation"))]
     /// Launch your application.
     pub fn launch(self, app: fn() -> Element) -> ! {
         let cfg = self.platform_config.unwrap_or_default();
 
-        (self.launch_fn)(app, self.contexts, cfg)
+        (self.launch_fn)(app, self.contexts, cfg);
+        unreachable!("Launching an application will never exit")
     }
 }
 
@@ -308,35 +319,46 @@ mod current_platform {
         root: fn() -> dioxus_core::Element,
         contexts: Vec<Box<super::ValidContext>>,
         platform_config: (),
-    ) {
+    ) -> ! {
         #[cfg(feature = "third-party-renderer")]
         panic!("No first party renderer feature enabled. It looks like you are trying to use a third party renderer. You will need to use the launch function from the third party renderer crate.");
 
-        panic!("No platform feature enabled. Please enable one of the following features: liveview, desktop, mobile, web, tui, fullstack to use the launch API.");
+        panic!("No platform feature enabled. Please enable one of the following features: liveview, desktop, mobile, web, tui, fullstack to use the launch API.")
     }
 }
 
-/// Launch your application without any additional configuration. See [`LaunchBuilder`] for more options.
-// If you aren't using a third party renderer and this is not a docs.rs build, generate a warning about no renderer being enabled
-#[cfg_attr(
-    all(not(any(
-        docsrs,
-        feature = "third-party-renderer",
-        feature = "liveview",
-        feature = "desktop",
-        feature = "mobile",
-        feature = "web",
-        feature = "fullstack",
-        feature = "static-generation"
-    ))),
-    deprecated(
-        note = "No renderer is enabled. You must enable a renderer feature on the dioxus crate before calling the launch function.\nAdd `web`, `desktop`, `mobile`, `fullstack`, or `static-generation` to the `features` of dioxus field in your Cargo.toml.\n# Example\n```toml\n# ...\n[dependencies]\ndioxus = { version = \"0.5.0\", features = [\"web\"] }\n# ...\n```"
-    )
-)]
-pub fn launch(app: fn() -> Element) -> ! {
-    #[allow(deprecated)]
-    LaunchBuilder::new().launch(app)
+// ! is unstable, so we can't name the type with an alias. Instead we need to generate different variants of items with macros
+macro_rules! impl_launch {
+    ($($return_type:tt),*) => {
+        /// Launch your application without any additional configuration. See [`LaunchBuilder`] for more options.
+        // If you aren't using a third party renderer and this is not a docs.rs build, generate a warning about no renderer being enabled
+        #[cfg_attr(
+            all(not(any(
+                docsrs,
+                feature = "third-party-renderer",
+                feature = "liveview",
+                feature = "desktop",
+                feature = "mobile",
+                feature = "web",
+                feature = "fullstack",
+                feature = "static-generation"
+            ))),
+            deprecated(
+                note = "No renderer is enabled. You must enable a renderer feature on the dioxus crate before calling the launch function.\nAdd `web`, `desktop`, `mobile`, `fullstack`, or `static-generation` to the `features` of dioxus field in your Cargo.toml.\n# Example\n```toml\n# ...\n[dependencies]\ndioxus = { version = \"0.5.0\", features = [\"web\"] }\n# ...\n```"
+            )
+        )]
+        pub fn launch(app: fn() -> Element) -> $($return_type)* {
+            #[allow(deprecated)]
+            LaunchBuilder::new().launch(app)
+        }
+    };
 }
+
+// Static generation is the only platform that may exit. We can't use the `!` type here
+#[cfg(feature = "static-generation")]
+impl_launch!(());
+#[cfg(not(feature = "static-generation"))]
+impl_launch!(!);
 
 #[cfg(feature = "web")]
 #[cfg_attr(docsrs, doc(cfg(feature = "web")))]

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -66,7 +66,7 @@ impl LaunchBuilder {
     #[cfg_attr(docsrs, doc(cfg(feature = "web")))]
     pub fn web() -> LaunchBuilder<dioxus_web::Config, UnsendContext> {
         LaunchBuilder {
-            launch_fn: |root, contexts, cfg| dioxus_web::launch::launch(root, contexts, cfg),
+            launch_fn: dioxus_web::launch::launch,
             contexts: Vec::new(),
             platform_config: None,
         }
@@ -189,7 +189,7 @@ impl<Cfg: Default + 'static, ContextFn: ?Sized> LaunchBuilder<Cfg, ContextFn> {
     }
 
     // Static generation is the only platform that may exit. We can't use the `!` type here
-    #[cfg(feature = "static-generation")]
+    #[cfg(any(feature = "static-generation", feature = "web"))]
     /// Launch your application.
     pub fn launch(self, app: fn() -> Element) {
         let cfg = self.platform_config.unwrap_or_default();
@@ -197,7 +197,7 @@ impl<Cfg: Default + 'static, ContextFn: ?Sized> LaunchBuilder<Cfg, ContextFn> {
         (self.launch_fn)(app, self.contexts, cfg)
     }
 
-    #[cfg(not(feature = "static-generation"))]
+    #[cfg(not(any(feature = "static-generation", feature = "web")))]
     /// Launch your application.
     pub fn launch(self, app: fn() -> Element) -> ! {
         let cfg = self.platform_config.unwrap_or_default();
@@ -355,9 +355,9 @@ macro_rules! impl_launch {
 }
 
 // Static generation is the only platform that may exit. We can't use the `!` type here
-#[cfg(feature = "static-generation")]
+#[cfg(any(feature = "static-generation", feature = "web"))]
 impl_launch!(());
-#[cfg(not(feature = "static-generation"))]
+#[cfg(not(any(feature = "static-generation", feature = "web")))]
 impl_launch!(!);
 
 #[cfg(feature = "web")]

--- a/packages/fullstack/src/launch.rs
+++ b/packages/fullstack/src/launch.rs
@@ -12,7 +12,7 @@ pub fn launch(
     root: fn() -> Element,
     contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
     platform_config: Config,
-) {
+) -> ! {
     let virtual_dom_factory = move || {
         let mut vdom = VirtualDom::new(root);
         for context in &contexts {
@@ -34,7 +34,7 @@ pub fn launch(
         {
             // TODO: this should pull the props from the document
             let cfg = platform_config.web_cfg.hydrate(true);
-            dioxus_web::launch::launch_virtual_dom(virtual_dom_factory(), cfg);
+            dioxus_web::launch::launch_virtual_dom(virtual_dom_factory(), cfg)
         }
 
         #[cfg(feature = "desktop")]
@@ -49,4 +49,6 @@ pub fn launch(
             dioxus_mobile::launch::launch_virtual_dom(virtual_dom_factory(), cfg)
         }
     }
+
+    unreachable!("Launching a fullstack app should never return")
 }

--- a/packages/liveview/src/launch.rs
+++ b/packages/liveview/src/launch.rs
@@ -8,7 +8,7 @@ pub fn launch(
     root: fn() -> Element,
     contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
     platform_config: Config,
-) {
+) -> ! {
     #[cfg(feature = "multi-threaded")]
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     #[cfg(not(feature = "multi-threaded"))]
@@ -28,4 +28,6 @@ pub fn launch(
             .launch()
             .await;
     });
+
+    panic!("Launching a liveview app should never return")
 }

--- a/packages/web/src/launch.rs
+++ b/packages/web/src/launch.rs
@@ -11,24 +11,25 @@ pub fn launch(
     root: fn() -> Element,
     contexts: Vec<Box<dyn Fn() -> Box<dyn Any>>>,
     platform_config: Config,
-) {
+) -> ! {
     let mut vdom = VirtualDom::new(root);
     for context in contexts {
         vdom.insert_any_root_context(context());
     }
-    launch_virtual_dom(vdom, platform_config);
+    launch_virtual_dom(vdom, platform_config)
 }
 
 /// Launch the web application with a prebuild virtual dom
 ///
 /// For a builder API, see `LaunchBuilder` defined in the `dioxus` crate.
-pub fn launch_virtual_dom(vdom: VirtualDom, platform_config: Config) {
+pub fn launch_virtual_dom(vdom: VirtualDom, platform_config: Config) -> ! {
     wasm_bindgen_futures::spawn_local(async move {
         crate::run(vdom, platform_config).await;
     });
+    unreachable!("launch will never exit")
 }
 
 /// Launch the web application with the given root component and config
-pub fn launch_cfg(root: fn() -> Element, platform_config: Config) {
-    launch_virtual_dom(VirtualDom::new(root), platform_config);
+pub fn launch_cfg(root: fn() -> Element, platform_config: Config) -> ! {
+    launch_virtual_dom(VirtualDom::new(root), platform_config)
 }

--- a/packages/web/src/launch.rs
+++ b/packages/web/src/launch.rs
@@ -11,7 +11,7 @@ pub fn launch(
     root: fn() -> Element,
     contexts: Vec<Box<dyn Fn() -> Box<dyn Any>>>,
     platform_config: Config,
-) -> ! {
+) {
     let mut vdom = VirtualDom::new(root);
     for context in contexts {
         vdom.insert_any_root_context(context());
@@ -22,14 +22,13 @@ pub fn launch(
 /// Launch the web application with a prebuild virtual dom
 ///
 /// For a builder API, see `LaunchBuilder` defined in the `dioxus` crate.
-pub fn launch_virtual_dom(vdom: VirtualDom, platform_config: Config) -> ! {
+pub fn launch_virtual_dom(vdom: VirtualDom, platform_config: Config) {
     wasm_bindgen_futures::spawn_local(async move {
         crate::run(vdom, platform_config).await;
     });
-    unreachable!("launch will never exit")
 }
 
 /// Launch the web application with the given root component and config
-pub fn launch_cfg(root: fn() -> Element, platform_config: Config) -> ! {
+pub fn launch_cfg(root: fn() -> Element, platform_config: Config) {
     launch_virtual_dom(VirtualDom::new(root), platform_config)
 }


### PR DESCRIPTION
This PR changes the function signature of `launch` to return `!`. This tells the compiler that it can never exit which provides warnings if you try to run code after the launch function like this code snippet:
![Screenshot 2024-06-13 at 4 56 58 PM](https://github.com/DioxusLabs/dioxus/assets/66571940/4fb8f589-6f38-45ea-8b8a-c5b4b7bbaf9f)
