### PR TITLE
fix: use prettier-please just in tests - no custom wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,9 +1326,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca2be1d5c43812bae364ee3f30b3afcb7877cf59f4aeb94c66f313a41d2fac9"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "bzip2"
@@ -5940,9 +5940,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "liquid"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9338405fdbc0bce9b01695b2a2ef6b20eca5363f385d47bce48ddf8323cc25"
+checksum = "7cdcc72b82748f47c2933c172313f5a9aea5b2c4eb3fa4c66b4ea55bb60bb4b1"
 dependencies = [
  "doc-comment",
  "liquid-core",
@@ -5953,9 +5953,9 @@ dependencies = [
 
 [[package]]
 name = "liquid-core"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb8fed70857010ed9016ed2ce5a7f34e7cc51d5d7255c9c9dc2e3243e490b42"
+checksum = "2752e978ffc53670f3f2e8b3ef09f348d6f7b5474a3be3f8a5befe5382e4effb"
 dependencies = [
  "anymap2",
  "itertools 0.13.0",
@@ -5971,9 +5971,9 @@ dependencies = [
 
 [[package]]
 name = "liquid-derive"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5aa659a76b649f0d639ef0b9c067a9499c42a9d7f3e7832e279f791704966"
+checksum = "3b51f1d220e3fa869e24cfd75915efe3164bd09bb11b3165db3f37f57bf673e3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5982,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "liquid-lib"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1794b5605e9f8864a8a4f41aa97976b42512cc81093f8c885d29fb94c6c556"
+checksum = "59b1a298d3d2287ee5b1e43840d885b8fdfc37d3f4e90d82aacfd04d021618da"
 dependencies = [
  "itertools 0.13.0",
  "liquid-core",
@@ -6826,12 +6826,12 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d73ba8daf8fac13b0501d1abeddcfe21ba7401ada61a819144b6c2a4f32209"
+checksum = "5ffd2b0a5634335b135d5728d84c5e0fd726954b87111f7506a61c502280d982"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7428,9 +7428,9 @@ dependencies = [
 
 [[package]]
 name = "prettier-please"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22020dfcf177fcc7bf5deaf7440af371400c67c0de14c399938d8ed4fb4645d3"
+checksum = "32db37eb2b0ec0af154e9c1b33425902d8cd9481e35167c4e9ffb28fec3916bb"
 dependencies = [
  "proc-macro2",
  "syn 2.0.72",
@@ -8647,9 +8647,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.121"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
+checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
 dependencies = [
  "itoa 1.0.11",
  "memchr",
@@ -9638,9 +9638,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1802b1642488aec58597dc55ea88992c165660d6e44e9838d4d93f7b78ab95f3"
+checksum = "457fb92efa9f0c849d6bc4e86561982d464176bc3df96bb22baed5e98309e090"
 dependencies = [
  "ahash 0.8.11",
  "ast_node",
@@ -10019,9 +10019,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.200.4"
+version = "0.200.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b92feddb27f3ad89dd296696f55e04f8e96cdc778df95a73a6f06664bf6919f3"
+checksum = "624e23b532c9a2f74ea850120b19079ab67f6e85af53c83d1984adbecc820b03"
 dependencies = [
  "arrayvec",
  "indexmap 2.3.0",
@@ -10054,9 +10054,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.148.1"
+version = "0.148.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8204235f635274dba4adc30c47ac896fd126ddfc53b27210676722423cbb2e7"
+checksum = "a05ef8f80461e19374d9e8197f459a399b2802da19f72ea951ef343752ff3c04"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -10302,9 +10302,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.194.3"
+version = "0.194.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f73c4ae3eb15adc5865dc729c4e111040529cec5a349d56ed0b4a0de1a86242"
+checksum = "99619353488c1dae960159faef86f0261e7fefe43b84ed1ba80c8cbc5a539434"
 dependencies = [
  "ryu-js",
  "serde",
@@ -12258,6 +12258,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,10 @@ manganis-cli-support = { version = "0.3.0-alpha.0", features = ["html"] }
 manganis = { version = "0.3.0-alpha.0", default-features = false }
 warnings = { version = "0.2.0" }
 
+
+# a fork of pretty please for tests
+prettier-please = { version = "0.3.0", features = ["verbatim"]}
+
 tracing = "0.1.37"
 tracing-futures = "0.2.5"
 toml = "0.8"

--- a/packages/rsx/Cargo.toml
+++ b/packages/rsx/Cargo.toml
@@ -21,7 +21,6 @@ serde = { workspace = true, features = ["derive"], optional = true }
 internment = { version = "0.7.0", optional = true }
 tracing = { workspace = true }
 proc-macro2-diagnostics = { version = "0.10", default-features = false }
-prettier-please = { version = "*" }
 
 [features]
 default = ["hot_reload"]
@@ -31,6 +30,7 @@ serde = ["dep:serde", "dioxus-core/serialize"]
 
 [dev-dependencies]
 prettyplease = { workspace = true }
+prettier-please = { workspace = true }
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -405,7 +405,7 @@ impl Display for ElementName {
 }
 
 #[cfg(test)]
-mod tests{
+mod tests {
     use super::*;
     use prettier_please::PrettyUnparse;
 

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -404,216 +404,222 @@ impl Display for ElementName {
     }
 }
 
-#[test]
-fn parses_name() {
-    let _parsed: ElementName = syn::parse2(quote::quote! { div }).unwrap();
-    let _parsed: ElementName = syn::parse2(quote::quote! { some-cool-element }).unwrap();
+#[cfg(test)]
+mod tests{
+    use super::*;
+    use prettier_please::PrettyUnparse;
 
-    let _parsed: Element = syn::parse2(quote::quote! { div {} }).unwrap();
-    let _parsed: Element = syn::parse2(quote::quote! { some-cool-element {} }).unwrap();
+    #[test]
+    fn parses_name() {
+        let _parsed: ElementName = syn::parse2(quote::quote! { div }).unwrap();
+        let _parsed: ElementName = syn::parse2(quote::quote! { some-cool-element }).unwrap();
 
-    let parsed: Element = syn::parse2(quote::quote! {
-        some-cool-div {
-            id: "hi",
-            id: "hi {abc}",
-            id: "hi {def}",
-            class: 123,
-            something: bool,
-            data_attr: "data",
-            data_attr: "data2",
-            data_attr: "data3",
-            exp: { some_expr },
-            something: {cool},
-            something: bool,
-            something: 123,
-            onclick: move |_| {
-                println!("hello world");
-            },
-            "some-attr": "hello world",
-            onclick: move |_| {},
-            class: "hello world",
-            id: "my-id",
-            data_attr: "data",
-            data_attr: "data2",
-            data_attr: "data3",
-            "somte_attr3": "hello world",
-            something: {cool},
-            something: bool,
-            something: 123,
-            onclick: move |_| {
-                println!("hello world");
-            },
-            ..attrs1,
-            ..attrs2,
-            ..attrs3
-        }
-    })
-    .unwrap();
+        let _parsed: Element = syn::parse2(quote::quote! { div {} }).unwrap();
+        let _parsed: Element = syn::parse2(quote::quote! { some-cool-element {} }).unwrap();
 
-    dbg!(parsed);
-}
-
-#[test]
-fn parses_variety() {
-    let input = quote::quote! {
-        div {
-            class: "hello world",
-            id: "my-id",
-            data_attr: "data",
-            data_attr: "data2",
-            data_attr: "data3",
-            "somte_attr3": "hello world",
-            something: {cool},
-            something: bool,
-            something: 123,
-            onclick: move |_| {
-                println!("hello world");
-            },
-            ..attrs,
-            ..attrs2,
-            ..attrs3
-        }
-    };
-
-    let parsed: Element = syn::parse2(input).unwrap();
-    dbg!(parsed);
-}
-
-#[test]
-fn to_tokens_properly() {
-    let input = quote::quote! {
-        div {
-            class: "hello world",
-            class2: "hello {world}",
-            class3: "goodbye {world}",
-            class4: "goodbye world",
-            "something": "cool {blah}",
-            "something2": "cooler",
-            div {
-                div {
-                    h1 { class: "h1 col" }
-                    h2 { class: "h2 col" }
-                    h3 { class: "h3 col" }
-                    div {}
-                }
-            }
-        }
-    };
-
-    let parsed: Element = syn::parse2(input).unwrap();
-    println!("{}", parsed.to_token_stream().pretty_unparse());
-}
-
-#[test]
-fn to_tokens_with_diagnostic() {
-    let input = quote::quote! {
-        div {
-            class: "hello world",
-            id: "my-id",
-            ..attrs,
-            div {
-                ..attrs,
+        let parsed: Element = syn::parse2(quote::quote! {
+            some-cool-div {
+                id: "hi",
+                id: "hi {abc}",
+                id: "hi {def}",
+                class: 123,
+                something: bool,
+                data_attr: "data",
+                data_attr: "data2",
+                data_attr: "data3",
+                exp: { some_expr },
+                something: {cool},
+                something: bool,
+                something: 123,
+                onclick: move |_| {
+                    println!("hello world");
+                },
+                "some-attr": "hello world",
+                onclick: move |_| {},
                 class: "hello world",
                 id: "my-id",
+                data_attr: "data",
+                data_attr: "data2",
+                data_attr: "data3",
+                "somte_attr3": "hello world",
+                something: {cool},
+                something: bool,
+                something: 123,
+                onclick: move |_| {
+                    println!("hello world");
+                },
+                ..attrs1,
+                ..attrs2,
+                ..attrs3
             }
-        }
-    };
+        })
+        .unwrap();
 
-    let parsed: Element = syn::parse2(input).unwrap();
-    println!("{}", parsed.to_token_stream().pretty_unparse());
-}
+        dbg!(parsed);
+    }
 
-#[test]
-fn merges_attributes() {
-    let input = quote::quote! {
-        div {
-            class: "hello world",
-            class: if count > 3 { "abc {def}" },
-            class: if count < 50 { "small" } else { "big" }
-        }
-    };
+    #[test]
+    fn parses_variety() {
+        let input = quote::quote! {
+            div {
+                class: "hello world",
+                id: "my-id",
+                data_attr: "data",
+                data_attr: "data2",
+                data_attr: "data3",
+                "somte_attr3": "hello world",
+                something: {cool},
+                something: bool,
+                something: 123,
+                onclick: move |_| {
+                    println!("hello world");
+                },
+                ..attrs,
+                ..attrs2,
+                ..attrs3
+            }
+        };
 
-    let parsed: Element = syn::parse2(input).unwrap();
-    assert_eq!(parsed.diagnostics.len(), 0);
-    assert_eq!(parsed.merged_attributes.len(), 1);
-    assert_eq!(
-        parsed.merged_attributes[0].name.to_string(),
-        "class".to_string()
-    );
+        let parsed: Element = syn::parse2(input).unwrap();
+        dbg!(parsed);
+    }
 
-    let attr = &parsed.merged_attributes[0].value;
+    #[test]
+    fn to_tokens_properly() {
+        let input = quote::quote! {
+            div {
+                class: "hello world",
+                class2: "hello {world}",
+                class3: "goodbye {world}",
+                class4: "goodbye world",
+                "something": "cool {blah}",
+                "something2": "cooler",
+                div {
+                    div {
+                        h1 { class: "h1 col" }
+                        h2 { class: "h2 col" }
+                        h3 { class: "h3 col" }
+                        div {}
+                    }
+                }
+            }
+        };
 
-    println!("{}", attr.to_token_stream().pretty_unparse());
+        let parsed: Element = syn::parse2(input).unwrap();
+        println!("{}", parsed.to_token_stream().pretty_unparse());
+    }
 
-    let _attr = match attr {
-        AttributeValue::AttrLiteral(lit) => lit,
-        _ => panic!("expected literal"),
-    };
-}
+    #[test]
+    fn to_tokens_with_diagnostic() {
+        let input = quote::quote! {
+            div {
+                class: "hello world",
+                id: "my-id",
+                ..attrs,
+                div {
+                    ..attrs,
+                    class: "hello world",
+                    id: "my-id",
+                }
+            }
+        };
 
-/// There are a number of cases where merging attributes doesn't make sense
-/// - merging two expressions together
-/// - merging two literals together
-/// - merging a literal and an expression together
-///
-/// etc
-///
-/// We really only want to merge formatted things together
-///
-/// IE
-/// class: "hello world ",
-/// class: if some_expr { "abc" }
-///
-/// Some open questions - should the delimiter be explicit?
-#[test]
-fn merging_weird_fails() {
-    let input = quote::quote! {
-        div {
-            class: "hello world",
-            class: if some_expr { 123 },
+        let parsed: Element = syn::parse2(input).unwrap();
+        println!("{}", parsed.to_token_stream().pretty_unparse());
+    }
 
-            style: "color: red;",
-            style: "color: blue;",
+    #[test]
+    fn merges_attributes() {
+        let input = quote::quote! {
+            div {
+                class: "hello world",
+                class: if count > 3 { "abc {def}" },
+                class: if count < 50 { "small" } else { "big" }
+            }
+        };
 
-            width: "1px",
-            width: 1,
-            width: false,
-            contenteditable: true,
-        }
-    };
+        let parsed: Element = syn::parse2(input).unwrap();
+        assert_eq!(parsed.diagnostics.len(), 0);
+        assert_eq!(parsed.merged_attributes.len(), 1);
+        assert_eq!(
+            parsed.merged_attributes[0].name.to_string(),
+            "class".to_string()
+        );
 
-    let parsed: Element = syn::parse2(input).unwrap();
+        let attr = &parsed.merged_attributes[0].value;
 
-    assert_eq!(parsed.merged_attributes.len(), 4);
-    assert_eq!(parsed.diagnostics.len(), 3);
+        println!("{}", attr.to_token_stream().pretty_unparse());
 
-    // style should not generate a diagnostic
-    assert!(!parsed
-        .diagnostics
-        .diagnostics
-        .into_iter()
-        .any(|f| f.emit_as_item_tokens().to_string().contains("style")));
-}
+        let _attr = match attr {
+            AttributeValue::AttrLiteral(lit) => lit,
+            _ => panic!("expected literal"),
+        };
+    }
 
-#[test]
-fn diagnostics() {
-    let input = quote::quote! {
-        p {
-            class: "foo bar"
-            "Hello world"
-        }
-    };
+    /// There are a number of cases where merging attributes doesn't make sense
+    /// - merging two expressions together
+    /// - merging two literals together
+    /// - merging a literal and an expression together
+    ///
+    /// etc
+    ///
+    /// We really only want to merge formatted things together
+    ///
+    /// IE
+    /// class: "hello world ",
+    /// class: if some_expr { "abc" }
+    ///
+    /// Some open questions - should the delimiter be explicit?
+    #[test]
+    fn merging_weird_fails() {
+        let input = quote::quote! {
+            div {
+                class: "hello world",
+                class: if some_expr { 123 },
 
-    let _parsed: Element = syn::parse2(input).unwrap();
-}
+                style: "color: red;",
+                style: "color: blue;",
 
-#[test]
-fn parses_raw_elements() {
-    let input = quote::quote! {
-        use {
-            "hello"
-        }
-    };
+                width: "1px",
+                width: 1,
+                width: false,
+                contenteditable: true,
+            }
+        };
 
-    let _parsed: Element = syn::parse2(input).unwrap();
+        let parsed: Element = syn::parse2(input).unwrap();
+
+        assert_eq!(parsed.merged_attributes.len(), 4);
+        assert_eq!(parsed.diagnostics.len(), 3);
+
+        // style should not generate a diagnostic
+        assert!(!parsed
+            .diagnostics
+            .diagnostics
+            .into_iter()
+            .any(|f| f.emit_as_item_tokens().to_string().contains("style")));
+    }
+
+    #[test]
+    fn diagnostics() {
+        let input = quote::quote! {
+            p {
+                class: "foo bar"
+                "Hello world"
+            }
+        };
+
+        let _parsed: Element = syn::parse2(input).unwrap();
+    }
+
+    #[test]
+    fn parses_raw_elements() {
+        let input = quote::quote! {
+            use {
+                "hello"
+            }
+        };
+
+        let _parsed: Element = syn::parse2(input).unwrap();
+    }
 }

--- a/packages/rsx/src/expr_node.rs
+++ b/packages/rsx/src/expr_node.rs
@@ -34,7 +34,7 @@ impl ToTokens for ExprNode {
 
 #[test]
 fn no_commas() {
-    use crate::PrettyUnparse;
+    use prettier_please::PrettyUnparse;
     let input = quote! {
         div {
             {label("Hello, world!")},

--- a/packages/rsx/src/ifmt.rs
+++ b/packages/rsx/src/ifmt.rs
@@ -358,7 +358,7 @@ impl Parse for IfmtInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PrettyUnparse;
+    use prettier_please::PrettyUnparse;
 
     #[test]
     fn raw_tokens() {

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -78,8 +78,6 @@ pub use partial_closure::PartialClosure;
 pub use rsx_call::*;
 pub use template_body::TemplateBody;
 
-pub use util::PrettyUnparse;
-
 pub mod hot_reload;
 
 #[cfg(feature = "hot_reload_traits")]

--- a/packages/rsx/src/literal.rs
+++ b/packages/rsx/src/literal.rs
@@ -216,7 +216,7 @@ impl ToTokens for HotReloadFormattedSegment {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PrettyUnparse;
+    use prettier_please::PrettyUnparse;
 
     #[test]
     fn parses_lits() {

--- a/packages/rsx/src/text_node.rs
+++ b/packages/rsx/src/text_node.rs
@@ -80,7 +80,7 @@ impl TextNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::PrettyUnparse;
+    use prettier_please::PrettyUnparse;
 
     #[test]
     fn parses() {

--- a/packages/rsx/src/util.rs
+++ b/packages/rsx/src/util.rs
@@ -19,20 +19,6 @@ pub(crate) fn intern<T: Eq + Hash + Send + Sync + ?Sized + 'static>(
     s.into().as_ref()
 }
 
-/// These are just helpful methods for tests to pretty print the token stream - they are not used in the actual code
-// #[cfg(test)]
-pub trait PrettyUnparse {
-    fn pretty_unparse(&self) -> String;
-}
-
-// #[cfg(test)]
-impl PrettyUnparse for TokenStream2 {
-    fn pretty_unparse(&self) -> String {
-        let parsed = syn::parse2::<syn::Expr>(self.clone()).unwrap();
-        prettier_please::unparse_expr(&parsed)
-    }
-}
-
 /// Parse a raw ident and return a new ident with the r# prefix added
 pub fn parse_raw_ident(parse_buffer: &ParseBuffer) -> syn::Result<Ident> {
     // First try to parse as a normal ident

--- a/packages/rsx/tests/parsing.rs
+++ b/packages/rsx/tests/parsing.rs
@@ -1,7 +1,7 @@
 use dioxus_rsx::CallBody;
 use quote::ToTokens;
 
-use dioxus_rsx::PrettyUnparse;
+use prettier_please::PrettyUnparse;
 
 #[test]
 fn callbody_ctx() {


### PR DESCRIPTION
Move to the published version of prettier-please so we don't need to re-export it into our tests.