### PR TITLE
Fix `debug_assertions` in `core::tasks`

### DIFF
--- a/packages/core/src/tasks.rs
+++ b/packages/core/src/tasks.rs
@@ -248,7 +248,7 @@ impl Runtime {
     }
 
     pub(crate) fn handle_task_wakeup(&self, id: Task) -> Poll<()> {
-        #[cfg(feature = "debug_assertions")]
+        #[cfg(debug_assertions)]
         {
             // Ensure we are currently inside a `Runtime`.
             Runtime::current().unwrap();


### PR DESCRIPTION
I added `#[cfg(feature = "debug_assertions")]` instead of `#[cfg(debug_assertions)]`, sorry I didn't notice the error until now