### PR TITLE
fix (desktop): hide window until the first render

### DIFF
--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -206,9 +206,10 @@ impl App {
 
     pub fn handle_start_cause_init(&mut self) {
         let virtual_dom = self.unmounted_dom.take().unwrap();
-        let cfg = self.cfg.take().unwrap();
+        let mut cfg = self.cfg.take().unwrap();
 
         self.is_visible_before_start = cfg.window.window.visible;
+        cfg.window = cfg.window.with_visible(false);
 
         let webview = WebviewInstance::new(cfg, virtual_dom, self.shared.clone());
 


### PR DESCRIPTION
fixes regression of https://github.com/DioxusLabs/dioxus/pull/1588 mentioned in discord.

It looks like a [single line](https://github.com/DioxusLabs/dioxus/pull/1588/files#diff-b0579535f28f7caa593a8664352df35bb34350c47fe2c326d6f4af792bb3a439R16) was missed when translating to v5 which changed the builder setting for `set_visible` to false until after rendering