### PR TITLE
Chore: move todo!() to unimplemented!()

### DIFF
--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -454,7 +454,7 @@ impl VNode {
     /// # use dioxus::prelude::*;
     /// # let enabled = true;
     /// # #[component]
-    /// # fn Component(enabled_sign: String) -> Element { todo!() }
+    /// # fn Component(enabled_sign: String) -> Element { unimplemented!() }
     /// if enabled {
     ///     rsx!{ Component { enabled_sign: "abc" } }
     /// } else {
@@ -468,7 +468,7 @@ impl VNode {
     /// ```rust, no_run
     /// # use dioxus::prelude::*;
     /// # #[component]
-    /// # fn Component(enabled_sign: String) -> Element { todo!() }
+    /// # fn Component(enabled_sign: String) -> Element { unimplemented!() }
     /// # let enabled = true;
     /// let props = if enabled {
     ///     ComponentProps { enabled_sign: "abc".to_string() }

--- a/packages/core/src/error_boundary.rs
+++ b/packages/core/src/error_boundary.rs
@@ -455,7 +455,7 @@ impl<
 ///
 /// ```rust
 /// # use dioxus::prelude::*;
-/// # fn ThrowsError() -> Element { todo!() }
+/// # fn ThrowsError() -> Element { unimplemented!() }
 /// rsx! {
 ///     ErrorBoundary {
 ///         handle_error: |error| rsx! { "Oops, we encountered an error. Please report {error} to the developer of this application" },

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -151,10 +151,10 @@ use tracing::instrument;
 /// #         Self {}
 /// #     }
 /// #     fn apply(&mut self) -> Mutations {
-/// #         todo!()
+/// #         unimplemented!()
 /// #     }
 /// #     async fn wait_for_event(&mut self) -> std::rc::Rc<dyn std::any::Any> {
-/// #         todo!()
+/// #         unimplemented!()
 /// #     }
 /// # }
 /// #

--- a/packages/fullstack/src/axum_adapter.rs
+++ b/packages/fullstack/src/axum_adapter.rs
@@ -220,7 +220,7 @@ where
                 Method::GET => self.route(path, get(handler)),
                 Method::POST => self.route(path, post(handler)),
                 Method::PUT => self.route(path, put(handler)),
-                _ => todo!(),
+                _ => unimplemented!("Unsupported server function method: {}", method),
             };
         }
 

