### PR TITLE
Fix component names when they are re-exported

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -1420,9 +1420,9 @@ Finally, call `.build()` to create the instance of `{name}`.
                         pub fn into_vcomponent<M: 'static>(
                             self,
                             render_fn: impl dioxus_core::prelude::ComponentFunction<#original_name #ty_generics, M>,
-                            component_name: &'static str,
                         ) -> dioxus_core::VComponent {
                             use dioxus_core::prelude::ComponentFunction;
+                            let component_name = ::std::any::type_name_of_val(&render_fn);
                             dioxus_core::VComponent::new(move |wrapper: Self| render_fn.rebuild(wrapper.inner), self, component_name)
                         }
                     }

--- a/packages/core/src/properties.rs
+++ b/packages/core/src/properties.rs
@@ -57,12 +57,9 @@ pub trait Properties: Clone + Sized + 'static {
     fn memoize(&mut self, other: &Self) -> bool;
 
     /// Create a component from the props.
-    fn into_vcomponent<M: 'static>(
-        self,
-        render_fn: impl ComponentFunction<Self, M>,
-        component_name: &'static str,
-    ) -> VComponent {
-        VComponent::new(render_fn, self, component_name)
+    fn into_vcomponent<M: 'static>(self, render_fn: impl ComponentFunction<Self, M>) -> VComponent {
+        let type_name = std::any::type_name_of_val(&render_fn);
+        VComponent::new(render_fn, self, type_name)
     }
 }
 
@@ -121,10 +118,7 @@ where
 #[warnings::warning]
 pub(crate) fn component_called_as_function<C: ComponentFunction<P, M>, P, M>(_: C) {
     // We trim WithOwner from the end of the type name for component with a builder that include a special owner which may not match the function name directly
-    let mut type_name = std::any::type_name::<C>();
-    if let Some((_, after_colons)) = type_name.rsplit_once("::") {
-        type_name = after_colons;
-    }
+    let type_name = std::any::type_name::<C>();
     let component_name = Runtime::with(|rt| {
         current_scope_id()
             .ok()

--- a/packages/core/src/root_wrapper.rs
+++ b/packages/core/src/root_wrapper.rs
@@ -29,7 +29,7 @@ pub(crate) fn RootScopeWrapper(props: RootProps<VComponent>) -> Element {
                                 Box::new([]),
                             )))
                             .build()
-                            .into_vcomponent(SuspenseBoundary, "SuspenseBoundary")
+                            .into_vcomponent(SuspenseBoundary)
                     })]),
                     Box::new([]),
                 )))

--- a/packages/core/src/root_wrapper.rs
+++ b/packages/core/src/root_wrapper.rs
@@ -34,7 +34,7 @@ pub(crate) fn RootScopeWrapper(props: RootProps<VComponent>) -> Element {
                     Box::new([]),
                 )))
                 .build()
-                .into_vcomponent(ErrorBoundary, "ErrorBoundary"),
+                .into_vcomponent(ErrorBoundary),
         )]),
         Box::new([]),
     ))

--- a/packages/core/src/suspense/component.rs
+++ b/packages/core/src/suspense/component.rs
@@ -178,8 +178,8 @@ impl SuspenseBoundaryPropsWithOwner {
     pub fn into_vcomponent<M: 'static>(
         self,
         render_fn: impl ComponentFunction<SuspenseBoundaryProps, M>,
-        component_name: &'static str,
     ) -> VComponent {
+        let component_name = std::any::type_name_of_val(&render_fn);
         VComponent::new(
             move |wrapper: Self| render_fn.rebuild(wrapper.inner),
             self,

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -24,7 +24,7 @@ use std::{collections::HashSet, vec};
 use syn::{
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    token, AngleBracketedGenericArguments, Expr, Ident, PathArguments, Result,
+    token, AngleBracketedGenericArguments, Expr, PathArguments, Result,
 };
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -296,10 +296,6 @@ impl Component {
                 Some((attr, value))
             })
             .collect()
-    }
-
-    fn fn_name(&self) -> Ident {
-        self.name.segments.last().unwrap().ident.clone()
     }
 
     fn empty(name: syn::Path, generics: Option<AngleBracketedGenericArguments>) -> Self {

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -92,9 +92,6 @@ impl ToTokens for Component {
         // Create props either from manual props or from the builder approach
         let props = self.create_props();
 
-        // Make sure we stringify the component name
-        let fn_name = self.fn_name().to_string();
-
         // Make sure we emit any errors
         let diagnostics = &self.diagnostics;
 
@@ -109,7 +106,6 @@ impl ToTokens for Component {
                     #props
                 }).into_vcomponent(
                     #name #generics,
-                    #fn_name
                 );
                 #diagnostics
                 __comp


### PR DESCRIPTION
This PR switches to using the actual name of the component function in the type system instead of the stringified version of the function we see in rsx

Fixes #2743 
Fixes #2624 