### PR TITLE
This fixes issue https://github.com/DioxusLabs/dioxus/issues/2723

### DIFF
--- a/packages/autofmt/src/lib.rs
+++ b/packages/autofmt/src/lib.rs
@@ -69,7 +69,14 @@ pub fn fmt_file(contents: &str, indent: IndentOptions) -> Vec<FormattedBlock> {
             continue;
         }
 
-        let body = item.parse_body_with(CallBody::parse_strict).unwrap();
+        let body = match item.parse_body_with(CallBody::parse_strict) {
+            Ok(v) => v,
+            //there is aparsing error, we give up and don't format the rsx
+            Err(e) => {
+                eprintln!("Error while parsing rsx {:?} ", e);
+                return formatted_blocks;
+            }
+        };
 
         let rsx_start = macro_path.span().start();
 

--- a/packages/autofmt/tests/wrong.rs
+++ b/packages/autofmt/tests/wrong.rs
@@ -30,3 +30,4 @@ twoway!("multiexpr-many" => multiexpr_many (IndentOptions::new(IndentType::Space
 twoway!("simple-combo-expr" => simple_combo_expr (IndentOptions::new(IndentType::Spaces, 4, false)));
 twoway!("oneline-expand" => online_expand (IndentOptions::new(IndentType::Spaces, 4, false)));
 twoway!("shortened" => shortened (IndentOptions::new(IndentType::Spaces, 4, false)));
+twoway!("syntax_error" => syntax_error (IndentOptions::new(IndentType::Spaces, 4, false)));

--- a/packages/autofmt/tests/wrong/syntax_error.rsx
+++ b/packages/autofmt/tests/wrong/syntax_error.rsx
@@ -1,0 +1,6 @@
+fn app() -> Element {
+    rsx! {
+        let x="hello world";
+        div { "hello world" }
+    }
+}

--- a/packages/autofmt/tests/wrong/syntax_error.wrong.rsx
+++ b/packages/autofmt/tests/wrong/syntax_error.wrong.rsx
@@ -1,0 +1,6 @@
+fn app() -> Element {
+    rsx! {
+        let x="hello world";
+        div { "hello world" }
+    }
+}


### PR DESCRIPTION
https://github.com/DioxusLabs/dioxus/issues/2723

In case we have a syntax error during parsing of rsx! we do the following:
- write out error msg to stderr unfortunately we are not able to provide info about the fiel which contains the error.
- stop parsing and returned the onmodified file

As this is done also in other cases (silent continue) these seems to be acceptable