### PR TITLE
small style tweak: make spacing cosnsistent for uses of `rsx! {`, switch `todo!()` to `unimplemented!()`

### DIFF
--- a/examples/errors.rs
+++ b/examples/errors.rs
@@ -81,7 +81,7 @@ fn ParseNumberWithShow() -> Element {
                 let request_data = "0.5";
                 let data: i32 = request_data.parse()
                     // You can attach rsx to results that can be displayed in the Error Boundary
-                    .show(|_| rsx!{
+                    .show(|_| rsx! {
                         div {
                             background_color: "red",
                             border: "black",

--- a/packages/core/src/error_boundary.rs
+++ b/packages/core/src/error_boundary.rs
@@ -106,7 +106,7 @@ pub trait Context<T, E>: private::Sealed {
     ///             "Error parsing number: {error}"
     ///         }
     ///     })?;
-    ///     todo!()
+    ///     unimplemented!()
     /// }
     /// ```
     fn show(self, display_error: impl FnOnce(&E) -> Element) -> Result<T>;
@@ -120,7 +120,7 @@ pub trait Context<T, E>: private::Sealed {
     ///     // You can bubble up errors with `?` inside components, and event handlers
     ///     // Along with the error itself, you can provide a way to display the error by calling `context`
     ///     let number = "-1234".parse::<usize>().context("Parsing number inside of the NumberParser")?;
-    ///     todo!()
+    ///     unimplemented!()
     /// }
     /// ```
     fn context<C: Display + 'static>(self, context: C) -> Result<T>;
@@ -134,7 +134,7 @@ pub trait Context<T, E>: private::Sealed {
     ///     // You can bubble up errors with `?` inside components, and event handlers
     ///     // Along with the error itself, you can provide a way to display the error by calling `context`
     ///     let number = "-1234".parse::<usize>().with_context(|| format!("Timestamp: {:?}", std::time::Instant::now()))?;
-    ///     todo!()
+    ///     unimplemented!()
     /// }
     /// ```
     fn with_context<C: Display + 'static>(self, context: impl FnOnce() -> C) -> Result<T>;

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -201,7 +201,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Event<T> {
 ///
 /// ```rust, no_run
 /// # use dioxus::prelude::*;
-/// rsx!{
+/// rsx! {
 ///     MyComponent { onclick: move |evt| tracing::debug!("clicked") }
 /// };
 ///
@@ -211,7 +211,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for Event<T> {
 /// }
 ///
 /// fn MyComponent(cx: MyProps) -> Element {
-///     rsx!{
+///     rsx! {
 ///         button {
 ///             onclick: move |evt| cx.onclick.call(evt),
 ///         }
@@ -228,7 +228,7 @@ pub type EventHandler<T = ()> = Callback<T>;
 /// # Example
 ///
 /// ```rust, ignore
-/// rsx!{
+/// rsx! {
 ///     MyComponent { onclick: move |evt| {
 ///         tracing::debug!("clicked");
 ///         42
@@ -241,7 +241,7 @@ pub type EventHandler<T = ()> = Callback<T>;
 /// }
 ///
 /// fn MyComponent(cx: MyProps) -> Element {
-///     rsx!{
+///     rsx! {
 ///         button {
 ///             onclick: move |evt| println!("number: {}", cx.onclick.call(evt)),
 ///         }
@@ -256,7 +256,7 @@ pub struct Callback<Args = (), Ret = ()> {
     /// # use dioxus::prelude::*;
     /// #[component]
     /// fn Child(onclick: EventHandler<MouseEvent>) -> Element {
-    ///     rsx!{
+    ///     rsx! {
     ///         button {
     ///             // Diffing Child will not rerun this component, it will just update the callback in place so that if this callback is called, it will run the latest version of the callback
     ///             onclick: move |evt| onclick(evt),

--- a/packages/core/src/fragment.rs
+++ b/packages/core/src/fragment.rs
@@ -14,7 +14,7 @@ use crate::innerlude::*;
 /// ```rust
 /// # use dioxus::prelude::*;
 /// let value = 1;
-/// rsx!{
+/// rsx! {
 ///     Fragment { key: "{value}" }
 /// };
 /// ```
@@ -76,7 +76,7 @@ impl<const A: bool> FragmentBuilder<A> {
 ///
 /// #[component]
 /// fn CustomCard(children: Element) -> Element {
-///     rsx!{
+///     rsx! {
 ///         div {
 ///             h1 {"Title card"}
 ///             {children}

--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -351,7 +351,7 @@ pub fn schedule_update_any() -> Arc<dyn Fn(ScopeId) + Send + Sync> {
 ///         window.scroll_with_x_and_y(original_scroll_position(), 0.0);
 ///     });
 ///
-///     rsx!{
+///     rsx! {
 ///         div {
 ///             id: "my_element",
 ///             "hello"

--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -25,13 +25,13 @@ pub fn vdom_is_rendering() -> bool {
 /// fn Component() -> Element {
 ///     let request = spawn(async move {
 ///         match reqwest::get("https://api.example.com").await {
-///             Ok(_) => todo!(),
+///             Ok(_) => unimplemented!(),
 ///             // You can explicitly throw an error into a scope with throw_error
 ///             Err(err) => ScopeId::APP.throw_error(err)
 ///         }
 ///     });
 ///
-///     todo!()
+///     unimplemented!()
 /// }
 /// ```
 pub fn throw_error(error: impl Into<CapturedError> + 'static) {

--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -435,7 +435,7 @@ impl Runtime {
 /// }
 ///
 /// fn app() -> Element {
-///     rsx!{ Component { runtime: Runtime::current().unwrap() } }
+///     rsx! { Component { runtime: Runtime::current().unwrap() } }
 /// }
 ///
 /// // In a dynamic library

--- a/packages/core/src/scope_context.rs
+++ b/packages/core/src/scope_context.rs
@@ -558,13 +558,13 @@ impl ScopeId {
     /// fn Component() -> Element {
     ///     let request = spawn(async move {
     ///         match reqwest::get("https://api.example.com").await {
-    ///             Ok(_) => todo!(),
+    ///             Ok(_) => unimplemented!(),
     ///             // You can explicitly throw an error into a scope with throw_error
     ///             Err(err) => ScopeId::APP.throw_error(err)
     ///         }
     ///     });
     ///
-    ///     todo!()
+    ///     unimplemented!()
     /// }
     /// ```
     pub fn throw_error(self, error: impl Into<CapturedError> + 'static) {

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -269,7 +269,7 @@ impl VirtualDom {
     /// }
     ///
     /// fn Example(cx: SomeProps) -> Element  {
-    ///     rsx!{ div { "hello {cx.name}" } }
+    ///     rsx! { div { "hello {cx.name}" } }
     /// }
     ///
     /// let dom = VirtualDom::new_with_props(Example, SomeProps { name: "world" });
@@ -285,7 +285,7 @@ impl VirtualDom {
     /// #     name: &'static str
     /// # }
     /// # fn Example(cx: SomeProps) -> Element  {
-    /// #     rsx!{ div { "hello {cx.name}" } }
+    /// #     rsx! { div { "hello {cx.name}" } }
     /// # }
     /// let mut dom = VirtualDom::new_with_props(Example, SomeProps { name: "jane" });
     /// dom.rebuild_in_place();

--- a/packages/fullstack/src/hooks/server_cached.rs
+++ b/packages/fullstack/src/hooks/server_cached.rs
@@ -17,7 +17,7 @@ use serde::{de::DeserializeOwned, Serialize};
 ///       1234
 ///    });
 ///
-///    todo!()
+///    unimplemented!()
 /// }
 /// ```
 pub fn use_server_cached<O: 'static + Clone + Serialize + DeserializeOwned>(

--- a/packages/fullstack/src/hooks/server_future.rs
+++ b/packages/fullstack/src/hooks/server_future.rs
@@ -40,7 +40,7 @@ use std::future::Future;
 ///
 /// ```rust, no_run
 /// # use dioxus::prelude::*;
-/// # async fn fetch_article(id: u32) -> String { todo!() }
+/// # async fn fetch_article(id: u32) -> String { unimplemented!() }
 /// use dioxus::prelude::*;
 ///
 /// fn App() -> Element {

--- a/packages/hooks/src/use_collection.rs
+++ b/packages/hooks/src/use_collection.rs
@@ -40,7 +40,7 @@ static TodoList: Component = |cx| {
     let todos = use_map(|| HashMap::new());
     let input = use_signal(|| None);
 
-    rsx!{
+    rsx! {
         div {
             button {
                 "Add todo"

--- a/packages/hooks/src/use_coroutine.rs
+++ b/packages/hooks/src/use_coroutine.rs
@@ -61,7 +61,7 @@ use std::future::Future;
 /// });
 ///
 ///
-/// rsx!{
+/// rsx! {
 ///     button {
 ///         onclick: move |_| chat_client.send(Action::Start),
 ///         "Start Chat Service"

--- a/packages/router/examples/simple_routes.rs
+++ b/packages/router/examples/simple_routes.rs
@@ -92,7 +92,7 @@ fn Route1(user_id: usize, dynamic: usize, query: String) -> Element {
 fn Route2(user_id: usize) -> Element {
     rsx! {
         pre { "Route2{{\n\tuser_id:{user_id}\n}}" }
-        {(0..user_id).map(|i| rsx!{ p { "{i}" } })}
+        {(0..user_id).map(|i| rsx! { p { "{i}" } })}
         p { "Footer" }
         Link {
             to: Route::Route3 {

--- a/packages/router/tests/parsing.rs
+++ b/packages/router/tests/parsing.rs
@@ -3,17 +3,17 @@ use std::str::FromStr;
 
 #[component]
 fn Root() -> Element {
-    todo!()
+    unimplemented!()
 }
 
 #[component]
 fn Test() -> Element {
-    todo!()
+    unimplemented!()
 }
 
 #[component]
 fn Dynamic(id: usize) -> Element {
-    todo!()
+    unimplemented!()
 }
 
 // Make sure trailing '/'s work correctly

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/79236386")]
 #![doc(html_favicon_url = "https://avatars.githubusercontent.com/u/79236386")]
 
-//! Parse the root tokens in the rsx!{ } macro
+//! Parse the root tokens in the rsx! { } macro
 //! =========================================
 //!
 //! This parsing path emerges directly from the macro call, with `RsxRender` being the primary entrance into parsing.

--- a/packages/rsx/tests/hotreload_pattern.rs
+++ b/packages/rsx/tests/hotreload_pattern.rs
@@ -501,7 +501,7 @@ fn template_generates() {
             "width2": 100,
             "height2": "100px",
             p { "hello world" }
-            {(0..10).map(|i| rsx!{"{i}"})}
+            {(0..10).map(|i| rsx! {"{i}"})}
         }
         div {
             width: 120,
@@ -536,9 +536,9 @@ fn diffs_complex() {
             "width2": 100,
             "height2": "100px",
             p { "hello world" }
-            {(0..10).map(|i| rsx!{"{i}"})},
-            {(0..10).map(|i| rsx!{"{i}"})},
-            {(0..11).map(|i| rsx!{"{i}"})},
+            {(0..10).map(|i| rsx! {"{i}"})},
+            {(0..10).map(|i| rsx! {"{i}"})},
+            {(0..11).map(|i| rsx! {"{i}"})},
             Comp {}
         }
     };
@@ -552,9 +552,9 @@ fn diffs_complex() {
             "height2": "100px",
             p { "hello world" }
             Comp {}
-            {(0..10).map(|i| rsx!{"{i}"})},
-            {(0..10).map(|i| rsx!{"{i}"})},
-            {(0..11).map(|i| rsx!{"{i}"})},
+            {(0..10).map(|i| rsx! {"{i}"})},
+            {(0..10).map(|i| rsx! {"{i}"})},
+            {(0..11).map(|i| rsx! {"{i}"})},
         }
     };
 
@@ -570,12 +570,12 @@ fn remove_node() {
         quote! {
             svg {
                 Comp {}
-                {(0..10).map(|i| rsx!{"{i}"})},
+                {(0..10).map(|i| rsx! {"{i}"})},
             }
         },
         quote! {
             div {
-                {(0..10).map(|i| rsx!{"{i}"})},
+                {(0..10).map(|i| rsx! {"{i}"})},
             }
         },
     )

--- a/packages/rsx/tests/parsing.rs
+++ b/packages/rsx/tests/parsing.rs
@@ -98,7 +98,7 @@ fn complex_kitchen_sink() {
                     }
                 })}
             }
-            div { class: "px-4", {is_current.then(|| rsx!{ children })} }
+            div { class: "px-4", {is_current.then(|| rsx! { children })} }
         }
 
         // No nesting

--- a/packages/signals/src/write.rs
+++ b/packages/signals/src/write.rs
@@ -17,7 +17,7 @@ pub type WritableRef<'a, T: Writable, O = <T as Readable>::Target> = T::Mut<'a, 
 /// }
 ///
 /// fn MyComponent(mut count: Signal<MyEnum>) -> Element {
-///     rsx!{
+///     rsx! {
 ///         button {
 ///             onclick: move |_| {
 ///                 // You can use any methods from the Writable trait on Signals

--- a/packages/web/examples/hydrate.rs
+++ b/packages/web/examples/hydrate.rs
@@ -12,7 +12,7 @@ fn app() -> Element {
             "asd"
             Bapp {}
         }
-        {(0..10).map(|f| rsx!{
+        {(0..10).map(|f| rsx! {
             div {
                 "thing {f}"
             }

--- a/packages/web/tests/hydrate.rs
+++ b/packages/web/tests/hydrate.rs
@@ -35,7 +35,7 @@ fn rehydrates() {
                     },
                     "listener test"
                 }
-                {false.then(|| rsx!{ "hello" })}
+                {false.then(|| rsx! { "hello" })}
             }
         }
     }


### PR DESCRIPTION
Switch from `rsx!{` to `rsx! {` in a number of places.

`dx fmt` re-formats this, so I just wanted to cut it out of #2779 to try and shrink that diff a bit.