### PR TITLE
Fix #2378: CLI MSRV and add MSRV to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,16 +53,7 @@ jobs:
         with:
           cache-all-crates: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # https://github.com/foresterre/cargo-msrv/blob/4345edfe3f4fc91cc8ae6c7d6804c0748fae92ae/.github/workflows/msrv.yml
-      - name: install_cargo_msrv
-        run: cargo install cargo-msrv --all-features
-      - name: version_of_cargo_msrv
-        run: cargo msrv --version
-      - name: run_cargo_msrv
-        run: cargo msrv --output-format json verify -- cargo check
-      - name: run_cargo_msrv_on_verify_failure
-        if: ${{ failure() }}
-        run: cargo msrv --output-format json -- cargo check
+      - run: cargo check --all --examples --tests --all-features --all-targets
 
   check-msrv:
     if: github.event.pull_request.draft == false
@@ -75,7 +66,16 @@ jobs:
         with:
           cache-all-crates: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo check --all --examples --tests --all-features --all-targets --bins --tests --workspace --exclude dioxus-desktop --exclude dioxus-mobile
+      # https://github.com/foresterre/cargo-msrv/blob/4345edfe3f4fc91cc8ae6c7d6804c0748fae92ae/.github/workflows/msrv.yml
+      - name: install_cargo_msrv
+        run: cargo install cargo-msrv --all-features
+      - name: version_of_cargo_msrv
+        run: cargo msrv --version
+      - name: run_cargo_msrv
+        run: cargo msrv --output-format json verify -- cargo check
+      - name: run_cargo_msrv_on_verify_failure
+        if: ${{ failure() }}
+        run: cargo msrv --output-format json -- cargo check
 
   test:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,29 @@ jobs:
         with:
           cache-all-crates: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo check --all --examples --tests --all-features --all-targets
+      # https://github.com/foresterre/cargo-msrv/blob/4345edfe3f4fc91cc8ae6c7d6804c0748fae92ae/.github/workflows/msrv.yml
+      - name: install_cargo_msrv
+        run: cargo install cargo-msrv --all-features
+      - name: version_of_cargo_msrv
+        run: cargo msrv --version
+      - name: run_cargo_msrv
+        run: cargo msrv --output-format json verify -- cargo check
+      - name: run_cargo_msrv_on_verify_failure
+        if: ${{ failure() }}
+        run: cargo msrv --output-format json -- cargo check
+
+  check-msrv:
+    if: github.event.pull_request.draft == false
+    name: Check MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: "true"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - run: cargo check --all --examples --tests --all-features --all-targets --bins --tests --workspace --exclude dioxus-desktop --exclude dioxus-mobile
 
   test:
     if: github.event.pull_request.draft == false
@@ -117,7 +139,7 @@ jobs:
           cache-all-crates: "true"
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo fmt --all -- --check
-  
+
   typos:
     if: github.event.pull_request.draft == false
     name: Check for typos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10382,7 +10382,7 @@ source = "git+https://github.com/DioxusLabs/warnings#9889b96cccb6ac91a8af924cfee
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
 documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
-rust-version = "1.60.0"
+rust-version = "1.79.0"
 publish = false
 
 [dependencies]

--- a/examples/tailwind/Cargo.toml
+++ b/examples/tailwind/Cargo.toml
@@ -8,7 +8,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
 documentation = "https://dioxuslabs.com"
-rust-version = "1.60.0"
 publish = false
 
 [dependencies]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -8,6 +8,7 @@ description = "CLI tool for developing, testing, and publishing Dioxus apps"
 repository = "https://github.com/DioxusLabs/dioxus/"
 license = "MIT OR Apache-2.0"
 keywords = ["react", "gui", "cli", "dioxus", "wasm"]
+rust-version = "1.79.0"
 
 [dependencies]
 # cli core

--- a/packages/dioxus-lib/Cargo.toml
+++ b/packages/dioxus-lib/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com/learn/0.5/"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
-rust-version = "1.65.0"
+rust-version = "1.79.0"
 
 [dependencies]
 dioxus-core = { workspace = true }

--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com/learn/0.5/"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
-rust-version = "1.65.0"
+rust-version = "1.79.0"
 
 [dependencies]
 dioxus-core = { workspace = true }

--- a/packages/rsx/src/hotreload.rs
+++ b/packages/rsx/src/hotreload.rs
@@ -155,7 +155,7 @@ impl HotReloadedTemplate {
         //
         // The paths will be different but the dynamic indexes will be the same
         let template = new.to_template_with_custom_paths::<Ctx>(
-            intern(self.make_location(old.template_idx.get()).leak()),
+            intern(self.make_location(old.template_idx.get())),
             new_node_paths,
             new_attribute_paths,
         );

--- a/packages/signals/Cargo.toml
+++ b/packages/signals/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"
 homepage = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
-rust-version = "1.64.0"
+rust-version = "1.79.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- Fix: bump msrv up to be valid for cli
- add binstall check to ci
- adjust msrv of tomls

Unfortunately due to a number of changes in our upstream and our own syntax uses, we have to move our msrv up to 1.79

It'd be nice to support lower versions

Fixes #2378 
