### PR TITLE
Add version number to package section of Cargo.toml to fix issue #2833

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "dioxus-examples"
-version = "0.0.0"
+version = "0.6.0-alpha.2"
 dependencies = [
  "base64 0.21.7",
  "ciborium",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,7 @@ documentation = "https://dioxuslabs.com"
 keywords = ["dom", "ui", "gui", "react", "wasm"]
 rust-version = "1.79.0"
 publish = false
+version = "0.6.0-alpha.2"
 
 [dependencies]
 manganis = { workspace = true, optional = true }


### PR DESCRIPTION
Fix for Issue #2833. 

This adds a version number to the `[package]` section of the `Cargo.toml`, which resolves the issue.

Admittedly, not the best solution, given that the version number there and in the `[workspace]` section will have to be kept in sync. I looked around for a better one and couldn't find it, but I'm very open to suggestions.
