### PR TITLE
Fix static generation serve

### DIFF
--- a/packages/cli/src/builder/fullstack.rs
+++ b/packages/cli/src/builder/fullstack.rs
@@ -98,7 +98,7 @@ impl BuildRequest {
 
     fn new_server(serve: bool, config: &DioxusCrate, build: &Build) -> Self {
         let mut build = build.clone();
-        if build.profile.is_none() {
+        if build.profile.is_none() && !build.release {
             build.profile = Some(CLIENT_PROFILE.to_string());
         }
         let client_feature = build.auto_detect_server_feature(config);

--- a/packages/cli/src/builder/fullstack.rs
+++ b/packages/cli/src/builder/fullstack.rs
@@ -113,7 +113,7 @@ impl BuildRequest {
 
     fn new_client(serve: bool, config: &DioxusCrate, build: &Build) -> Self {
         let mut build = build.clone();
-        if build.profile.is_none() {
+        if build.profile.is_none() && !build.release {
             build.profile = Some(SERVER_PROFILE.to_string());
         }
         let (client_feature, client_platform) = build.auto_detect_client_platform(config);

--- a/packages/static-generation/src/launch.rs
+++ b/packages/static-generation/src/launch.rs
@@ -41,7 +41,9 @@ pub fn launch(
                 .unwrap();
 
             // Serve the program if we are running with cargo
-            if std::env::var_os("CARGO").is_some() || std::env::var_os("DIOXUS_ACTIVE").is_some() {
+            if std::env::var_os("CARGO").is_some()
+                || std::env::var_os(dioxus_cli_config::__private::SERVE_ENV).is_some()
+            {
                 // Get the address the server should run on. If the CLI is running, the CLI proxies static generation into the main address
                 // and we use the generated address the CLI gives us
                 let cli_args = dioxus_cli_config::RuntimeCLIArguments::from_cli();


### PR DESCRIPTION
Static generation was looking for an environment variable that the CLI no longer sets when serving. This PR fixes that issue and makes dx serve just work