### PR TITLE
Fix: CLI Progress

### DIFF
--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -702,7 +702,7 @@ impl Output {
                         },
                         Line::from("  ").gray(),
                         Line::from(" [/] more").gray(),
-                        Line::from(" [r] reload").gray(),
+                        Line::from(" [r] rebuild").gray(),
                         Line::from(" [c] clear").gray(),
                         Line::from(" [o] open").gray(),
                         Line::from(" [h] hide").gray(),
@@ -888,8 +888,8 @@ impl ActiveBuild {
     fn update(&mut self, update: UpdateBuildProgress) {
         match update.update {
             UpdateStage::Start => {
-                // If we are already past the stage, don't roll back
-                if self.stage > update.stage {
+                // If we are already past the stage, don't roll back, but allow a fresh build to update.
+                if self.stage > update.stage && self.stage < Stage::Finished {
                     return;
                 }
                 self.stage = update.stage;


### PR DESCRIPTION
On a rebuild of a non-fullstack app, the CLI status would not be updated. This PR fixes that and additionally renames `[r] reload` to `[r] rebuild`.

Issue Mentioned Here: https://github.com/DioxusLabs/dioxus/issues/2788#issuecomment-2270538452