### PR TITLE
desktop app saves window position fix

### DIFF
--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -175,6 +175,7 @@ impl App {
 
         match self.window_behavior {
             LastWindowExitsApp => {
+                self.persist_window_state();
                 self.webviews.remove(&id);
                 if self.webviews.is_empty() {
                     self.control_flow = ControlFlow::Exit

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -177,7 +177,7 @@ impl App {
             LastWindowExitsApp => {
                 #[cfg(debug_assertions)]
                 self.persist_window_state();
-                
+
                 self.webviews.remove(&id);
                 if self.webviews.is_empty() {
                     self.control_flow = ControlFlow::Exit

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -175,7 +175,9 @@ impl App {
 
         match self.window_behavior {
             LastWindowExitsApp => {
+                #[cfg(debug_assertions)]
                 self.persist_window_state();
+                
                 self.webviews.remove(&id);
                 if self.webviews.is_empty() {
                     self.control_flow = ControlFlow::Exit


### PR DESCRIPTION
fixes [this](https://github.com/DioxusLabs/dioxus/issues/2729)
`app.handle_loop_destroyed` is called after the window is destroyed so it cannot be saved
added another save right before the last window is destroyed