### PR TITLE
Expand to a partial Component if a shorthand attribute starts with a capital letter

### DIFF
--- a/packages/rsx/src/rsx_block.rs
+++ b/packages/rsx/src/rsx_block.rs
@@ -139,8 +139,19 @@ impl RsxBlock {
 
             // Parse shorthand attributes
             // todo: this might cause complications with partial expansion... think more about the cases
-            // where we can imagine expansion and what better diagnostics we can providea
-            if content.peek(Ident)
+            // where we can imagine expansion and what better diagnostics we can provide
+            let looks_like_attribute = match content.fork().parse::<Ident>() {
+                // If it is an ident, it is only a shorthand attribute if it starts with a lowercase letter
+                // Otherwise this is the start of a component
+                Ok(ident) => ident
+                    .to_string()
+                    .chars()
+                    .next()
+                    .unwrap()
+                    .is_ascii_lowercase(),
+                Err(_) => false,
+            };
+            if looks_like_attribute
                 && !content.peek2(Brace)
                 && !content.peek2(Token![:]) // regular attributes / components with generics
                 && !content.peek2(Token![-]) // web components


### PR DESCRIPTION
If we hit something like this:
```rust
div {
    Com
}
```

This PR expands `Com` to a partial component instead of an attribute. For elements this should be non-breaking, but for component properties, this is technically breaking if anyone was using properties that start with a capital letter