### PR TITLE
Update `dioxus_desktop::Config` to also allow for asynchronous custom protocol handlers

### DIFF
--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -169,6 +169,10 @@ impl WebviewInstance {
             webview = webview.with_custom_protocol(name, handler);
         }
 
+        for (name, handler) in cfg.asynchronous_protocols.drain(..) {
+            webview = webview.with_asynchronous_custom_protocol(name, handler);
+        }
+
         const INITIALIZATION_SCRIPT: &str = r#"
         if (document.addEventListener) {
             document.addEventListener('contextmenu', function(e) {


### PR DESCRIPTION
This is a very simple PR, that is tested to work on my Fedora machine, although I'm unable to do any real testing on other OSs.

For some reason `wry` doesn't like using synchronous custom protocols, I'm sure you've experienced that since it appear's you're also using the asynchronous one, so I've added an extra config option that adds asynchronous ones.

this is gonna be a case of certified ISO 9000 - Works on my machine, as such I encourage others to test on their machines.

Also added a QoL fix that allows the passing of anything that implements `ToString` instead of a string, since it may be a safe assumption that most of the time, it'd be passed in as a string literal.

