### PR TITLE
Move component state from the `VirtualDom` to the `Runtime`

### DIFF
--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -81,15 +81,22 @@ impl VirtualDom {
     // Note: This will not remove any ids from the arena
     pub(crate) fn drop_scope(&mut self, id: ScopeId) {
         let height = {
-            let scope = self.scopes.remove(id.0);
-            let context = scope.state();
+            let scope = self.runtime.scopes.borrow_mut().remove(id.0);
+            let scope_ref = scope.borrow();
+            let context = scope_ref.state();
             context.height
         };
 
-        self.dirty_scopes.remove(&ScopeOrder::new(height, id));
+        self.runtime
+            .dirty_scopes
+            .borrow_mut()
+            .remove(&ScopeOrder::new(height, id));
 
         // If this scope was a suspense boundary, remove it from the resolved scopes
-        self.resolved_scopes.retain(|s| s != &id);
+        self.runtime
+            .resolved_scopes
+            .borrow_mut()
+            .retain(|s| s != &id);
     }
 }
 

--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -82,9 +82,7 @@ impl VirtualDom {
     pub(crate) fn drop_scope(&mut self, id: ScopeId) {
         let height = {
             let scope = self.runtime.scopes.borrow_mut().remove(id.0);
-            let scope_ref = scope.borrow();
-            let context = scope_ref.state();
-            context.height
+            scope.with_state(|state| state.height)
         };
 
         self.runtime

--- a/packages/core/src/diff/iterator.rs
+++ b/packages/core/src/diff/iterator.rs
@@ -498,8 +498,7 @@ impl VNode {
                     Some((idx, DynamicNode::Component(_))) => {
                         let scope_id = ScopeId(mount.mounted_dynamic_nodes[idx]);
                         let scope = dom.get_scope(scope_id).unwrap();
-                        let scope_ref = scope.borrow();
-                        let node = scope_ref.root_node();
+                        let node = scope.root_node();
                         node.push_all_root_nodes(dom, to)
                     }
                     // This is a static root node or a single dynamic node, just push it

--- a/packages/core/src/diff/iterator.rs
+++ b/packages/core/src/diff/iterator.rs
@@ -496,8 +496,10 @@ impl VNode {
                         accumulated
                     }
                     Some((idx, DynamicNode::Component(_))) => {
-                        let scope = ScopeId(mount.mounted_dynamic_nodes[idx]);
-                        let node = dom.get_scope(scope).unwrap().root_node();
+                        let scope_id = ScopeId(mount.mounted_dynamic_nodes[idx]);
+                        let scope = dom.get_scope(scope_id).unwrap();
+                        let scope_ref = scope.borrow();
+                        let node = scope_ref.root_node();
                         node.push_all_root_nodes(dom, to)
                     }
                     // This is a static root node or a single dynamic node, just push it

--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -167,7 +167,6 @@ impl VNode {
                 let scope = ScopeId(dom.get_mounted_dyn_node(mount_id, id));
                 dom.get_scope(scope)
                     .unwrap()
-                    .borrow()
                     .root_node()
                     .find_first_element(dom)
             }
@@ -199,7 +198,6 @@ impl VNode {
                 let scope = ScopeId(dom.get_mounted_dyn_node(mount_id, id));
                 dom.get_scope(scope)
                     .unwrap()
-                    .borrow()
                     .root_node()
                     .find_last_element(dom)
             }

--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -167,6 +167,7 @@ impl VNode {
                 let scope = ScopeId(dom.get_mounted_dyn_node(mount_id, id));
                 dom.get_scope(scope)
                     .unwrap()
+                    .borrow()
                     .root_node()
                     .find_first_element(dom)
             }
@@ -198,6 +199,7 @@ impl VNode {
                 let scope = ScopeId(dom.get_mounted_dyn_node(mount_id, id));
                 dom.get_scope(scope)
                     .unwrap()
+                    .borrow()
                     .root_node()
                     .find_last_element(dom)
             }

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -6,7 +6,8 @@ use crate::{
     innerlude::{ElementRef, EventHandler, MountId},
     properties::ComponentFunction,
 };
-use crate::{Properties, ScopeId, VirtualDom};
+use crate::{Properties, Runtime, ScopeId, VirtualDom};
+use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::vec;
@@ -609,13 +610,18 @@ impl VComponent {
         dynamic_node_index: usize,
         vnode: &VNode,
         dom: &'a VirtualDom,
-    ) -> Option<&'a ScopeState> {
+    ) -> Option<Rc<RefCell<ScopeState>>> {
         let mount = vnode.mount.get().as_usize()?;
 
         let mounts = dom.runtime.mounts.borrow();
         let scope_id = mounts.get(mount)?.mounted_dynamic_nodes[dynamic_node_index];
 
-        dom.scopes.get(scope_id)
+        Runtime::current()
+            .unwrap()
+            .scopes
+            .borrow()
+            .get(scope_id)
+            .cloned()
     }
 }
 

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -604,11 +604,7 @@ impl VComponent {
     /// This is useful for rendering nodes outside of the VirtualDom, such as in SSR
     ///
     /// Returns [`None`] if the node is not mounted
-    pub fn mounted_scope<'a>(
-        &self,
-        dynamic_node_index: usize,
-        vnode: &VNode,
-    ) -> Option<ScopeState> {
+    pub fn mounted_scope(&self, dynamic_node_index: usize, vnode: &VNode) -> Option<ScopeState> {
         let mount = vnode.mount.get().as_usize()?;
 
         let rt = Runtime::current().unwrap();

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -7,7 +7,6 @@ use crate::{
     properties::ComponentFunction,
 };
 use crate::{Properties, Runtime, ScopeId, VirtualDom};
-use std::cell::RefCell;
 use std::ops::Deref;
 use std::rc::Rc;
 use std::vec;
@@ -609,19 +608,15 @@ impl VComponent {
         &self,
         dynamic_node_index: usize,
         vnode: &VNode,
-        dom: &'a VirtualDom,
-    ) -> Option<Rc<RefCell<ScopeState>>> {
+    ) -> Option<ScopeState> {
         let mount = vnode.mount.get().as_usize()?;
 
-        let mounts = dom.runtime.mounts.borrow();
+        let rt = Runtime::current().unwrap();
+        let mounts = rt.mounts.borrow();
         let scope_id = mounts.get(mount)?.mounted_dynamic_nodes[dynamic_node_index];
 
-        Runtime::current()
-            .unwrap()
-            .scopes
-            .borrow()
-            .get(scope_id)
-            .cloned()
+        let scopes = rt.scopes.borrow();
+        scopes.get(scope_id).cloned()
     }
 }
 

--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -28,7 +28,7 @@ thread_local! {
 /// A global runtime that is shared across all scopes that provides the async runtime and context API
 pub struct Runtime {
     // TODO (Matt): Combine the below scope-related fields into a single RefCell?
-    pub(crate) scopes: RefCell<Slab<Rc<RefCell<ScopeState>>>>,
+    pub(crate) scopes: RefCell<Slab<ScopeState>>,
 
     pub(crate) dirty_scopes: RefCell<BTreeSet<ScopeOrder>>,
 

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -1,6 +1,3 @@
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use crate::innerlude::{throw_error, RenderError, ScopeOrder};
 use crate::prelude::ReactiveContext;
 use crate::scope_context::SuspenseLocation;

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -66,7 +66,7 @@ impl VirtualDom {
                     span.in_scope(|| {
                         scope.inner.borrow().reactive_context.reset_and_run_in(|| {
                             let mut render_return = props.render();
-                            self.handle_element_return(&mut render_return, scope_id, &scope_state);
+                            self.handle_element_return(&mut render_return, scope_id, scope_state);
                             render_return
                         })
                     })

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -139,6 +139,6 @@ impl ScopeState {
     pub(crate) fn with_state<O>(&self, f: impl FnOnce(&Scope) -> O) -> O {
         let inner = self.inner.borrow();
         let state = inner.runtime.get_state(inner.context_id).unwrap();
-        f(&*state)
+        f(&state)
     }
 }

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -14,9 +14,6 @@ use crate::{
 };
 use crate::{Task, VComponent};
 use futures_util::StreamExt;
-use slab::Slab;
-use std::cell::RefCell;
-use std::collections::BTreeSet;
 use std::{any::Any, rc::Rc};
 use tracing::instrument;
 

--- a/packages/fullstack/src/html_storage/serialize.rs
+++ b/packages/fullstack/src/html_storage/serialize.rs
@@ -66,7 +66,7 @@ impl super::HTMLData {
                 }
             }
             if let Some(node) = scope.try_root_node() {
-                self.take_from_vnode(vdom, node);
+                self.take_from_vnode(vdom, &node);
             }
         }
     }
@@ -75,7 +75,7 @@ impl super::HTMLData {
         for (dynamic_node_index, dyn_node) in vnode.dynamic_nodes.iter().enumerate() {
             match dyn_node {
                 DynamicNode::Component(comp) => {
-                    if let Some(scope) = comp.mounted_scope(dynamic_node_index, vnode, vdom) {
+                    if let Some(scope) = comp.mounted_scope(dynamic_node_index, vnode) {
                         self.take_from_scope(vdom, scope.id());
                     }
                 }

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -165,7 +165,7 @@ impl Renderer {
 
                             render_components(self, &mut buf, dom, scope_id)?;
                         } else {
-                            let scope = node.mounted_scope(*idx, template, dom).unwrap();
+                            let scope = node.mounted_scope(*idx, template).unwrap();
                             let node = scope.root_node();
                             self.render_template(buf, dom, node)?
                         }

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -95,7 +95,7 @@ impl Renderer {
         scope: ScopeId,
     ) -> std::fmt::Result {
         let node = dom.get_scope(scope).unwrap().root_node();
-        self.render_template(buf, dom, node)?;
+        self.render_template(buf, dom, &node)?;
 
         Ok(())
     }
@@ -167,7 +167,7 @@ impl Renderer {
                         } else {
                             let scope = node.mounted_scope(*idx, template).unwrap();
                             let node = scope.root_node();
-                            self.render_template(buf, dom, node)?
+                            self.render_template(buf, dom, &node)?
                         }
                     }
                     DynamicNode::Text(text) => {

--- a/packages/web/src/hydration/hydrate.rs
+++ b/packages/web/src/hydration/hydrate.rs
@@ -240,7 +240,7 @@ impl WebsysDom {
             }
         }
 
-        self.rehydrate_vnode(dom, scope.root_node(), ids, to_mount)
+        self.rehydrate_vnode(dom, &scope.root_node(), ids, to_mount)
     }
 
     fn rehydrate_vnode(
@@ -340,9 +340,9 @@ impl WebsysDom {
             }
             dioxus_core::DynamicNode::Component(comp) => {
                 let scope = comp
-                    .mounted_scope(dynamic_node_index, vnode, dom)
+                    .mounted_scope(dynamic_node_index, vnode)
                     .ok_or(VNodeNotInitialized)?;
-                self.rehydrate_scope(scope, dom, ids, to_mount)?;
+                self.rehydrate_scope(&*scope.borrow(), dom, ids, to_mount)?;
             }
             dioxus_core::DynamicNode::Fragment(fragment) => {
                 for vnode in fragment {

--- a/packages/web/src/hydration/hydrate.rs
+++ b/packages/web/src/hydration/hydrate.rs
@@ -173,7 +173,7 @@ impl WebsysDom {
         self.suspense_hydration_ids
             .current_path
             .clone_from(&suspense_path);
-        self.start_hydration_at_scope(root_scope, dom, children)?;
+        self.start_hydration_at_scope(&root_scope, dom, children)?;
 
         Ok(())
     }
@@ -218,7 +218,7 @@ impl WebsysDom {
 
         // Rehydrate the root scope that was rendered on the server. We will likely run into suspense boundaries.
         // Any suspense boundaries we run into are stored for hydration later.
-        self.start_hydration_at_scope(vdom.base_scope(), vdom, vec![self.root.clone().into()])?;
+        self.start_hydration_at_scope(&vdom.base_scope(), vdom, vec![self.root.clone().into()])?;
 
         Ok(rx)
     }
@@ -342,7 +342,7 @@ impl WebsysDom {
                 let scope = comp
                     .mounted_scope(dynamic_node_index, vnode)
                     .ok_or(VNodeNotInitialized)?;
-                self.rehydrate_scope(&*scope.borrow(), dom, ids, to_mount)?;
+                self.rehydrate_scope(&scope, dom, ids, to_mount)?;
             }
             dioxus_core::DynamicNode::Fragment(fragment) => {
                 for vnode in fragment {


### PR DESCRIPTION
First draft at moving component state from the `VirtualDom` to the `Runtime`.
This allows access to component state while a Dioxus app is running, allowing for `VNode` iterators/visitors, new lints, and debugging.

Replaces `ScopeState` with a wrapper around an inner struct that is hidden from the external API:
```rs
pub(crate) struct Inner { ... }

pub struct ScopeState {
    inner: Rc<RefCell<Inner>>
}
```

Helps with https://github.com/DioxusLabs/dioxus/issues/1177:
 - https://github.com/DioxusLabs/dioxus/pull/2946
 - https://github.com/DioxusLabs/dioxus/pull/2722

Tasks:
- [x] Move component data to the `Runtime`
- [x] Update crates that depend on `dioxus-core`
- [ ] Fix missing root `ScopeState` in `provide_context`