### PR TITLE
Fix #2612: adjust readable trait to allow try_peek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10382,7 +10382,7 @@ source = "git+https://github.com/DioxusLabs/warnings#9889b96cccb6ac91a8af924cfee
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/packages/generational-box/src/error.rs
+++ b/packages/generational-box/src/error.rs
@@ -4,6 +4,9 @@ use std::fmt::Display;
 
 use crate::GenerationalLocation;
 
+/// A result that can be returned from a borrow operation.
+pub type BorrowResult<T> = std::result::Result<T, BorrowError>;
+
 #[derive(Debug, Clone, PartialEq)]
 /// An error that can occur when trying to borrow a value.
 pub enum BorrowError {

--- a/packages/hooks/src/use_future.rs
+++ b/packages/hooks/src/use_future.rs
@@ -175,8 +175,10 @@ impl Readable for UseFuture {
     }
 
     #[track_caller]
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-        self.state.peek_unchecked()
+    fn try_peek_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+        self.state.try_peek_unchecked()
     }
 }
 

--- a/packages/hooks/src/use_resource.rs
+++ b/packages/hooks/src/use_resource.rs
@@ -441,8 +441,10 @@ impl<T> Readable for Resource<T> {
     }
 
     #[track_caller]
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-        self.value.peek_unchecked()
+    fn try_peek_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+        self.value.try_peek_unchecked()
     }
 }
 

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -1,5 +1,5 @@
-use generational_box::GenerationalBoxId;
 use generational_box::UnsyncStorage;
+use generational_box::{BorrowResult, GenerationalBoxId};
 use std::ops::Deref;
 
 use dioxus_core::prelude::*;
@@ -129,8 +129,8 @@ impl<T: 'static, S: Storage<T>> Readable for CopyValue<T, S> {
     }
 
     #[track_caller]
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-        self.value.read()
+    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>> {
+        self.value.try_read()
     }
 }
 

--- a/packages/signals/src/global/memo.rs
+++ b/packages/signals/src/global/memo.rs
@@ -1,7 +1,7 @@
 use crate::{read::Readable, Memo, ReadableRef};
 use crate::{read_impls, GlobalKey};
 use dioxus_core::prelude::ScopeId;
-use generational_box::UnsyncStorage;
+use generational_box::{BorrowResult, UnsyncStorage};
 use std::ops::Deref;
 
 use crate::Signal;
@@ -75,8 +75,8 @@ impl<T: PartialEq + 'static> Readable for GlobalMemo<T> {
     }
 
     #[track_caller]
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-        self.memo().peek_unchecked()
+    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>> {
+        self.memo().try_peek_unchecked()
     }
 }
 

--- a/packages/signals/src/global/signal.rs
+++ b/packages/signals/src/global/signal.rs
@@ -2,7 +2,7 @@ use crate::{read::Readable, ReadableRef};
 use crate::{write::Writable, GlobalKey};
 use crate::{WritableRef, Write};
 use dioxus_core::{prelude::ScopeId, Runtime};
-use generational_box::UnsyncStorage;
+use generational_box::{BorrowResult, UnsyncStorage};
 use std::ops::Deref;
 
 use super::get_global_context;
@@ -110,8 +110,8 @@ impl<T: 'static> Readable for GlobalSignal<T> {
     }
 
     #[track_caller]
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-        self.signal().peek_unchecked()
+    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>> {
+        self.signal().try_peek_unchecked()
     }
 }
 

--- a/packages/signals/src/impls.rs
+++ b/packages/signals/src/impls.rs
@@ -25,8 +25,10 @@
 ///         self.value.try_read_unchecked()
 ///     }
 ///
-///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-///         self.value.read_unchecked()
+///     fn try_peek_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
 ///     }
 /// }
 ///
