### PR TITLE
Workspace support for `dx fmt`

### DIFF
--- a/packages/cli/src/cli/autoformat.rs
+++ b/packages/cli/src/cli/autoformat.rs
@@ -51,8 +51,10 @@ impl Autoformat {
         } = self;
 
         // TODO (matt): Do we need to use the entire `DioxusCrate` here?
-        let mut target_args = TargetArgs::default();
-        target_args.package = self.package;
+        let target_args = TargetArgs {
+            package: self.package,
+            ..Default::default()
+        };
         let dx_crate = match DioxusCrate::new(&target_args) {
             Ok(x) => x,
             Err(error) => {


### PR DESCRIPTION
Adds `dx fmt -p my_package` and `dx fmt --package my_package` to specify formatting a package in a Cargo workspace.

Fixes https://github.com/DioxusLabs/dioxus/issues/1547

This uses the new workspace logic in `DioxusCrate` to get the path to a specific package in a workspace. Maybe we should split up `DioxusCrate` into smaller parts here eventually instead of re-using it entirely?