### PR TITLE
speed up incremental cli builds by making wasm-opt optional

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,7 +98,7 @@ jobs:
           checksum: sha256
           manifest_path: packages/cli/Cargo.toml
           ref: refs/tags/${{ env.RELEASE_POST }}
-
+          features: wasm-opt
 
   # todo: these things
   # Run benchmarks, which we'll use to display on the website
@@ -146,13 +146,12 @@ jobs:
   #         # todo: actually just publish!
   #         # cargo workspaces publish -y ${{ github.event.inputs.semver }}
 
-      # this will be more useful when we publish the website with updated docs
-      # Build the docs.rs docs and publish them to the website under the right folder
-      # v0.4.x -> docs/0.4
-      # v0.5.x -> docs/0.5 etc
-      # main -> docs/nightly
-      # strip the v from the channel, and the .x from the end, and replace main with nightly
-      # - name: determine docs folder by channel
-      #   id: determine_docs_folder
-      #   run: echo "::set-output name=folder::$(echo ${{ github.event.inputs.channel }} | sed 's/v//g' | sed 's/\.x//g' | sed 's/main/nightly/g')"
-
+  # this will be more useful when we publish the website with updated docs
+  # Build the docs.rs docs and publish them to the website under the right folder
+  # v0.4.x -> docs/0.4
+  # v0.5.x -> docs/0.5 etc
+  # main -> docs/nightly
+  # strip the v from the channel, and the .x from the end, and replace main with nightly
+  # - name: determine docs folder by channel
+  #   id: determine_docs_folder
+  #   run: echo "::set-output name=folder::$(echo ${{ github.event.inputs.channel }} | sed 's/v//g' | sed 's/\.x//g' | sed 's/main/nightly/g')"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -99,7 +99,7 @@ env_logger = "0.11.3"
 tracing-subscriber = { version = "0.3.18", features = ["std", "env-filter"] }
 console-subscriber = { version = "0.3.0", optional = true }
 tracing = { workspace = true }
-wasm-opt = "0.116.1"
+wasm-opt = { version = "0.116.1", optional = true }
 ratatui = { version = "0.27.0", features = ["crossterm", "unstable"] }
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 ansi-to-tui = "=5.0.0-rc.1"
@@ -116,6 +116,9 @@ built = { version = "=0.7.3", features = ["git2"] }
 default = []
 plugin = []
 tokio-console = ["dep:console-subscriber"]
+
+# when releasing dioxus, we want to enable wasm-opt
+wasm-opt = ["dep:wasm-opt"]
 
 [[bin]]
 path = "src/main.rs"

