### PR TITLE
Use of `async_std::task::sleep` instead of `tokio::time::sleep` in examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,7 @@ dependencies = [
 name = "dioxus-examples"
 version = "0.6.0-alpha.2"
 dependencies = [
+ "async-std",
  "base64 0.21.7",
  "ciborium",
  "dioxus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2620,6 +2620,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -11941,6 +11942,16 @@ name = "web-sys"
 version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,6 +213,7 @@ tokio = { version = "1.16.1", default-features = false, features = [
     "rt",
     "time"
 ] }
+web-time = "1.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.16.1", features = ["full"] }
@@ -282,7 +283,6 @@ doc-scrape-examples = true
 
 [[example]]
 name = "clock"
-required-features = ["desktop"]
 doc-scrape-examples = true
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,3 +367,11 @@ doc-scrape-examples = true
 name = "window_zoom"
 required-features = ["desktop"]
 doc-scrape-examples = true
+
+[[example]]
+name = "control_focus"
+doc-scrape-examples = true
+
+[[example]]
+name = "eval"
+doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 rand = { version = "0.8.4", features = ["small_rng"] }
 form_urlencoded = "1.2.0"
+async-std = "1.12.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
@@ -316,7 +317,6 @@ doc-scrape-examples = true
 
 [[example]]
 name = "future"
-required-features = ["desktop"]
 doc-scrape-examples = true
 
 [[example]]
@@ -351,7 +351,6 @@ doc-scrape-examples = true
 
 [[example]]
 name = "streams"
-required-features = ["desktop"]
 doc-scrape-examples = true
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ serde_json = "1.0.79"
 rand = { version = "0.8.4", features = ["small_rng"] }
 form_urlencoded = "1.2.0"
 async-std = "1.12.0"
+web-time = "1.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
@@ -213,7 +214,6 @@ tokio = { version = "1.16.1", default-features = false, features = [
     "rt",
     "time"
 ] }
-web-time = "1.1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.16.1", features = ["full"] }

--- a/examples/backgrounded_futures.rs
+++ b/examples/backgrounded_futures.rs
@@ -7,10 +7,11 @@
 //!
 //! This example is more of a demonstration of the behavior than a practical use case, but it's still interesting to see.
 
