### PR TITLE
chore(cli): improved package version & commit hash usage

### DIFF
--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -74,11 +74,10 @@ pub static CURRENT_CONFIG: once_cell::sync::Lazy<
     match serde_json::from_str(config) {
         Ok(config) => Ok(config),
         Err(err) => {
-            let mut cli_version = crate::build_info::PKG_VERSION.to_string();
+            let mut cli_version = env!("CARGO_PKG_VERSION").to_string();
 
             if let Some(hash) = crate::build_info::GIT_COMMIT_HASH_SHORT {
-                let hash = &hash.trim_start_matches('g')[..4];
-                cli_version.push_str(&format!("-{hash}"));
+                cli_version.push_str(&format!("-{}", &hash[..4]));
             }
 
             let dioxus_version = std::option_env!("DIOXUS_CLI_VERSION").unwrap_or("unknown");

--- a/packages/cli/src/builder/cargo.rs
+++ b/packages/cli/src/builder/cargo.rs
@@ -104,10 +104,9 @@ impl BuildRequest {
         tracing::info!("🚅 Running build [Desktop] command...");
 
         // Set up runtime guards
-        let mut dioxus_version = crate::dx_build_info::PKG_VERSION.to_string();
+        let mut dioxus_version = env!("CARGO_PKG_VERSION").to_string();
         if let Some(hash) = crate::dx_build_info::GIT_COMMIT_HASH_SHORT {
-            let hash = &hash.trim_start_matches('g')[..4];
-            dioxus_version.push_str(&format!("-{hash}"));
+            dioxus_version.push_str(&format!("-{}", &hash[..4]));
         }
         let _guard = dioxus_cli_config::__private::save_config(
             &self.dioxus_crate.dioxus_config,

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -26,7 +26,7 @@ use std::{
 pub static VERSION: Lazy<String> = Lazy::new(|| {
     format!(
         "{} ({})",
-        crate::dx_build_info::PKG_VERSION,
+        env!("CARGO_PKG_VERSION"),
         crate::dx_build_info::GIT_COMMIT_HASH_SHORT.unwrap_or("was built without git repository")
     )
 });

--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -157,9 +157,7 @@ impl Output {
 
         if !is_cli_release {
             if let Some(hash) = crate::dx_build_info::GIT_COMMIT_HASH_SHORT {
-                let hash = &hash.trim_start_matches('g')[..4];
-                dx_version.push('-');
-                dx_version.push_str(hash);
+                dx_version.push_str(&format!("-{}", &hash[..4]));
             }
         }
 


### PR DESCRIPTION
The valuable part from the dismissed #2710. `CARGO_PKG_VERSION` is a [standard environment variable](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates).
