### PR TITLE
Update bug report format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,8 @@ Steps to reproduce the behavior:
  - App platform:    <!-- e.g. `web`, `desktop` -->
 
 **Questionnaire**
-<!-- If you feel up to the challenge, please check one of the boxes below: -->
-- [ ] I'm interested in fixing this myself but don't know where to start
-- [ ] I would like to fix and I have a solution
-- [ ] I don't have time to fix this right now, but maybe later
+<!-- If you feel up to the challenge, please uncomment one of the lines below: -->
+
+<!-- I'm interested in fixing this myself but don't know where to start -->
+<!-- I would like to fix and I have a solution -->
+<!-- I don't have time to fix this right now, but maybe later -->


### PR DESCRIPTION
The current bug report formatting conflicts slightly with GitHub's integration for task lists:
<img width="364" alt="Screenshot 2024-09-12 at 6 48 22 PM" src="https://github.com/user-attachments/assets/7620c59a-12d9-4205-8e07-f04294ca1ee3">

This replaces the checkboxes with lines commented-out and instructions.