### PR TITLE
Fix: File Watcher Ignore List

### DIFF
--- a/packages/cli/src/serve/watcher.rs
+++ b/packages/cli/src/serve/watcher.rs
@@ -38,8 +38,12 @@ impl Watcher {
         allow_watch_path.dedup();
 
         let crate_dir = config.crate_dir();
-        let gitignore_file_path = crate_dir.join(".gitignore");
-        let mut builder = ignore::gitignore::GitignoreBuilder::new(gitignore_file_path);
+        let mut builder = ignore::gitignore::GitignoreBuilder::new(&crate_dir);
+        builder.add(crate_dir.join(".gitignore"));
+
+        let out_dir = config.out_dir();
+        let out_dir_str = out_dir.display().to_string();
+
         let excluded_paths = vec![
             ".git",
             ".github",
@@ -48,9 +52,12 @@ impl Watcher {
             "node_modules",
             "dist",
             ".dioxus",
+            &out_dir_str,
         ];
         for path in excluded_paths {
-            builder.add(path);
+            builder
+                .add_line(None, path)
+                .expect("failed to add path to file excluder");
         }
         let ignore = builder.build().unwrap();
 


### PR DESCRIPTION
We were feeding the `ignore` crate the wrong data and it would build an empty ignore list. Fixing this greatly speeds up `serve` start times as we aren't checking every file in folders like `target`.