### PR TITLE
ci: Add workflow for building `flake.nix`

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -14,6 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Install omnix
         run: nix --accept-flake-config profile install "github:juspay/omnix"
       - name: Build all flake outputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,3 +19,5 @@ jobs:
         run: nix --accept-flake-config profile install "github:juspay/omnix"
       - name: Build all flake outputs
         run: om ci
+      - name: Ensure devShell has all build deps
+        run: nix develop -c cargo build -p dioxus-cli

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,20 @@
+name: "Nix CI"
+on:
+  # Run only when pushing to mainline, and making PRs
+  push:
+    branches:
+      - main
+  pull_request:
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Install omnix
+        run: nix --accept-flake-config profile install "github:juspay/omnix"
+      - name: Build all flake outputs
+        run: om ci


### PR DESCRIPTION
This will build all flake outputs (using [omnix](https://omnix.page/om/ci.html)). It will also run `cargo build` inside the Nix devShell to make sure that it works, since that seems to be our primary intended use case of Nix in this repo.