### PR TITLE
Remove implicit Sized bounds on `CopyValue` and `GenerationalBox`

### DIFF
--- a/packages/generational-box/src/lib.rs
+++ b/packages/generational-box/src/lib.rs
@@ -39,7 +39,7 @@ impl Debug for GenerationalBoxId {
 }
 
 /// The core Copy state type. The generational box will be dropped when the [Owner] is dropped.
-pub struct GenerationalBox<T, S: 'static = UnsyncStorage> {
+pub struct GenerationalBox<T: ?Sized, S: 'static = UnsyncStorage> {
     raw: GenerationalPointer<S>,
     _marker: PhantomData<T>,
 }
@@ -138,7 +138,7 @@ impl<T, S> Clone for GenerationalBox<T, S> {
 }
 
 /// A trait for a storage backing type. (RefCell, RwLock, etc.)
-pub trait Storage<Data = ()>: AnyStorage + 'static {
+pub trait Storage<Data: ?Sized = ()>: AnyStorage + 'static {
     /// Try to read the value. Returns None if the value is no longer valid.
     fn try_read(
         location: GenerationalPointer<Self>,

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -19,7 +19,7 @@ use crate::{default_impl, write_impls};
 /// CopyValue is a wrapper around a value to make the value mutable and Copy.
 ///
 /// It is internally backed by [`generational_box::GenerationalBox`].
-pub struct CopyValue<T: 'static, S: Storage<T> = UnsyncStorage> {
+pub struct CopyValue<T: ?Sized + 'static, S: Storage<T> = UnsyncStorage> {
     pub(crate) value: GenerationalBox<T, S>,
     pub(crate) origin_scope: ScopeId,
 }


### PR DESCRIPTION
This should allow for optimizations like `CopyValue<dyn Trait>` instead of `CopyValue<Box<dyn Trait>>`