### PR TITLE
Fix WSL Hot Reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10382,7 +10382,7 @@ source = "git+https://github.com/DioxusLabs/warnings#9889b96cccb6ac91a8af924cfee
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.71",
+ "syn 2.0.72",
 ]
 
 [[package]]

--- a/packages/cli/src/cli/config.rs
+++ b/packages/cli/src/cli/config.rs
@@ -34,14 +34,11 @@ pub enum Config {
 #[derive(Debug, Clone, Copy, Deserialize, Subcommand)]
 pub enum Setting {
     /// Set the value of the always-hot-reload setting.
-    #[clap(action=ArgAction::Set)]
-    AlwaysHotReload { value: bool },
+    AlwaysHotReload { value: BoolValue },
     /// Set the value of the always-open-browser setting.
-    #[clap(action=ArgAction::Set)]
-    AlwaysOpenBrowser { value: bool },
+    AlwaysOpenBrowser { value: BoolValue },
     /// Set the value of the always-on-top desktop setting.
-    #[clap(action=ArgAction::Set)]
-    AlwaysOnTop { value: bool },
+    AlwaysOnTop { value: BoolValue },
     /// Set the interval that file changes are polled on WSL for hot reloading.
     WSLFilePollInterval { value: u16 },
 }
@@ -49,10 +46,27 @@ pub enum Setting {
 impl Display for Setting {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AlwaysHotReload { value: _ } => write!(f, "always_hot_reload"),
-            Self::AlwaysOpenBrowser { value: _ } => write!(f, "always_open_browser"),
-            Self::AlwaysOnTop { value: _ } => write!(f, "always_on_top"),
-            Self::WSLFilePollInterval { value: _ } => write!(f, "wsl_file_poll_interval"),
+            Self::AlwaysHotReload { value: _ } => write!(f, "always-hot-reload"),
+            Self::AlwaysOpenBrowser { value: _ } => write!(f, "always-open-browser"),
+            Self::AlwaysOnTop { value: _ } => write!(f, "always-on-top"),
+            Self::WSLFilePollInterval { value: _ } => write!(f, "wsl-file-poll-interval"),
+        }
+    }
+}
+
+// Clap complains if we use a bool directly and I can't find much info about it.
+// "Argument 'value` is positional and it must take a value but action is SetTrue"
+#[derive(Debug, Clone, Copy, Deserialize, clap::ValueEnum)]
+pub enum BoolValue {
+    True,
+    False,
+}
+
+impl From<BoolValue> for bool {
+    fn from(value: BoolValue) -> Self {
+        match value {
+            BoolValue::True => true,
+            BoolValue::False => false,
         }
     }
 }
@@ -104,7 +118,7 @@ impl Config {
                         settings.always_open_browser = Some(value.into())
                     }
                     Setting::WSLFilePollInterval { value } => {
-                        settings.wsl_file_poll_interval = Some(value.into())
+                        settings.wsl_file_poll_interval = Some(value)
                     }
                 })?;
                 tracing::info!("🚩 CLI setting `{setting}` has been set.");

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -36,6 +36,10 @@ pub struct ServeArguments {
     /// Additional arguments to pass to the executable
     #[clap(long)]
     pub args: Vec<String>,
+
+    /// Sets the interval in seconds that the CLI will poll for file changes on WSL.
+    #[clap(long, default_missing_value = "2")]
+    pub wsl_file_poll_interval: Option<u16>,
 }
 
 /// Run the WASM project on dev-server
