### PR TITLE
fix autofmt: don't panic when writing blocks out without a srcfile

### DIFF
--- a/packages/autofmt/src/lib.rs
+++ b/packages/autofmt/src/lib.rs
@@ -93,7 +93,7 @@ pub fn try_fmt_file(
         writer.out.indent_level = writer
             .out
             .indent
-            .count_indents(writer.src[rsx_start.line - 1]);
+            .count_indents(writer.src.get(rsx_start.line - 1).unwrap_or(&""));
 
         // TESTME
         // Writing *should* not fail but it's possible that it does

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -16,8 +16,6 @@ macro_rules! twoway {
                 let src = include_str!(concat!("./samples/", stringify!($name), ".rsx"));
                 let formatted = dioxus_autofmt::fmt_file(src, Default::default());
                 let out = dioxus_autofmt::apply_formats(src, formatted);
-
-
                 // normalize line endings
                 let out = out.replace("\r", "");
                 let src = src.replace("\r", "");

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -16,6 +16,8 @@ macro_rules! twoway {
                 let src = include_str!(concat!("./samples/", stringify!($name), ".rsx"));
                 let formatted = dioxus_autofmt::fmt_file(src, Default::default());
                 let out = dioxus_autofmt::apply_formats(src, formatted);
+
+
                 // normalize line endings
                 let out = out.replace("\r", "");
                 let src = src.replace("\r", "");

--- a/packages/autofmt/tests/srcless.rs
+++ b/packages/autofmt/tests/srcless.rs
@@ -1,0 +1,14 @@
+use dioxus_rsx::CallBody;
+use proc_macro2::TokenStream as TokenStream2;
+
+#[test]
+fn write_block_out() {
+    let src = include_str!("./srcless/basic_expr.rsx");
+
+    let tokens: TokenStream2 = syn::parse_str(src).unwrap();
+    let parsed: CallBody = syn::parse2(tokens).unwrap();
+
+    let block = dioxus_autofmt::write_block_out(&parsed).unwrap();
+
+    pretty_assertions::assert_eq!(block.trim(), src.trim());
+}

--- a/packages/autofmt/tests/srcless.rs
+++ b/packages/autofmt/tests/srcless.rs
@@ -1,6 +1,9 @@
 use dioxus_rsx::CallBody;
 use proc_macro2::TokenStream as TokenStream2;
 
+/// Ensure we can write RSX blocks without a source file
+///
+/// Useful in code generation use cases where we still want formatted code.
 #[test]
 fn write_block_out() {
     let src = include_str!("./srcless/basic_expr.rsx");

--- a/packages/autofmt/tests/srcless.rs
+++ b/packages/autofmt/tests/srcless.rs
@@ -13,5 +13,9 @@ fn write_block_out() {
 
     let block = dioxus_autofmt::write_block_out(&parsed).unwrap();
 
-    pretty_assertions::assert_eq!(block.trim(), src.trim());
+    // normalize line endings for windows tests to pass
+    pretty_assertions::assert_eq!(
+        block.trim().lines().collect::<Vec<_>>().join("\n"),
+        src.trim().lines().collect::<Vec<_>>().join("\n")
+    );
 }

--- a/packages/autofmt/tests/srcless/basic_expr.rsx
+++ b/packages/autofmt/tests/srcless/basic_expr.rsx
@@ -1,0 +1,42 @@
+    div {
+        "hi"
+        {children}
+    }
+    Fragment {
+        Fragment {
+            Fragment {
+                Fragment {
+                    Fragment {
+                        div { "Finally have a real node!" }
+                    }
+                }
+            }
+        }
+    }
+    div { class, "hello world" }
+    h1 { class, "hello world" }
+    h1 { class, {children} }
+    h1 { class, id, {children} }
+    h1 { class,
+        "hello world"
+        {children}
+    }
+    h1 { id,
+        "hello world"
+        {children}
+    }
+    Other { class, children }
+    Other { class,
+        "hello world"
+        {children}
+    }
+    div {
+        class: "asdasd",
+        onclick: move |_| {
+            let a = 10;
+            let b = 40;
+            let c = 50;
+        },
+        "hi"
+    }
+    div { class: "asd", "Jon" }

--- a/packages/core/src/hotreload_utils.rs
+++ b/packages/core/src/hotreload_utils.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Clone)]
 pub struct HotreloadedLiteral {
@@ -19,7 +18,6 @@ pub struct HotreloadedLiteral {
 }
 
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Clone)]
 pub enum HotReloadLiteral {
@@ -71,7 +69,6 @@ impl Hash for HotReloadLiteral {
 }
 
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct FmtedSegments {
@@ -98,6 +95,8 @@ impl FmtedSegments {
     }
 }
 
+type StaticStr = &'static str;
+
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -107,7 +106,7 @@ pub enum FmtSegment {
             feature = "serialize",
             serde(deserialize_with = "deserialize_string_leaky")
         )]
-        value: &'static str,
+        value: StaticStr,
     },
     Dynamic {
         id: usize,
@@ -313,16 +312,16 @@ impl DynamicValuePool {
 #[doc(hidden)]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 pub struct HotReloadTemplateWithLocation {
     pub location: String,
     pub template: HotReloadedTemplate,
 }
 
+type StaticTemplateArray = &'static [TemplateNode];
+
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 pub struct HotReloadedTemplate {
     pub key: Option<FmtedSegments>,
     pub dynamic_nodes: Vec<HotReloadDynamicNode>,
@@ -332,7 +331,7 @@ pub struct HotReloadedTemplate {
         feature = "serialize",
         serde(deserialize_with = "crate::nodes::deserialize_leaky")
     )]
-    pub roots: &'static [TemplateNode],
+    pub roots: StaticTemplateArray,
     /// The template that is computed from the hot reload roots
     template: Template,
 }
