### PR TITLE
[feat:host-env] To deploy fullstack on AWS Fargate, added `HOST` environment to expose service externally

### DIFF
--- a/packages/fullstack/src/config.rs
+++ b/packages/fullstack/src/config.rs
@@ -32,7 +32,10 @@ impl Default for Config {
             #[cfg(feature = "server")]
             server_fn_route: "",
             #[cfg(feature = "server")]
-            addr: std::net::SocketAddr::from(([127, 0, 0, 1], 8080)),
+            addr:  match option_env!("HOST") {
+                Some(addr) => addr.parse().unwrap(),
+                None => std::net::SocketAddr::from(([127, 0, 0, 1], 8080)),
+            },
             #[cfg(feature = "server")]
             server_cfg: ServeConfigBuilder::new(),
             #[cfg(feature = "web")]


### PR DESCRIPTION
- Fargate is the only way to deploy of dioxus fullstack on AWS.
  - However, `127.0.0.1` blocks to expose port to ESC Service.

Currently, we can change host address by `addr` function. However, to use it, we need to handle complicated entry point at apps.
