### PR TITLE
Fix hot reloading spreads

### DIFF
--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -76,7 +76,7 @@ impl Parse for Element {
         // Assemble the new element from the contents of the block
         let mut element = Element {
             brace,
-            name,
+            name: name.clone(),
             raw_attributes: block.attributes,
             children: block.children,
             diagnostics: block.diagnostics,
@@ -98,7 +98,7 @@ impl Parse for Element {
                 value: AttributeValue::AttrExpr(PartialExpr::from_expr(&spread.expr)),
                 comma: spread.comma,
                 dyn_idx: spread.dyn_idx.clone(),
-                el_name: None,
+                el_name: Some(name.clone()),
             });
         }
 

--- a/packages/rsx/tests/hotreload_pattern.rs
+++ b/packages/rsx/tests/hotreload_pattern.rs
@@ -1125,3 +1125,25 @@ fn valid_fill_empty() {
 
     assert!(valid);
 }
+
+// We should be able to hot reload spreads
+#[test]
+fn valid_spread() {
+    let valid = can_hotreload(
+        quote! {
+            div {
+                ..spread
+            }
+        },
+        quote! {
+            div {
+                "hello world"
+            }
+            h1 {
+                ..spread
+            }
+        },
+    );
+
+    assert!(valid);
+}


### PR DESCRIPTION
Spreads did not have an element name assigned which caused a panic in hot reloading if the project contained a spread