### PR TITLE
Fix assets folder workspace

### DIFF
--- a/packages/cli/src/builder/cargo.rs
+++ b/packages/cli/src/builder/cargo.rs
@@ -236,7 +236,7 @@ impl BuildRequest {
 
     pub fn copy_assets_dir(&self) -> anyhow::Result<()> {
         tracing::info!("Copying public assets to the output directory...");
-        let out_dir = self.dioxus_crate.out_dir();
+        let out_dir = self.target_out_dir();
         let asset_dir = self.dioxus_crate.asset_dir();
 
         if asset_dir.is_dir() {

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -180,7 +180,7 @@ impl DioxusCrate {
     /// Compose an asset directory. Represents the typical "public" directory
     /// with publicly available resources (configurable in the `Dioxus.toml`).
     pub fn asset_dir(&self) -> PathBuf {
-        self.workspace_dir()
+        self.crate_dir()
             .join(&self.dioxus_config.application.asset_dir)
     }
 


### PR DESCRIPTION
We were copying the legacy assets folder from and to the wrong directory in workspaces. This PR fixes that issue

Fixes #2819 