### PR TITLE
Feat: Auto Default Into

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -1373,10 +1373,10 @@ Finally, call `.build()` to create the instance of `{name}`.
                     quote!(let #name = self.#name;)
                 } else if let Some(ref default) = field.builder_attr.default {
                     // If field has `into`, apply it to the default value.
-                    let into = if field.builder_attr.auto_into { 
+                    let into = if field.builder_attr.auto_into {
                         quote!{ .into() }
                     } else if field.builder_attr.auto_to_string {
-                        quote!{ .to_string() }  
+                        quote!{ .to_string() }
                     } else {
                         quote!{}
                     };

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -213,6 +213,9 @@ mod field_info {
                 {
                     builder_attr.from_displayable = true;
                     // ToString is both more general and provides a more useful error message than From<String>. If the user tries to use `#[into]`, use ToString instead.
+                    if builder_attr.auto_into {
+                        builder_attr.auto_to_string = true;
+                    }
                     builder_attr.auto_into = false;
                 }
 
@@ -275,6 +278,7 @@ mod field_info {
         pub docs: Vec<syn::Attribute>,
         pub skip: bool,
         pub auto_into: bool,
+        pub auto_to_string: bool,
         pub from_displayable: bool,
         pub strip_option: bool,
         pub ignore_option: bool,
@@ -1368,10 +1372,19 @@ Finally, call `.build()` to create the instance of `{name}`.
                 if !field.builder_attr.extends.is_empty() {
                     quote!(let #name = self.#name;)
                 } else if let Some(ref default) = field.builder_attr.default {
-                    if field.builder_attr.skip {
-                        quote!(let #name = #default;)
+                    // If field has `into`, apply it to the default value.
+                    let into = if field.builder_attr.auto_into { 
+                        quote!{ .into() }
+                    } else if field.builder_attr.auto_to_string {
+                        quote!{ .to_string() }  
                     } else {
-                        quote!(let #name = #helper_trait_name::into_value(#name, || #default);)
+                        quote!{}
+                    };
+
+                    if field.builder_attr.skip {
+                        quote!(let #name = #default #into;)
+                    } else {
+                        quote!(let #name = #helper_trait_name::into_value(#name, || #default #into);)
                     }
                 } else {
                     quote!(let #name = #name.0;)

--- a/packages/core-macro/tests/rsx.rs
+++ b/packages/core-macro/tests/rsx.rs
@@ -3,3 +3,51 @@ fn rsx() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/rsx/trailing-comma-0.rs");
 }
+
+/// This test ensures that automatic `into` conversion occurs for default values.
+///
+/// These are compile-time tests.
+/// See https://github.com/DioxusLabs/dioxus/issues/2373
+#[cfg(test)]
+mod test_default_into {
+    use dioxus::prelude::*;
+
+    #[derive(Props, Clone, PartialEq)]
+    struct MyCoolProps {
+        // Test different into configurations
+        #[props(into, default = true)]
+        pub val_into_w_default_val: u16,
+
+        #[props(into, default)]
+        pub val_into_w_default: u16,
+
+        #[props(default = true.into())]
+        pub val_default: u16,
+
+        // Test different into configurations with strings
+        #[props(into, default = "abc")]
+        pub str_into_w_default_val: String,
+
+        #[props(into, default)]
+        pub str_into_w_default: String,
+
+        #[props(default = "abc".into())]
+        pub str_default: String,
+
+        // Test options
+        #[props(into, default = Some("abc"))]
+        pub opt_into_w_default_val: Option<String>,
+
+        #[props(into, default)]
+        pub opt_into_w_default: Option<String>,
+
+        #[props(default = Some("abc"))]
+        pub opt_default: Option<String>,
+
+        // Test no default
+        #[props(into)]
+        pub some_data: bool,
+
+        pub some_other_data: bool,
+    }
+}


### PR DESCRIPTION
Allows automatic `into()` for the default value in props.

```rs
// E.g. instead of 

#[derive(Clone, PartialEq, Props)]
pub struct SomeCoolProps {
    #[props(into, default = "abc".to_string())]
    pub data: String,

    #[props(into, default = true.into())]
    pub other_data: u64,

    #[props(into, default = true.into())]
    pub other_other_data: u16,
}

// you can now do this

#[derive(Clone, PartialEq, Props)]
pub struct SomeCoolProps {
    #[props(into, default = "abc")]
    pub data: String,

    #[props(into, default = true)]
    pub other_data: u64,

    #[props(into, default = true)]
    pub other_other_data: u16,
}
```

Closes #2373