### PR TITLE
Improve error message when the CLI and dioxus versions don't match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2558,6 +2558,7 @@ dependencies = [
 name = "dioxus-cli-config"
 version = "0.5.2"
 dependencies = [
+ "built",
  "cargo_toml",
  "clap 4.5.9",
  "dirs",

--- a/packages/cli-config/Cargo.toml
+++ b/packages/cli-config/Cargo.toml
@@ -23,6 +23,9 @@ tauri-utils = { workspace = true, optional = true }
 
 dirs = { workspace = true, optional = true }
 
+[build-dependencies]
+built = { version = "=0.7.3", features = ["git2"] }
+
 [features]
 default = ["read-config"]
 cli = ["dep:tauri-bundler", "dep:tauri-utils", "read-from-args", "dep:toml", "dep:cargo_toml", "dep:dirs"]

--- a/packages/cli-config/build.rs
+++ b/packages/cli-config/build.rs
@@ -2,6 +2,8 @@
 // This means that some library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application.
 
 fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+
     println!("cargo:rerun-if-env-changed=DIOXUS_CONFIG");
     let dioxus_config = std::env::var("DIOXUS_CONFIG");
     let built_with_dioxus = dioxus_config.is_ok();

--- a/packages/cli-config/src/build_info.rs
+++ b/packages/cli-config/src/build_info.rs
@@ -1,0 +1,2 @@
+// The file has been placed there by the build script.
+include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -11,19 +11,23 @@ pub use bundle::*;
 mod serve;
 pub use serve::*;
 
+mod build_info;
+
 #[doc(hidden)]
 pub mod __private {
     use crate::DioxusConfig;
 
+    pub(crate) const DIOXUS_CLI_VERSION: &str = "DIOXUS_CLI_VERSION";
     pub(crate) const CONFIG_ENV: &str = "DIOXUS_CONFIG";
     pub(crate) const CONFIG_BASE_PATH_ENV: &str = "DIOXUS_CONFIG_BASE_PATH";
 
-    pub fn save_config(config: &DioxusConfig) -> CrateConfigDropGuard {
+    pub fn save_config(config: &DioxusConfig, cli_version: &str) -> CrateConfigDropGuard {
         std::env::set_var(CONFIG_ENV, serde_json::to_string(config).unwrap());
         std::env::set_var(
             CONFIG_BASE_PATH_ENV,
             config.web.app.base_path.clone().unwrap_or_default(),
         );
+        std::env::set_var(DIOXUS_CLI_VERSION, cli_version);
         CrateConfigDropGuard
     }
 
@@ -34,6 +38,7 @@ pub mod __private {
         fn drop(&mut self) {
             std::env::remove_var(CONFIG_ENV);
             std::env::remove_var(CONFIG_BASE_PATH_ENV);
+            std::env::remove_var(DIOXUS_CLI_VERSION);
         }
     }
 
@@ -61,11 +66,28 @@ pub static CURRENT_CONFIG: once_cell::sync::Lazy<
     Result<crate::config::DioxusConfig, DioxusCLINotUsed>,
 > = once_cell::sync::Lazy::new(|| {
     CURRENT_CONFIG_JSON
-        .and_then(|config| serde_json::from_str(config).ok())
-        .ok_or_else(|| {
-            tracing::warn!("A library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application.");
-            DioxusCLINotUsed
-    })
+    .ok_or_else(|| {
+        tracing::warn!("A library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application.");
+        DioxusCLINotUsed
+}).and_then(
+    |config|
+    match serde_json::from_str(config) {
+        Ok(config) => Ok(config),
+        Err(err) => {
+            let mut cli_version = crate::build_info::PKG_VERSION.to_string();
+
+            if let Some(hash) = crate::build_info::GIT_COMMIT_HASH_SHORT {
+                let hash = &hash.trim_start_matches('g')[..4];
+                cli_version.push_str(&format!("-{hash}"));
+            }
+
+            let dioxus_version = std::option_env!("DIOXUS_CLI_VERSION").unwrap_or("unknown");
+
+            tracing::warn!("Failed to parse the CLI config file. This is likely caused by a mismatch between the version of the CLI and the dioxus version.\nCLI version: {cli_version}\nDioxus version: {dioxus_version}\nSerialization error: {err}");
+            Err(DioxusCLINotUsed)
+        }
+    }
+)
 });
 
 #[cfg(feature = "read-config")]

--- a/packages/cli/src/builder/cargo.rs
+++ b/packages/cli/src/builder/cargo.rs
@@ -96,7 +96,15 @@ impl BuildRequest {
         tracing::info!("🚅 Running build [Desktop] command...");
 
         // Set up runtime guards
-        let _guard = dioxus_cli_config::__private::save_config(&self.dioxus_crate.dioxus_config);
+        let mut dioxus_version = crate::dx_build_info::PKG_VERSION.to_string();
+        if let Some(hash) = crate::dx_build_info::GIT_COMMIT_HASH_SHORT {
+            let hash = &hash.trim_start_matches('g')[..4];
+            dioxus_version.push_str(&format!("-{hash}"));
+        }
+        let _guard = dioxus_cli_config::__private::save_config(
+            &self.dioxus_crate.dioxus_config,
+            &dioxus_version,
+        );
         let _manganis_support = ManganisSupportGuard::default();
         let _asset_guard = AssetConfigDropGuard::new();
 


### PR DESCRIPTION
Instead of complaining that the application isn't built with the CLI if serialization of the dioxus config fails. This PR tells the user that the versions might be mismatching and prints the versions for debugging