### PR TITLE
Parse trailing route slash

### DIFF
--- a/packages/fullstack/examples/router/src/main.rs
+++ b/packages/fullstack/examples/router/src/main.rs
@@ -24,7 +24,7 @@ enum Route {
     #[route("/")]
     Home {},
 
-    #[route("/blog/:id")]
+    #[route("/blog/:id/")]
     Blog { id: i32 },
 }
 

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -600,7 +600,7 @@ impl RouteEnum {
                     let (route, hash) = route.split_once('#').unwrap_or((route, ""));
                     let (route, query) = route.split_once('?').unwrap_or((route, ""));
                     // Remove any trailing slashes. We parse /route/ and /route in the same way
-                    // Note: we don't use trim because it incudes more code
+                    // Note: we don't use trim because it includes more code
                     let route = route.strip_suffix('/').unwrap_or(route);
                     let query = dioxus_router::exports::urlencoding::decode(query).unwrap_or(query.into());
                     let hash = dioxus_router::exports::urlencoding::decode(hash).unwrap_or(hash.into());

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -14,7 +14,7 @@ use syn::{parse::ParseStream, parse_macro_input, Ident, Token, Type};
 
 use proc_macro2::TokenStream as TokenStream2;
 
-use crate::{layout::LayoutId, route_tree::RouteTree};
+use crate::{layout::LayoutId, route_tree::ParseRouteTree};
 
 mod hash;
 mod layout;
@@ -574,7 +574,7 @@ impl RouteEnum {
     }
 
     fn parse_impl(&self) -> TokenStream2 {
-        let tree = RouteTree::new(&self.endpoints, &self.nests);
+        let tree = ParseRouteTree::new(&self.endpoints, &self.nests);
         let name = &self.name;
 
         let error_name = format_ident!("{}MatchError", self.name);
@@ -599,14 +599,16 @@ impl RouteEnum {
                     let route = s;
                     let (route, hash) = route.split_once('#').unwrap_or((route, ""));
                     let (route, query) = route.split_once('?').unwrap_or((route, ""));
+                    // Remove any trailing slashes. We parse /route/ and /route in the same way
+                    // Note: we don't use trim because it incudes more code
+                    let route = route.strip_suffix('/').unwrap_or(route);
                     let query = dioxus_router::exports::urlencoding::decode(query).unwrap_or(query.into());
                     let hash = dioxus_router::exports::urlencoding::decode(hash).unwrap_or(hash.into());
                     let mut segments = route.split('/').map(|s| dioxus_router::exports::urlencoding::decode(s).unwrap_or(s.into()));
                     // skip the first empty segment
                     if s.starts_with('/') {
                         let _ = segments.next();
-                    }
-                    else {
+                    } else {
                         // if this route does not start with a slash, it is not a valid route
                         return Err(dioxus_router::routable::RouteParseError {
                             attempted_routes: Vec::new(),

--- a/packages/router-macro/src/segment.rs
+++ b/packages/router-macro/src/segment.rs
@@ -65,18 +65,10 @@ impl RouteSegment {
                         let mut segments = segments.clone();
                         let segment = segments.next();
                         let segment = segment.as_deref();
-                        let parsed = if let Some(#segment) = segment {
-                            Ok(())
+                        if let Some(#segment) = segment {
+                            #parse_children
                         } else {
-                            Err(#error_enum_name::#error_enum_variant(#inner_parse_enum::#error_name(segment.map(|s|s.to_string()).unwrap_or_default())))
-                        };
-                        match parsed {
-                            Ok(_) => {
-                                #parse_children
-                            }
-                            Err(err) => {
-                                errors.push(err);
-                            }
+                            errors.push(#error_enum_name::#error_enum_variant(#inner_parse_enum::#error_name(segment.map(|s|s.to_string()).unwrap_or_default())));
                         }
                     }
                 }

--- a/packages/router/tests/parsing.rs
+++ b/packages/router/tests/parsing.rs
@@ -1,0 +1,77 @@
+use dioxus::prelude::*;
+use std::str::FromStr;
+
+#[component]
+fn Root() -> Element {
+    todo!()
+}
+
+#[component]
+fn Test() -> Element {
+    todo!()
+}
+
+#[component]
+fn Dynamic(id: usize) -> Element {
+    todo!()
+}
+
+// Make sure trailing '/'s work correctly
+#[test]
+fn trailing_slashes_parse() {
+    #[derive(Routable, Clone, Copy, PartialEq, Debug)]
+    enum Route {
+        #[route("/")]
+        Root {},
+        #[route("/test/")]
+        Test {},
+        #[route("/:id/test/")]
+        Dynamic { id: usize },
+    }
+
+    assert_eq!(Route::from_str("/").unwrap(), Route::Root {});
+    assert_eq!(Route::from_str("/test/").unwrap(), Route::Test {});
+    assert_eq!(Route::from_str("/test").unwrap(), Route::Test {});
+    assert_eq!(
+        Route::from_str("/123/test/").unwrap(),
+        Route::Dynamic { id: 123 }
+    );
+    assert_eq!(
+        Route::from_str("/123/test").unwrap(),
+        Route::Dynamic { id: 123 }
+    );
+}
+
+#[test]
+fn without_trailing_slashes_parse() {
+    #[derive(Routable, Clone, Copy, PartialEq, Debug)]
+    enum RouteWithoutTrailingSlash {
+        #[route("/")]
+        Root {},
+        #[route("/test")]
+        Test {},
+        #[route("/:id/test")]
+        Dynamic { id: usize },
+    }
+
+    assert_eq!(
+        RouteWithoutTrailingSlash::from_str("/").unwrap(),
+        RouteWithoutTrailingSlash::Root {}
+    );
+    assert_eq!(
+        RouteWithoutTrailingSlash::from_str("/test/").unwrap(),
+        RouteWithoutTrailingSlash::Test {}
+    );
+    assert_eq!(
+        RouteWithoutTrailingSlash::from_str("/test").unwrap(),
+        RouteWithoutTrailingSlash::Test {}
+    );
+    assert_eq!(
+        RouteWithoutTrailingSlash::from_str("/123/test/").unwrap(),
+        RouteWithoutTrailingSlash::Dynamic { id: 123 }
+    );
+    assert_eq!(
+        RouteWithoutTrailingSlash::from_str("/123/test").unwrap(),
+        RouteWithoutTrailingSlash::Dynamic { id: 123 }
+    );
+}


### PR DESCRIPTION
The router currently accepts `/path/` if you try define the route `route("/path")`, but it doesn't accept `/path` if you define the route `route("/path/")`. This PR accepts both variants and adds more tests for parsing