### PR TITLE
Fix: CLI Drain Logs

### DIFF
--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -246,12 +246,14 @@ impl Output {
     /// to be.
     fn drain_print_logs(&mut self) {
         // todo: print the build info here for the most recent build, and then the logs of the most recent build
-        for (platform, build) in self.build_progress.build_logs.iter() {
+        for (platform, build) in self.build_progress.build_logs.iter_mut() {
             if build.messages.is_empty() {
                 continue;
             }
 
-            for message in build.messages.iter() {
+            let messages = build.messages.drain(0..);
+
+            for message in messages {
                 match &message.message {
                     MessageType::Cargo(diagnostic) => {
                         println!(


### PR DESCRIPTION
Logs weren't being removed after printing and would spam in the console in non-interactive mode.