### PR TITLE
Fix `Error parsing user_event: Error("EOF while parsing a value", line: 1, column: 0)`

### DIFF
--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -57,6 +57,14 @@ tao = { version = "0.26.1", features = ["rwh_05"] }
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.17"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+wry = { version = "0.41.0", features = [
+    "os-webview",
+    "protocol",
+    "drag-drop",
+    "linux-body"
+] }
+
 [target.'cfg(any(target_os = "windows",target_os = "macos",target_os = "linux",target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 global-hotkey = "0.5.0"
 rfd = { version = "0.14", default-features = false, features = ["xdg-portal", "tokio"] }


### PR DESCRIPTION
Hello,

On Linux (with `nightly-x86_64-unknown-linux-gnu` toolchain) desktop platform, it seems that the webview events are not deserialized properly by wry. For example, the following error is displayed each time I click on a button: `Error parsing user_event: Error("EOF while parsing a value", line: 1, column: 0)`

After investigating, wry doesn´t deserialize the body of the IPC requests if the `linux-body` feature flag is not set (cf. https://github.com/tauri-apps/wry/blob/wry-v0.41/src/webkitgtk/web_context.rs#L322).

the fix could to enable the `linux-body` feature flag for `linux` target os.


Then, the issue seems to cause `headless_tests` to crash on Linux:
```
cargo test --test check_events
warning: dioxus-cli-config@0.6.0-alpha.2: A library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application. Information about the Dioxus CLI is available at https://dioxuslabs.com/learn/0.5/CLI/installation
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running headless_tests/events.rs (/home/adrien/dev/dioxuslabs/dioxus/target/debug/deps/check_events-454abb8f5440c095)
expecting 0 events
received 0 events
expecting 16 events
received 0 events
expecting 16 events
received 0 events
expecting 32 events
received 0 events
expecting 32 events
received 0 events
thread 'main' panicked at packages/desktop/headless_tests/./utils.rs:53:29:
called `Result::unwrap()` on an `Err` value: Communication("Error receiving query result: \"Error running JS: TypeError: null is not an object (evaluating 'element.dispatchEvent')\"")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: test failed, to rerun pass `--test check_events
```

Does it mean that we should add a new CI job to run headless_tests for `x86_64-unknown-linux-gnu` platform ?

The `headless_tests` succeeds locally once the `linux-body` feature enabled:
```
cargo test --test check_events
warning: dioxus-cli-config@0.6.0-alpha.2: A library is trying to access the crate's configuration, but the dioxus CLI was not used to build the application. Information about the Dioxus CLI is available at https://dioxuslabs.com/learn/0.5/CLI/installation
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running headless_tests/events.rs (/home/adrien/dev/dioxuslabs/dioxus/target/debug/deps/check_events-81542a4c35536863)
expecting 0 events
received 0 events
expecting 16 events
received 0 events
rect: Rect(100.0x100.0 at (8.0, 8.0))
expecting 16 events
received 1 events
MouseData { coordinates: Coordinates { screen: (0.0, 0.0), client: (0.0, 0.0), element: (-8.0, -119.0), page: (0.0, 0.0) }, modifiers: Modifiers(0x0), held_buttons: EnumSet(), trigger_button: Some(Primary) }
expecting 16 events
received 2 events
MouseData { coordinates: Coordinates { screen: (0.0, 0.0), client: (0.0, 0.0), element: (-8.0, -128.0), page: (0.0, 0.0) }, modifiers: Modifiers(0x0), held_buttons: EnumSet(Secondary), trigger_button: Some(Primary) }
MouseData { coordinates: Coordinates { screen: (0.0, 0.0), client: (0.0, 0.0), element: (-8.0, -128.0), page: (0.0, 0.0) }, modifiers: Modifiers(0x0), held_buttons: EnumSet(Secondary), trigger_button: Some(Secondary) }
MouseData { coordinates: Coordinates { screen: (0.0, 0.0), client: (0.0, 0.0), element: (-8.0, -128.0), page: (0.0, 0.0) }, modifiers: Modifiers(0x0), held_buttons: EnumSet(Primary | Secondary), trigger_button: Some(Secondary) }
MouseData { coordinates: Coordinates { screen: (0.0, 0.0), client: (0.0, 0.0), element: (-8.0, -128.0), page: (0.0, 0.0) }, modifiers: Modifiers(0x0), held_buttons: EnumSet(Secondary), trigger_button: Some(Secondary) }
MouseData { coordinates: Coordinates { screen: (0.0, 0.0), client: (0.0, 0.0), element: (-8.0, -128.0), page: (0.0, 0.0) }, modifiers: Modifiers(0x0), held_buttons: EnumSet(), trigger_button: Some(Primary) }
WheelData { delta: Pixels((1.0, 2.0, 3.0)), coordinates: Coordinates { screen: (0.0, 0.0), client: (0.0, 0.0), element: (-8.0, -128.0), page: (0.0, 0.0) }, modifiers: Modifiers(0x0), held_buttons: EnumSet(), trigger_button: Some(Primary) }
KeyboardData { key: Character("a"), code: KeyA, modifiers: Modifiers(0x0), location: Standard, is_auto_repeating: true, is_composing: true }
KeyboardData { key: Character("a"), code: KeyA, modifiers: Modifiers(0x0), location: Standard, is_auto_repeating: false, is_composing: false }
KeyboardData { key: Character("a"), code: KeyA, modifiers: Modifiers(0x0), location: Standard, is_auto_repeating: false, is_composing: false }
FocusData
FocusData
expecting 16 events
received 16 events
all events received
```