### PR TITLE
Improve warnings when trying to update outside of pending suspense boundaries on the server

### DIFF
--- a/packages/core/src/any_props.rs
+++ b/packages/core/src/any_props.rs
@@ -83,7 +83,7 @@ impl<F: ComponentFunction<P, M> + Clone, P: Clone + 'static, M: 'static> AnyProp
             Ok(node) => RenderReturn { node },
             Err(err) => {
                 let component_name = self.name;
-                tracing::error!("Error while rendering component `{component_name}`: {err:?}");
+                tracing::error!("Panic while rendering component `{component_name}`: {err:?}");
                 let panic = CapturedPanic { error: err };
                 RenderReturn {
                     node: Err(panic.into()),

--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -85,6 +85,9 @@ impl VirtualDom {
         };
 
         self.dirty_scopes.remove(&ScopeOrder::new(height, id));
+
+        // If this scope was a suspense boundary, remove it from the resolved scopes
+        self.resolved_scopes.retain(|s| s != &id);
     }
 }
 

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -23,10 +23,7 @@ impl VirtualDom {
         };
         let suspense_boundary = self
             .runtime
-            .suspense_stack
-            .borrow()
-            .last()
-            .cloned()
+            .current_suspense_location()
             .unwrap_or(SuspenseLocation::NotSuspended);
         let entry = self.scopes.vacant_entry();
         let id = ScopeId(entry.key());
@@ -55,45 +52,46 @@ impl VirtualDom {
             crate::Runtime::current().is_some(),
             "Must be in a dioxus runtime"
         );
-        self.runtime.push_scope(scope_id);
+        self.runtime.clone().with_scope_on_stack(scope_id, || {
+            let scope = &self.scopes[scope_id.0];
+            let output = {
+                let scope_state = scope.state();
 
-        let scope = &self.scopes[scope_id.0];
-        let output = {
+                scope_state.hook_index.set(0);
+
+                // Run all pre-render hooks
+                for pre_run in scope_state.before_render.borrow_mut().iter_mut() {
+                    pre_run();
+                }
+
+                let props: &dyn AnyProps = &*scope.props;
+
+                let span = tracing::trace_span!("render", scope = %scope.state().name);
+                span.in_scope(|| {
+                    scope.reactive_context.reset_and_run_in(|| {
+                        let mut render_return = props.render();
+                        self.handle_element_return(
+                            &mut render_return.node,
+                            scope_id,
+                            &scope.state(),
+                        );
+                        render_return
+                    })
+                })
+            };
+
             let scope_state = scope.state();
 
-            scope_state.hook_index.set(0);
-
-            // Run all pre-render hooks
-            for pre_run in scope_state.before_render.borrow_mut().iter_mut() {
-                pre_run();
+            // Run all post-render hooks
+            for post_run in scope_state.after_render.borrow_mut().iter_mut() {
+                post_run();
             }
 
-            let props: &dyn AnyProps = &*scope.props;
-
-            let span = tracing::trace_span!("render", scope = %scope.state().name);
-            span.in_scope(|| {
-                scope.reactive_context.reset_and_run_in(|| {
-                    let mut render_return = props.render();
-                    self.handle_element_return(&mut render_return.node, scope_id, &scope.state());
-                    render_return
-                })
-            })
-        };
-
-        let scope_state = scope.state();
-
-        // Run all post-render hooks
-        for post_run in scope_state.after_render.borrow_mut().iter_mut() {
-            post_run();
-        }
-
-        // remove this scope from dirty scopes
-        self.dirty_scopes
-            .remove(&ScopeOrder::new(scope_state.height, scope_id));
-
-        self.runtime.pop_scope();
-
-        output
+            // remove this scope from dirty scopes
+            self.dirty_scopes
+                .remove(&ScopeOrder::new(scope_state.height, scope_id));
+            output
+        })
     }
 
     /// Insert any errors, or suspended tasks from an element return into the runtime
