### PR TITLE
Fix ordering issues when with_menu(None) is called before setting the window builder

### DIFF
--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -18,10 +18,26 @@ pub enum WindowCloseBehaviour {
     CloseWindow,
 }
 
+/// The state of the menu builder. We need to keep track of if the state is default
+/// so we only swap out the default menu bar when decorations are disabled
+pub(crate) enum MenuBuilderState {
+    Unset,
+    Set(Option<DioxusMenu>),
+}
+
+impl From<MenuBuilderState> for Option<DioxusMenu> {
+    fn from(val: MenuBuilderState) -> Self {
+        match val {
+            MenuBuilderState::Unset => Some(default_menu_bar()),
+            MenuBuilderState::Set(menu) => menu,
+        }
+    }
+}
+
 /// The configuration for the desktop application.
 pub struct Config {
     pub(crate) window: WindowBuilder,
-    pub(crate) menu: Option<DioxusMenu>,
+    pub(crate) menu: MenuBuilderState,
     pub(crate) protocols: Vec<WryProtocol>,
     pub(crate) asynchronous_protocols: Vec<AsyncWryProtocol>,
     pub(crate) pre_rendered: Option<String>,
@@ -67,7 +83,7 @@ impl Config {
 
         Self {
             window,
-            menu: Some(default_menu_bar()),
+            menu: MenuBuilderState::Unset,
             protocols: Vec::new(),
             asynchronous_protocols: Vec::new(),
             pre_rendered: None,
@@ -110,15 +126,11 @@ impl Config {
 
     /// Set the configuration for the window.
     pub fn with_window(mut self, window: WindowBuilder) -> Self {
-        // gots to do a swap because the window builder only takes itself as muy self
-        // I wish more people knew about returning &mut Self
+        // We need to do a swap because the window builder only takes itself as muy self
         self.window = window;
-        if self.window.window.decorations {
-            if self.menu.is_none() {
-                self.menu = Some(default_menu_bar());
-            }
-        } else {
-            self.menu = None;
+        // If the decorations are off for the window, remove the menu as well
+        if !self.window.window.decorations && matches!(self.menu, MenuBuilderState::Unset) {
+            self.menu = MenuBuilderState::Set(None);
         }
         self
     }
@@ -224,7 +236,7 @@ impl Config {
         #[cfg(not(any(target_os = "ios", target_os = "android")))]
         {
             if self.window.window.decorations {
-                self.menu = menu.into();
+                self.menu = MenuBuilderState::Set(menu.into())
             }
         }
         self

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -317,10 +317,11 @@ impl WebviewInstance {
         let webview = webview.build().unwrap();
 
         let menu = if cfg!(not(any(target_os = "android", target_os = "ios"))) {
-            if let Some(menu) = &cfg.menu {
+            let menu_option = cfg.menu.into();
+            if let Some(menu) = &menu_option {
                 crate::menubar::init_menu_bar(menu, &window);
             }
-            cfg.menu
+            menu_option
         } else {
             None
         };


### PR DESCRIPTION
This example currently shows the default menu even though the menu is explicitly set to None:
```rust
use dioxus::{desktop::WindowBuilder, prelude::*};

fn main() {
    let window = WindowBuilder::new()
        .with_always_on_top(false)
        .with_resizable(false)
        .with_title("Marionette");

    let config = dioxus::desktop::Config::new()
        // The menu is set here
        .with_menu(None)
        // But then reset to the default here
        .with_window(window);
    let launcher = LaunchBuilder::new().with_cfg(config);
    launcher.launch(app);
}

fn app() -> Element {
    rsx! {
        "hello world"
    }
}
```

This PR fixes that issue