### PR TITLE
Bump sledgehammer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2768,6 +2768,7 @@ dependencies = [
  "dioxus-html",
  "js-sys",
  "lazy-js-bundle",
+ "rustc-hash 1.1.0",
  "serde",
  "sledgehammer_bindgen",
  "sledgehammer_utils",
@@ -8944,9 +8945,9 @@ dependencies = [
 
 [[package]]
 name = "sledgehammer_bindgen"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcfaf791ff02f48f3518ce825d32cf419c13a43c1d8b1232f74ac89f339c46d2"
+checksum = "49e83e178d176459c92bc129cfd0958afac3ced925471b889b3a75546cfc4133"
 dependencies = [
  "sledgehammer_bindgen_macro",
  "wasm-bindgen",
@@ -8954,9 +8955,9 @@ dependencies = [
 
 [[package]]
 name = "sledgehammer_bindgen_macro"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc90d3e8623d29a664cd8dba5078b600dd203444f00b9739f744e4c6e7aeaf2"
+checksum = "33a1b4f13e2bbf2f5b29d09dfebc9de69229ffee245aed80e3b70f9b5fd28c06"
 dependencies = [
  "quote",
  "syn 2.0.74",
@@ -8964,12 +8965,10 @@ dependencies = [
 
 [[package]]
 name = "sledgehammer_utils"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20798defa0e9d4eff9ca451c7f84774c7378a9c3b5a40112cfa2b3eadb97ae2"
+checksum = "d4f70244f6c3edbc73f4d82f10ba50ff6ed4be22737beca5840e8761ac6a4cdb"
 dependencies = [
- "lru 0.12.4",
- "once_cell",
  "rustc-hash 1.1.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8965,9 +8965,9 @@ dependencies = [
 
 [[package]]
 name = "sledgehammer_utils"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4f70244f6c3edbc73f4d82f10ba50ff6ed4be22737beca5840e8761ac6a4cdb"
+checksum = "debdd4b83524961983cea3c55383b3910fd2f24fd13a188f5b091d2d504a61ae"
 dependencies = [
  "rustc-hash 1.1.0",
 ]

--- a/packages/interpreter/Cargo.toml
+++ b/packages/interpreter/Cargo.toml
@@ -19,7 +19,7 @@ web-sys = { version = "0.3.56", optional = true, features = [
     "Node",
 ] }
 sledgehammer_bindgen = { version = "0.6.0", default-features = false, optional = true }
-sledgehammer_utils = { version = "0.3.0", optional = true }
+sledgehammer_utils = { version = "0.3.1", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 rustc-hash = { workspace = true, optional = true }
 

--- a/packages/interpreter/Cargo.toml
+++ b/packages/interpreter/Cargo.toml
@@ -18,9 +18,10 @@ web-sys = { version = "0.3.56", optional = true, features = [
     "Element",
     "Node",
 ] }
-sledgehammer_bindgen = { version = "0.5.0", default-features = false, optional = true }
-sledgehammer_utils = { version = "0.2", optional = true }
+sledgehammer_bindgen = { version = "0.6.0", default-features = false, optional = true }
+sledgehammer_utils = { version = "0.3.0", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
+rustc-hash = { workspace = true, optional = true }
 
 dioxus-core = { workspace = true, optional = true }
 dioxus-html = { workspace = true, optional = true }
@@ -31,7 +32,7 @@ lazy-js-bundle = { workspace = true }
 [features]
 default = []
 serialize = ["dep:serde"]
-sledgehammer = ["dep:sledgehammer_bindgen", "dep:sledgehammer_utils"]
+sledgehammer = ["dep:sledgehammer_bindgen", "dep:sledgehammer_utils", "dep:rustc-hash"]
 webonly = [
     "sledgehammer",
     "dep:wasm-bindgen",

--- a/packages/interpreter/src/write_native_mutations.rs
+++ b/packages/interpreter/src/write_native_mutations.rs
@@ -1,7 +1,7 @@
 use crate::unified_bindings::Interpreter as Channel;
 use dioxus_core::{Template, TemplateAttribute, TemplateNode, WriteMutations};
 use dioxus_html::event_bubbles;
-use sledgehammer_utils::rustc_hash::FxHashMap;
+use rustc_hash::FxHashMap;
 
 /// The state needed to apply mutations to a channel. This state should be kept across all mutations for the app
 #[derive(Default)]


### PR DESCRIPTION
This PR bumps sledgehammer to 0.6.0 which removes the LRU dependency from the tree. Sledgehammer already had a hand rolled LRU for const pointers, the new release just expands the LRU for more types