@@ -101,7 +99,7 @@ impl VirtualDom {
         match node {
             Err(RenderError::Aborted(e)) => {
                 tracing::error!(
-                    "Error while rendering component `{}`: {e:?}",
+                    "Error while rendering component `{}`:\n{e}",
                     scope_state.name
                 );
                 throw_error(e.clone_mounted());
@@ -114,7 +112,7 @@ impl VirtualDom {
                     .runtime
                     .get_state(scope_id)
                     .unwrap()
-                    .suspense_boundary();
+                    .suspense_location();
                 let already_suspended = self
                     .runtime
                     .tasks

--- a/packages/core/src/scope_context.rs
+++ b/packages/core/src/scope_context.rs
@@ -24,8 +24,9 @@ pub(crate) enum ScopeStatus {
 pub(crate) enum SuspenseLocation {
     #[default]
     NotSuspended,
-    InSuspensePlaceholder(SuspenseContext),
+    SuspenseBoundary(SuspenseContext),
     UnderSuspense(SuspenseContext),
+    InSuspensePlaceholder(SuspenseContext),
 }
 
 impl SuspenseLocation {
@@ -33,6 +34,7 @@ impl SuspenseLocation {
         match self {
             SuspenseLocation::InSuspensePlaceholder(context) => Some(context),
             SuspenseLocation::UnderSuspense(context) => Some(context),
+            SuspenseLocation::SuspenseBoundary(context) => Some(context),
             _ => None,
         }
     }
@@ -108,17 +110,26 @@ impl Scope {
         }
     }
 
-    /// Get the suspense boundary this scope is currently in (if any)
-    pub(crate) fn suspense_boundary(&self) -> SuspenseLocation {
+    /// Get the suspense location of this scope
+    pub(crate) fn suspense_location(&self) -> SuspenseLocation {
         self.suspense_boundary.clone()
+    }
+
+    /// If this scope is a suspense boundary, return the suspense context
+    pub(crate) fn suspense_boundary(&self) -> Option<SuspenseContext> {
+        match self.suspense_location() {
+            SuspenseLocation::SuspenseBoundary(context) => Some(context),
+            _ => None,
+        }
     }
 
     /// Check if a node should run during suspense
     pub(crate) fn should_run_during_suspense(&self) -> bool {
-        matches!(
-            self.suspense_boundary,
-            SuspenseLocation::UnderSuspense(_) | SuspenseLocation::InSuspensePlaceholder(_)
-        )
+        let Some(context) = self.suspense_boundary.suspense_context() else {
+            return false;
+        };
+
+        !context.frozen()
     }
 
     /// Mark this scope as dirty, and schedule a render for it.

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides the primary mechanics to create a hook-based, concurrent VDOM for Rust.
 
-use crate::innerlude::{SuspenseBoundaryProps, Work};
+use crate::innerlude::Work;
 use crate::properties::RootProps;
 use crate::root_wrapper::RootScopeWrapper;
 use crate::{
@@ -229,6 +229,9 @@ pub struct VirtualDom {
 
     pub(crate) runtime: Rc<Runtime>,
 
+    // The scopes that have been resolved since the last render
+    pub(crate) resolved_scopes: Vec<ScopeId>,
+
     rx: futures_channel::mpsc::UnboundedReceiver<SchedulerMsg>,
 }
 
@@ -334,6 +337,7 @@ impl VirtualDom {
             queued_templates: Default::default(),
             elements: Default::default(),
             mounts: Default::default(),
+            resolved_scopes: Default::default(),
         };
 
         let root = VProps::new(
@@ -776,8 +780,6 @@ impl VirtualDom {
         // Queue any new events before we start working
         self.queue_events();
 
-        let mut resolved_scopes = Vec::new();
-
         // Render whatever work needs to be rendered, unlocking new futures and suspense leaves
         let _runtime = RuntimeGuard::new(self.runtime.clone());
 
@@ -791,34 +793,21 @@ impl VirtualDom {
                     }
                 }
                 Work::RerunScope(scope) => {
-                    if self
+                    let scope_id: ScopeId = scope.id;
+                    let run_scope = self
                         .runtime
                         .get_state(scope.id)
                         .filter(|scope| scope.should_run_during_suspense())
-                        .is_some()
-                    {
-                        let scope_state = self.get_scope(scope.id).unwrap();
-                        let was_suspended =
-                            SuspenseBoundaryProps::downcast_ref_from_props(&*scope_state.props)
-                                .filter(|props| props.suspended())
-                                .is_some();
+                        .is_some();
+                    if run_scope {
                         // If the scope is dirty, run the scope and get the mutations
-                        self.run_and_diff_scope(None::<&mut NoOpMutations>, scope.id);
-                        let scope_state = self.get_scope(scope.id).unwrap();
-                        let is_now_suspended =
-                            SuspenseBoundaryProps::downcast_ref_from_props(&*scope_state.props)
-                                .filter(|props| props.suspended())
-                                .is_some();
+                        self.run_and_diff_scope(None::<&mut NoOpMutations>, scope_id);
 
-                        if is_now_suspended {
-                            resolved_scopes.retain(|&id| id != scope.id);
-                        } else if was_suspended {
-                            resolved_scopes.push(scope.id);
-                        }
+                        tracing::trace!("Ran scope {:?} during suspense", scope_id);
                     } else {
                         tracing::warn!(
                             "Scope {:?} was marked as dirty, but will not rerun during suspense. Only nodes that are under a suspense boundary rerun during suspense",
-                            scope.id
+                            scope_id
                         );
                     }
                 }
@@ -833,8 +822,9 @@ impl VirtualDom {
             }
         }
 
-        resolved_scopes.sort_by_key(|&id| self.runtime.get_state(id).unwrap().height);
-        resolved_scopes
+        self.resolved_scopes
+            .sort_by_key(|&id| self.runtime.get_state(id).unwrap().height);
+        std::mem::take(&mut self.resolved_scopes)
     }
 
     /// Get the current runtime

--- a/packages/fullstack/src/html_storage/serialize.rs
+++ b/packages/fullstack/src/html_storage/serialize.rs
@@ -1,6 +1,7 @@
 use dioxus_lib::prelude::dioxus_core::DynamicNode;
 use dioxus_lib::prelude::{
-    has_context, try_consume_context, ScopeId, SuspenseBoundaryProps, VNode, VirtualDom,
+    has_context, try_consume_context, ScopeId, SuspenseBoundaryProps, SuspenseContext, VNode,
+    VirtualDom,
 };
 use serde::Serialize;
 
@@ -49,9 +50,11 @@ impl super::HTMLData {
         // then continue to any children
         if let Some(scope) = vdom.get_scope(scope) {
             // If this is a suspense boundary, move into the children first (even if they are suspended) because that will be run first on the client
-            if let Some(suspense_boundary) = SuspenseBoundaryProps::downcast_from_scope(scope) {
-                if let Some(node) = suspense_boundary.suspended_nodes.as_ref() {
-                    self.take_from_vnode(vdom, node);
+            if let Some(suspense_boundary) =
+                SuspenseContext::downcast_suspense_boundary_from_scope(&vdom.runtime(), scope.id())
+            {
+                if let Some(node) = suspense_boundary.suspended_nodes() {
+                    self.take_from_vnode(vdom, &node);
                 }
             }
             if let Some(node) = scope.try_root_node() {

--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -243,7 +243,6 @@ impl SsrRendererPool {
 
                 // Just rerender the resolved nodes
                 for scope in resolved_suspense_nodes {
-                    tracing::info!("Resolving {scope:?}");
                     let mount = {
                         let mut lock = scope_to_mount_mapping.write().unwrap();
                         lock.remove(&scope)

--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -181,10 +181,12 @@ impl SsrRendererPool {
                 let scope_to_mount_mapping = scope_to_mount_mapping.clone();
                 let stream = stream.clone();
                 renderer.set_render_components(move |renderer, to, vdom, scope| {
-                    let is_suspense_boundary = vdom
-                        .get_scope(scope)
-                        .and_then(|s| SuspenseBoundaryProps::downcast_from_scope(s))
-                        .filter(|s| s.suspended())
+                    let is_suspense_boundary =
+                        SuspenseContext::downcast_suspense_boundary_from_scope(
+                            &vdom.runtime(),
+                            scope,
+                        )
+                        .filter(|s| s.has_suspended_tasks())
                         .is_some();
                     if is_suspense_boundary {
                         let mount = stream.render_placeholder(
@@ -241,29 +243,40 @@ impl SsrRendererPool {
 
                 // Just rerender the resolved nodes
                 for scope in resolved_suspense_nodes {
+                    tracing::info!("Resolving {scope:?}");
                     let mount = {
                         let mut lock = scope_to_mount_mapping.write().unwrap();
-                        lock.remove(&scope).unwrap()
+                        lock.remove(&scope)
                     };
-                    let mut resolved_chunk = String::new();
-                    // After we replace the placeholder in the dom with javascript, we need to send down the resolved data so that the client can hydrate the node
-                    let render_suspense = |into: &mut String| {
-                        renderer.reset_hydration();
-                        renderer.render_scope(into, &virtual_dom, scope)
-                    };
-                    let resolved_data = serialize_server_data(&virtual_dom, scope);
-                    if let Err(err) = stream.replace_placeholder(
-                        mount,
-                        render_suspense,
-                        resolved_data,
-                        &mut resolved_chunk,
-                    ) {
-                        throw_error!(
-                            dioxus_ssr::incremental::IncrementalRendererError::RenderError(err)
-                        );
-                    }
+                    // If the suspense boundary was immediately removed, it may not have a mount. We can just skip resolving it
+                    if let Some(mount) = mount {
+                        let mut resolved_chunk = String::new();
+                        // After we replace the placeholder in the dom with javascript, we need to send down the resolved data so that the client can hydrate the node
+                        let render_suspense = |into: &mut String| {
+                            renderer.reset_hydration();
+                            renderer.render_scope(into, &virtual_dom, scope)
+                        };
+                        let resolved_data = serialize_server_data(&virtual_dom, scope);
+                        if let Err(err) = stream.replace_placeholder(
+                            mount,
+                            render_suspense,
+                            resolved_data,
+                            &mut resolved_chunk,
+                        ) {
+                            throw_error!(
+                                dioxus_ssr::incremental::IncrementalRendererError::RenderError(err)
+                            );
+                        }
 
-                    stream.render(resolved_chunk);
+                        stream.render(resolved_chunk);
+                    }
+                    // Freeze the suspense boundary to prevent future reruns of any child nodes of the suspense boundary
+                    if let Some(suspense) = SuspenseContext::downcast_suspense_boundary_from_scope(
+                        &virtual_dom.runtime(),
+                        scope,
+                    ) {
+                        suspense.freeze();
+                    }
                 }
             }
             tracing::info!("Suspense resolved");

--- a/packages/web/src/hydration/hydrate.rs
+++ b/packages/web/src/hydration/hydrate.rs
@@ -226,8 +226,10 @@ impl WebsysDom {
         to_mount: &mut Vec<ElementId>,
     ) -> Result<(), RehydrationError> {
         // If this scope is a suspense boundary that is pending, add it to the list of pending suspense boundaries
-        if let Some(suspense) = SuspenseBoundaryProps::downcast_from_scope(scope) {
-            if suspense.suspended() {
+        if let Some(suspense) =
+            SuspenseContext::downcast_suspense_boundary_from_scope(&dom.runtime(), scope.id())
+        {
+            if suspense.has_suspended_tasks() {
                 self.suspense_hydration_ids
                     .add_suspense_boundary(scope.id());
             }


### PR DESCRIPTION
Fixes the panic in https://github.com/DioxusLabs/dioxus/issues/2570. This PR fixes warnings when trying to update nodes on the server in the resolved part of the tree. This can happen when an error boundary is above a suspense boundary and the suspense boundary throws an error up into the client controlled error boundary.

It also fixes `render_suspense_immediate` returning `ScopeId`s that were removed