### PR TITLE
Fix: Make Toast Fixed & Increase Z-Index

### DIFF
--- a/packages/cli/assets/toast.html
+++ b/packages/cli/assets/toast.html
@@ -14,12 +14,12 @@
     padding-right: 10px;
     user-select: none;
     transition: transform 0.2s ease;
-    overflow: hidden;
+    z-index: 10;
   }
 
   .dx-toast .dx-toast-inner {
     transition: right 0.2s ease-out;
-    position: relative;
+    position: fixed;
 
     background-color: #181B20;
     color: #ffffff;

--- a/packages/cli/assets/toast.html
+++ b/packages/cli/assets/toast.html
@@ -14,7 +14,7 @@
     padding-right: 10px;
     user-select: none;
     transition: transform 0.2s ease;
-    z-index: 10;
+    z-index: 2147483647;
   }
 
   .dx-toast .dx-toast-inner {


### PR DESCRIPTION
Makes the cli toasts fixed so they follow the page as the user scrolls and increases the z-index to a reasonable 10 so that it overlays on top of most content.