@@ -425,7 +424,6 @@ impl HotReloadedTemplate {
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Clone, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 pub enum HotReloadDynamicNode {
     Dynamic(usize),
     Formatted(FmtedSegments),
@@ -434,7 +432,6 @@ pub enum HotReloadDynamicNode {
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Clone, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 pub enum HotReloadDynamicAttribute {
     Dynamic(usize),
     Named(NamedAttribute),
@@ -449,13 +446,13 @@ pub struct NamedAttribute {
         feature = "serialize",
         serde(deserialize_with = "crate::nodes::deserialize_string_leaky")
     )]
-    name: &'static str,
+    name: StaticStr,
     /// The namespace of this attribute. Does not exist in the HTML spec
     #[cfg_attr(
         feature = "serialize",
         serde(deserialize_with = "crate::nodes::deserialize_option_leaky")
     )]
-    namespace: Option<&'static str>,
+    namespace: Option<StaticStr>,
 
     value: HotReloadAttributeValue,
 }
@@ -477,7 +474,6 @@ impl NamedAttribute {
 #[doc(hidden)]
 #[derive(Debug, PartialEq, Clone, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serialize", serde(bound(deserialize = "'de: 'static")))]
 pub enum HotReloadAttributeValue {
     Literal(HotReloadLiteral),
     Dynamic(usize),

--- a/packages/hot-reload/src/lib.rs
+++ b/packages/hot-reload/src/lib.rs
@@ -16,7 +16,6 @@ pub use ws_receiver::*;
 
 /// A message the hot reloading server sends to the client
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(bound(deserialize = "'de: 'static"))]
 pub enum DevserverMsg {
     /// Attempt a hotreload
     /// This includes all the templates/literals/assets/binary patches that have changed in one shot
@@ -47,7 +46,6 @@ pub enum ClientMsg {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-#[serde(bound(deserialize = "'de: 'static"))]
 pub struct HotReloadMsg {
     pub templates: Vec<HotReloadTemplateWithLocation>,
     pub assets: Vec<PathBuf>,

--- a/packages/hot-reload/src/ws_receiver.rs
+++ b/packages/hot-reload/src/ws_receiver.rs
@@ -51,8 +51,8 @@ impl NativeReceiver {
             match res {
                 Ok(res) => match res {
                     Message::Text(text) => {
-                        let leaked: &'static str = Box::leak(text.into_boxed_str());
-                        let msg = serde_json::from_str::<DevserverMsg>(leaked);
+                        // let leaked: &'static str = Box::leak(text.into_boxed_str());
+                        let msg = serde_json::from_str::<DevserverMsg>(&text);
                         if let Ok(msg) = msg {
                             return Some(Ok(msg));
                         }

--- a/packages/web/src/hot_reload.rs
+++ b/packages/web/src/hot_reload.rs
@@ -57,9 +57,9 @@ fn make_ws(tx: UnboundedSender<HotReloadMsg>, poll_interval: i32, reload: bool) 
 
             // The devserver messages have some &'static strs in them, so we need to leak the source string
             let string: String = text.into();
-            let leaked: &'static str = Box::leak(Box::new(string));
+            // let leaked: &'static str = Box::leak(Box::new(string));
 
-            match serde_json::from_str::<DevserverMsg>(leaked) {
+            match serde_json::from_str::<DevserverMsg>(&string) {
                 Ok(DevserverMsg::HotReload(hr)) => _ = tx_.unbounded_send(hr),
 
                 // todo: we want to throw a screen here that shows the user that the devserver has disconnected


### PR DESCRIPTION
Code generators don't always have a srcfile, and in many places, we were indexing the srcfile looking for whitespace.

This fixes that by properly guarding against empty src files in a number of places.