### PR TITLE
fix collapsing of multiline components and rsx!{} calls

### DIFF
--- a/packages/autofmt/src/lib.rs
+++ b/packages/autofmt/src/lib.rs
@@ -118,7 +118,12 @@ pub fn try_fmt_file(
         let body_is_solo_expr = body.body.roots.len() == 1
             && matches!(body.body.roots[0], BodyNode::RawExpr(_) | BodyNode::Text(_));
 
-        if formatted.len() <= 80 && !formatted.contains('\n') && !body_is_solo_expr {
+        // If it's short, and it's not a single expression, and it's not empty, then we can collapse it
+        if formatted.len() <= 80
+            && !formatted.contains('\n')
+            && !body_is_solo_expr
+            && !formatted.trim().is_empty()
+        {
             formatted = format!(" {formatted} ");
         }
 

--- a/packages/autofmt/src/prettier_please.rs
+++ b/packages/autofmt/src/prettier_please.rs
@@ -85,11 +85,12 @@ pub fn unparse_expr(expr: &Expr, src: &str, cfg: &IndentOptions) -> String {
     // now we can replace the macros with the formatted blocks
     for fmted in replacer.formatted_stack.drain(..) {
         let is_multiline = fmted.contains('{');
+        let is_empty = fmted.trim().is_empty();
 
         let mut out_fmt = String::from("rsx! {");
         if is_multiline {
             out_fmt.push('\n');
-        } else {
+        } else if !is_empty {
             out_fmt.push(' ');
         }
 
@@ -122,7 +123,7 @@ pub fn unparse_expr(expr: &Expr, src: &str, cfg: &IndentOptions) -> String {
         if is_multiline {
             out_fmt.push('\n');
             out_fmt.push_str(&cfg.indent_str().repeat(whitespace));
-        } else {
+        } else if !is_empty {
             out_fmt.push(' ');
         }
 

--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -836,13 +836,20 @@ impl<'a> Writer<'a> {
             }
 
             // TODO: let rawexprs to be inlined
-            [BodyNode::Component(ref comp)] if comp.fields.is_empty() => Some(
-                comp.name
-                    .segments
-                    .iter()
-                    .map(|s| s.ident.to_string().len() + 2)
-                    .sum::<usize>(),
-            ),
+            [BodyNode::Component(ref comp)]
+            // basically if the component is completely empty, we can inline it
+                if comp.fields.is_empty()
+                    && comp.children.is_empty()
+                    && comp.spreads.is_empty() =>
+            {
+                Some(
+                    comp.name
+                        .segments
+                        .iter()
+                        .map(|s| s.ident.to_string().len() + 2)
+                        .sum::<usize>(),
+                )
+            }
 
             // Feedback on discord indicates folks don't like combining multiple children on the same line
             // We used to do a lot of math to figure out if we should expand out the line, but folks just

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -6,8 +6,8 @@ macro_rules! twoway {
 
             // doc attrs
             $( #[doc = $doc:expr] )*
-            $name:ident
-        ),*
+            $name:ident,
+        )*
     ) => {
         $(
             $( #[doc = $doc] )*
@@ -59,5 +59,6 @@ twoway![
     trailing_expr,
     oneline,
     prop_rsx,
-    asset
+    asset,
+    collapse,
 ];

--- a/packages/autofmt/tests/samples/collapse.rsx
+++ b/packages/autofmt/tests/samples/collapse.rsx
@@ -1,0 +1,21 @@
+// nesting pushes out
+rsx! {
+    Fragment {
+        Fragment {
+            Fragment {
+                Fragment {
+                    Fragment {
+                        div { "Finally have a real node!" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// we don't make extra spaces
+rsx! {
+    Component { blah: rsx! {} }
+}
+
+rsx! {}


### PR DESCRIPTION
These two cases were annoying me but are now fixed.
Just random regressions that slipped through with the refactor/cleanup.

This was getting collapsed:
```rust
        Fragment {
            Fragment {
                Fragment {
                    Fragment {
                        Fragment { 
	                        div { "Finally have a real node!" } 
                        }
                    }
                }
            }
        }
```

We were randomly injecting more spaces than we should have
```rust
return rsx!();
return rsx!(  );
```

There's still a few more issues I'm not addressing here:

```
// this is getting collapsed to one line when I'd rather it not - all closures should force a newline
FancyButton { 
    onclick: move |event| println!("Clicked! {event:?}"), 
}

// we're just eating comments completely with empty
rsx! {
   // please dont kill me :/
}

// we're also eating trailing comments, which I thought we fixed. Sometimes it saves them but with wrong indentation
rsx! {
   div {}
   // please dont kill me :/
}
```