### PR TITLE
Fix custom launch builder with unsized context types

### DIFF
--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -123,7 +123,33 @@ impl LaunchBuilder {
     /// Provide a custom launch function for your application.
     ///
     /// Useful for third party renderers to tap into the launch builder API without having to reimplement it.
-    pub fn custom<Cfg, List>(launch_fn: LaunchFn<Cfg, List>) -> LaunchBuilder<Cfg, List> {
+    ///
+    /// # Example
+    /// ```rust, no_run
+    /// use dioxus::prelude::*;
+    /// use std::any::Any;
+    ///
+    /// #[derive(Default)]
+    /// struct Config;
+    ///
+    /// fn my_custom_launcher(root: fn() -> Element, contexts: Vec<Box<dyn Any>>, cfg: Config) {
+    ///     println!("launching with root: {:?}", root());
+    ///     loop {
+    ///         println!("running...");
+    ///     }
+    /// }
+    ///
+    /// fn app() -> Element {
+    ///     rsx! {
+    ///         div { "Hello, world!" }
+    ///     }
+    /// }
+    ///
+    /// LaunchBuilder::custom(my_custom_launcher).launch(app);
+    /// ```
+    pub fn custom<Config, Context: ?Sized>(
+        launch_fn: LaunchFn<Config, Context>,
+    ) -> LaunchBuilder<Config, Context> {
         LaunchBuilder {
             launch_fn,
             contexts: vec![],


### PR DESCRIPTION
Fixes #2909 and adds an example to prevent regressions in the future