### PR TITLE
Fix: #1964: Use the correct to-static impl for sending escaped strings via hotreload

### DIFF
--- a/packages/rsx/src/ifmt.rs
+++ b/packages/rsx/src/ifmt.rs
@@ -408,4 +408,13 @@ mod tests {
         println!("{}", input.to_string_with_quotes());
         assert!(input.is_static());
     }
+
+    #[test]
+    fn to_static() {
+        let input = syn::parse2::<IfmtInput>(quote! { "body {{ background: red; }}" }).unwrap();
+        assert_eq!(
+            input.to_static(),
+            Some("body { background: red; }".to_string())
+        );
+    }
 }

--- a/packages/rsx/src/node.rs
+++ b/packages/rsx/src/node.rs
@@ -156,14 +156,7 @@ impl BodyNode {
                     ),
                 }
             }
-            BodyNode::Text(text) if text.is_static() => {
-                let text = text.input.source.clone();
-                let text = intern(text.value().as_str());
-                TemplateNode::Text { text }
-            }
-            BodyNode::Text(text) => TemplateNode::Dynamic {
-                id: text.dyn_idx.get(),
-            },
+            BodyNode::Text(text) => text.to_template_node(),
             BodyNode::RawExpr(exp) => TemplateNode::Dynamic {
                 id: exp.dyn_idx.get(),
             },
@@ -209,7 +202,7 @@ impl BodyNode {
         match self {
             BodyNode::Element(el) => el.name.span(),
             BodyNode::Component(component) => component.name.span(),
-            BodyNode::Text(text) => text.input.source.span(),
+            BodyNode::Text(text) => text.input.span(),
             BodyNode::RawExpr(exp) => exp.span(),
             BodyNode::ForLoop(fl) => fl.for_token.span(),
             BodyNode::IfChain(f) => f.if_token.span(),

--- a/packages/rsx/src/text_node.rs
+++ b/packages/rsx/src/text_node.rs
@@ -66,13 +66,11 @@ impl TextNode {
     #[cfg(feature = "hot_reload")]
     pub fn to_template_node(&self) -> TemplateNode {
         use crate::intern;
-        match self.is_static() {
-            true => {
-                let text = self.input.source.clone();
-                let text = intern(text.value().as_str());
-                TemplateNode::Text { text }
-            }
-            false => TemplateNode::Dynamic {
+        match self.input.to_static() {
+            Some(text) => TemplateNode::Text {
+                text: intern(text.as_str()),
+            },
+            None => TemplateNode::Dynamic {
                 id: self.dyn_idx.get(),
             },
         }


### PR DESCRIPTION
Fix: #1964