### PR TITLE
adding the Access-Control-Allow-Origin header to assets

### DIFF
--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -201,6 +201,7 @@ fn serve_from_fs(path: PathBuf) -> Result<Response<Vec<u8>>> {
 
     Ok(Response::builder()
         .header("Content-Type", get_mime_from_path(&asset)?)
+        .header("Access-Control-Allow-Origin", "*")
         .body(std::fs::read(asset)?)?)
 }
 


### PR DESCRIPTION
This fixes the issue #2817

I've just added the Access-Control-Allow-Origin header to all assets returned by dioxus, the same way it is done for the index request. 

This removes the problem with Webview2 blocking some local assets due to CORS policy violation.