+use async_std::task::sleep;
 use dioxus::prelude::*;
 
 fn main() {
-    launch_desktop(app);
+    launch(app);
 }
 
 fn app() -> Element {
@@ -48,7 +49,7 @@ fn Child(count: Signal<i32>) -> Element {
 
     use_future(move || async move {
         loop {
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            sleep(std::time::Duration::from_millis(100)).await;
             println!("Child")
         }
     });

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -4,10 +4,15 @@
 use async_std::task::sleep;
 use dioxus::prelude::*;
 
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
+
 const STYLE: &str = asset!("./examples/assets/clock.css");
 
 fn main() {
-    launch_desktop(app);
+    launch(app);
 }
 
 fn app() -> Element {
@@ -15,7 +20,7 @@ fn app() -> Element {
 
     use_future(move || async move {
         // Save our initial timea
-        let start = std::time::Instant::now();
+        let start = Instant::now();
 
         loop {
             sleep(std::time::Duration::from_millis(27)).await;

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,12 +1,8 @@
 //! A simple little clock that updates the time every few milliseconds.
 //!
 
-use async_std::task::sleep;
 use dioxus::prelude::*;
-
-#[cfg(not(target_family = "wasm"))]
-use std::time::Instant;
-#[cfg(target_family = "wasm")]
+use tokio::time::sleep;
 use web_time::Instant;
 
 const STYLE: &str = asset!("./examples/assets/clock.css");

--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,8 +1,7 @@
 //! A simple little clock that updates the time every few milliseconds.
 //!
-//! Neither Rust nor Tokio have an interval function, so we just sleep until the next update.
-//! Tokio timer's don't work on WASM though, so you'll need to use a slightly different approach if you're targeting the web.
 
+use async_std::task::sleep;
 use dioxus::prelude::*;
 
 const STYLE: &str = asset!("./examples/assets/clock.css");
@@ -19,9 +18,7 @@ fn app() -> Element {
         let start = std::time::Instant::now();
 
         loop {
-            // In lieu of an interval, we just sleep until the next update
-            let now = tokio::time::Instant::now();
-            tokio::time::sleep_until(now + std::time::Duration::from_millis(27)).await;
+            sleep(std::time::Duration::from_millis(27)).await;
 
             // Update the time, using a more precise approach of getting the duration since we started the timer
             millis.set(start.elapsed().as_millis() as i64);

--- a/examples/control_focus.rs
+++ b/examples/control_focus.rs
@@ -3,13 +3,15 @@
 //! This example shows how to manage focus in a Dioxus application. We implement a "roulette" that focuses on each input
 //! in the grid every few milliseconds until the user interacts with the inputs.
 
-use dioxus::prelude::*;
 use std::rc::Rc;
+
+use async_std::task::sleep;
+use dioxus::prelude::*;
 
 const STYLE: &str = asset!("./examples/assets/roulette.css");
 
 fn main() {
-    launch_desktop(app);
+    launch(app);
 }
 
 fn app() -> Element {
@@ -21,7 +23,7 @@ fn app() -> Element {
         let mut focused = 0;
 
         loop {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            sleep(std::time::Duration::from_millis(50)).await;
 
             if !running() {
                 continue;

--- a/examples/eval.rs
+++ b/examples/eval.rs
@@ -3,6 +3,7 @@
 //! Eval will only work with renderers that support javascript - so currently only the web and desktop/mobile renderers
 //! that use a webview. Native renderers will throw "unsupported" errors when calling `eval`.
 
+use async_std::task::sleep;
 use dioxus::prelude::*;
 
 fn main() {
@@ -13,7 +14,7 @@ fn app() -> Element {
     // Create a future that will resolve once the javascript has been successfully executed.
     let future = use_resource(move || async move {
         // Wait a little bit just to give the appearance of a loading screen
-        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        sleep(std::time::Duration::from_secs(1)).await;
 
         // The `eval` is available in the prelude - and simply takes a block of JS.
         // Dioxus' eval is interesting since it allows sending messages to and from the JS code using the `await dioxus.recv()`

--- a/examples/future.rs
+++ b/examples/future.rs
@@ -3,11 +3,11 @@
 //! use_future won't return a value, analogous to use_effect.
 //! If you want to return a value from a future, use use_resource instead.
 
+use async_std::task::sleep;
 use dioxus::prelude::*;
-use std::time::Duration;
 
 fn main() {
-    launch_desktop(app);
+    launch(app);
 }
 
 fn app() -> Element {
@@ -16,7 +16,7 @@ fn app() -> Element {
     // use_future will run the future
     use_future(move || async move {
         loop {
-            tokio::time::sleep(Duration::from_millis(200)).await;
+            sleep(std::time::Duration::from_millis(200)).await;
             count += 1;
         }
     });
@@ -24,7 +24,7 @@ fn app() -> Element {
     // We can also spawn futures from effects, handlers, or other futures
     use_effect(move || {
         spawn(async move {
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            sleep(std::time::Duration::from_secs(5)).await;
             count.set(100);
         });
     });

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -6,8 +6,8 @@
 //! Most signals implement Into<ReadOnlySignal<T>>, making ReadOnlySignal a good default type when building new
 //! library components that don't need to modify their values.
 
+use async_std::task::sleep;
 use dioxus::prelude::*;
-use std::time::Duration;
 
 fn main() {
     launch(app);
@@ -39,13 +39,13 @@ fn app() -> Element {
             if running() {
                 count += 1;
             }
-            tokio::time::sleep(Duration::from_millis(400)).await;
+            sleep(std::time::Duration::from_millis(400)).await;
         }
     });
 
     // use_resource will spawn a future that resolves to a value
     let _slow_count = use_resource(move || async move {
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        sleep(std::time::Duration::from_millis(200)).await;
         count() * 2
     });
 

--- a/examples/streams.rs
+++ b/examples/streams.rs
@@ -1,11 +1,11 @@
 //! Handle async streams using use_future and awaiting the next value.
 
+use async_std::task::sleep;
 use dioxus::prelude::*;
 use futures_util::{future, stream, Stream, StreamExt};
-use std::time::Duration;
 
 fn main() {
-    launch_desktop(app);
+    launch(app);
 }
 
 fn app() -> Element {
@@ -30,7 +30,7 @@ fn app() -> Element {
 fn some_stream() -> std::pin::Pin<Box<dyn Stream<Item = i32>>> {
     Box::pin(
         stream::once(future::ready(0)).chain(stream::iter(1..).then(|second| async move {
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            sleep(std::time::Duration::from_secs(1)).await;
             second
         })),
     )


### PR DESCRIPTION
Proposal for https://github.com/DioxusLabs/dioxus/issues/2908 issue. Replacing tokio allows the following examples to run on wasm platforms:
- backgrounded_futures
- clock
- control_focus
- eval
- future
- signals
- streams

What about the documentation?