### PR TITLE
Fix hot reloading component properties out of order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2714,6 +2714,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.23.1",
  "tracing",
+ "warnings",
 ]
 
 [[package]]

--- a/packages/hot-reload/Cargo.toml
+++ b/packages/hot-reload/Cargo.toml
@@ -29,6 +29,7 @@ tokio-stream = { version = "0.1.12", features = ["sync"], optional = true }
 futures-util = { workspace = true, features = ["async-await-macro"], optional = true }
 tokio = { workspace = true, features = ["sync", "rt-multi-thread"], optional = true }
 tracing = { workspace = true }
+warnings.workspace = true
 
 # use rustls on android
 [target.'cfg(target_os = "android")'.dependencies]

--- a/packages/hot-reload/src/client.rs
+++ b/packages/hot-reload/src/client.rs
@@ -1,6 +1,7 @@
 use crate::HotReloadMsg;
 use dioxus_core::{ScopeId, VirtualDom};
 use dioxus_signals::Writable;
+use warnings::Warning;
 
 /// Applies template and literal changes to the VirtualDom
 ///
@@ -13,7 +14,11 @@ pub fn apply_changes(dom: &mut VirtualDom, msg: &HotReloadMsg) {
             let id = &template.location;
             let value = template.template.clone();
             if let Some(mut signal) = ctx.get_signal_with_key(id) {
-                signal.set(Some(value));
+                dioxus_signals::warnings::signal_read_and_write_in_reactive_scope::allow(|| {
+                    dioxus_signals::warnings::signal_write_in_component_body::allow(|| {
+                        signal.set(Some(value));
+                    });
+                });
             }
         }
     });

--- a/packages/rsx/src/hot_reload/diff.rs
+++ b/packages/rsx/src/hot_reload/diff.rs
@@ -411,13 +411,14 @@ impl HotReloadResult {
         }
 
         let mut new_fields = new_component.fields.clone();
-        new_fields.sort_by(|a, b| a.name.to_string().cmp(&b.name.to_string()));
-        let mut old_fields = old_component.fields.clone();
-        old_fields.sort_by(|a, b| a.name.to_string().cmp(&b.name.to_string()));
+        new_fields.sort_by_key(|attribute| attribute.name.to_string());
+        let mut old_fields = old_component.fields.iter().enumerate().collect::<Vec<_>>();
+        old_fields.sort_by_key(|(_, attribute)| attribute.name.to_string());
 
-        let mut literal_component_properties = Vec::new();
+        // The literal component properties for the component in same the order as the original component property literals
+        let mut literal_component_properties = vec![None; old_fields.len()];
 
-        for (new_field, old_field) in new_fields.iter().zip(old_fields.iter()) {
+        for (new_field, (index, old_field)) in new_fields.iter().zip(old_fields.iter()) {
             // Verify the names match
             if new_field.name != old_field.name {
                 return None;
@@ -435,7 +436,7 @@ impl HotReloadResult {
                         return None;
                     }
                     let literal = self.full_rebuild_state.hotreload_hot_literal(new_value)?;
-                    literal_component_properties.push(literal);
+                    literal_component_properties[*index] = Some(literal);
                 }
                 _ => {
                     if new_field.value != old_field.value {
@@ -445,7 +446,7 @@ impl HotReloadResult {
             }
         }
 
-        Some(literal_component_properties)
+        literal_component_properties.into_iter().collect()
     }
 
     /// Hot reload an if chain

--- a/packages/rsx/src/hot_reload/diff.rs
+++ b/packages/rsx/src/hot_reload/diff.rs
@@ -446,7 +446,7 @@ impl HotReloadResult {
             }
         }
 
-        literal_component_properties.into_iter().collect()
+        Some(literal_component_properties.into_iter().flatten().collect())
     }
 
     /// Hot reload an if chain

--- a/packages/rsx/tests/hotreload_pattern.rs
+++ b/packages/rsx/tests/hotreload_pattern.rs
@@ -1069,8 +1069,20 @@ fn component_with_handlers() {
         }
     };
 
-    let valid = can_hotreload(a, b);
-    assert!(valid);
+    let hot_reload = hot_reload_from_tokens(a, b).unwrap();
+    let template = hot_reload.get(&0).unwrap();
+    assert_eq!(
+        template.component_values,
+        &[
+            HotReloadLiteral::Int(456),
+            HotReloadLiteral::Float(789.456),
+            HotReloadLiteral::Bool(false),
+            HotReloadLiteral::Fmted(FmtedSegments::new(vec![
+                FmtSegment::Literal { value: "goodbye " },
+                FmtSegment::Dynamic { id: 0 }
+            ])),
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
The hot reloading code was collecting hot reloading literals for component in the order of the sorted fields instead of the order of the original component. That caused this code snippet to fail because the values for the bool and string attributes are swapped and the types fail to match
```rust
use dioxus::prelude::*;

fn main() {
    dioxus_logger::init(tracing::Level::DEBUG).unwrap();
    launch(app);
}

fn app() -> Element {
    rsx!{
        Router::<Route> {}
    }
}

#[derive(Clone, PartialEq, Routable)]
pub enum Route {
    #[route("/")]
    Homepage,
    #[route("/hello")]
    Testing,
}

#[component]
fn Homepage() -> Element {
    rsx!{
        Link {
            to: "https://google.com",
            new_tab: true,
            class: "block text-gray-400 hover:text-gray-500 dark:hover:text-gray-300",
            "hello"
        }
    }
}

#[component]
fn Testing() -> Element {
    rsx!{
        "Testing"
    }
}
```