### PR TITLE
Revision: Change Default Fullstack IP

### DIFF
--- a/packages/fullstack/src/config.rs
+++ b/packages/fullstack/src/config.rs
@@ -32,7 +32,7 @@ impl Default for Config {
             #[cfg(feature = "server")]
             server_fn_route: "",
             #[cfg(feature = "server")]
-            addr: std::net::SocketAddr::from(([127, 0, 0, 1], 8080)),
+            addr: std::net::SocketAddr::from(([0, 0, 0, 0], 8080)),
             #[cfg(feature = "server")]
             server_cfg: ServeConfigBuilder::new(),
             #[cfg(feature = "web")]


### PR DESCRIPTION
Changes the default listen IP for fullstack from `127.0.0.1` to `0.0.0.0` so that external connections are allowed by default for a more "launch and go" experience with deployment.