### PR TITLE
Skip running Nix CI for draft PRs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,10 +1,30 @@
 name: "Nix CI"
+
 on:
-  # Run only when pushing to mainline, and making PRs
   push:
     branches:
       - main
+    paths:
+      - packages/**
+      - examples/**
+      - docs/guide/**
+      - src/**
+      - .github/**
+      - lib.rs
+      - Cargo.toml
+      - Makefile.toml
+
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - main
+    paths:
+      - packages/**
+      - examples/**
+      - src/**
+      - .github/**
+      - lib.rs
+      - Cargo.toml
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Skips running the new Nix CI for draft and other minimal PRs (using the same config as the main CI).

My fault I might've merged that Nix PR too soon, I forgot GitHub doesn't skip drafts and other minor changes by default.