### PR TITLE
Allow hooks in the expression of a match statement and if statement

### DIFF
--- a/packages/check/src/metadata.rs
+++ b/packages/check/src/metadata.rs
@@ -112,6 +112,18 @@ impl ClosureInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Information about an async block.
+pub struct AsyncInfo {
+    pub span: Span,
+}
+
+impl AsyncInfo {
+    pub const fn new(span: Span) -> Self {
+        Self { span }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// Information about a component function.
 pub struct ComponentInfo {
     pub span: Span,

--- a/packages/core/src/scope_context.rs
+++ b/packages/core/src/scope_context.rs
@@ -424,6 +424,8 @@ impl Scope {
 
                 You likely used the hook in a conditional. Hooks rely on consistent ordering between renders.
                 Functions prefixed with "use" should never be called conditionally.
+
+                Help: Run `dx check` to look for check for some common hook errors.
                 "#,
             )
     }


### PR DESCRIPTION
Fixes `dx check` for this code snippet:
```rust
if use_signal(|| true) {
     println!("123")
}

match use_signal(|| true) {
    true => println!("false"),
    false => println!("true")
}
```

And report errors for this code snippet:
```rust
use_hook(|| use_signal(|| 0));
spawn(async move { use_signal(|| 0) });
```