### PR TITLE
chore(cli): slimmed down codebase by using vergen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,9 +1181,6 @@ name = "built"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6a6c0b39c38fd754ac338b00a88066436389c0f029da5d37d1e01091d9b7c17"
-dependencies = [
- "git2",
-]
 
 [[package]]
 name = "bumpalo"
@@ -1306,7 +1303,7 @@ dependencies = [
  "env_logger 0.11.3",
  "fs-err",
  "git2",
- "gix-config",
+ "gix-config 0.36.1",
  "heck 0.5.0",
  "home",
  "ignore",
@@ -1544,6 +1541,12 @@ name = "clap_lex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "clru"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
 
 [[package]]
 name = "cocoa"
@@ -2298,6 +2301,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,7 +2444,6 @@ dependencies = [
  "axum-extra",
  "axum-server",
  "brotli",
- "built",
  "cargo-generate",
  "cargo_metadata",
  "cargo_toml",
@@ -2470,6 +2503,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "vergen-gix",
  "walkdir",
  "wasm-bindgen-cli-support",
  "wasm-bindgen-shared",
@@ -2481,7 +2515,6 @@ dependencies = [
 name = "dioxus-cli-config"
 version = "0.5.2"
 dependencies = [
- "built",
  "cargo_toml",
  "clap 4.5.9",
  "dirs",
@@ -2492,6 +2525,7 @@ dependencies = [
  "tauri-utils",
  "toml 0.8.15",
  "tracing",
+ "vergen-gix",
 ]
 
 [[package]]
@@ -3935,6 +3969,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4028,6 +4074,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984c5018adfa7a4536ade67990b3ebc6e11ab57b3d6cd9968de0947ca99b4b06"
+dependencies = [
+ "gix-actor",
+ "gix-commitgraph",
+ "gix-config 0.37.0",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-features",
+ "gix-fs 0.11.2",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-index",
+ "gix-lock 14.0.0",
+ "gix-macros",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-ref 0.44.1",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-tempfile 14.0.1",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "once_cell",
+ "parking_lot",
+ "signal-hook",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-actor"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4042,6 +4130,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-bitmap"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a371db66cbd4e13f0ed9dc4c0fea712d7276805fccc877f77e96374d317e87ae"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c8751169961ba7640b513c3b24af61aa962c967aaf04116734975cd5af0c52"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133b06f67f565836ec0c473e2116a60fb74f80b6435e21d88013ac0e3c60fc78"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-config"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4052,7 +4172,28 @@ dependencies = [
  "gix-features",
  "gix-glob",
  "gix-path",
- "gix-ref",
+ "gix-ref 0.43.0",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow 0.6.14",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fafe42957e11d98e354a66b6bd70aeea00faf2f62dd11164188224a507c840"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref 0.44.1",
  "gix-sec",
  "memchr",
  "once_cell",
@@ -4088,17 +4229,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-diff"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1996d5c8a305b59709467d80617c9fde48d9d75fd1f4179ea970912630886c9d"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-object",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc27c699b63da66b50d50c00668bc0b7e90c3a382ef302865e891559935f3dbf"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs 0.11.2",
+ "gix-hash",
+ "gix-path",
+ "gix-ref 0.44.1",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-features"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac7045ac9fe5f9c727f38799d002a7ed3583cd777e3322a7c4b43e3cf437dc69"
 dependencies = [
+ "crc32fast",
+ "flate2",
  "gix-hash",
  "gix-trace",
  "gix-utils",
  "libc",
+ "once_cell",
  "prodash",
  "sha1_smol",
+ "thiserror",
  "walkdir",
 ]
 
@@ -4108,6 +4281,17 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2184c40e7910529677831c8b481acf788ffd92427ed21fad65b6aa637e631b8"
 dependencies = [
+ "gix-features",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6adf99c27cdf17b1c4d77680c917e0d94d8783d4e1c73d3be0d1d63107163d7a"
+dependencies = [
+ "fastrand 2.1.0",
  "gix-features",
  "gix-utils",
 ]
@@ -4135,14 +4319,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-hashtable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddf80e16f3c19ac06ce415a38b8591993d3f73aede049cb561becb5b3a8e242"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.14.5",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9a44eb55bd84bb48f8a44980e951968ced21e171b22d115d1cdcef82a7d73f"
+dependencies = [
+ "bitflags 2.6.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs 0.11.2",
+ "gix-hash",
+ "gix-lock 14.0.0",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.14.5",
+ "itoa 1.0.11",
+ "libc",
+ "memmap2",
+ "rustix 0.38.34",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-lock"
 version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c359f81f01b8352063319bcb39789b7ea0887b406406381106e38c4a34d049"
 dependencies = [
- "gix-tempfile",
+ "gix-tempfile 13.1.1",
  "gix-utils",
  "thiserror",
+]
+
+[[package]]
+name = "gix-lock"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bc7fe297f1f4614774989c00ec8b1add59571dc9b024b4c00acb7dedd4e19d"
+dependencies = [
+ "gix-tempfile 14.0.1",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -4165,6 +4410,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-odb"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20d384fe541d93d8a3bb7d5d5ef210780d6df4f50c4e684ccba32665a5e3bc9b"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features",
+ "gix-fs 0.11.2",
+ "gix-hash",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0594491fffe55df94ba1c111a6566b7f56b3f8d2e1efc750e77d572f5f5229"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-path"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4178,6 +4461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix-quote"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbff4f9b9ea3fa7a25a70ee62f545143abef624ac6aa5884344e70c8b0a1d9ff"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
 name = "gix-ref"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4186,17 +4480,84 @@ dependencies = [
  "gix-actor",
  "gix-date",
  "gix-features",
- "gix-fs",
+ "gix-fs 0.10.2",
  "gix-hash",
- "gix-lock",
+ "gix-lock 13.1.1",
  "gix-object",
  "gix-path",
- "gix-tempfile",
+ "gix-tempfile 13.1.1",
  "gix-utils",
  "gix-validate",
  "memmap2",
  "thiserror",
  "winnow 0.6.14",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3394a2997e5bc6b22ebc1e1a87b41eeefbcfcff3dbfa7c4bd73cb0ac8f1f3e2e"
+dependencies = [
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-fs 0.11.2",
+ "gix-hash",
+ "gix-lock 14.0.0",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile 14.0.1",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+ "winnow 0.6.14",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6868f8cd2e62555d1f7c78b784bece43ace40dd2a462daf3b588d5416e603f37"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b13e43c2118c4b0537ddac7d0821ae0dfa90b7b8dbf20c711e153fb749adce"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b030ccaab71af141f537e0225f19b9e74f25fefdba0372246b844491cab43e0"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -4217,10 +4578,25 @@ version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a761d76594f4443b675e85928e4902dec333273836bd386906f01e7e346a0d11"
 dependencies = [
- "gix-fs",
+ "gix-fs 0.10.2",
  "libc",
  "once_cell",
  "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "14.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "006acf5a613e0b5cf095d8e4b3f48c12a60d9062aa2b2dd105afaf8344a5600c"
+dependencies = [
+ "gix-fs 0.11.2",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-registry",
  "tempfile",
 ]
 
@@ -4229,6 +4605,37 @@ name = "gix-trace"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f924267408915fddcd558e3f37295cc7d6a3e50f8bd8b606cee0808c3915157e"
+
+[[package]]
+name = "gix-traverse"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e499a18c511e71cf4a20413b743b9f5bcf64b3d9e81e9c3c6cd399eae55a8840"
+dependencies = [
+ "bitflags 2.6.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eb9b35bba92ea8f0b5ab406fad3cf6b87f7929aa677ff10aa042c6da621156"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "home",
+ "thiserror",
+ "url",
+]
 
 [[package]]
 name = "gix-utils"
@@ -10294,6 +10701,48 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c32e7318e93a9ac53693b6caccfb05ff22e04a44c7cf8a279051f24c09da286f"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "derive_builder",
+ "getset",
+ "regex",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gix"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf11588e10333838eeb5b0d341e3364dfc1bfaf7c1b3beccf8f8706c49d5d34"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "gix",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06bee42361e43b60f363bad49d63798d0f42fb1768091812270eca00c784720"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "getset",
+ "rustversion",
+]
 
 [[package]]
 name = "version-compare"

--- a/packages/cli-config/Cargo.toml
+++ b/packages/cli-config/Cargo.toml
@@ -24,7 +24,7 @@ tauri-utils = { workspace = true, optional = true }
 dirs = { workspace = true, optional = true }
 
 [build-dependencies]
-built = { version = "=0.7.3", features = ["git2"] }
+vergen-gix = "1.0.0"
 
 [features]
 default = ["read-config"]

--- a/packages/cli-config/build.rs
+++ b/packages/cli-config/build.rs
@@ -1,8 +1,12 @@
+use std::error::Error;
+use vergen_gix::{Emitter, GixBuilder as GitBuilder};
+
 // warn if the "read-config" feature is enabled, but the DIOXUS_CONFIG environment variable is not set
 // This means that some library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application.
-
-fn main() {
-    built::write_built_file().expect("Failed to acquire build-time information");
+fn main() -> Result<(), Box<dyn Error>> {
+    Emitter::default()
+        .add_instructions(&GitBuilder::all_git()?)?
+        .emit()?;
 
     println!("cargo:rerun-if-env-changed=DIOXUS_CONFIG");
     let dioxus_config = std::env::var("DIOXUS_CONFIG");
@@ -10,4 +14,5 @@ fn main() {
     if cfg!(feature = "read-config") && !built_with_dioxus {
         println!("cargo:warning=A library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application. Information about the Dioxus CLI is available at https://dioxuslabs.com/learn/0.5/CLI/installation");
     }
+    Ok(())
 }

--- a/packages/cli-config/src/build_info.rs
+++ b/packages/cli-config/src/build_info.rs
@@ -1,2 +1,0 @@
-// The file has been placed there by the build script.
-include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -11,8 +11,6 @@ pub use bundle::*;
 mod serve;
 pub use serve::*;
 
-mod build_info;
-
 #[doc(hidden)]
 pub mod __private {
     use crate::DioxusConfig;
@@ -74,11 +72,10 @@ pub static CURRENT_CONFIG: once_cell::sync::Lazy<
     match serde_json::from_str(config) {
         Ok(config) => Ok(config),
         Err(err) => {
-            let mut cli_version = crate::build_info::PKG_VERSION.to_string();
+            let mut cli_version = env!("CARGO_PKG_VERSION").to_string();
 
-            if let Some(hash) = crate::build_info::GIT_COMMIT_HASH_SHORT {
-                let hash = &hash.trim_start_matches('g')[..4];
-                cli_version.push_str(&format!("-{hash}"));
+            if let Some(hash) = option_env!("VERGEN_GIT_SHA") {
+                cli_version.push_str(&format!("-{}", &hash[..4]));
             }
 
             let dioxus_version = std::option_env!("DIOXUS_CLI_VERSION").unwrap_or("unknown");

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -110,7 +110,7 @@ ansi-to-html = "0.2.1"
 # openssl = { version = "0.10", features = ["vendored"] }
 
 [build-dependencies]
-built = { version = "=0.7.3", features = ["git2"] }
+vergen-gix = { version = "1.0.0", features = ["cargo"] }
 
 [features]
 default = []

--- a/packages/cli/build.rs
+++ b/packages/cli/build.rs
@@ -1,3 +1,10 @@
-fn main() {
-    built::write_built_file().expect("Failed to acquire build-time information");
+use std::error::Error;
+use vergen_gix::{CargoBuilder, Emitter, GixBuilder as GitBuilder};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Emitter::default()
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GitBuilder::all_git()?)?
+        .emit()?;
+    Ok(())
 }

--- a/packages/cli/src/builder/cargo.rs
+++ b/packages/cli/src/builder/cargo.rs
@@ -96,10 +96,9 @@ impl BuildRequest {
         tracing::info!("🚅 Running build [Desktop] command...");
 
         // Set up runtime guards
-        let mut dioxus_version = crate::dx_build_info::PKG_VERSION.to_string();
-        if let Some(hash) = crate::dx_build_info::GIT_COMMIT_HASH_SHORT {
-            let hash = &hash.trim_start_matches('g')[..4];
-            dioxus_version.push_str(&format!("-{hash}"));
+        let mut dioxus_version = env!("CARGO_PKG_VERSION").to_string();
+        if let Some(hash) = option_env!("VERGEN_GIT_SHA") {
+            dioxus_version.push_str(&format!("-{}", &hash[..4]));
         }
         let _guard = dioxus_cli_config::__private::save_config(
             &self.dioxus_crate.dioxus_config,

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -26,8 +26,8 @@ use std::{
 pub static VERSION: Lazy<String> = Lazy::new(|| {
     format!(
         "{} ({})",
-        crate::dx_build_info::PKG_VERSION,
-        crate::dx_build_info::GIT_COMMIT_HASH_SHORT.unwrap_or("was built without git repository")
+        env!("CARGO_PKG_VERSION"),
+        option_env!("VERGEN_GIT_SHA").map_or("was built without git repository", |h| &h[..8])
     )
 });
 

--- a/packages/cli/src/dx_build_info.rs
+++ b/packages/cli/src/dx_build_info.rs
@@ -1,2 +1,0 @@
-// The file has been placed there by the build script.
-include!(concat!(env!("OUT_DIR"), "/built.rs"));

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -3,7 +3,6 @@
 #![doc(html_favicon_url = "https://avatars.githubusercontent.com/u/79236386")]
 
 pub mod assets;
-pub mod dx_build_info;
 pub mod serve;
 pub mod tools;
 

--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -122,13 +122,11 @@ impl Output {
 
         dx_version.push_str(env!("CARGO_PKG_VERSION"));
 
-        let is_cli_release = crate::dx_build_info::PROFILE == "release";
+        let is_cli_release = env!("VERGEN_CARGO_DEBUG") != "true";
 
         if !is_cli_release {
-            if let Some(hash) = crate::dx_build_info::GIT_COMMIT_HASH_SHORT {
-                let hash = &hash.trim_start_matches('g')[..4];
-                dx_version.push('-');
-                dx_version.push_str(hash);
+            if let Some(hash) = option_env!("VERGEN_GIT_SHA") {
+                dx_version.push_str(&format!("-{}", &hash[..4]));
             }
         }
 


### PR DESCRIPTION
Auxiliary files had to be created to use `built` crate. Now they are removed.

Now any build-time info can be grabbed from env var via `env!()`. For some additional data only a new feature must be added with a corresponding line in the `build.rs` to enable it.

One concern is that the number of built crates increased by 91. But I think practically all of them are tiny, so it wouldn't affect compile time much, if at all.

I run 2 tests and the first time the difference was 5 m 34 s vs. 9 m 17 s (I think it was an "improvement"). The second time it was 5 m 32 s vs. 5 m 41 s. 2.7% slower, without proper testing. I think it doesn't matter since you have to wait 5.5 minutes either way.
