### PR TITLE
feat(cli): added git commit hash to version output

### DIFF
--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -13,6 +13,7 @@ pub mod translate;
 use crate::{custom_error, error::Result, Error};
 use clap::{Parser, Subcommand};
 use html_parser::Dom;
+use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::{
     fmt::Display,
@@ -22,9 +23,17 @@ use std::{
     process::{Command, Stdio},
 };
 
+pub static VERSION: Lazy<String> = Lazy::new(|| {
+    format!(
+        "{} ({})",
+        crate::dx_build_info::PKG_VERSION,
+        crate::dx_build_info::GIT_COMMIT_HASH_SHORT.unwrap_or("was built without git repository")
+    )
+});
+
 /// Build, Bundle & Ship Dioxus Apps.
 #[derive(Parser)]
-#[clap(name = "dioxus", version)]
+#[clap(name = "dioxus", version = VERSION.as_str())]
 pub struct Cli {
     #[clap(subcommand)]
     pub action: Commands,


### PR DESCRIPTION
A few notes:
- consider updating `built`'s version
- consider using [`vergen`](https://crates.io/crates/vergen) [instead](https://discord.com/channels/899851952891002890/928812591126569000/1265731211100291072)
- maybe change the message when failed to get commit hash during built (no `.git` etc.)
- used [tinymist](https://github.com/Myriad-Dreamin/tinymist/blob/ff729623342c91576485c60e60fd9d48707ad1a7/crates/tinymist/src/args.rs#L52) as a reference

Closes #2693.
