### PR TITLE
Add placeholder doc comments to macro-generated enums

### DIFF
--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -643,7 +643,11 @@ impl RouteEnum {
                     let error_name = route.error_ident();
                     let route_str = &route.route;
 
-                    error_variants.push(quote! { #route_name(#error_name) });
+                    error_variants.push(quote! {
+                        // Placeholder doc to silence -W missing-docs warning in consuming code.
+                        #[doc = " TODO: Add documentation here"]
+                        #route_name(#error_name)
+                    });
                     display_match.push(quote! { Self::#route_name(err) => write!(f, "Route '{}' ('{}') did not match:\n{}", stringify!(#route_name), #route_str, err)? });
                     type_defs.push(route.error_type());
                 }
@@ -652,7 +656,11 @@ impl RouteEnum {
                     let error_name = redirect.error_ident();
                     let route_str = &redirect.route;
 
-                    error_variants.push(quote! { #error_variant(#error_name) });
+                    error_variants.push(quote! {
+                        // Placeholder doc to silence -W missing-docs warning in consuming code.
+                        #[doc = " TODO: Add documentation here"]
+                        #error_variant(#error_name)
+                    });
                     display_match.push(quote! { Self::#error_variant(err) => write!(f, "Redirect '{}' ('{}') did not match:\n{}", stringify!(#error_name), #route_str, err)? });
                     type_defs.push(redirect.error_type());
                 }
@@ -664,7 +672,11 @@ impl RouteEnum {
             let error_name = nest.error_ident();
             let route_str = &nest.route;
 
-            error_variants.push(quote! { #error_variant(#error_name) });
+            error_variants.push(quote! {
+                // Placeholder doc to silence -W missing-docs warning in consuming code.
+                #[doc = " TODO: Add documentation here"]
+                #error_variant(#error_name)
+            });
             display_match.push(quote! { Self::#error_variant(err) => write!(f, "Nest '{}' ('{}') did not match:\n{}", stringify!(#error_name), #route_str, err)? });
             type_defs.push(nest.error_type());
         }
@@ -672,6 +684,8 @@ impl RouteEnum {
         quote! {
             #(#type_defs)*
 
+            // Placeholder doc to silence -W missing-docs warning in consuming code.
+            #[doc = " TODO: Add documentation here"]
             #[allow(non_camel_case_types)]
             #[allow(clippy::derive_partial_eq_without_eq)]
             pub enum #match_error_name {

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -642,10 +642,15 @@ impl RouteEnum {
 
                     let error_name = route.error_ident();
                     let route_str = &route.route;
+                    let comment = format!(
+                        " An error that can occur when trying to parse the route [`{}::{}`] ('{}').",
+                        self.name,
+                        route_name,
+                        route_str
+                    );
 
                     error_variants.push(quote! {
-                        // Placeholder doc to silence -W missing-docs warning in consuming code.
-                        #[doc = " TODO: Add documentation here"]
+                        #[doc = #comment]
                         #route_name(#error_name)
                     });
                     display_match.push(quote! { Self::#route_name(err) => write!(f, "Route '{}' ('{}') did not match:\n{}", stringify!(#route_name), #route_str, err)? });
@@ -655,10 +660,13 @@ impl RouteEnum {
                     let error_variant = redirect.error_variant();
                     let error_name = redirect.error_ident();
                     let route_str = &redirect.route;
+                    let comment = format!(
+                        " An error that can occur when trying to parse the redirect '{}'.",
+                        route_str.value()
+                    );
 
                     error_variants.push(quote! {
-                        // Placeholder doc to silence -W missing-docs warning in consuming code.
-                        #[doc = " TODO: Add documentation here"]
+                        #[doc = #comment]
                         #error_variant(#error_name)
                     });
                     display_match.push(quote! { Self::#error_variant(err) => write!(f, "Redirect '{}' ('{}') did not match:\n{}", stringify!(#error_name), #route_str, err)? });
@@ -671,21 +679,28 @@ impl RouteEnum {
             let error_variant = nest.error_variant();
             let error_name = nest.error_ident();
             let route_str = &nest.route;
+            let comment = format!(
+                " An error that can occur when trying to parse the nested segment {} ('{}').",
+                error_name, route_str
+            );
 
             error_variants.push(quote! {
-                // Placeholder doc to silence -W missing-docs warning in consuming code.
-                #[doc = " TODO: Add documentation here"]
+                #[doc = #comment]
                 #error_variant(#error_name)
             });
             display_match.push(quote! { Self::#error_variant(err) => write!(f, "Nest '{}' ('{}') did not match:\n{}", stringify!(#error_name), #route_str, err)? });
             type_defs.push(nest.error_type());
         }
 
+        let comment = format!(
+            " An error that can occur when trying to parse the route enum [`{}`].",
+            self.name
+        );
+
         quote! {
             #(#type_defs)*
 
-            // Placeholder doc to silence -W missing-docs warning in consuming code.
-            #[doc = " TODO: Add documentation here"]
+            #[doc = #comment]
             #[allow(non_camel_case_types)]
             #[allow(clippy::derive_partial_eq_without_eq)]
             pub enum #match_error_name {

--- a/packages/router-macro/src/nest.rs
+++ b/packages/router-macro/src/nest.rs
@@ -82,6 +82,6 @@ impl Nest {
     pub fn error_type(&self) -> TokenStream {
         let error_name = self.error_ident();
 
-        create_error_type(error_name, &self.segments, None)
+        create_error_type(&self.route, error_name, &self.segments, None)
     }
 }

--- a/packages/router-macro/src/redirect.rs
+++ b/packages/router-macro/src/redirect.rs
@@ -32,7 +32,7 @@ impl Redirect {
     pub fn error_type(&self) -> TokenStream {
         let error_name = self.error_ident();
 
-        create_error_type(error_name, &self.segments, None)
+        create_error_type(&self.route.value(), error_name, &self.segments, None)
     }
 
     pub fn parse_query(&self) -> TokenStream {

--- a/packages/router-macro/src/route.rs
+++ b/packages/router-macro/src/route.rs
@@ -338,7 +338,7 @@ impl Route {
             RouteType::Leaf { .. } => None,
         };
 
-        create_error_type(error_name, &self.segments, child_type)
+        create_error_type(&self.route, error_name, &self.segments, child_type)
     }
 
     pub fn parse_query(&self) -> TokenStream2 {

--- a/packages/router-macro/src/segment.rs
+++ b/packages/router-macro/src/segment.rs
@@ -241,20 +241,34 @@ pub(crate) fn create_error_type(
         let error_name = segment.error_name(i);
         match segment {
             RouteSegment::Static(index) => {
-                error_variants.push(quote! { #error_name(String) });
+                error_variants.push(quote! {
+                    // Placeholder doc to silence -W missing-docs warning in consuming code.
+                    #[doc = " TODO: Add documentation here"]
+                    #error_name(String)
+                });
                 display_match.push(quote! { Self::#error_name(found) => write!(f, "Static segment '{}' did not match instead found '{}'", #index, found)? });
             }
             RouteSegment::Dynamic(ident, ty) => {
                 let missing_error = segment.missing_error_name().unwrap();
-                error_variants.push(
-                    quote! { #error_name(<#ty as dioxus_router::routable::FromRouteSegment>::Err) },
-                );
+                error_variants.push(quote! {
+                    // Placeholder doc to silence -W missing-docs warning in consuming code.
+                    #[doc = " TODO: Add documentation here"]
+                    #error_name(<#ty as dioxus_router::routable::FromRouteSegment>::Err)
+                });
                 display_match.push(quote! { Self::#error_name(err) => write!(f, "Dynamic segment '({}:{})' did not match: {}", stringify!(#ident), stringify!(#ty), err)? });
-                error_variants.push(quote! { #missing_error });
+                error_variants.push(quote! {
+                    // Placeholder doc to silence -W missing-docs warning in consuming code.
+                    #[doc = " TODO: Add documentation here"]
+                    #missing_error
+                });
                 display_match.push(quote! { Self::#missing_error => write!(f, "Dynamic segment '({}:{})' was missing", stringify!(#ident), stringify!(#ty))? });
             }
             RouteSegment::CatchAll(ident, ty) => {
-                error_variants.push(quote! { #error_name(<#ty as dioxus_router::routable::FromRouteSegments>::Err) });
+                error_variants.push(quote! {
+                    // Placeholder doc to silence -W missing-docs warning in consuming code.
+                    #[doc = " TODO: Add documentation here"]
+                    #error_name(<#ty as dioxus_router::routable::FromRouteSegments>::Err)
+                });
                 display_match.push(quote! { Self::#error_name(err) => write!(f, "Catch-all segment '({}:{})' did not match: {}", stringify!(#ident), stringify!(#ty), err)? });
             }
         }
@@ -262,7 +276,11 @@ pub(crate) fn create_error_type(
 
     let child_type_variant = child_type
         .map(|child_type| {
-            quote! { ChildRoute(<#child_type as std::str::FromStr>::Err) }
+            quote! {
+                // Placeholder doc to silence -W missing-docs warning in consuming code.
+                #[doc = " TODO: Add documentation here"]
+                ChildRoute(<#child_type as std::str::FromStr>::Err)
+            }
         })
         .into_iter();
 
@@ -277,9 +295,13 @@ pub(crate) fn create_error_type(
         .into_iter();
 
     quote! {
+        // Placeholder doc to silence -W missing-docs warning in consuming code.
+        #[doc = " TODO: Add documentation here"]
         #[allow(non_camel_case_types)]
         #[allow(clippy::derive_partial_eq_without_eq)]
         pub enum #error_name {
+            // Placeholder doc to silence -W missing-docs warning in consuming code.
+            #[doc = " TODO: Add documentation here"]
             ExtraSegments(String),
             #(#child_type_variant,)*
             #(#error_variants,)*


### PR DESCRIPTION
This removes some yellow squiggles present in workspaces/crates that build with
```
[workspace.lints.rust]
missing_docs = "warn"`
```
![image](https://github.com/user-attachments/assets/27ff2eb9-cee5-424e-8553-4848334cdb63)

I don't feel that I'm familiar enough with the structure of these enums to suggest real doc comments, so I just tossed in placeholders. Would love to see some more descriptive text replace the TODOs.

Another option for resolving the warnings would be to replace all the placeholders with an `#[allow(missing_docs)]` attribute added above the two `quote!`d `pub enum`s on lib.rs:689 and segment.rs:300