--- a/packages/cli/src/builder/web.rs
+++ b/packages/cli/src/builder/web.rs
@@ -131,7 +131,7 @@ impl BuildRequest {
 
         // Only run wasm-opt if the feature is enabled
         // Wasm-opt has an expensive build script that makes it annoying to keep enabled for iterative dev
-        #[cfg(any(feature = "wasm-opt", not(debug_assertions)))]
+        #[cfg(feature = "wasm-opt")]
         {
             // Run wasm-opt if this is a release build
             if self.build_arguments.release {

--- a/packages/cli/src/builder/web.rs
+++ b/packages/cli/src/builder/web.rs
@@ -5,7 +5,6 @@ use crate::builder::progress::Stage;
 use crate::builder::progress::UpdateBuildProgress;
 use crate::builder::progress::UpdateStage;
 use crate::error::{Error, Result};
-use dioxus_cli_config::WasmOptLevel;
 use futures_channel::mpsc::UnboundedSender;
 use manganis_cli_support::AssetManifest;
 use std::path::Path;
@@ -130,38 +129,45 @@ impl BuildRequest {
         // Run wasm-bindgen
         self.run_wasm_bindgen(&input_path, &bindgen_outdir).await?;
 
-        // Run wasm-opt if this is a release build
-        if self.build_arguments.release {
-            tracing::info!("Running optimization with wasm-opt...");
-            let mut options = match self.dioxus_crate.dioxus_config.web.wasm_opt.level {
-                WasmOptLevel::Z => {
-                    wasm_opt::OptimizationOptions::new_optimize_for_size_aggressively()
-                }
-                WasmOptLevel::S => wasm_opt::OptimizationOptions::new_optimize_for_size(),
-                WasmOptLevel::Zero => wasm_opt::OptimizationOptions::new_opt_level_0(),
-                WasmOptLevel::One => wasm_opt::OptimizationOptions::new_opt_level_1(),
-                WasmOptLevel::Two => wasm_opt::OptimizationOptions::new_opt_level_2(),
-                WasmOptLevel::Three => wasm_opt::OptimizationOptions::new_opt_level_3(),
-                WasmOptLevel::Four => wasm_opt::OptimizationOptions::new_opt_level_4(),
-            };
-            let wasm_file = bindgen_outdir.join(format!(
-                "{}_bg.wasm",
-                self.dioxus_crate.dioxus_config.application.name
-            ));
-            let old_size = wasm_file.metadata()?.len();
-            options
-                // WASM bindgen relies on reference types
-                .enable_feature(wasm_opt::Feature::ReferenceTypes)
-                .debug_info(self.dioxus_crate.dioxus_config.web.wasm_opt.debug)
-                .run(&wasm_file, &wasm_file)
-                .map_err(|err| Error::Other(anyhow::anyhow!(err)))?;
-            let new_size = wasm_file.metadata()?.len();
-            tracing::info!(
-                "wasm-opt reduced WASM size from {} to {} ({:2}%)",
-                old_size,
-                new_size,
-                (new_size as f64 - old_size as f64) / old_size as f64 * 100.0
-            );
+        // Only run wasm-opt if the feature is enabled
+        // Wasm-opt has an expensive build script that makes it annoying to keep enabled for iterative dev
+        #[cfg(any(feature = "wasm-opt", not(debug_assertions)))]
+        {
+            // Run wasm-opt if this is a release build
+            if self.build_arguments.release {
+                use dioxus_cli_config::WasmOptLevel;
+
+                tracing::info!("Running optimization with wasm-opt...");
+                let mut options = match self.dioxus_crate.dioxus_config.web.wasm_opt.level {
+                    WasmOptLevel::Z => {
+                        wasm_opt::OptimizationOptions::new_optimize_for_size_aggressively()
+                    }
+                    WasmOptLevel::S => wasm_opt::OptimizationOptions::new_optimize_for_size(),
+                    WasmOptLevel::Zero => wasm_opt::OptimizationOptions::new_opt_level_0(),
+                    WasmOptLevel::One => wasm_opt::OptimizationOptions::new_opt_level_1(),
+                    WasmOptLevel::Two => wasm_opt::OptimizationOptions::new_opt_level_2(),
+                    WasmOptLevel::Three => wasm_opt::OptimizationOptions::new_opt_level_3(),
+                    WasmOptLevel::Four => wasm_opt::OptimizationOptions::new_opt_level_4(),
+                };
+                let wasm_file = bindgen_outdir.join(format!(
+                    "{}_bg.wasm",
+                    self.dioxus_crate.dioxus_config.application.name
+                ));
+                let old_size = wasm_file.metadata()?.len();
+                options
+                    // WASM bindgen relies on reference types
+                    .enable_feature(wasm_opt::Feature::ReferenceTypes)
+                    .debug_info(self.dioxus_crate.dioxus_config.web.wasm_opt.debug)
+                    .run(&wasm_file, &wasm_file)
+                    .map_err(|err| Error::Other(anyhow::anyhow!(err)))?;
+                let new_size = wasm_file.metadata()?.len();
+                tracing::info!(
+                    "wasm-opt reduced WASM size from {} to {} ({:2}%)",
+                    old_size,
+                    new_size,
+                    (new_size as f64 - old_size as f64) / old_size as f64 * 100.0
+                );
+            }
         }
 
         // If pre-compressing is enabled, we can pre_compress the wasm-bindgen output


### PR DESCRIPTION
passes wasm-opt to our release action so at least the binstalls have the feature enabled