### PR TITLE
Allow no trailing comma after attributes

### DIFF
--- a/packages/rsx/src/attribute.rs
+++ b/packages/rsx/src/attribute.rs
@@ -352,7 +352,7 @@ impl Attribute {
                     // Autocomplete as an element
                     pub use super::dioxus_elements::elements::completions::CompleteWithBraces::*;
                     fn ignore() {
-                        #name
+                        #name;
                     }
                 }
             }


### PR DESCRIPTION
We parse attributes with no trailing comma, but because of the way we expand the completions module, it was generating a compile error. This PR fixes that issue

Fixes #2626