### PR TITLE
Simplify TodoMVC example

### DIFF
--- a/examples/todomvc.rs
+++ b/examples/todomvc.rs
@@ -18,7 +18,6 @@ enum FilterState {
 
 #[derive(Debug, PartialEq, Eq)]
 struct TodoItem {
-    id: u32,
     checked: bool,
     contents: String,
 }
@@ -120,7 +119,6 @@ fn TodoHeader(mut todos: Signal<HashMap<u32, TodoItem>>) -> Element {
         if evt.key() == Key::Enter && !draft.read().is_empty() {
             let id = todo_id();
             let todo = TodoItem {
-                id,
                 checked: false,
                 contents: draft.to_string(),
             };

--- a/examples/todomvc.rs
+++ b/examples/todomvc.rs
@@ -16,7 +16,6 @@ enum FilterState {
     Completed,
 }
 
-#[derive(Debug, PartialEq, Eq)]
 struct TodoItem {
     checked: bool,
     contents: String,


### PR DESCRIPTION
* Removes the unused `id` field from `TodoItem` to reduce the total memory stored in the `HashMap`
* Removes derived traits from `TodoItem`