### PR TITLE
Fix #2309: rfd doesn't need async-std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_repr",
+ "tokio",
  "url",
  "zbus",
 ]
@@ -11328,6 +11329,7 @@ dependencies = [
  "serde_repr",
  "sha1",
  "static_assertions",
+ "tokio",
  "tracing",
  "uds_windows",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10382,7 +10382,7 @@ source = "git+https://github.com/DioxusLabs/warnings#9889b96cccb6ac91a8af924cfee
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,8 +314,6 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093"
 dependencies = [
- "async-fs",
- "async-net",
  "enumflags2",
  "futures-channel",
  "futures-util",
@@ -398,17 +396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcd09b382f40fcd159c2d695175b2ae620ffa5f3bd6f664131efff4e8b9e04a"
-dependencies = [
- "async-lock 3.4.0",
- "blocking",
- "futures-lite 2.3.0",
-]
-
-[[package]]
 name = "async-global-executor"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,17 +467,6 @@ dependencies = [
  "event-listener 5.3.1",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io 2.3.3",
- "blocking",
- "futures-lite 2.3.0",
 ]
 
 [[package]]
@@ -2760,7 +2736,6 @@ dependencies = [
  "keyboard-types",
  "lazy-js-bundle",
  "manganis",
- "rfd",
  "rustversion",
  "serde",
  "serde_json",
@@ -11307,15 +11282,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
 dependencies = [
  "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io 2.3.3",
- "async-lock 3.4.0",
  "async-process",
  "async-recursion",
- "async-task",
  "async-trait",
- "blocking",
  "enumflags2",
  "event-listener 5.3.1",
  "futures-core",

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -59,7 +59,7 @@ signal-hook = "0.3.17"
 
 [target.'cfg(any(target_os = "windows",target_os = "macos",target_os = "linux",target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 global-hotkey = "0.5.0"
-rfd = "0.14"
+rfd = { version = "0.14", default-features = false, features = ["xdg-portal"] }
 muda = "0.11.3"
 
 

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -59,7 +59,7 @@ signal-hook = "0.3.17"
 
 [target.'cfg(any(target_os = "windows",target_os = "macos",target_os = "linux",target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 global-hotkey = "0.5.0"
-rfd = { version = "0.14", default-features = false, features = ["xdg-portal"] }
+rfd = { version = "0.14", default-features = false, features = ["xdg-portal", "tokio"] }
 muda = "0.11.3"
 
 

--- a/packages/html/Cargo.toml
+++ b/packages/html/Cargo.toml
@@ -26,7 +26,6 @@ enumset = "1.1.2"
 keyboard-types = { version = "0.7", default-features = false }
 async-trait = { version = "0.1.58", optional = true }
 tokio = { workspace = true, features = ["fs", "io-util"], optional = true }
-rfd = { version = "0.14", optional = true }
 futures-channel = { workspace = true }
 serde_json = { version = "1", optional = true }
 tracing.workspace = true


### PR DESCRIPTION
Simply disable the async-std feature on rfd in favor of tokio. We already import tokio in our graph, so it's a free dependency.

RFD doesn't give you great options - either you need an async runtime or you need to use gtk3. We should consider refactoring their stuff to give you a req/res approach (similar to how wry gives us async protocols) such that an async runtime is not required.

Fix #2309 