--- a/packages/hooks/src/use_sorted.rs
+++ b/packages/hooks/src/use_sorted.rs
@@ -14,7 +14,7 @@ pub fn use_sorted<V: 'static, T: PartialEq>(
 //     I: DerefMut<Target = [T]> + Clone + PartialEq,
 {
     use_memo(move || {
-        todo!()
+        unimplemented!()
         // let mut iterable = collection();
         // iterable.sort();
         // iterable

--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -230,7 +230,7 @@ macro_rules! impl_element {
         /// ```rust, no_run
         /// # use dioxus::prelude::*;
         /// # let attributes = vec![];
-        /// # fn ChildComponent() -> Element { todo!() }
+        /// # fn ChildComponent() -> Element { unimplemented!() }
         /// # let raw_expression: Element = rsx! {};
         /// rsx! {
         ///     // Elements are followed by braces that surround any attributes and children for that element
@@ -283,7 +283,7 @@ macro_rules! impl_element {
         /// ```rust, no_run
         /// # use dioxus::prelude::*;
         /// # let attributes = vec![];
-        /// # fn ChildComponent() -> Element { todo!() }
+        /// # fn ChildComponent() -> Element { unimplemented!() }
         /// # let raw_expression: Element = rsx! {};
         /// rsx! {
         ///     // Elements are followed by braces that surround any attributes and children for that element
@@ -337,7 +337,7 @@ macro_rules! impl_element {
         /// ```rust, no_run
         /// # use dioxus::prelude::*;
         /// # let attributes = vec![];
-        /// # fn ChildComponent() -> Element { todo!() }
+        /// # fn ChildComponent() -> Element { unimplemented!() }
         /// # let raw_expression: Element = rsx! {};
         /// rsx! {
         ///     // Elements are followed by braces that surround any attributes and children for that element
@@ -584,7 +584,7 @@ macro_rules! builder_constructors {
                     /// ```rust, no_run
                     /// # use dioxus::prelude::*;
                     /// # let attributes = vec![];
-                    /// # fn ChildComponent() -> Element { todo!() }
+                    /// # fn ChildComponent() -> Element { unimplemented!() }
                     /// # let raw_expression: Element = rsx! {};
                     /// rsx! {
                     ///     // Elements are followed by braces that surround any attributes and children for that element

--- a/packages/router/src/routable.rs
+++ b/packages/router/src/routable.rs
@@ -64,7 +64,7 @@ impl<E: Display> Display for RouteParseError<E> {
 ///
 /// # #[component]
 /// # fn Home(query: CustomQuery) -> Element {
-/// #     todo!()
+/// #     unimplemented!()
 /// # }
 /// ```
 #[rustversion::attr(
@@ -132,7 +132,7 @@ impl<T: for<'a> From<&'a str>> FromQuery for T {
 ///
 /// # #[component]
 /// # fn Home(query: CustomQuery, other: i32) -> Element {
-/// #     todo!()
+/// #     unimplemented!()
 /// # }
 /// ```
 #[rustversion::attr(
@@ -190,7 +190,7 @@ where
 ///
 /// #[component]
 /// fn Home(url_hash: State) -> Element {
-///     todo!()
+///     unimplemented!()
 /// }
 ///
 ///
@@ -217,7 +217,7 @@ where
 ///
 ///         let first = first.parse().unwrap();
 ///         let second = second.parse().unwrap();
-///         
+///
 ///         State {
 ///             count: first,
 ///             other_count: second,
@@ -301,7 +301,7 @@ where
 ///
 /// # #[component]
 /// # fn Home(route_segment_one: CustomRouteSegment, route_segment_two: i32) -> Element {
-/// #     todo!()
+/// #     unimplemented!()
 /// # }
 /// ```
 #[rustversion::attr(
@@ -388,7 +388,7 @@ fn full_circle() {
 ///
 /// # #[component]
 /// # fn Home(numeric_route_segments: NumericRouteSegments) -> Element {
-/// #     todo!()
+/// #     unimplemented!()
 /// # }
 /// ```
 pub trait ToRouteSegments {
@@ -478,7 +478,7 @@ fn to_route_segments() {
 ///
 /// # #[component]
 /// # fn Home(numeric_route_segments: NumericRouteSegments) -> Element {
-/// #     todo!()
+/// #     unimplemented!()
 /// # }
 /// ```
 #[rustversion::attr(

--- a/packages/router/tests/site_map.rs
+++ b/packages/router/tests/site_map.rs
@@ -22,22 +22,22 @@ fn with_class() {
 
     #[component]
     fn Test() -> Element {
-        todo!()
+        unimplemented!()
     }
 
     #[component]
     fn Root() -> Element {
-        todo!()
+        unimplemented!()
     }
 
     #[component]
     fn ChildRoot() -> Element {
-        todo!()
+        unimplemented!()
     }
 
     #[component]
     fn NotStatic(not_static: String) -> Element {
-        todo!()
+        unimplemented!()
     }
 
     assert_eq!(

--- a/packages/server-macro/src/lib.rs
+++ b/packages/server-macro/src/lib.rs
@@ -53,7 +53,7 @@ use syn::__private::ToTokens;
 ///   output = Json
 /// )]
 /// pub async fn my_wacky_server_fn(input: Vec<String>) -> Result<usize, ServerFnError> {
-///   todo!()
+///   unimplemented!()
 /// }
 ///
 /// // expands to

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -272,13 +272,13 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
     /// main.rs:
     /// ```rust, no_run
     /// # use dioxus::prelude::*;
-    /// # fn Child() -> Element { todo!() }
+    /// # fn Child() -> Element { unimplemented!() }
     /// fn app() -> Element {
     ///     let signal = use_context_provider(|| Signal::new(0));
-    ///     
+    ///
     ///     // We want to log the value of the signal whenever the app component reruns
     ///     println!("{}", *signal.read());
-    ///     
+    ///
     ///     rsx! {
     ///         button {
     ///             // If we don't want to rerun the app component when the button is clicked, we can use write_silent
@@ -294,7 +294,7 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
     /// # use dioxus::prelude::*;
     /// fn Child() -> Element {
     ///     let signal: Signal<i32> = use_context();
-    ///     
+    ///
     ///     // It is difficult to tell that changing the button to use write_silent in the main.rs file will cause UI to be out of sync in a completely different file
     ///     rsx! {
     ///         "{signal}"
@@ -308,13 +308,13 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
     /// main.rs:
     /// ```rust, no_run
     /// # use dioxus::prelude::*;
-    /// # fn Child() -> Element { todo!() }
+    /// # fn Child() -> Element { unimplemented!() }
     /// fn app() -> Element {
     ///     let mut signal = use_context_provider(|| Signal::new(0));
-    ///     
+    ///
     ///     // We want to log the value of the signal whenever the app component reruns, but we don't want to rerun the app component when the signal is updated so we use peek instead of read
     ///     println!("{}", *signal.peek());
-    ///     
+    ///
     ///     rsx! {
     ///         button {
     ///             // We can use write like normal and update the child component automatically
@@ -330,7 +330,7 @@ impl<T: 'static, S: Storage<SignalData<T>>> Signal<T, S> {
     /// # use dioxus::prelude::*;
     /// fn Child() -> Element {
     ///     let signal: Signal<i32> = use_context();
-    ///     
+    ///
     ///     rsx! {
     ///         "{signal}"
     ///     }
@@ -550,7 +550,7 @@ struct Counts {
 
 fn app() -> Element {
     let mut counts = use_signal(|| Counts { count1: 0, count2: 0 });
-    
+
     use_effect(move || {
         // This effect both reads and writes to counts
         counts.write().count1 = counts().count2;


### PR DESCRIPTION
I like using todo!() as an indicator of code that hasn't been finished yet in a given PR but having them scattered throughout main breaks that workflow.

This simple tweak changes todo!() to unimplemented!() in the doctests which leaves us with zero todo!() left in the codebase.

I did this in #2258 but am splitting this out to a separate PR to shrink the diff on that PR.