### PR TITLE
Fix deriving props with a where clause and an owner

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -1397,12 +1397,13 @@ Finally, call `.build()` to create the instance of `{name}`.
                 let original_name = &self.name;
                 let vis = &self.vis;
                 let generics_with_bounds = &self.generics;
+                let where_clause = &self.generics.where_clause;
 
                 quote! {
                     #[doc(hidden)]
                     #[allow(dead_code, non_camel_case_types, missing_docs)]
                     #[derive(Clone)]
-                    #vis struct #name #generics_with_bounds {
+                    #vis struct #name #generics_with_bounds #where_clause {
                         inner: #original_name #ty_generics,
                         owner: Owner,
                     }

--- a/packages/core-macro/tests/generics.rs
+++ b/packages/core-macro/tests/generics.rs
@@ -1,0 +1,64 @@
+use dioxus::prelude::*;
+
+// This test just checks that props compile with generics
+// It will not actually run any code
+#[test]
+#[allow(unused)]
+#[allow(non_snake_case)]
+fn generic_props_compile() {
+    fn app() -> Element {
+        rsx! {
+            TakesClone {
+                value: "hello world"
+            }
+            TakesCloneManual {
+                value: "hello world"
+            }
+            TakesCloneManualWhere {
+                value: "hello world"
+            }
+        }
+    }
+
+    #[component]
+    fn TakesClone<T: Clone + PartialEq + 'static>(value: T) -> Element {
+        rsx! {}
+    }
+
+    #[derive(Props, Clone, PartialEq)]
+    struct TakesCloneManualProps<T: Clone + PartialEq + 'static> {
+        value: T,
+    }
+
+    fn TakesCloneManual<T: Clone + PartialEq>(props: TakesCloneManualProps<T>) -> Element {
+        rsx! {}
+    }
+
+    #[derive(Props, Clone, PartialEq)]
+    struct TakesCloneManualWhereProps<T>
+    where
+        T: Clone + PartialEq + 'static,
+    {
+        value: T,
+    }
+
+    fn TakesCloneManualWhere<T: Clone + PartialEq>(
+        props: TakesCloneManualWhereProps<T>,
+    ) -> Element {
+        rsx! {}
+    }
+
+    #[derive(Props, Clone, PartialEq)]
+    struct TakesCloneManualWhereWithOwnerProps<T>
+    where
+        T: Clone + PartialEq + 'static,
+    {
+        value: EventHandler<T>,
+    }
+
+    fn TakesCloneManualWhereWithOwner<T: Clone + PartialEq>(
+        props: TakesCloneManualWhereWithOwnerProps<T>,
+    ) -> Element {
+        rsx! {}
+    }
+}


### PR DESCRIPTION
If the struct is defined with a where clause we need to forward that clause to the version of the builder that owns the data. This PR forwards the clause and adds tests for prop generics to prevent regressions

Fixes #2663