### PR TITLE
fix formatting and merging if chains in attributes

### DIFF
--- a/examples/rsx_usage.rs
+++ b/examples/rsx_usage.rs
@@ -87,6 +87,7 @@ fn app() -> Element {
                 class: if formatting.contains("form") { "{asd}" },
                 // longer if chains also work
                 class: if formatting.contains("form") { "{asd}" } else if formatting.contains("my other form") { "{asd}" },
+                class: if formatting.contains("form") { "{asd}" } else if formatting.contains("my other form") { "{asd}" } else { "{asd}" },
                 div {
                     class: {
                         const WORD: &str = "expressions";

--- a/examples/rsx_usage.rs
+++ b/examples/rsx_usage.rs
@@ -85,6 +85,8 @@ fn app() -> Element {
                 class: "{asd}",
                 // if statements can be used to conditionally render attributes
                 class: if formatting.contains("form") { "{asd}" },
+                // longer if chains also work
+                class: if formatting.contains("form") { "{asd}" } else if formatting.contains("my other form") { "{asd}" },
                 div {
                     class: {
                         const WORD: &str = "expressions";

--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -249,10 +249,18 @@ impl<'a> Writer<'a> {
 
     pub(crate) fn attr_value_len(&mut self, value: &ElementAttrValue) -> usize {
         match value {
-            ElementAttrValue::AttrOptionalExpr { condition, value } => {
-                let condition_len = self.retrieve_formatted_expr(condition).len();
-                let value_len = self.attr_value_len(value);
-                condition_len + value_len + 6
+            ElementAttrValue::IfExpr(if_chain) => {
+                let condition_len = self.retrieve_formatted_expr(&if_chain.condition).len();
+                let value_len = self.attr_value_len(&if_chain.then_value);
+                let if_len = 2;
+                let brace_len = 2;
+                let space_len = 2;
+                let else_len = if_chain
+                    .else_value
+                    .as_ref()
+                    .map(|else_value| self.attr_value_len(else_value) + 1)
+                    .unwrap_or_default();
+                condition_len + value_len + if_len + brace_len + space_len + else_len
             }
             ElementAttrValue::AttrLiteral(lit) => lit.to_string().len(),
             ElementAttrValue::Shorthand(expr) => expr.span().line_length(),

--- a/packages/core-macro/tests/rsx/trailing-comma-0.stderr
+++ b/packages/core-macro/tests/rsx/trailing-comma-0.stderr
@@ -1,6 +1,7 @@
 error: Attributes must be separated by commas
-       = help: Did you forget a comma?
  --> tests/rsx/trailing-comma-0.rs:9:13
   |
 9 |             class: "foo bar"
   |             ^^^^^
+  |
+  = help: Did you forget a comma?

--- a/packages/core-macro/tests/rsx/trailing-comma-0.stderr
+++ b/packages/core-macro/tests/rsx/trailing-comma-0.stderr
@@ -1,7 +1,6 @@
 error: Attributes must be separated by commas
+       = help: Did you forget a comma?
  --> tests/rsx/trailing-comma-0.rs:9:13
   |
 9 |             class: "foo bar"
   |             ^^^^^
-  |
-  = help: Did you forget a comma?

--- a/packages/rsx/src/attribute.rs
+++ b/packages/rsx/src/attribute.rs
@@ -516,9 +516,9 @@ impl AttributeValue {
 /// A if else chain attribute value
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct IfAttributeValue {
-    pub(crate) condition: Expr,
-    pub(crate) then_value: Box<AttributeValue>,
-    pub(crate) else_value: Option<Box<AttributeValue>>,
+    pub condition: Expr,
+    pub then_value: Box<AttributeValue>,
+    pub else_value: Option<Box<AttributeValue>>,
 }
 
 impl IfAttributeValue {

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -226,9 +226,15 @@ impl Element {
     /// }
     /// ```
     fn merge_attributes(&mut self) {
-        let mut attrs = self.raw_attributes.clone();
-        attrs.sort_by_key(|attr| attr.name.to_string());
-        attrs.dedup_by_key(|attr| attr.name.to_string());
+        let mut attrs: Vec<&Attribute> = vec![];
+
+        for attr in &self.raw_attributes {
+            if attrs.iter().any(|old_attr| old_attr.name == attr.name) {
+                continue;
+            }
+
+            attrs.push(attr);
+        }
 
         for attr in attrs {
             if attr.name.to_string() == "key" {

--- a/packages/rsx/src/ifchain.rs
+++ b/packages/rsx/src/ifchain.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{
     parse::{Parse, ParseStream},
-    Expr, ExprIf, Result, Token,
+    Expr, Result, Token,
 };
 
 use crate::TemplateBody;
@@ -135,21 +135,6 @@ impl ToTokens for IfChain {
                 ___nodes
             }
         })
-    }
-}
-
-pub(crate) fn is_if_chain_terminated(chain: &ExprIf) -> bool {
-    let mut current = chain;
-    loop {
-        if let Some((_, else_block)) = &current.else_branch {
-            if let Expr::If(else_if) = else_block.as_ref() {
-                current = else_if;
-            } else {
-                return true;
-            }
-        } else {
-            return false;
-        }
     }
 }
 

--- a/packages/rsx/src/ifmt.rs
+++ b/packages/rsx/src/ifmt.rs
@@ -20,6 +20,12 @@ pub struct IfmtInput {
     pub segments: Vec<Segment>,
 }
 
+impl Default for IfmtInput {
+    fn default() -> Self {
+        Self::new(Span::call_site())
+    }
+}
+
 impl IfmtInput {
     pub fn new(span: Span) -> Self {
         Self {
@@ -43,22 +49,6 @@ impl IfmtInput {
 
     pub fn push_ifmt(&mut self, other: IfmtInput) {
         self.segments.extend(other.segments);
-    }
-
-    pub fn push_condition(&mut self, condition: Expr, contents: IfmtInput) {
-        let desugared = quote! {
-            {
-                let _cond = if #condition { #contents.to_string() } else { String::new() };
-                _cond
-            }
-        };
-
-        let parsed = syn::parse2::<Expr>(desugared).unwrap();
-
-        self.segments.push(Segment::Formatted(FormattedSegment {
-            format_args: String::new(),
-            segment: FormattedSegmentType::Expr(Box::new(parsed)),
-        }));
     }
 
     pub fn push_expr(&mut self, expr: Expr) {
@@ -479,18 +469,6 @@ mod tests {
         let input = syn::parse2::<IfmtInput>(quote! { r#"hello"# }).unwrap();
         println!("{}", input.to_string_with_quotes());
         assert!(input.is_static());
-    }
-
-    #[test]
-    fn pushing_conditional() {
-        let mut input = syn::parse2::<IfmtInput>(quote! { "hello " }).unwrap();
-
-        input.push_condition(
-            parse_quote! { true },
-            syn::parse2::<IfmtInput>(quote! { "world" }).unwrap(),
-        );
-        println!("{}", input.to_token_stream().pretty_unparse());
-        dbg!(input.segments);
     }
 
     #[test]

--- a/packages/rsx/src/scoring.rs
+++ b/packages/rsx/src/scoring.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "hot_reload")]
 
-use crate::{Attribute, AttributeValue, BodyNode, HotLiteralType, IfmtInput};
+use crate::{Attribute, AttributeValue, BodyNode, HotLiteralType, IfAttributeValue, IfmtInput};
 
 /// Take two nodes and return their similarity score
 ///
@@ -114,17 +114,24 @@ fn score_attr_value(old_attr: &AttributeValue, new_attr: &AttributeValue) -> usi
         }
 
         (
-            AttrOptionalExpr {
+            IfExpr(IfAttributeValue {
                 condition: cond_a,
-                value: value_a,
-            },
-            AttrOptionalExpr {
+                then_value: value_a,
+                else_value: else_value_a,
+            }),
+            IfExpr(IfAttributeValue {
                 condition: cond_b,
-                value: value_b,
-            },
+                then_value: value_b,
+                else_value: else_value_b,
+            }),
         ) if cond_a == cond_b => {
             // If the condition is the same, we can hotreload it
             score_attr_value(value_a, value_b)
+                + match (else_value_a, else_value_b) {
+                    (Some(a), Some(b)) => score_attr_value(a, b),
+                    (None, None) => 0,
+                    _ => usize::MAX,
+                }
         }
 
         // todo: we should try and score recursively if we can - templates need to propagate up their


### PR DESCRIPTION
We were parsing `if {} else {}` as expressions which means any string values in the branches were not formatted correctly and we didn't allow merging the attribute because it was an expression

Fixes #2691