### PR TITLE
feat(cli): added Ctrl+Z (SIGTSTP) support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,8 @@ dependencies = [
  "rustls 0.23.12",
  "serde",
  "serde_json",
+ "signal-hook",
+ "signal-hook-tokio",
  "subprocess",
  "syn 2.0.74",
  "tar",
@@ -5822,7 +5824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8939,6 +8941,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -104,6 +104,8 @@ ratatui = { version = "0.27.0", features = ["crossterm", "unstable"] }
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 ansi-to-tui = "=5.0.0-rc.1"
 ansi-to-html = "0.2.1"
+signal-hook = "0.3.17"
+signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 
 # on macos, we need to specify the vendored feature on ssl when cross compiling
 # [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Fixes one entry from https://github.com/DioxusLabs/dioxus/issues/2788#issuecomment-2270538452 by adding support for Ctrl+Z. [I did face a few problems](https://discord.com/channels/899851952891002890/936277970644000778/1272989881433460836). But overall it works.

It adds `(signal)` to the zsh's suspend job log message, which isn't there when SIGTSTP is used in other programs. Another thing is that when it is stopped in the middle of some building process (at least during Wasm shenanigans) it can ruin the build (with a panic message) and the `dx serve` must be restarted. This should be explored more because suspending shouldn't break anything _ideally_.

The quirk that is interesting is where the execution is continued. This is nice to know as I used a condition check in the main loop before and didn't understand why no logs from it showed up. The less code, the cleaner it gets!

It looks like there is only 1 new package according to `Cargo.lock`. Nice.

I added a few notes in different places. Like using private field from `screen` variable isn't great.
