### PR TITLE
Fix dx bundle command and resources panic

### DIFF
--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -13,8 +13,9 @@ use super::*;
 #[derive(Clone, Debug, Parser)]
 #[clap(name = "bundle")]
 pub struct Bundle {
+    /// The package types to bundle
     #[clap(long)]
-    pub package: Option<Vec<String>>,
+    pub packages: Option<Vec<PackageType>>,
     /// The arguments for the dioxus build
     #[clap(flatten)]
     pub build_arguments: Build,
@@ -28,7 +29,7 @@ impl Deref for Bundle {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum PackageType {
     MacOsBundle,
     IosBundle,
@@ -162,6 +163,15 @@ impl Bundle {
             }
         }
 
+        // Drain any resources set in the config into the resources map. Tauri bundle doesn't let you set both resources and resources_map https://github.com/DioxusLabs/dioxus/issues/2941
+        for resource_path in bundle_settings.resources.take().into_iter().flatten() {
+            if let Some(resources) = &mut bundle_settings.resources_map {
+                resources.insert(resource_path, "".to_string());
+            } else {
+                bundle_settings.resources_map = Some([(resource_path, "".to_string())].into());
+            }
+        }
+
         let mut settings = SettingsBuilder::new()
             .project_out_directory(dioxus_crate.out_dir())
             .package_settings(PackageSettings {
@@ -174,13 +184,8 @@ impl Bundle {
             })
             .binaries(binaries)
             .bundle_settings(bundle_settings);
-        if let Some(packages) = &self.package {
-            settings = settings.package_types(
-                packages
-                    .iter()
-                    .map(|p| p.parse::<PackageType>().unwrap().into())
-                    .collect(),
-            );
+        if let Some(packages) = &self.packages {
+            settings = settings.package_types(packages.iter().map(|p| (*p).into()).collect());
         }
 
         if let Some(target) = &self.target_args.target {


### PR DESCRIPTION
This PR fixes two panics that are currently causing `dx bundle` to fail:
1) the bundle command uses `package` twice
2) the bundle command uses resources and resources_map which causes a panic in tauri bundler
Fixes https://github.com/DioxusLabs/dioxus/issues/2941