@@ -85,8 +87,10 @@ macro_rules! default_impl {
 ///         self.value.try_read_unchecked()
 ///     }
 ///
-///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-///         self.value.read_unchecked()
+///     fn try_peek_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
 ///     }
 /// }
 ///
@@ -156,8 +160,10 @@ macro_rules! read_impls {
 ///         self.value.try_read_unchecked()
 ///     }
 ///
-///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-///         self.value.read_unchecked()
+///     fn try_peek_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
 ///     }
 /// }
 ///
@@ -230,8 +236,10 @@ macro_rules! fmt_impls {
 ///         self.value.try_read_unchecked()
 ///     }
 ///
-///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-///         self.value.read_unchecked()
+///     fn try_peek_unchecked(
+///         &self,
+///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
+///         self.value.try_read_unchecked()
 ///     }
 /// }
 ///

--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -10,7 +10,7 @@ use std::{
 
 use dioxus_core::prelude::*;
 use futures_util::StreamExt;
-use generational_box::{AnyStorage, UnsyncStorage};
+use generational_box::{AnyStorage, BorrowResult, UnsyncStorage};
 
 struct UpdateInformation<T> {
     dirty: Arc<AtomicBool>,
@@ -164,8 +164,8 @@ where
     ///
     /// If the signal has been dropped, this will panic.
     #[track_caller]
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
-        self.inner.peek_unchecked()
+    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>> {
+        self.inner.try_peek_unchecked()
     }
 }
 

--- a/packages/signals/src/read.rs
+++ b/packages/signals/src/read.rs
@@ -83,10 +83,20 @@ pub trait Readable {
                 dyn Fn() -> Result<ReadableRef<'static, Self, O>, generational_box::BorrowError>
                     + 'static,
             >;
-        let peek = Rc::new(move || {
-            <Self::Storage as AnyStorage>::map(self.peek_unchecked(), |r| mapping(r))
-        }) as Rc<dyn Fn() -> ReadableRef<'static, Self, O> + 'static>;
-        MappedSignal::new(try_read, peek)
+        let try_peek = Rc::new({
+            let self_ = self.clone();
+            let mapping = mapping.clone();
+            move || {
+                self_
+                    .try_peek_unchecked()
+                    .map(|ref_| <Self::Storage as AnyStorage>::map(ref_, |r| mapping(r)))
+            }
+        })
+            as Rc<
+                dyn Fn() -> Result<ReadableRef<'static, Self, O>, generational_box::BorrowError>
+                    + 'static,
+            >;
+        MappedSignal::new(try_read, try_peek)
     }
 
     /// Get the current value of the state. If this is a signal, this will subscribe the current scope to the signal.
@@ -104,13 +114,6 @@ pub trait Readable {
             .map(Self::Storage::downcast_lifetime_ref)
     }
 
-    /// Try to get a reference to the value without checking the lifetime. This will subscribe the current scope to the signal.
-    ///
-    /// NOTE: This method is completely safe because borrow checking is done at runtime.
-    fn try_read_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>;
-
     /// Get a reference to the value without checking the lifetime. This will subscribe the current scope to the signal.
     ///
     /// NOTE: This method is completely safe because borrow checking is done at runtime.
@@ -119,12 +122,12 @@ pub trait Readable {
         self.try_read_unchecked().unwrap()
     }
 
-    /// Get the current value of the signal without checking the lifetime. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
-    ///
-    /// If the signal has been dropped, this will panic.
+    /// Try to get a reference to the value without checking the lifetime. This will subscribe the current scope to the signal.
     ///
     /// NOTE: This method is completely safe because borrow checking is done at runtime.
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self>;
+    fn try_read_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>;
 
     /// Get the current value of the state without subscribing to updates. If the value has been dropped, this will panic.
     ///
@@ -163,6 +166,30 @@ pub trait Readable {
     fn peek(&self) -> ReadableRef<Self> {
         Self::Storage::downcast_lifetime_ref(self.peek_unchecked())
     }
+
+    /// Try to peek the current value of the signal without subscribing to updates. If the value has
+    /// been dropped, this will return an error.
+    #[track_caller]
+    fn try_peek(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError> {
+        self.try_peek_unchecked()
+            .map(Self::Storage::downcast_lifetime_ref)
+    }
+
+    /// Get the current value of the signal without checking the lifetime. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
+    ///
+    /// If the signal has been dropped, this will panic.
+    #[track_caller]
+    fn peek_unchecked(&self) -> ReadableRef<'static, Self> {
+        self.try_peek_unchecked().unwrap()
+    }
+
+    /// Try to peek the current value of the signal without subscribing to updates. If the value has
+    /// been dropped, this will return an error.
+    ///
+    /// NOTE: This method is completely safe because borrow checking is done at runtime.
+    fn try_peek_unchecked(
+        &self,
+    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>;
 
     /// Clone the inner value and return it. If the value has been dropped, this will panic.
     #[track_caller]

--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 
 use crate::{default_impl, read_impls};
 use dioxus_core::{prelude::IntoAttributeValue, ScopeId};
-use generational_box::{Storage, UnsyncStorage};
+use generational_box::{BorrowResult, Storage, UnsyncStorage};
 
 /// A signal that can only be read from.
 pub struct ReadOnlySignal<T: 'static, S: Storage<SignalData<T>> = UnsyncStorage> {
@@ -79,8 +79,8 @@ impl<T, S: Storage<SignalData<T>>> Readable for ReadOnlySignal<T, S> {
     ///
     /// If the signal has been dropped, this will panic.
     #[track_caller]
-    fn peek_unchecked(&self) -> S::Ref<'static, T> {
-        self.inner.peek_unchecked()
+    fn try_peek_unchecked(&self) -> BorrowResult<S::Ref<'static, T>> {
+        self.inner.try_peek_unchecked()
     }
 }
 


### PR DESCRIPTION
Our implementation for Readable was inconsistent.
We had a try_unchecked variant for read but not for peek.
This resolves that by making a breaking change to the
Readable interface.


Fix #2612
