### PR TITLE
Create `Visit` trait

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -26,6 +26,8 @@ mod scopes;
 mod suspense;
 mod tasks;
 mod virtual_dom;
+
+/// Visitor for VNodes.
 pub mod visit;
 
 mod hotreload_utils;
@@ -63,6 +65,7 @@ pub(crate) mod innerlude {
     pub use crate::suspense::*;
     pub use crate::tasks::*;
     pub use crate::virtual_dom::*;
+    pub use crate::visit::{self, Visit};
 
     /// An [`Element`] is a possibly-none [`VNode`] created by calling `render` on [`ScopeId`] or [`ScopeState`].
     ///
@@ -92,13 +95,13 @@ pub mod prelude {
         provide_context, provide_error_boundary, provide_root_context, queue_effect, remove_future,
         schedule_update, schedule_update_any, spawn, spawn_forever, spawn_isomorphic, suspend,
         throw_error, try_consume_context, use_after_render, use_before_render, use_drop, use_hook,
-        use_hook_with_cleanup, with_owner, AnyValue, Attribute, Callback, Component,
+        use_hook_with_cleanup, visit, with_owner, AnyValue, Attribute, Callback, Component,
         ComponentFunction, Context, Element, ErrorBoundary, ErrorContext, Event, EventHandler,
         Fragment, HasAttributes, IntoAttributeValue, IntoDynNode, OptionStringFromMarker,
         Properties, ReactiveContext, RenderError, Runtime, RuntimeGuard, ScopeId, ScopeState,
         SuperFrom, SuperInto, SuspendedFuture, SuspenseBoundary, SuspenseBoundaryProps,
         SuspenseContext, SuspenseExtension, Task, Template, TemplateAttribute, TemplateNode, VNode,
-        VNodeInner, VirtualDom,
+        VNodeInner, VirtualDom, Visit,
     };
 }
 

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -26,6 +26,7 @@ mod scopes;
 mod suspense;
 mod tasks;
 mod virtual_dom;
+pub mod visit;
 
 mod hotreload_utils;
 

