### PR TITLE
Support Optional Read Signals

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -492,10 +492,20 @@ fn type_from_inside_option(ty: &syn::Type, check_option_name: bool) -> Option<&s
     } else {
         return None;
     };
+
+    let mut is_optional = false;
+    
+    // Check if last path segment is optional.
     let segment = path.segments.last()?;
-    if check_option_name && segment.ident != "Option" {
+    if segment.ident == "Option" {
+        is_optional = true;
+    }
+
+    // We didn't detect any supported optional props.
+    if check_option_name && !is_optional {
         return None;
     }
+
     let generic_params =
         if let syn::PathArguments::AngleBracketed(generic_params) = &segment.arguments {
             generic_params

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -512,7 +512,6 @@ fn type_from_inside_option(ty: &syn::Type) -> Option<&syn::Type> {
         }
     }
 
-
     None
 }
 

--- a/packages/core-macro/tests/rsx.rs
+++ b/packages/core-macro/tests/rsx.rs
@@ -51,8 +51,8 @@ mod test_default_into {
         pub some_other_data: bool,
     }
 }
-/// This test ensures that signals that contain an option (`Signal<Option<u16>>`) and the
-/// read-only varients are correctly created as default when not provided.
+/// This test ensures that read-only signals that contain an option (`Signal<Option<u16>>`) 
+/// are correctly created as default when not provided.
 ///
 /// These are compile-time tests.
 /// See https://github.com/DioxusLabs/dioxus/issues/2648
@@ -74,7 +74,6 @@ mod test_optional_signals {
     #[derive(Props, Clone, PartialEq)]
     struct MyTestProps {
         pub optional_read_signal: ReadOnlySignal<Option<u16>>,
-        //pub basic_opt: Option<u16>,
     }
 
     #[component]

--- a/packages/core-macro/tests/rsx.rs
+++ b/packages/core-macro/tests/rsx.rs
@@ -57,6 +57,7 @@ mod test_default_into {
 /// These are compile-time tests.
 /// See https://github.com/DioxusLabs/dioxus/issues/2648
 #[cfg(test)]
+#[allow(unused)]
 mod test_optional_signals {
     use dioxus::prelude::*;
 
@@ -65,28 +66,25 @@ mod test_optional_signals {
     fn UsesComponents() -> Element {
         rsx! {
             PropsStruct {}
-            PropsParams {}
+            PropParams {}
         }
     }
 
     // Test props as struct param.
     #[derive(Props, Clone, PartialEq)]
     struct MyTestProps {
-        pub optional_signal: Signal<Option<u16>>,
-        pub optional_read_signal: ReadOnlySignal<Option<16>>,
+        pub optional_read_signal: ReadOnlySignal<Option<u16>>,
+        //pub basic_opt: Option<u16>,
     }
 
     #[component]
-    fn PropsStruct(_props: MyTestProps) -> Element {
+    fn PropsStruct(props: MyTestProps) -> Element {
         rsx! { "hi" }
     }
 
     // Test props as params.
     #[component]
-    fn PropParams(
-        opt_sig: Signal<Option<u16>>,
-        opt_read_sig: ReadOnlySignal<Option<u16>>,
-    ) -> Element {
+    fn PropParams(opt_read_sig: ReadOnlySignal<Option<u16>>) -> Element {
         rsx! { "hi!" }
     }
 }

--- a/packages/core-macro/tests/rsx.rs
+++ b/packages/core-macro/tests/rsx.rs
@@ -51,3 +51,42 @@ mod test_default_into {
         pub some_other_data: bool,
     }
 }
+/// This test ensures that signals that contain an option (`Signal<Option<u16>>`) and the
+/// read-only varients are correctly created as default when not provided.
+///
+/// These are compile-time tests.
+/// See https://github.com/DioxusLabs/dioxus/issues/2648
+#[cfg(test)]
+mod test_optional_signals {
+    use dioxus::prelude::*;
+
+    // Test if test components fail to compile.
+    #[component]
+    fn UsesComponents() -> Element {
+        rsx! {
+            PropsStruct {}
+            PropsParams {}
+        }
+    }
+
+    // Test props as struct param.
+    #[derive(Props, Clone, PartialEq)]
+    struct MyTestProps {
+        pub optional_signal: Signal<Option<u16>>,
+        pub optional_read_signal: ReadOnlySignal<Option<16>>,
+    }
+
+    #[component]
+    fn PropsStruct(_props: MyTestProps) -> Element {
+        rsx! { "hi" }
+    }
+
+    // Test props as params.
+    #[component]
+    fn PropParams(
+        opt_sig: Signal<Option<u16>>,
+        opt_read_sig: ReadOnlySignal<Option<u16>>,
+    ) -> Element {
+        rsx! { "hi!" }
+    }
+}


### PR DESCRIPTION
Allows:
```rs
#[derive(Props, Clone, PartialEq)]
struct MyTestProps {
    pub optional_read_signal: ReadOnlySignal<Option<u16>>, // This is now truly optional when calling components!
    pub opt: Option<u16>, // Originally you could only get away with this
}
```

Closes #2648 