### PR TITLE
Mobile tooling with `cargo-mobile2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1077,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bcder"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
+dependencies = [
+ "bytes",
+ "smallvec",
+]
+
+[[package]]
 name = "better_scoped_tls"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,7 +1135,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.72",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -1393,7 +1412,7 @@ checksum = "9917a953205900b20fe9c77776e2a95607a177c25faefc776920d1aa1a079079"
 dependencies = [
  "anyhow",
  "auth-git2",
- "clap",
+ "clap 4.5.13",
  "console",
  "dialoguer",
  "env_logger 0.11.5",
@@ -1424,6 +1443,44 @@ dependencies = [
  "time",
  "toml 0.8.19",
  "walkdir",
+]
+
+[[package]]
+name = "cargo-mobile2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06f70f6ff0db884929c9b3b7825031607e2800e40ce1569e8f9c6a58bd82eae8"
+dependencies = [
+ "colored 2.1.0",
+ "core-foundation",
+ "deunicode",
+ "duct",
+ "dunce",
+ "embed-resource",
+ "english-numbers",
+ "env_logger 0.11.5",
+ "freedesktop_entry_parser",
+ "handlebars 5.1.2",
+ "heck 0.5.0",
+ "home",
+ "ignore",
+ "java-properties",
+ "libc",
+ "log",
+ "once-cell-regex",
+ "os_info",
+ "os_pipe",
+ "path_abs",
+ "serde",
+ "serde_json",
+ "structopt",
+ "textwrap 0.16.1",
+ "thiserror",
+ "toml 0.8.19",
+ "ureq",
+ "which 6.0.2",
+ "windows 0.57.0",
+ "x509-certificate",
 ]
 
 [[package]]
@@ -1605,6 +1662,21 @@ dependencies = [
  "glob",
  "libc",
  "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
 ]
 
 [[package]]
@@ -2015,7 +2087,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap",
+ "clap 4.5.13",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -2375,6 +2447,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
+
+[[package]]
 name = "dialoguer"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,10 +2554,11 @@ dependencies = [
  "brotli",
  "built",
  "cargo-generate",
+ "cargo-mobile2",
  "cargo_metadata",
  "cargo_toml",
  "chrono",
- "clap",
+ "clap 4.5.13",
  "colored 2.1.0",
  "console",
  "console-subscriber",
@@ -2547,7 +2626,7 @@ version = "0.6.0-alpha.1"
 dependencies = [
  "built",
  "cargo_toml",
- "clap",
+ "clap 4.5.13",
  "dirs",
  "once_cell",
  "serde",
@@ -2701,7 +2780,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "ciborium",
- "clap",
+ "clap 4.5.13",
  "dioxus",
  "dioxus-cli-config",
  "dioxus-desktop",
@@ -3237,6 +3316,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "duct"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+dependencies = [
+ "libc",
+ "once_cell",
+ "os_pipe",
+ "shared_child",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3249,6 +3340,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "embed-resource"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edcacde9351c33139a41e3c97eb2334351a81a2791bebb0b243df837128f602"
+dependencies = [
+ "cc",
+ "memchr",
+ "rustc_version 0.4.0",
+ "toml 0.8.19",
+ "vswhom",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -3271,6 +3376,12 @@ name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "english-numbers"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4f5d6e192964d498b45abee72ca445e91909094bc8e8791259e82c2a0d1aa6"
 
 [[package]]
 name = "enumflags2"
@@ -3632,6 +3743,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
 dependencies = [
  "nonempty",
+ "thiserror",
+]
+
+[[package]]
+name = "freedesktop_entry_parser"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9c27b72f19a99a895f8ca89e2d26e4ef31013376e56fdafef697627306c3e4"
+dependencies = [
+ "nom",
  "thiserror",
 ]
 
@@ -4715,6 +4836,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "handlebars"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08485b96a0e6393e9e4d1b8d48cf74ad6c063cd905eb33f42c1ce3f0377539b"
+dependencies = [
+ "log",
+ "pest",
+ "pest_derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5550,6 +5685,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "java-properties"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37bf6f484471c451f2b51eabd9e66b3fa7274550c5ec4b6c3d6070840945117f"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "javascriptcore-rs"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6233,7 +6379,7 @@ dependencies = [
  "cfg-if",
  "miette-derive",
  "owo-colors",
- "textwrap",
+ "textwrap 0.16.1",
  "thiserror",
  "unicode-width",
 ]
@@ -6736,6 +6882,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "once-cell-regex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3de7e389a5043420c8f2b95ed03f3f104ad6f4c41f7d7e27298f033abc253e8"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6822,6 +6978,17 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
+dependencies = [
+ "log",
+ "serde",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6987,6 +7154,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "path_abs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ef02f6342ac01d8a93b65f96db53fe68a92a15f41144f97fb00a9e669633c3"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "std_prelude",
+ "stfu8",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7002,6 +7181,16 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -8857,6 +9046,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9411,6 +9610,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "std_prelude"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8207e78455ffdf55661170876f88daf85356e4edd54e0a3dbc79586ca1e50cbe"
+
+[[package]]
+name = "stfu8"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
 name = "string_cache"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9461,6 +9672,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -9470,6 +9687,30 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
+dependencies = [
+ "clap 2.34.0",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "strum"
@@ -10643,7 +10884,7 @@ dependencies = [
  "dirs-next",
  "dunce",
  "glob",
- "handlebars",
+ "handlebars 4.5.0",
  "heck 0.4.1",
  "hex",
  "image 0.24.9",
@@ -10753,12 +10994,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.27",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
+ "terminal_size",
  "unicode-linebreak",
  "unicode-width",
 ]
@@ -11506,7 +11767,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72139d247e5f97a3eff96229a7ae85ead5328a39efe76f8bf5a06313d505b6ea"
 dependencies = [
  "base64 0.22.1",
+ "flate2",
  "log",
+ "native-tls",
  "once_cell",
  "rustls 0.23.12",
  "rustls-pki-types",
@@ -11585,6 +11848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
 name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11601,6 +11870,26 @@ name = "vlq"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65dd7eed29412da847b0f78bcec0ac98588165988a8cfe41d4ea1d429f8ccfff"
+
+[[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b17ae1f6c8a2b28506cd96d412eebf83b4a0ff2cbefeeb952f2f9dfa44ba18"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"
@@ -12089,6 +12378,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d9c5ed668ee1f17edb3b627225343d210006a90bb1e3745ce1f30b1fb115075"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.34",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12507,6 +12808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wry"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12576,6 +12883,25 @@ dependencies = [
  "libc",
  "once_cell",
  "pkg-config",
+]
+
+[[package]]
+name = "x509-certificate"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66534846dec7a11d7c50a74b7cdb208b9a581cad890b7866430d438455847c85"
+dependencies = [
+ "bcder",
+ "bytes",
+ "chrono",
+ "der",
+ "hex",
+ "pem",
+ "ring",
+ "signature",
+ "spki",
+ "thiserror",
+ "zeroize",
 ]
 
 [[package]]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -73,6 +73,7 @@ once_cell = "1.19.0"
 # plugin packages
 open = "5.0.1"
 cargo-generate = "=0.21.1"
+cargo-mobile2 = "0.13.0"
 toml_edit = "0.22.15"
 
 # bundling

--- a/packages/cli/src/cli/apple.rs
+++ b/packages/cli/src/cli/apple.rs
@@ -1,0 +1,56 @@
+use cargo_mobile2::{
+    apple::{
+        cli::{Command, Input},
+        target::Target,
+    },
+    opts::NoiseLevel,
+    target::TargetTrait,
+    util::cli::{Exec, GlobalFlags, Profile, TextWrapper},
+};
+use clap::Parser;
+
+#[derive(Clone, Debug, Parser)]
+pub enum Apple {
+    #[clap(name = "open", about = "Open project in Xcode")]
+    Open,
+    #[clap(name = "check", about = "Checks if code compiles for target(s)")]
+    Check {
+        #[clap(name = "targets", default_value = Target::DEFAULT_KEY)]
+        targets: Vec<String>,
+    },
+    #[clap(name = "build", about = "Builds static libraries for target(s)")]
+    Build {
+        #[clap(name = "targets", default_value = Target::DEFAULT_KEY)]
+        targets: Vec<String>,
+    },
+
+    #[clap(name = "run", about = "Deploys IPA to connected device")]
+    Run,
+}
+
+impl From<Apple> for Command {
+    fn from(value: Apple) -> Self {
+        match value {
+            Apple::Open => todo!(),
+            Apple::Check { targets } => todo!(),
+            Apple::Build { targets } => todo!(),
+            Apple::Run => Command::Run {
+                profile: Profile {
+                    profile: cargo_mobile2::opts::Profile::Debug,
+                },
+            },
+        }
+    }
+}
+
+pub fn run(cmd: Apple) {
+    Input::new(
+        GlobalFlags {
+            noise_level: NoiseLevel::LoudAndProud,
+            non_interactive: false,
+        },
+        cmd.into(),
+    )
+    .exec(&TextWrapper::default())
+    .unwrap();
+}

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -1,3 +1,4 @@
+pub mod apple;
 pub mod autoformat;
 pub mod build;
 pub mod bundle;
@@ -86,6 +87,9 @@ pub enum Commands {
     /// Handles parsing of linker arguments for linker-based systems
     /// such as Manganis and binary patching.
     Link(link::LinkCommand),
+
+    #[clap(subcommand)]
+    Apple(apple::Apple),
 }
 
 impl Display for Commands {
@@ -102,6 +106,7 @@ impl Display for Commands {
             Commands::Check(_) => write!(f, "check"),
             Commands::Bundle(_) => write!(f, "bundle"),
             Commands::Link(_) => write!(f, "link"),
+            Commands::Apple(_) => write!(f, "apple"),
         }
     }
 }

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -83,6 +83,11 @@ async fn main() -> anyhow::Result<()> {
             .bundle()
             .await
             .context(error_wrapper("Bundling project failed")),
+
+        Apple(opts) => {
+            apple::run(opts);
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
Connects the `dx` CLI to [`cargo-mobile2`](https://github.com/tauri-apps/cargo-mobile2/) to inline mobile tooling.

This adds two new subcommands,`dx apple` and `dx android`, that execute `cargo-mobile2` underneath

- [x] `dx apple`
  ```
  dx apple -h                                        
  Usage: dx apple [OPTIONS] <COMMAND>
  
  Commands:
    open   Open project in Xcode
    check  Checks if code compiles for target(s)
    build  Builds static libraries for target(s)
    run    Deploys IPA to connected device
    help   Print this message or the help of the given subcommand(s)
  
  Options:
        --bin <BIN>  Specify a binary target
    -h, --help       Print help
    ```
- [ ] `dx android`