--- a/packages/core/src/visit.rs
+++ b/packages/core/src/visit.rs
@@ -126,9 +126,11 @@ pub fn visit_dynamic<V: Visit + ?Sized>(
 ) {
     match node {
         DynamicNode::Component(component) => {
-            let scope = component.mounted_scope(index, vnode, vdom).unwrap();
-            let root_node = scope.root_node();
-            visitor.visit_vnode(vdom, root_node)
+            if let Some(scope) = component.mounted_scope(index, vnode, vdom) {
+                if let Some(root_node) = scope.try_root_node() {
+                    visitor.visit_vnode(vdom, root_node)
+                }
+            }
         }
         DynamicNode::Text(text) => visitor.visit_text(vdom, vnode, &text.value),
         DynamicNode::Placeholder(_) => visitor.visit_placeholder(vdom, vnode, index),

--- a/packages/core/src/visit.rs
+++ b/packages/core/src/visit.rs
@@ -156,9 +156,9 @@ pub fn visit_fragment<V: Visit + ?Sized>(
     vnode: &VNode,
     roots: &[VNode],
 ) {
+    let _ = vnode;
+
     for root_vnode in roots {
-        for root_node in root_vnode.template.roots {
-            visitor.visit_node(vdom, vnode, *root_node)
-        }
+        visitor.visit_vnode(vdom, root_vnode);
     }
 }

--- a/packages/core/src/visit.rs
+++ b/packages/core/src/visit.rs
@@ -1,0 +1,80 @@
+use crate::innerlude::*;
+
+pub trait Visit {
+    fn visit_node(&mut self, vdom: &VirtualDom, vnode: &VNode, node: TemplateNode) {
+        match node {
+            TemplateNode::Element {
+                tag,
+                namespace,
+                attrs,
+                children,
+            } => {
+                self.visit_element(vdom, vnode, tag, namespace, attrs, children);
+            }
+            TemplateNode::Text { text } => {
+                self.visit_text(vdom, vnode, text);
+            }
+            TemplateNode::Dynamic { id } => {
+                let node = vnode.dynamic_nodes.get(id).unwrap();
+                self.visit_dynamic(vdom, vnode, id, node);
+            }
+        }
+    }
+
+    fn visit_element(
+        &mut self,
+        vdom: &VirtualDom,
+        vnode: &VNode,
+        tag: &'static str,
+        namespace: Option<&'static str>,
+        attrs: &'static [TemplateAttribute],
+        children: &'static [TemplateNode],
+    ) {
+        for attr in attrs.iter() {
+            self.visit_attr(vdom, vnode, attr);
+        }
+
+        for child in children.iter() {
+            self.visit_node(vdom, vnode, *child);
+        }
+    }
+
+    fn visit_attr(&mut self, vdom: &VirtualDom, vnode: &VNode, attr: &TemplateAttribute) {}
+
+    fn visit_dynamic(
+        &mut self,
+        vdom: &VirtualDom,
+        vnode: &VNode,
+        index: usize,
+        node: &DynamicNode,
+    ) {
+        match node {
+            DynamicNode::Component(component) => {
+                let scope = component.mounted_scope(index, vnode, vdom).unwrap();
+                let root_node = scope.root_node();
+
+                for root in root_node.template.roots {
+                    self.visit_node(vdom, vnode, *root)
+                }
+            }
+            DynamicNode::Text(text) => self.visit_text(vdom, vnode, &text.value),
+            DynamicNode::Placeholder(_) => self.visit_placeholder(vdom, vnode, index),
+            DynamicNode::Fragment(roots) => self.visit_fragment(vdom, vnode, roots),
+        }
+    }
+
+    fn visit_placeholder(&mut self, vdom: &VirtualDom, vnode: &VNode, index: usize) {
+        let node = vnode.dynamic_nodes.get(index).unwrap();
+        self.visit_dynamic(vdom, vnode, index, node);
+    }
+
+    fn visit_fragment(&mut self, vdom: &VirtualDom, vnode: &VNode, roots: &[VNode]) {
+        for root_vnode in roots {
+            for root_node in root_vnode.template.roots {
+                self.visit_node(vdom, vnode, *root_node)
+            }
+        }
+    }
+
+    fn visit_text(&mut self, vdom: &VirtualDom, vnode: &VNode, text: &str) {}
+}

--- a/packages/core/src/visit.rs
+++ b/packages/core/src/visit.rs
@@ -1,26 +1,13 @@
 use crate::innerlude::*;
 
+/// Visitor for a [`VNode`].
 pub trait Visit {
+    /// Visit a template node.
     fn visit_node(&mut self, vdom: &VirtualDom, vnode: &VNode, node: TemplateNode) {
-        match node {
-            TemplateNode::Element {
-                tag,
-                namespace,
-                attrs,
-                children,
-            } => {
-                self.visit_element(vdom, vnode, tag, namespace, attrs, children);
-            }
-            TemplateNode::Text { text } => {
-                self.visit_text(vdom, vnode, text);
-            }
-            TemplateNode::Dynamic { id } => {
-                let node = vnode.dynamic_nodes.get(id).unwrap();
-                self.visit_dynamic(vdom, vnode, id, node);
-            }
-        }
+        visit_node(self, vdom, vnode, node)
     }
 
+    /// Visit an element.
     fn visit_element(
         &mut self,
         vdom: &VirtualDom,
@@ -30,17 +17,17 @@ pub trait Visit {
         attrs: &'static [TemplateAttribute],
         children: &'static [TemplateNode],
     ) {
-        for attr in attrs.iter() {
-            self.visit_attr(vdom, vnode, attr);
-        }
-
-        for child in children.iter() {
-            self.visit_node(vdom, vnode, *child);
-        }
+        visit_element(self, vdom, vnode, tag, namespace, attrs, children)
     }
 
-    fn visit_attr(&mut self, vdom: &VirtualDom, vnode: &VNode, attr: &TemplateAttribute) {}
+    /// Visit an element attribute.
+    fn visit_attr(&mut self, vdom: &VirtualDom, vnode: &VNode, attr: &TemplateAttribute) {
+        let _ = vdom;
+        let _ = vnode;
+        let _ = attr;
+    }
 
+    /// Visit a dynamic node.
     fn visit_dynamic(
         &mut self,
         vdom: &VirtualDom,
@@ -48,33 +35,119 @@ pub trait Visit {
         index: usize,
         node: &DynamicNode,
     ) {
-        match node {
-            DynamicNode::Component(component) => {
-                let scope = component.mounted_scope(index, vnode, vdom).unwrap();
-                let root_node = scope.root_node();
-
-                for root in root_node.template.roots {
-                    self.visit_node(vdom, vnode, *root)
-                }
-            }
-            DynamicNode::Text(text) => self.visit_text(vdom, vnode, &text.value),
-            DynamicNode::Placeholder(_) => self.visit_placeholder(vdom, vnode, index),
-            DynamicNode::Fragment(roots) => self.visit_fragment(vdom, vnode, roots),
-        }
+        visit_dynamic(self, vdom, vnode, index, node)
     }
 
+    /// Visit a placeholder.
     fn visit_placeholder(&mut self, vdom: &VirtualDom, vnode: &VNode, index: usize) {
-        let node = vnode.dynamic_nodes.get(index).unwrap();
-        self.visit_dynamic(vdom, vnode, index, node);
+        visit_placeholder(self, vdom, vnode, index)
     }
 
+    /// Visit a fragment.
     fn visit_fragment(&mut self, vdom: &VirtualDom, vnode: &VNode, roots: &[VNode]) {
-        for root_vnode in roots {
-            for root_node in root_vnode.template.roots {
-                self.visit_node(vdom, vnode, *root_node)
-            }
+        visit_fragment(self, vdom, vnode, roots)
+    }
+
+    /// Visit a text node.
+    fn visit_text(&mut self, vdom: &VirtualDom, vnode: &VNode, text: &str) {
+        let _ = vdom;
+        let _ = vnode;
+        let _ = text;
+    }
+}
+
+/// Default method to visit a template node.
+pub fn visit_node<V: Visit + ?Sized>(
+    visitor: &mut V,
+    vdom: &VirtualDom,
+    vnode: &VNode,
+    node: TemplateNode,
+) {
+    match node {
+        TemplateNode::Element {
+            tag,
+            namespace,
+            attrs,
+            children,
+        } => {
+            visitor.visit_element(vdom, vnode, tag, namespace, attrs, children);
+        }
+        TemplateNode::Text { text } => {
+            visitor.visit_text(vdom, vnode, text);
+        }
+        TemplateNode::Dynamic { id } => {
+            let node = vnode.dynamic_nodes.get(id).unwrap();
+            visitor.visit_dynamic(vdom, vnode, id, node);
         }
     }
+}
 
-    fn visit_text(&mut self, vdom: &VirtualDom, vnode: &VNode, text: &str) {}
+/// Default method to visit an element.
+pub fn visit_element<V: Visit + ?Sized>(
+    visitor: &mut V,
+    vdom: &VirtualDom,
+    vnode: &VNode,
+    tag: &'static str,
+    namespace: Option<&'static str>,
+    attrs: &'static [TemplateAttribute],
+    children: &'static [TemplateNode],
+) {
+    let _ = tag;
+    let _ = namespace;
+
+    for attr in attrs.iter() {
+        visitor.visit_attr(vdom, vnode, attr);
+    }
+
+    for child in children.iter() {
+        visitor.visit_node(vdom, vnode, *child);
+    }
+}
+
+/// Default method to visit a dynamic node.
+pub fn visit_dynamic<V: Visit + ?Sized>(
+    visitor: &mut V,
+    vdom: &VirtualDom,
+    vnode: &VNode,
+    index: usize,
+    node: &DynamicNode,
+) {
+    match node {
+        DynamicNode::Component(component) => {
+            let scope = component.mounted_scope(index, vnode, vdom).unwrap();
+            let root_node = scope.root_node();
+
+            for root in root_node.template.roots {
+                visitor.visit_node(vdom, vnode, *root)
+            }
+        }
+        DynamicNode::Text(text) => visitor.visit_text(vdom, vnode, &text.value),
+        DynamicNode::Placeholder(_) => visitor.visit_placeholder(vdom, vnode, index),
+        DynamicNode::Fragment(roots) => visitor.visit_fragment(vdom, vnode, roots),
+    }
+}
+
+/// Default method to visit a placeholder.
+pub fn visit_placeholder<V: Visit + ?Sized>(
+    visitor: &mut V,
+    vdom: &VirtualDom,
+    vnode: &VNode,
+    index: usize,
+) {
+    let node = vnode.dynamic_nodes.get(index).unwrap();
+    visitor.visit_dynamic(vdom, vnode, index, node);
+}
+
+/// Default method to visit a fragment.
+pub fn visit_fragment<V: Visit + ?Sized>(
+    visitor: &mut V,
+    vdom: &VirtualDom,
+    vnode: &VNode,
+    roots: &[VNode],
+) {
+    for root_vnode in roots {
+        for root_node in root_vnode.template.roots {
+            visitor.visit_node(vdom, vnode, *root_node)
+        }
+    }
 }


### PR DESCRIPTION
Implements a zero-cost visitor for VNodes via a trait pattern instead of an iterator.

Alternative to https://github.com/DioxusLabs/dioxus/pull/2722 to solve https://github.com/DioxusLabs/dioxus/issues/1177.

Exports the `Visit` trait:
```rs
pub trait Visit {
    /// Visit a [`VNode`].
    fn visit_vnode(&mut self, vdom: &VirtualDom, vnode: &VNode) { ... }

    /// Visit a template node.
    fn visit_node(&mut self, vdom: &VirtualDom, vnode: &VNode, node: TemplateNode) { ... }

    /// Visit an element.
    fn visit_element(
        &mut self,
        vdom: &VirtualDom,
        vnode: &VNode,
        tag: &'static str,
        namespace: Option<&'static str>,
        attrs: &'static [TemplateAttribute],
        children: &'static [TemplateNode],
    ) { ... }

    /// Visit an element attribute.
    fn visit_attr(&mut self, vdom: &VirtualDom, vnode: &VNode, attr: &TemplateAttribute) { ... }

    /// Visit a dynamic node.
    fn visit_dynamic(
        &mut self,
        vdom: &VirtualDom,
        vnode: &VNode,
        index: usize,
        node: &DynamicNode,
    ) { ... }

    /// Visit a placeholder.
    fn visit_placeholder(&mut self, vdom: &VirtualDom, vnode: &VNode, index: usize) { ... }

    /// Visit a fragment.
    fn visit_fragment(&mut self, vdom: &VirtualDom, vnode: &VNode, roots: &[VNode]) { ... }

    /// Visit a text node.
    fn visit_text(&mut self, vdom: &VirtualDom, vnode: &VNode, text: &str) { ... }
}
```

And default methods under the `visit` module:
```rs
/// Default method to visit a [`VNode`].
pub fn visit_vnode<V: Visit + ?Sized>(visitor: &mut V, vdom: &VirtualDom, vnode: &VNode) { ... }

/// Default method to visit a template node.
pub fn visit_node<V: Visit + ?Sized>(
    visitor: &mut V,
    vdom: &VirtualDom,
    vnode: &VNode,
    node: TemplateNode,
) { ... }

/// Default method to visit an element.
pub fn visit_element<V: Visit + ?Sized>(
    visitor: &mut V,
    vdom: &VirtualDom,
    vnode: &VNode,
    tag: &'static str,
    namespace: Option<&'static str>,
    attrs: &'static [TemplateAttribute],
    children: &'static [TemplateNode],
) { ... }

/// Default method to visit a dynamic node.
pub fn visit_dynamic<V: Visit + ?Sized>(
    visitor: &mut V,
    vdom: &VirtualDom,
    vnode: &VNode,
    index: usize,
    node: &DynamicNode,
) { ... }

/// Default method to visit a placeholder.
pub fn visit_placeholder<V: Visit + ?Sized>(
    visitor: &mut V,
    vdom: &VirtualDom,
    vnode: &VNode,
    index: usize,
) { ... }

/// Default method to visit a fragment.
pub fn visit_fragment<V: Visit + ?Sized>(
    visitor: &mut V,
    vdom: &VirtualDom,
    vnode: &VNode,
    roots: &[VNode],
) { ... }
```