### PR TITLE
Fix clock example (` tokio::time::sleep` -> `async_std::task::sleep`)

### DIFF
--- a/examples/clock.rs
+++ b/examples/clock.rs
@@ -1,8 +1,8 @@
 //! A simple little clock that updates the time every few milliseconds.
 //!
 
+use async_std::task::sleep;
 use dioxus::prelude::*;
-use tokio::time::sleep;
 use web_time::Instant;
 
 const STYLE: &str = asset!("./examples/assets/clock.css");


### PR DESCRIPTION
Make the clock example work on the web platform (`tokio::time::sleep` doesn't work on `wasm32-unknown-unknown` platform).