@@ -59,15 +63,26 @@ pub struct Serve {
 impl Serve {
     /// Resolve the serve arguments from the arguments or the config
     fn resolve(&mut self, crate_config: &mut DioxusCrate) -> Result<()> {
-        // Set config settings
+        // Set config settings.
         let settings = settings::CliSettings::load();
 
+        // Enable hot reload.
         if self.server_arguments.hot_reload.is_none() {
             self.server_arguments.hot_reload = Some(settings.always_hot_reload.unwrap_or(true));
         }
+
+        // Open browser.
         if self.server_arguments.open.is_none() {
             self.server_arguments.open = Some(settings.always_open_browser.unwrap_or_default());
         }
+
+        // Set WSL file poll interval.
+        if self.server_arguments.wsl_file_poll_interval.is_none() {
+            self.server_arguments.wsl_file_poll_interval =
+                Some(settings.wsl_file_poll_interval.unwrap_or(2));
+        }
+
+        // Set always-on-top for desktop.
         if self.server_arguments.always_on_top.is_none() {
             self.server_arguments.always_on_top = Some(settings.always_on_top.unwrap_or(true))
         }

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -52,7 +52,7 @@ pub async fn serve_all(serve: Serve, dioxus_crate: DioxusCrate) -> Result<()> {
     builder.build();
 
     let mut server = Server::start(&serve, &dioxus_crate);
-    let mut watcher = Watcher::start(&dioxus_crate);
+    let mut watcher = Watcher::start(&serve, &dioxus_crate);
     let mut screen = Output::start(&serve).expect("Failed to open terminal logger");
 
     loop {

--- a/packages/cli/src/serve/watcher.rs
+++ b/packages/cli/src/serve/watcher.rs
@@ -76,7 +76,7 @@ impl Watcher {
             }
         };
 
-        // If we are in WSL, we must use Notify's poll watcher due to an event propogation issue.
+        // If we are in WSL, we must use Notify's poll watcher due to an event propagation issue.
         let is_wsl = is_wsl();
         const NOTIFY_ERROR_MSG: &str = "Failed to create file watcher.\nEnsure you have the required permissions to watch the specified directories.";
 
@@ -310,7 +310,7 @@ const WSL_KEYWORDS: [&str; 2] = ["microsoft", "wsl"];
 /// Detects if `dx` is being ran in a WSL environment.
 ///
 /// We determine this based on whether the keyword `microsoft` or `wsl` is contained within the [`WSL_1`] or [`WSL_2`] files.
-/// This may fail in the future as it isn't gauranteed by Microsoft.
+/// This may fail in the future as it isn't guaranteed by Microsoft.
 /// See https://github.com/microsoft/WSL/issues/423#issuecomment-221627364
 fn is_wsl() -> bool {
     // Test 1st File

--- a/packages/cli/src/settings.rs
+++ b/packages/cli/src/settings.rs
@@ -25,6 +25,9 @@ pub struct CliSettings {
     pub always_open_browser: Option<bool>,
     /// Describes whether desktop apps in development will be pinned always-on-top.
     pub always_on_top: Option<bool>,
+    /// Describes the interval in seconds that the CLI should poll for file changes on WSL.
+    #[serde(default = "default_wsl_file_poll_interval")]
+    pub wsl_file_poll_interval: Option<u16>,
 }
 
 impl CliSettings {
@@ -101,4 +104,8 @@ impl CliSettings {
 
         Ok(())
     }
+}
+
+fn default_wsl_file_poll_interval() -> Option<u16> {
+    Some(2)
 }

--- a/packages/cli/src/settings.rs
+++ b/packages/cli/src/settings.rs
@@ -77,7 +77,19 @@ impl CliSettings {
             CrateConfigError::Io(Error::new(ErrorKind::Other, e.to_string()))
         })?;
 
-        let result = fs::write(path.clone(), data.clone());
+        // Create the directory structure if it doesn't exist.
+        let parent_path = path.parent().unwrap();
+        if let Err(e) = fs::create_dir_all(parent_path) {
+            error!(
+                ?data,
+                ?path,
+                "failed to create directories for settings file"
+            );
+            return Err(CrateConfigError::Io(e));
+        }
+
+        // Write the data.
+        let result = fs::write(&path, data.clone());
         if let Err(e) = result {
             error!(?data, ?path, "failed to save global cli settings");
             return Err(CrateConfigError::Io(e));


### PR DESCRIPTION
WSL has issues propagating file modification events to our CLI through the `notify` crate. We use notify's poll watcher to fix this when we detect a WSL host. Additionally, this PR adds a new CLI setting to specify the poll interval as it can consume resources for larger projects.

- WSL detection & Poll Watcher
- `wsl-file-poll-interval` CLI setting
- `--wsl-file-poll-interval=` serve argument
- Slight difference in `dx config set` command usage
- Fixes a bug in CLI settings where writing to `settings.toml` with a non-complete directory structure could fail.

Closes #1867 