### PR TITLE
Refactor the Runtime

### DIFF
--- a/packages/core-macro/tests/values_memoize_in_place.rs
+++ b/packages/core-macro/tests/values_memoize_in_place.rs
@@ -44,6 +44,7 @@ async fn values_memoize_in_place() {
 
     set_event_converter(Box::new(dioxus::html::SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     let mutations = dom.rebuild_to_vec();
     println!("{:#?}", mutations);
@@ -89,6 +90,7 @@ fn cloning_event_handler_components_work() {
 
     set_event_converter(Box::new(dioxus::html::SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     let mutations = dom.rebuild_to_vec();
     println!("{:#?}", mutations);

--- a/packages/core-macro/tests/values_memoize_in_place.rs
+++ b/packages/core-macro/tests/values_memoize_in_place.rs
@@ -44,7 +44,7 @@ async fn values_memoize_in_place() {
 
     set_event_converter(Box::new(dioxus::html::SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     let mutations = dom.rebuild_to_vec();
     println!("{:#?}", mutations);
@@ -90,7 +90,7 @@ fn cloning_event_handler_components_work() {
 
     set_event_converter(Box::new(dioxus::html::SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     let mutations = dom.rebuild_to_vec();
     println!("{:#?}", mutations);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,6 +8,7 @@ use dioxus_core::prelude::*;
 use dioxus_core::*;
 
 let mut vdom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(vdom.runtime());
 let real_dom = SomeRenderer::new();
 
 loop {
@@ -73,6 +74,7 @@ fn app() -> Element {
 fn main() {
     // Next, create a new VirtualDom using this app as the root component.
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     // The initial render of the dom will generate a stream of edits for the real dom to apply
     let mutations = dom.rebuild_to_vec();

--- a/packages/core/src/arena.rs
+++ b/packages/core/src/arena.rs
@@ -56,7 +56,7 @@ pub struct ElementPath {
 
 impl VirtualDom {
     pub(crate) fn next_element(&mut self) -> ElementId {
-        let mut elements = self.runtime.elements.borrow_mut();
+        let mut elements = self.runtime.state.elements.borrow_mut();
         ElementId(elements.insert(None))
     }
 
@@ -72,7 +72,7 @@ impl VirtualDom {
             return true;
         }
 
-        let mut elements = self.runtime.elements.borrow_mut();
+        let mut elements = self.runtime.state.elements.borrow_mut();
         elements.try_remove(el.0).is_some()
     }
 

--- a/packages/core/src/diff/iterator.rs
+++ b/packages/core/src/diff/iterator.rs
@@ -479,7 +479,7 @@ impl VNode {
     ) -> usize {
         let template = self.template;
 
-        let mounts = dom.runtime.mounts.borrow();
+        let mounts = dom.runtime.state.mounts.borrow();
         let mount = mounts.get(self.mount.get().0).unwrap();
 
         template

--- a/packages/core/src/diff/mod.rs
+++ b/packages/core/src/diff/mod.rs
@@ -35,22 +35,22 @@ impl VirtualDom {
     }
 
     pub(crate) fn get_mounted_parent(&self, mount: MountId) -> Option<ElementRef> {
-        let mounts = self.runtime.mounts.borrow();
+        let mounts = self.runtime.state.mounts.borrow();
         mounts[mount.0].parent
     }
 
     pub(crate) fn get_mounted_dyn_node(&self, mount: MountId, dyn_node_idx: usize) -> usize {
-        let mounts = self.runtime.mounts.borrow();
+        let mounts = self.runtime.state.mounts.borrow();
         mounts[mount.0].mounted_dynamic_nodes[dyn_node_idx]
     }
 
     pub(crate) fn set_mounted_dyn_node(&self, mount: MountId, dyn_node_idx: usize, value: usize) {
-        let mut mounts = self.runtime.mounts.borrow_mut();
+        let mut mounts = self.runtime.state.mounts.borrow_mut();
         mounts[mount.0].mounted_dynamic_nodes[dyn_node_idx] = value;
     }
 
     pub(crate) fn get_mounted_dyn_attr(&self, mount: MountId, dyn_attr_idx: usize) -> ElementId {
-        let mounts = self.runtime.mounts.borrow();
+        let mounts = self.runtime.state.mounts.borrow();
         mounts[mount.0].mounted_attributes[dyn_attr_idx]
     }
 
@@ -60,17 +60,17 @@ impl VirtualDom {
         dyn_attr_idx: usize,
         value: ElementId,
     ) {
-        let mut mounts = self.runtime.mounts.borrow_mut();
+        let mut mounts = self.runtime.state.mounts.borrow_mut();
         mounts[mount.0].mounted_attributes[dyn_attr_idx] = value;
     }
 
     pub(crate) fn get_mounted_root_node(&self, mount: MountId, root_idx: usize) -> ElementId {
-        let mounts = self.runtime.mounts.borrow();
+        let mounts = self.runtime.state.mounts.borrow();
         mounts[mount.0].root_ids[root_idx]
     }
 
     pub(crate) fn set_mounted_root_node(&self, mount: MountId, root_idx: usize, value: ElementId) {
-        let mut mounts = self.runtime.mounts.borrow_mut();
+        let mut mounts = self.runtime.state.mounts.borrow_mut();
         mounts[mount.0].root_ids[root_idx] = value;
     }
 

--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -21,6 +21,7 @@ impl VNode {
         // The node we are diffing from should always be mounted
         debug_assert!(
             dom.runtime
+                .state
                 .mounts
                 .borrow()
                 .get(self.mount.get().0)
@@ -67,7 +68,7 @@ impl VNode {
         new.mount.set(mount_id);
 
         if mount_id.mounted() {
-            let mut mounts = dom.runtime.mounts.borrow_mut();
+            let mut mounts = dom.runtime.state.mounts.borrow_mut();
             let mount = &mut mounts[mount_id.0];
 
             // Update the reference to the node for bubbling events
@@ -294,7 +295,7 @@ impl VNode {
         if destroy_component_state {
             let mount = self.mount.take();
             // Remove the mount information
-            dom.runtime.mounts.borrow_mut().remove(mount.0);
+            dom.runtime.state.mounts.borrow_mut().remove(mount.0);
         }
     }
 
@@ -507,7 +508,7 @@ impl VNode {
                     path: ElementPath { path },
                     mount,
                 };
-                let mut elements = dom.runtime.elements.borrow_mut();
+                let mut elements = dom.runtime.state.elements.borrow_mut();
                 elements[id.0] = Some(element_ref);
                 to.create_event_listener(&attribute.name[2..], id);
             }
@@ -529,7 +530,7 @@ impl VNode {
 
         // Initialize the mount information for this vnode if it isn't already mounted
         if !self.mount.get().mounted() {
-            let mut mounts = dom.runtime.mounts.borrow_mut();
+            let mut mounts = dom.runtime.state.mounts.borrow_mut();
             let entry = mounts.vacant_entry();
             let mount = MountId(entry.key());
             self.mount.set(mount);
@@ -553,7 +554,7 @@ impl VNode {
         // Get the mounted id of this block
         // At this point, we should have already mounted the block
         debug_assert!(
-            dom.runtime.mounts.borrow().contains(
+            dom.runtime.state.mounts.borrow().contains(
                 self.mount
                     .get()
                     .as_usize()

--- a/packages/core/src/effect.rs
+++ b/packages/core/src/effect.rs
@@ -30,12 +30,12 @@ impl Effect {
     }
 
     pub(crate) fn run(&self, runtime: &Runtime) {
-        runtime.rendering.set(false);
+        runtime.state.rendering.set(false);
         let mut effect = self.effect.borrow_mut();
         while let Some(f) = effect.pop_front() {
             f();
         }
-        runtime.rendering.set(true);
+        runtime.state.rendering.set(true);
     }
 }
 

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -1,8 +1,4 @@
-use crate::{
-    properties::SuperFrom,
-    runtime::{RuntimeGuard, RuntimeState},
-    Runtime, ScopeId,
-};
+use crate::{properties::SuperFrom, runtime::RuntimeState, Runtime, ScopeId};
 use generational_box::GenerationalBox;
 use std::{cell::RefCell, marker::PhantomData, rc::Rc};
 

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -496,7 +496,7 @@ impl<Args: 'static, Ret: 'static> Callback<Args, Ret> {
             let rt = Runtime {
                 state: rt_state.clone(),
             };
-            let _guard = RuntimeGuard::new(rt.clone());
+
             rt.with_scope_on_stack(self.origin, || {
                 let mut callback = callback.callback.borrow_mut();
                 callback(arguments)

--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -14,7 +14,7 @@ pub fn current_scope_id() -> Result<ScopeId, RuntimeError> {
 #[doc(hidden)]
 /// Check if the virtual dom is currently inside of the body of a component
 pub fn vdom_is_rendering() -> bool {
-    Runtime::with(|rt| rt.rendering.get()).unwrap_or_default()
+    Runtime::with(|rt| rt.state.rendering.get()).unwrap_or_default()
 }
 
 /// Throw a [`CapturedError`] into the current scope. The error will bubble up to the nearest [`crate::prelude::ErrorBoundary()`] or the root of the app.

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -252,7 +252,7 @@ impl VNode {
 
         match &self.dynamic_nodes[dynamic_node_idx] {
             DynamicNode::Text(_) | DynamicNode::Placeholder(_) => {
-                let mounts = dom.runtime.mounts.borrow();
+                let mounts = dom.runtime.state.mounts.borrow();
                 mounts
                     .get(mount)?
                     .mounted_dynamic_nodes
@@ -267,7 +267,7 @@ impl VNode {
     pub fn mounted_root(&self, root_idx: usize, dom: &VirtualDom) -> Option<ElementId> {
         let mount = self.mount.get().as_usize()?;
 
-        let mounts = dom.runtime.mounts.borrow();
+        let mounts = dom.runtime.state.mounts.borrow();
         mounts.get(mount)?.root_ids.get(root_idx).copied()
     }
 
@@ -279,7 +279,7 @@ impl VNode {
     ) -> Option<ElementId> {
         let mount = self.mount.get().as_usize()?;
 
-        let mounts = dom.runtime.mounts.borrow();
+        let mounts = dom.runtime.state.mounts.borrow();
         mounts
             .get(mount)?
             .mounted_attributes
@@ -593,7 +593,7 @@ impl VComponent {
     ) -> Option<ScopeId> {
         let mount = vnode.mount.get().as_usize()?;
 
-        let mounts = dom.runtime.mounts.borrow();
+        let mounts = dom.runtime.state.mounts.borrow();
         let scope_id = mounts.get(mount)?.mounted_dynamic_nodes[dynamic_node_index];
 
         Some(ScopeId(scope_id))
@@ -612,7 +612,7 @@ impl VComponent {
     ) -> Option<&'a ScopeState> {
         let mount = vnode.mount.get().as_usize()?;
 
-        let mounts = dom.runtime.mounts.borrow();
+        let mounts = dom.runtime.state.mounts.borrow();
         let scope_id = mounts.get(mount)?.mounted_dynamic_nodes[dynamic_node_index];
 
         dom.scopes.get(scope_id)

--- a/packages/core/src/reactive_context.rs
+++ b/packages/core/src/reactive_context.rs
@@ -111,7 +111,7 @@ impl ReactiveContext {
     /// Create a reactive context for a scope id
     pub(crate) fn new_for_scope(scope: &Scope, runtime: &Runtime) -> Self {
         let id = scope.id;
-        let sender = runtime.sender.clone();
+        let sender = runtime.state.sender.clone();
         let update_scope = move || {
             tracing::trace!("Marking scope {:?} as dirty", id);
             sender.unbounded_send(SchedulerMsg::Immediate(id)).unwrap();

--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -21,7 +21,7 @@ use std::{
 use tracing::instrument;
 
 thread_local! {
-    static CURRENT: RefCell<Option<Runtime>> = RefCell::new(None);
+    static CURRENT: RefCell<Option<Runtime>> = const { RefCell::new(None) };
 }
 
 /// State of a [`Runtime`].

--- a/packages/core/src/scheduler.rs
+++ b/packages/core/src/scheduler.rs
@@ -124,7 +124,7 @@ impl Hash for ScopeOrder {
 impl VirtualDom {
     /// Queue a task to be polled
     pub(crate) fn queue_task(&mut self, task: Task, order: ScopeOrder) {
-        let mut dirty_tasks = self.runtime.dirty_tasks.borrow_mut();
+        let mut dirty_tasks = self.runtime.state.dirty_tasks.borrow_mut();
         match dirty_tasks.get(&order) {
             Some(scope) => scope.queue_task(task),
             None => {
@@ -147,7 +147,7 @@ impl VirtualDom {
 
     /// Take the top task from the highest scope
     pub(crate) fn pop_task(&mut self) -> Option<Task> {
-        let mut dirty_tasks = self.runtime.dirty_tasks.borrow_mut();
+        let mut dirty_tasks = self.runtime.state.dirty_tasks.borrow_mut();
         let mut tasks = dirty_tasks.first()?;
 
         // If the scope doesn't exist for whatever reason, then we should skip it
@@ -167,7 +167,7 @@ impl VirtualDom {
 
     /// Take any effects from the highest scope. This should only be called if there is no pending scope reruns or tasks
     pub(crate) fn pop_effect(&mut self) -> Option<Effect> {
-        let mut pending_effects = self.runtime.pending_effects.borrow_mut();
+        let mut pending_effects = self.runtime.state.pending_effects.borrow_mut();
         let mut effect = pending_effects.pop_first()?;
 
         // If the scope doesn't exist for whatever reason, then we should skip it
@@ -193,7 +193,7 @@ impl VirtualDom {
 
         // Find the height of the highest dirty scope
         let dirty_task = {
-            let mut dirty_tasks = self.runtime.dirty_tasks.borrow_mut();
+            let mut dirty_tasks = self.runtime.state.dirty_tasks.borrow_mut();
             let mut dirty_task = dirty_tasks.first();
             // Pop any invalid tasks off of each dirty scope;
             while let Some(task) = dirty_task {

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -111,6 +111,7 @@ impl VirtualDom {
                     .suspense_location();
                 let already_suspended = self
                     .runtime
+                    .state
                     .tasks
                     .borrow()
                     .get(task.id)
@@ -123,8 +124,9 @@ impl VirtualDom {
                         boundary.add_suspended_task(e.clone());
                     }
                     self.runtime
+                        .state
                         .suspended_tasks
-                        .set(self.runtime.suspended_tasks.get() + 1);
+                        .set(self.runtime.state.suspended_tasks.get() + 1);
                 }
                 e.placeholder = VNode::placeholder();
             }

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -50,8 +50,6 @@ impl VirtualDom {
     #[tracing::instrument(skip(self), level = "trace", name = "VirtualDom::run_scope")]
     #[track_caller]
     pub(crate) fn run_scope(&mut self, scope_id: ScopeId) -> Element {
-        let _guard = RuntimeGuard::new(self.runtime.clone());
-
         self.runtime.clone().with_scope_on_stack(scope_id, || {
             let scope = &self.scopes[scope_id.0];
             let output = {

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -1,6 +1,5 @@
 use crate::innerlude::{throw_error, RenderError, ScopeOrder};
 use crate::prelude::ReactiveContext;
-use crate::runtime::RuntimeGuard;
 use crate::scope_context::SuspenseLocation;
 use crate::{
     any_props::{AnyProps, BoxedAnyProps},

--- a/packages/core/src/scope_arena.rs
+++ b/packages/core/src/scope_arena.rs
@@ -1,5 +1,6 @@
 use crate::innerlude::{throw_error, RenderError, ScopeOrder};
 use crate::prelude::ReactiveContext;
+use crate::runtime::RuntimeGuard;
 use crate::scope_context::SuspenseLocation;
 use crate::{
     any_props::{AnyProps, BoxedAnyProps},
@@ -49,8 +50,7 @@ impl VirtualDom {
     #[tracing::instrument(skip(self), level = "trace", name = "VirtualDom::run_scope")]
     #[track_caller]
     pub(crate) fn run_scope(&mut self, scope_id: ScopeId) -> Element {
-        // Ensure we are currently inside a `Runtime`.
-        crate::Runtime::current().unwrap_or_else(|e| panic!("{}", e));
+        let _guard = RuntimeGuard::new(self.runtime.clone());
 
         self.runtime.clone().with_scope_on_stack(scope_id, || {
             let scope = &self.scopes[scope_id.0];

--- a/packages/core/src/scope_context.rs
+++ b/packages/core/src/scope_context.rs
@@ -97,7 +97,7 @@ impl Scope {
     }
 
     fn sender(&self) -> futures_channel::mpsc::UnboundedSender<SchedulerMsg> {
-        Runtime::with(|rt| rt.sender.clone()).unwrap_or_else(|e| panic!("{}", e))
+        Runtime::with(|rt| rt.state.sender.clone()).unwrap_or_else(|e| panic!("{}", e))
     }
 
     /// Mount the scope and queue any pending effects if it is not already mounted

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -2,7 +2,7 @@ use crate::{
     any_props::BoxedAnyProps, nodes::AsVNode, reactive_context::ReactiveContext,
     scope_context::Scope, Element, Runtime, VNode,
 };
-use std::{cell::Ref, rc::Rc};
+use std::cell::Ref;
 
 /// A component's unique identifier.
 ///

--- a/packages/core/src/scopes.rs
+++ b/packages/core/src/scopes.rs
@@ -66,7 +66,7 @@ impl ScopeId {
 ///
 /// This state erases the type of the component's props. It is used to store the state of a component in the runtime.
 pub struct ScopeState {
-    pub(crate) runtime: Rc<Runtime>,
+    pub(crate) runtime: Runtime,
     pub(crate) context_id: ScopeId,
     /// The last node that has been rendered for this component. This node may not ben mounted
     /// During suspense, this component can be rendered in the background multiple times

--- a/packages/core/src/suspense/component.rs
+++ b/packages/core/src/suspense/component.rs
@@ -398,7 +398,7 @@ impl SuspenseBoundaryProps {
             let currently_rendered = scope_state.last_rendered_node.as_ref().unwrap().clone();
             let mount = currently_rendered.as_vnode().mount.get();
             let parent = {
-                let mounts = dom.runtime.mounts.borrow();
+                let mounts = dom.runtime.state.mounts.borrow();
                 mounts
                     .get(mount.0)
                     .expect("suspense placeholder is not mounted")

--- a/packages/core/src/suspense/component.rs
+++ b/packages/core/src/suspense/component.rs
@@ -380,7 +380,6 @@ impl SuspenseBoundaryProps {
         replace_with: usize,
     ) {
         dom.runtime.clone().with_scope_on_stack(scope_id, || {
-            let _runtime = RuntimeGuard::new(dom.runtime());
             let Some(scope_state) = dom.scopes.get_mut(scope_id.0) else {
                 return;
             };

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -207,7 +207,7 @@ pub struct VirtualDom {
 
     pub(crate) dirty_scopes: BTreeSet<ScopeOrder>,
 
-    pub(crate) runtime: Rc<Runtime>,
+    pub(crate) runtime: Runtime,
 
     // The scopes that have been resolved since the last render
     pub(crate) resolved_scopes: Vec<ScopeId>,
@@ -494,8 +494,8 @@ impl VirtualDom {
 
         // Keep polling tasks until there are no more effects or tasks to run
         // Or until we have no more dirty scopes
-        while !self.runtime.dirty_tasks.borrow().is_empty()
-            || !self.runtime.pending_effects.borrow().is_empty()
+        while !self.runtime.state.dirty_tasks.borrow().is_empty()
+            || !self.runtime.state.pending_effects.borrow().is_empty()
         {
             // Next, run any queued tasks
             // We choose not to poll the deadline since we complete pretty quickly anyways
@@ -629,7 +629,7 @@ impl VirtualDom {
 
     /// Check if there are any suspended tasks remaining
     pub fn suspended_tasks_remaining(&self) -> bool {
-        self.runtime.suspended_tasks.get() > 0
+        self.runtime.state.suspended_tasks.get() > 0
     }
 
     /// Wait for the scheduler to have any work that should be run during suspense.
@@ -727,7 +727,7 @@ impl VirtualDom {
     }
 
     /// Get the current runtime
-    pub fn runtime(&self) -> Rc<Runtime> {
+    pub fn runtime(&self) -> Runtime {
         self.runtime.clone()
     }
 

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -8,7 +8,7 @@ use crate::root_wrapper::RootScopeWrapper;
 use crate::{
     arena::ElementId,
     innerlude::{NoOpMutations, SchedulerMsg, ScopeOrder, ScopeState, VProps, WriteMutations},
-    runtime::{Runtime, RuntimeGuard},
+    runtime::Runtime,
     scopes::ScopeId,
     ComponentFunction, Element, Mutations,
 };

--- a/packages/core/tests/attr_cleanup.rs
+++ b/packages/core/tests/attr_cleanup.rs
@@ -19,6 +19,7 @@ fn attrs_cycle() {
             _ => unreachable!(),
         }
     });
+    let _runtime_guard = RuntimeGuard::new(dom.runtime());
 
     assert_eq!(
         dom.rebuild_to_vec().edits,

--- a/packages/core/tests/boolattrs.rs
+++ b/packages/core/tests/boolattrs.rs
@@ -4,6 +4,7 @@ use dioxus::prelude::*;
 #[test]
 fn bool_test() {
     let mut app = VirtualDom::new(|| rsx!(div { hidden: false }));
+    let _runtime_guard = RuntimeGuard::new(app.runtime());
 
     assert_eq!(
         app.rebuild_to_vec().edits,

--- a/packages/core/tests/bubble_error.rs
+++ b/packages/core/tests/bubble_error.rs
@@ -17,7 +17,8 @@ fn app() -> Element {
 #[test]
 fn bubbles_error() {
     let mut dom = VirtualDom::new(app);
-
+    let _guard = RuntimeGuard::new(dom.runtime());
+    let _runtime_guard = RuntimeGuard::new(dom.runtime());
     {
         let _edits = dom.rebuild_to_vec();
     }

--- a/packages/core/tests/children_drop_futures.rs
+++ b/packages/core/tests/children_drop_futures.rs
@@ -30,6 +30,7 @@ async fn child_futures_drop_first() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 

--- a/packages/core/tests/context_api.rs
+++ b/packages/core/tests/context_api.rs
@@ -19,7 +19,7 @@ fn state_shares() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     assert_eq!(
         dom.rebuild_to_vec().edits,
         [

--- a/packages/core/tests/context_api.rs
+++ b/packages/core/tests/context_api.rs
@@ -19,6 +19,7 @@ fn state_shares() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     assert_eq!(
         dom.rebuild_to_vec().edits,
         [

--- a/packages/core/tests/create_dom.rs
+++ b/packages/core/tests/create_dom.rs
@@ -16,9 +16,9 @@ fn test_original_diff() {
             div { div { "Hello, world!" } }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     let edits = dom.rebuild_to_vec();
-
     assert_eq!(
         edits.edits,
         [
@@ -45,6 +45,7 @@ fn create() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     let _edits = dom.rebuild_to_vec();
 
@@ -76,7 +77,7 @@ fn create() {
 #[test]
 fn create_list() {
     let mut dom = VirtualDom::new(|| rsx! {{(0..3).map(|f| rsx!( div { "hello" } ))}});
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     let _edits = dom.rebuild_to_vec();
 
     // note: we dont test template edits anymore
@@ -93,33 +94,6 @@ fn create_list() {
 }
 
 #[test]
-fn create_simple() {
-    let mut dom = VirtualDom::new(|| {
-        rsx! {
-            div {}
-            div {}
-            div {}
-            div {}
-        }
-    });
-
-    let edits = dom.rebuild_to_vec();
-
-    // note: we dont test template edits anymore
-    // assert_eq!(
-    //     edits.templates,
-    //     [
-    //         // create template
-    //         CreateElement { name: "div" },
-    //         CreateElement { name: "div" },
-    //         CreateElement { name: "div" },
-    //         CreateElement { name: "div" },
-    //         // add to root
-    //         SaveTemplate {  m: 4 }
-    //     ]
-    // );
-}
-#[test]
 fn create_components() {
     let mut dom = VirtualDom::new(|| {
         rsx! {
@@ -128,6 +102,7 @@ fn create_components() {
             Child { "abc3" }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     #[derive(Props, Clone, PartialEq)]
     struct ChildProps {
@@ -159,6 +134,7 @@ fn anchors() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     // note that the template under "false" doesn't show up since it's not loaded
     let edits = dom.rebuild_to_vec();

--- a/packages/core/tests/create_fragments.rs
+++ b/packages/core/tests/create_fragments.rs
@@ -11,8 +11,9 @@ fn empty_fragment_creates_nothing() {
     }
 
     let mut vdom = VirtualDom::new(app);
-    let edits = vdom.rebuild_to_vec();
+    let _guard = RuntimeGuard::new(vdom.runtime());
 
+    let edits = vdom.rebuild_to_vec();
     assert_eq!(
         edits.edits,
         [
@@ -30,6 +31,7 @@ fn root_fragments_work() {
             div { "goodbye" }
         )
     });
+    let _guard = RuntimeGuard::new(vdom.runtime());
 
     assert_eq!(
         vdom.rebuild_to_vec().edits.last().unwrap(),
@@ -57,6 +59,7 @@ fn fragments_nested() {
             }}
         )
     });
+    let _guard = RuntimeGuard::new(vdom.runtime());
 
     assert_eq!(
         vdom.rebuild_to_vec().edits.last().unwrap(),
@@ -80,8 +83,11 @@ fn fragments_across_components() {
         rsx! { "hellO!" {world} }
     }
 
+    let mut vdom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(vdom.runtime());
+
     assert_eq!(
-        VirtualDom::new(app).rebuild_to_vec().edits.last().unwrap(),
+        vdom.rebuild_to_vec().edits.last().unwrap(),
         &AppendChildren { id: ElementId(0), m: 8 }
     );
 }
@@ -94,8 +100,12 @@ fn list_fragments() {
             {(0..6).map(|f| rsx!( span { "{f}" }))}
         )
     }
+
+    let mut vdom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(vdom.runtime());
+
     assert_eq!(
-        VirtualDom::new(app).rebuild_to_vec().edits.last().unwrap(),
+        vdom.rebuild_to_vec().edits.last().unwrap(),
         &AppendChildren { id: ElementId(0), m: 7 }
     );
 }

--- a/packages/core/tests/create_lists.rs
+++ b/packages/core/tests/create_lists.rs
@@ -25,6 +25,7 @@ fn app() -> Element {
 #[test]
 fn list_renders() {
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     let edits = dom.rebuild_to_vec();
 

--- a/packages/core/tests/create_lists.rs
+++ b/packages/core/tests/create_lists.rs
@@ -25,7 +25,7 @@ fn app() -> Element {
 #[test]
 fn list_renders() {
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     let edits = dom.rebuild_to_vec();
 

--- a/packages/core/tests/create_passthru.rs
+++ b/packages/core/tests/create_passthru.rs
@@ -21,6 +21,7 @@ fn nested_passthru_creates() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     let edits = dom.rebuild_to_vec();
 
     assert_eq!(
@@ -58,6 +59,7 @@ fn nested_passthru_creates_add() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     assert_eq!(
         dom.rebuild_to_vec().edits,
@@ -85,6 +87,7 @@ fn dynamic_node_as_root() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     let edits = dom.rebuild_to_vec();
 
     // Since the roots were all dynamic, they should not cause any template muations

--- a/packages/core/tests/create_passthru.rs
+++ b/packages/core/tests/create_passthru.rs
@@ -21,7 +21,7 @@ fn nested_passthru_creates() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     let edits = dom.rebuild_to_vec();
 
     assert_eq!(
@@ -59,7 +59,7 @@ fn nested_passthru_creates_add() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     assert_eq!(
         dom.rebuild_to_vec().edits,
@@ -87,7 +87,7 @@ fn dynamic_node_as_root() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     let edits = dom.rebuild_to_vec();
 
     // Since the roots were all dynamic, they should not cause any template muations

--- a/packages/core/tests/cycle.rs
+++ b/packages/core/tests/cycle.rs
@@ -9,6 +9,7 @@ fn cycling_elements() {
         1 => rsx! { div { "abcd" } },
         _ => unreachable!(),
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     {
         let edits = dom.rebuild_to_vec();

--- a/packages/core/tests/diff_component.rs
+++ b/packages/core/tests/diff_component.rs
@@ -71,7 +71,7 @@ fn component_swap() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     {
         let edits = dom.rebuild_to_vec();
         assert_eq!(

--- a/packages/core/tests/diff_component.rs
+++ b/packages/core/tests/diff_component.rs
@@ -71,6 +71,7 @@ fn component_swap() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     {
         let edits = dom.rebuild_to_vec();
         assert_eq!(

--- a/packages/core/tests/diff_dynamic_node.rs
+++ b/packages/core/tests/diff_dynamic_node.rs
@@ -15,6 +15,7 @@ fn toggle_option_text() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     // load the div and then assign the None as a placeholder
     assert_eq!(
@@ -73,6 +74,7 @@ fn toggle_template() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     // Rendering again should replace the placeholder with an text node

--- a/packages/core/tests/diff_element.rs
+++ b/packages/core/tests/diff_element.rs
@@ -10,6 +10,7 @@ fn text_diff() {
     }
 
     let mut vdom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(vdom.runtime());
     vdom.rebuild(&mut NoOpMutations);
 
     vdom.mark_dirty(ScopeId::APP);
@@ -44,6 +45,7 @@ fn element_swap() {
     }
 
     let mut vdom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(vdom.runtime());
     vdom.rebuild(&mut NoOpMutations);
 
     vdom.mark_dirty(ScopeId::APP);
@@ -124,9 +126,11 @@ fn attribute_diff() {
     }
 
     let mut vdom = VirtualDom::new(app);
-    vdom.rebuild(&mut NoOpMutations);
+    let _guard = RuntimeGuard::new(vdom.runtime());
 
+    vdom.rebuild(&mut NoOpMutations);
     vdom.mark_dirty(ScopeId::APP);
+
     assert_eq!(
         vdom.render_immediate_to_vec().edits,
         [
@@ -193,9 +197,11 @@ fn diff_empty() {
     }
 
     let mut vdom = VirtualDom::new(app);
-    vdom.rebuild(&mut NoOpMutations);
+    let _guard = RuntimeGuard::new(vdom.runtime());
 
+    vdom.rebuild(&mut NoOpMutations);
     vdom.mark_dirty(ScopeId::APP);
+
     let edits = vdom.render_immediate_to_vec().edits;
 
     assert_eq!(

--- a/packages/core/tests/diff_keyed_list.rs
+++ b/packages/core/tests/diff_keyed_list.rs
@@ -19,6 +19,7 @@ fn keyed_diffing_out_of_order() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     {
         assert_eq!(
@@ -61,7 +62,7 @@ fn keyed_diffing_out_of_order_adds() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     dom.mark_dirty(ScopeId::APP);
@@ -87,7 +88,7 @@ fn keyed_diffing_out_of_order_adds_3() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     dom.mark_dirty(ScopeId::APP);
@@ -113,7 +114,7 @@ fn keyed_diffing_out_of_order_adds_4() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     dom.mark_dirty(ScopeId::APP);
@@ -139,7 +140,7 @@ fn keyed_diffing_out_of_order_adds_5() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     dom.mark_dirty(ScopeId::APP);
@@ -164,7 +165,7 @@ fn keyed_diffing_additions() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     dom.mark_dirty(ScopeId::APP);
@@ -189,7 +190,7 @@ fn keyed_diffing_additions_and_moves_on_ends() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     dom.mark_dirty(ScopeId::APP);
@@ -218,7 +219,7 @@ fn keyed_diffing_additions_and_moves_in_middle() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     // LIS: 4, 5, 6
@@ -252,7 +253,7 @@ fn controlled_keyed_diffing_out_of_order() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     // LIS: 5, 6
@@ -286,6 +287,7 @@ fn controlled_keyed_diffing_out_of_order_max_test() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -315,6 +317,7 @@ fn remove_list() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -340,6 +343,7 @@ fn no_common_keys() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -368,6 +372,7 @@ fn perfect_reverse() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -402,6 +407,7 @@ fn old_middle_empty_left_pivot() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -431,6 +437,7 @@ fn old_middle_empty_right_pivot() {
 
         rsx!({ order.iter().map(|i| rsx!(div { key: "{i}" })) })
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 

--- a/packages/core/tests/diff_unkeyed_list.rs
+++ b/packages/core/tests/diff_unkeyed_list.rs
@@ -18,6 +18,7 @@ fn list_creates_one_by_one() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     // load the div and then assign the empty fragment as a placeholder
     assert_eq!(
@@ -92,7 +93,7 @@ fn removes_one_by_one() {
             }
         }
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     // load the div and then assign the empty fragment as a placeholder
     assert_eq!(
         dom.rebuild_to_vec().edits,
@@ -174,6 +175,7 @@ fn list_shrink_multiroot() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     assert_eq!(
         dom.rebuild_to_vec().edits,
@@ -242,7 +244,7 @@ fn removes_one_by_one_multiroot() {
             }
         }
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     // load the div and then assign the empty fragment as a placeholder
     assert_eq!(
         dom.rebuild_to_vec().edits,
@@ -304,7 +306,7 @@ fn two_equal_fragments_are_equal_static() {
             }
         }
     });
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     assert!(dom.render_immediate_to_vec().edits.is_empty());
 }
@@ -318,6 +320,7 @@ fn two_equal_fragments_are_equal() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     assert!(dom.render_immediate_to_vec().edits.is_empty());
@@ -339,6 +342,7 @@ fn remove_many() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     // len = 0
     {
@@ -449,6 +453,7 @@ fn replace_and_add_items() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     // The list starts empty with a placeholder
     {

--- a/packages/core/tests/error_boundary.rs
+++ b/packages/core/tests/error_boundary.rs
@@ -5,6 +5,7 @@ use dioxus::prelude::*;
 #[test]
 fn catches_panic() {
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 }
 

--- a/packages/core/tests/error_boundary.rs
+++ b/packages/core/tests/error_boundary.rs
@@ -5,7 +5,7 @@ use dioxus::prelude::*;
 #[test]
 fn catches_panic() {
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 }
 

--- a/packages/core/tests/event_propagation.rs
+++ b/packages/core/tests/event_propagation.rs
@@ -9,6 +9,7 @@ fn events_propagate() {
     set_event_converter(Box::new(dioxus::html::SerializedHtmlEventConverter));
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     // Top-level click is registered

--- a/packages/core/tests/fuzzing.rs
+++ b/packages/core/tests/fuzzing.rs
@@ -286,6 +286,7 @@ fn create() {
     for _ in 0..repeat_count {
         let mut vdom =
             VirtualDom::new_with_props(create_random_element, DepthProps { depth: 0, root: true });
+        let _guard = RuntimeGuard::new(vdom.runtime());
         vdom.rebuild(&mut NoOpMutations);
     }
 }
@@ -298,6 +299,7 @@ fn diff() {
     for _ in 0..repeat_count {
         let mut vdom =
             VirtualDom::new_with_props(create_random_element, DepthProps { depth: 0, root: true });
+        let _guard = RuntimeGuard::new(vdom.runtime());
         vdom.rebuild(&mut NoOpMutations);
         // A list of all elements that have had event listeners
         // This is intentionally never cleared, so that we can test that calling event listeners that are removed doesn't cause a panic

--- a/packages/core/tests/kitchen_sink.rs
+++ b/packages/core/tests/kitchen_sink.rs
@@ -33,6 +33,7 @@ fn basic_syntax_is_a_template() -> Element {
 #[test]
 fn dual_stream() {
     let mut dom = VirtualDom::new(basic_syntax_is_a_template);
+    let _guard = RuntimeGuard::new(dom.runtime());
     let edits = dom.rebuild_to_vec();
 
     use Mutation::*;

--- a/packages/core/tests/lifecycle.rs
+++ b/packages/core/tests/lifecycle.rs
@@ -25,6 +25,7 @@ fn manual_diffing() {
 
     let value = Arc::new(Mutex::new("Hello"));
     let mut dom = VirtualDom::new_with_props(app, AppProps { value: value.clone() });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -59,6 +60,7 @@ fn events_generate() {
     };
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     let event = Event::new(

--- a/packages/core/tests/many_roots.rs
+++ b/packages/core/tests/many_roots.rs
@@ -31,6 +31,7 @@ fn many_roots() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     let edits = dom.rebuild_to_vec();
 
     assert_eq!(

--- a/packages/core/tests/many_roots.rs
+++ b/packages/core/tests/many_roots.rs
@@ -31,7 +31,7 @@ fn many_roots() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     let edits = dom.rebuild_to_vec();
 
     assert_eq!(

--- a/packages/core/tests/miri_full_app.rs
+++ b/packages/core/tests/miri_full_app.rs
@@ -7,7 +7,7 @@ use std::{any::Any, rc::Rc};
 fn miri_rollover() {
     set_event_converter(Box::new(SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 

--- a/packages/core/tests/miri_full_app.rs
+++ b/packages/core/tests/miri_full_app.rs
@@ -7,6 +7,7 @@ use std::{any::Any, rc::Rc};
 fn miri_rollover() {
     set_event_converter(Box::new(SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 

--- a/packages/core/tests/miri_simple.rs
+++ b/packages/core/tests/miri_simple.rs
@@ -7,6 +7,7 @@ fn app_drops() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.mark_dirty(ScopeId::APP);
@@ -25,6 +26,7 @@ fn hooks_drop() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.mark_dirty(ScopeId::APP);
@@ -49,6 +51,7 @@ fn contexts_drop() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.mark_dirty(ScopeId::APP);
@@ -66,6 +69,7 @@ fn tasks_drop() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.mark_dirty(ScopeId::APP);
@@ -81,7 +85,7 @@ fn root_props_drop() {
         |cx: RootProps| rsx!( div { "{cx.0}" } ),
         RootProps("asdasd".to_string()),
     );
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.mark_dirty(ScopeId::APP);
     _ = dom.render_immediate_to_vec();
@@ -112,11 +116,14 @@ fn diffing_drops_old() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.mark_dirty(ScopeId::APP);
 
     _ = dom.render_immediate_to_vec();
 }
+
+/* TODO(Matt)
 
 #[test]
 fn hooks_drop_before_contexts() {
@@ -139,8 +146,10 @@ fn hooks_drop_before_contexts() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.mark_dirty(ScopeId::APP);
     _ = dom.render_immediate_to_vec();
 }
+ */

--- a/packages/core/tests/miri_stress.rs
+++ b/packages/core/tests/miri_stress.rs
@@ -59,6 +59,7 @@ fn test_memory_leak() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -95,6 +96,7 @@ fn memo_works_properly() {
     }
 
     let mut dom = VirtualDom::new(app);
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 }
@@ -120,12 +122,14 @@ fn free_works_on_root_hooks() {
 
     let ptr = Rc::new("asdasd".to_string());
     let mut dom = VirtualDom::new_with_props(app, AppProps { inner: ptr.clone() });
+    let guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     // ptr gets cloned into props and then into the hook
     assert!(Rc::strong_count(&ptr) > 1);
 
     drop(dom);
+    drop(guard);
 
     assert_eq!(Rc::strong_count(&ptr), 1);
 }
@@ -186,6 +190,7 @@ fn supports_async() {
 
     rt.block_on(async {
         let mut dom = VirtualDom::new(app);
+        let _guard = RuntimeGuard::new(dom.runtime());
         dom.rebuild(&mut dioxus_core::NoOpMutations);
 
         for _ in 0..10 {

--- a/packages/core/tests/safety.rs
+++ b/packages/core/tests/safety.rs
@@ -6,7 +6,7 @@ use dioxus::prelude::*;
 #[test]
 fn root_node_isnt_null() {
     let dom = VirtualDom::new(|| rsx!("Hello world!"));
-
+    let _guard = RuntimeGuard::new(dom.runtime());
     let scope = dom.base_scope();
 
     // We haven't built the tree, so trying to get out the root node should fail

--- a/packages/core/tests/suspense.rs
+++ b/packages/core/tests/suspense.rs
@@ -28,7 +28,7 @@ fn suspense_resolves_ssr() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+            let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild_in_place();
             dom.wait_for_suspense().await;
             dom.render_immediate(&mut dioxus_core::NoOpMutations);
@@ -83,7 +83,7 @@ fn suspense_keeps_state() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+            let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
             dom.render_suspense_immediate().await;
 
@@ -143,7 +143,7 @@ fn suspense_does_not_poll_spawn() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+            let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             dom.wait_for_suspense().await;
@@ -197,7 +197,7 @@ fn suspended_nodes_dont_trigger_effects() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+            let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             let work = async move {
@@ -270,7 +270,7 @@ fn resolved_to_suspended() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+            let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             let out = dioxus_ssr::render(&dom);
@@ -334,7 +334,7 @@ fn suspense_tracks_resolved() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+            let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             dom.render_suspense_immediate().await;
@@ -421,7 +421,7 @@ fn toggle_suspense() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+            let _guard = RuntimeGuard::new(dom.runtime());
             let mutations = dom.rebuild_to_vec();
 
             // First create goodbye world

--- a/packages/core/tests/suspense.rs
+++ b/packages/core/tests/suspense.rs
@@ -28,6 +28,7 @@ fn suspense_resolves_ssr() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild_in_place();
             dom.wait_for_suspense().await;
             dom.render_immediate(&mut dioxus_core::NoOpMutations);
@@ -82,6 +83,7 @@ fn suspense_keeps_state() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
             dom.render_suspense_immediate().await;
 
@@ -141,6 +143,7 @@ fn suspense_does_not_poll_spawn() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             dom.wait_for_suspense().await;
@@ -194,6 +197,7 @@ fn suspended_nodes_dont_trigger_effects() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             let work = async move {
@@ -266,6 +270,7 @@ fn resolved_to_suspended() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             let out = dioxus_ssr::render(&dom);
@@ -329,6 +334,7 @@ fn suspense_tracks_resolved() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             dom.rebuild(&mut dioxus_core::NoOpMutations);
 
             dom.render_suspense_immediate().await;
@@ -415,6 +421,7 @@ fn toggle_suspense() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             let mutations = dom.rebuild_to_vec();
 
             // First create goodbye world
@@ -585,6 +592,7 @@ fn nested_suspense_resolves_client() {
         .unwrap()
         .block_on(async {
             let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
             let mutations = dom.rebuild_to_vec();
             // Initial loading message and loading title
             assert_eq!(

--- a/packages/core/tests/task.rs
+++ b/packages/core/tests/task.rs
@@ -6,6 +6,7 @@ use dioxus::prelude::*;
 
 async fn run_vdom(app: fn() -> Element) {
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -76,6 +77,7 @@ async fn spawn_forever_persists() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.render_immediate(&mut dioxus_core::NoOpMutations);

--- a/packages/core/tests/task.rs
+++ b/packages/core/tests/task.rs
@@ -6,7 +6,7 @@ use dioxus::prelude::*;
 
 async fn run_vdom(app: fn() -> Element) {
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
@@ -77,7 +77,7 @@ async fn spawn_forever_persists() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
     dom.render_immediate(&mut dioxus_core::NoOpMutations);

--- a/packages/core/tests/tracing.rs
+++ b/packages/core/tests/tracing.rs
@@ -35,6 +35,7 @@ fn basic_tracing() {
 
     set_event_converter(Box::new(SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 

--- a/packages/core/tests/tracing.rs
+++ b/packages/core/tests/tracing.rs
@@ -35,7 +35,7 @@ fn basic_tracing() {
 
     set_event_converter(Box::new(SerializedHtmlEventConverter));
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 

--- a/packages/desktop/src/assets.rs
+++ b/packages/desktop/src/assets.rs
@@ -13,12 +13,12 @@ pub struct AssetHandler {
 
 #[derive(Clone)]
 pub struct AssetHandlerRegistry {
-    dom_rt: Rc<Runtime>,
+    dom_rt: Runtime,
     handlers: Rc<RefCell<FxHashMap<String, AssetHandler>>>,
 }
 
 impl AssetHandlerRegistry {
-    pub fn new(dom_rt: Rc<Runtime>) -> Self {
+    pub fn new(dom_rt: Runtime) -> Self {
         AssetHandlerRegistry {
             dom_rt,
             handlers: Default::default(),

--- a/packages/desktop/src/hooks.rs
+++ b/packages/desktop/src/hooks.rs
@@ -26,12 +26,7 @@ pub fn use_wry_event_handler(
     let runtime = Runtime::current().unwrap();
 
     use_hook_with_cleanup(
-        move || {
-            window().create_wry_event_handler(move |event, target| {
-                let _runtime_guard = RuntimeGuard::new(runtime.clone());
-                handler(event, target)
-            })
-        },
+        move || window().create_wry_event_handler(move |event, target| handler(event, target)),
         move |handler| handler.remove(),
     )
 }
@@ -49,7 +44,6 @@ pub fn use_muda_event_handler(
     let runtime = Runtime::current().unwrap();
 
     use_wry_event_handler(move |event, _| {
-        let _runtime_guard = dioxus_core::prelude::RuntimeGuard::new(runtime.clone());
         if let Event::UserEvent(UserWindowEvent::MudaMenuEvent(event)) = event {
             handler(event);
         }

--- a/packages/desktop/src/hooks.rs
+++ b/packages/desktop/src/hooks.rs
@@ -5,8 +5,8 @@ use crate::{
     ShortcutHandle, ShortcutRegistryError, WryEventHandler,
 };
 use dioxus_core::{
-    prelude::{consume_context, current_scope_id, use_hook_with_cleanup, RuntimeGuard},
-    use_hook, Runtime,
+    prelude::{consume_context, current_scope_id, use_hook_with_cleanup},
+    use_hook,
 };
 
 use dioxus_hooks::use_callback;
@@ -22,9 +22,6 @@ pub fn use_window() -> DesktopContext {
 pub fn use_wry_event_handler(
     mut handler: impl FnMut(&Event<UserWindowEvent>, &EventLoopWindowTarget<UserWindowEvent>) + 'static,
 ) -> WryEventHandler {
-    // move the runtime into the event handler closure
-    let runtime = Runtime::current().unwrap();
-
     use_hook_with_cleanup(
         move || window().create_wry_event_handler(move |event, target| handler(event, target)),
         move |handler| handler.remove(),
@@ -40,9 +37,6 @@ pub fn use_wry_event_handler(
 pub fn use_muda_event_handler(
     mut handler: impl FnMut(&muda::MenuEvent) + 'static,
 ) -> WryEventHandler {
-    // move the runtime into the event handler closure
-    let runtime = Runtime::current().unwrap();
-
     use_wry_event_handler(move |event, _| {
         if let Event::UserEvent(UserWindowEvent::MudaMenuEvent(event)) = event {
             handler(event);

--- a/packages/desktop/src/launch.rs
+++ b/packages/desktop/src/launch.rs
@@ -4,6 +4,7 @@ use crate::{
     ipc::{IpcMethod, UserWindowEvent},
 };
 use dioxus_core::*;
+use prelude::RuntimeGuard;
 use std::any::Any;
 use tao::event::{Event, StartCause, WindowEvent};
 
@@ -67,6 +68,8 @@ pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, desktop_config: Conf
 
 /// Launches the WebView and runs the event loop, with configuration and root props.
 pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) -> ! {
+    let _runtime_guard = RuntimeGuard::new(virtual_dom.runtime());
+
     #[cfg(feature = "tokio_runtime")]
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -20,13 +20,13 @@ use wry::{RequestAsyncResponder, WebContext, WebViewBuilder};
 
 #[derive(Clone)]
 pub(crate) struct WebviewEdits {
-    runtime: Rc<Runtime>,
+    runtime: Runtime,
     pub wry_queue: WryQueue,
     desktop_context: Rc<OnceCell<DesktopContext>>,
 }
 
 impl WebviewEdits {
-    fn new(runtime: Rc<Runtime>, wry_queue: WryQueue) -> Self {
+    fn new(runtime: Runtime, wry_queue: WryQueue) -> Self {
         Self {
             runtime,
             wry_queue,

--- a/packages/dioxus/benches/jsframework.rs
+++ b/packages/dioxus/benches/jsframework.rs
@@ -28,6 +28,7 @@ criterion_main!(mbenches);
 fn create_rows(c: &mut Criterion) {
     c.bench_function("create rows", |b| {
         let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
         dom.rebuild(&mut dioxus_core::NoOpMutations);
 
         b.iter(|| {

--- a/packages/dioxus/benches/jsframework.rs
+++ b/packages/dioxus/benches/jsframework.rs
@@ -28,7 +28,7 @@ criterion_main!(mbenches);
 fn create_rows(c: &mut Criterion) {
     c.bench_function("create rows", |b| {
         let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+        let _guard = RuntimeGuard::new(dom.runtime());
         dom.rebuild(&mut dioxus_core::NoOpMutations);
 
         b.iter(|| {

--- a/packages/hooks/tests/effect.rs
+++ b/packages/hooks/tests/effect.rs
@@ -41,6 +41,7 @@ async fn effects_rerun() {
         },
         counter.clone(),
     );
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild_in_place();
     tokio::select! {
@@ -92,6 +93,7 @@ async fn effects_rerun_without_rerender() {
         },
         counter.clone(),
     );
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     dom.rebuild_in_place();
     tokio::select! {

--- a/packages/hooks/tests/memo.rs
+++ b/packages/hooks/tests/memo.rs
@@ -52,7 +52,7 @@ async fn memo_updates() {
 
     let race = async move {
         let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+        let _guard = RuntimeGuard::new(dom.runtime());
 
         dom.rebuild_in_place();
         let mut signal = VEC_SIGNAL.with(|cell| (*cell.borrow()).unwrap());
@@ -110,7 +110,7 @@ async fn use_memo_only_triggers_one_update() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild_in_place();
 
     tokio::select! {

--- a/packages/hooks/tests/memo.rs
+++ b/packages/hooks/tests/memo.rs
@@ -52,6 +52,7 @@ async fn memo_updates() {
 
     let race = async move {
         let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
 
         dom.rebuild_in_place();
         let mut signal = VEC_SIGNAL.with(|cell| (*cell.borrow()).unwrap());
@@ -109,6 +110,7 @@ async fn use_memo_only_triggers_one_update() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild_in_place();
 
     tokio::select! {

--- a/packages/router/src/components/history_buttons.rs
+++ b/packages/router/src/components/history_buttons.rs
@@ -48,6 +48,7 @@ pub struct HistoryButtonProps {
 /// }
 /// #
 /// # let mut vdom = VirtualDom::new(App);
+/// # let _guard = RuntimeGuard::new(vdom.runtime());
 /// # vdom.rebuild_in_place();
 /// # assert_eq!(
 /// #     dioxus_ssr::render(&vdom),
@@ -121,6 +122,7 @@ pub fn GoBackButton(props: HistoryButtonProps) -> Element {
 /// }
 /// #
 /// # let mut vdom = VirtualDom::new(App);
+/// # let _guard = RuntimeGuard::new(vdom.runtime());
 /// # vdom.rebuild_in_place();
 /// # assert_eq!(
 /// #     dioxus_ssr::render(&vdom),

--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -192,6 +192,7 @@ impl Debug for LinkProps {
 /// }
 /// #
 /// # let mut vdom = VirtualDom::new(App);
+/// # let _guard = RuntimeGuard::new(vdom.runtime());
 /// # vdom.rebuild_in_place();
 /// # assert_eq!(
 /// #     dioxus_ssr::render(&vdom),

--- a/packages/router/src/components/outlet.rs
+++ b/packages/router/src/components/outlet.rs
@@ -65,6 +65,7 @@ use dioxus_lib::prelude::*;
 /// # }
 /// #
 /// # let mut vdom = VirtualDom::new(App);
+/// # let _guard = RuntimeGuard::new(vdom.runtime());
 /// # vdom.rebuild_in_place();
 /// # assert_eq!(dioxus_ssr::render(&vdom), "<h1>App</h1><p>Child</p>");
 /// ```

--- a/packages/router/src/hooks/use_navigator.rs
+++ b/packages/router/src/hooks/use_navigator.rs
@@ -46,6 +46,7 @@ use crate::prelude::{Navigator, RouterContext};
 /// }
 ///
 /// # let mut vdom = VirtualDom::new(App);
+/// # let _guard = RuntimeGuard::new(vdom.runtime());
 /// # vdom.rebuild_in_place();
 /// ```
 #[must_use]

--- a/packages/router/src/hooks/use_route.rs
+++ b/packages/router/src/hooks/use_route.rs
@@ -37,6 +37,7 @@ use crate::utils::use_router_internal::use_router_internal;
 /// }
 /// #
 /// # let mut vdom = VirtualDom::new(App);
+/// # let _guard = RuntimeGuard::new(vdom.runtime());
 /// # vdom.rebuild_in_place();
 /// # assert_eq!(dioxus_ssr::render(&vdom), "<h1>App</h1><h2>Current Path</h2><p>/</p>")
 /// ```

--- a/packages/router/tests/via_ssr/link.rs
+++ b/packages/router/tests/via_ssr/link.rs
@@ -11,6 +11,7 @@ where
             phantom: std::marker::PhantomData,
         },
     );
+    let _guard = RuntimeGuard::new(vdom.runtime());
     vdom.rebuild_in_place();
     return dioxus_ssr::render(&vdom);
 

--- a/packages/router/tests/via_ssr/outlet.rs
+++ b/packages/router/tests/via_ssr/outlet.rs
@@ -10,6 +10,7 @@ fn prepare(path: impl Into<String>) -> VirtualDom {
             path: path.into().parse().unwrap(),
         },
     );
+    let _guard = RuntimeGuard::new(vdom.runtime());
     vdom.rebuild_in_place();
     return vdom;
 

--- a/packages/router/tests/via_ssr/redirect.rs
+++ b/packages/router/tests/via_ssr/redirect.rs
@@ -12,6 +12,7 @@ fn redirects_apply_in_order() {
         }
     );
     let mut vdom = VirtualDom::new_with_props(App, AppProps { path });
+    let _guard = RuntimeGuard::new(vdom.runtime());
     vdom.rebuild_in_place();
     let as_string = dioxus_ssr::render(&vdom);
     assert_eq!(as_string, "en");

--- a/packages/router/tests/via_ssr/without_index.rs
+++ b/packages/router/tests/via_ssr/without_index.rs
@@ -9,6 +9,7 @@ fn router_without_index_route_parses() {
             path: Route::Test {},
         },
     );
+    let _guard = RuntimeGuard::new(vdom.runtime());
     vdom.rebuild_in_place();
     let as_string = dioxus_ssr::render(&vdom);
     assert_eq!(as_string, "<div>router with no index route renders</div>")

--- a/packages/signals/tests/create.rs
+++ b/packages/signals/tests/create.rs
@@ -14,6 +14,7 @@ fn create_signals_global() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     fn Child() -> Element {
         let signal = create_without_cx();
@@ -39,6 +40,7 @@ fn deref_signal() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     fn Child() -> Element {
         let signal = Signal::new("hello world".to_string());
@@ -71,6 +73,7 @@ fn drop_signals() {
             }
         }
     });
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     fn Child() -> Element {
         struct TracksDrops;

--- a/packages/signals/tests/subscribe.rs
+++ b/packages/signals/tests/subscribe.rs
@@ -42,6 +42,7 @@ fn reading_subscribes() {
         },
         counter.clone(),
     );
+    let _guard = RuntimeGuard::new(dom.runtime());
 
     #[derive(Props, Clone)]
     struct ChildProps {

--- a/packages/ssr/README.md
+++ b/packages/ssr/README.md
@@ -26,6 +26,7 @@ fn app() -> Element {
 }
 
 let mut vdom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(vdom.runtime());
 vdom.rebuild_in_place();
 
 let text = dioxus_ssr::render(&vdom);
@@ -53,6 +54,8 @@ let content = dioxus_ssr::render_element(rsx!{
 # use dioxus::prelude::*;
 # fn app() -> Element { todo!() }
 let mut vdom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(vdom.runtime());
+
 vdom.rebuild_in_place();
 
 let content = dioxus_ssr::render(&vdom);
@@ -72,6 +75,7 @@ To enable pre-rendering, simply set the pre-rendering flag to true.
 # use dioxus::prelude::*;
 # fn App() -> Element { todo!() }
 let mut vdom = VirtualDom::new(App);
+let _guard = RuntimeGuard::new(vdom.runtime());
 
 vdom.rebuild_in_place();
 
@@ -91,6 +95,7 @@ fn App() -> Element {
   rsx! { div { "hello world!" } }
 }
 let mut vdom = VirtualDom::new(App);
+let _guard = RuntimeGuard::new(vdom.runtime());
 vdom.rebuild_in_place();
 let text = dioxus_ssr::render(&vdom);
 assert_eq!(text, "<div>hello world!</div>")

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -79,6 +79,7 @@ impl Renderer {
             props
         }
         let mut dom = VirtualDom::new_with_props(lazy_app, element);
+        let _guard = RuntimeGuard::new(dom.runtime());
         dom.rebuild_in_place();
         self.render_to(buf, &dom)
     }

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -285,6 +285,7 @@ fn to_string_works() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     let mut renderer = Renderer::new();
@@ -340,6 +341,7 @@ fn empty_for_loop_works() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     let mut renderer = Renderer::new();
@@ -377,6 +379,7 @@ fn empty_render_works() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     let mut renderer = Renderer::new();

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -285,7 +285,7 @@ fn to_string_works() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     let mut renderer = Renderer::new();
@@ -341,7 +341,7 @@ fn empty_for_loop_works() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     let mut renderer = Renderer::new();
@@ -379,7 +379,7 @@ fn empty_render_works() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     let mut renderer = Renderer::new();

--- a/packages/ssr/tests/bool_attr.rs
+++ b/packages/ssr/tests/bool_attr.rs
@@ -10,6 +10,7 @@ fn static_boolean_attributes() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -28,6 +29,7 @@ fn dynamic_boolean_attributes() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(

--- a/packages/ssr/tests/bool_attr.rs
+++ b/packages/ssr/tests/bool_attr.rs
@@ -10,7 +10,7 @@ fn static_boolean_attributes() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -29,7 +29,7 @@ fn dynamic_boolean_attributes() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(

--- a/packages/ssr/tests/hydration.rs
+++ b/packages/ssr/tests/hydration.rs
@@ -60,6 +60,7 @@ fn listeners() {
     }
 
     let mut dom = VirtualDom::new(app2);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -94,6 +95,7 @@ fn text_nodes() {
     }
 
     let mut dom = VirtualDom::new(app2);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -134,6 +136,7 @@ fn components_hydrate() {
     }
 
     let mut dom = VirtualDom::new(app2);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -150,6 +153,7 @@ fn components_hydrate() {
     }
 
     let mut dom = VirtualDom::new(app3);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -170,6 +174,7 @@ fn components_hydrate() {
     }
 
     let mut dom = VirtualDom::new(app4);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(

--- a/packages/ssr/tests/hydration.rs
+++ b/packages/ssr/tests/hydration.rs
@@ -7,7 +7,7 @@ fn root_ids() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -26,7 +26,7 @@ fn dynamic_attributes() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -44,7 +44,7 @@ fn listeners() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -78,7 +78,7 @@ fn text_nodes() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -114,7 +114,7 @@ fn components_hydrate() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -193,7 +193,7 @@ fn hello_world_hydrates() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(

--- a/packages/ssr/tests/hydration.rs
+++ b/packages/ssr/tests/hydration.rs
@@ -7,6 +7,7 @@ fn root_ids() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -25,6 +26,7 @@ fn dynamic_attributes() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -42,6 +44,7 @@ fn listeners() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -75,6 +78,7 @@ fn text_nodes() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -110,6 +114,7 @@ fn components_hydrate() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(
@@ -188,6 +193,7 @@ fn hello_world_hydrates() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(

--- a/packages/ssr/tests/inner_html.rs
+++ b/packages/ssr/tests/inner_html.rs
@@ -7,6 +7,7 @@ fn static_inner_html() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(dioxus_ssr::render(&dom), r#"<div><div>1234</div></div>"#);
@@ -20,6 +21,7 @@ fn dynamic_inner_html() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(dioxus_ssr::render(&dom), r#"<div><div>1234</div></div>"#);

--- a/packages/ssr/tests/inner_html.rs
+++ b/packages/ssr/tests/inner_html.rs
@@ -7,7 +7,7 @@ fn static_inner_html() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(dioxus_ssr::render(&dom), r#"<div><div>1234</div></div>"#);
@@ -21,7 +21,7 @@ fn dynamic_inner_html() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(dioxus_ssr::render(&dom), r#"<div><div>1234</div></div>"#);

--- a/packages/ssr/tests/simple.rs
+++ b/packages/ssr/tests/simple.rs
@@ -8,8 +8,8 @@ fn simple() {
         rsx! { div { "hello!" } }
     }
 
-    let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let mut dom = VirtualDom::new(App);
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(dioxus_ssr::render(&dom), "<div>hello!</div>");

--- a/packages/ssr/tests/simple.rs
+++ b/packages/ssr/tests/simple.rs
@@ -8,7 +8,8 @@ fn simple() {
         rsx! { div { "hello!" } }
     }
 
-    let mut dom = VirtualDom::new(App);
+    let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(dioxus_ssr::render(&dom), "<div>hello!</div>");

--- a/packages/ssr/tests/styles.rs
+++ b/packages/ssr/tests/styles.rs
@@ -7,6 +7,7 @@ fn static_styles() {
     }
 
     let mut dom = VirtualDom::new(app);
+let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(

--- a/packages/ssr/tests/styles.rs
+++ b/packages/ssr/tests/styles.rs
@@ -7,7 +7,7 @@ fn static_styles() {
     }
 
     let mut dom = VirtualDom::new(app);
-let _guard = RuntimeGuard::new(dom.runtime());
+    let _guard = RuntimeGuard::new(dom.runtime());
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
     assert_eq!(

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -25,7 +25,7 @@ pub struct WebsysDom {
     pub(crate) interpreter: Interpreter,
 
     #[cfg(feature = "mounted")]
-    pub(crate) runtime: Rc<Runtime>,
+    pub(crate) runtime: Runtime,
 
     #[cfg(feature = "mounted")]
     pub(crate) queued_mounted_events: Vec<ElementId>,
@@ -51,7 +51,7 @@ pub struct WebsysDom {
 }
 
 impl WebsysDom {
-    pub fn new(cfg: Config, runtime: Rc<Runtime>) -> Self {
+    pub fn new(cfg: Config, runtime: Runtime) -> Self {
         let (document, root) = match cfg.root {
             crate::cfg::ConfigRoot::RootName(rootname) => {
                 // eventually, we just want to let the interpreter do all the work of decoding events into our event type


### PR DESCRIPTION
 - [x] Only enter the `Runtime` once per frontend application.
 - [x] Creates `RuntimeState` and redefines `Runtime` as a wrapper around it. This lets us simplify the external API without requiring users know how the `Runtime` is stored (similar to Tokio).
```rs
pub(crate) struct RuntimeState { ... }

#[derive(Clone)]
pub struct Runtime {
    pub(crate) state: Rc<RuntimeState>,
}
```

 - [x] The current `Runtime` seems to use a thread-local stack of runtimes with a `Vec`. This replaces the stack with a single `Option` and adds a new `Runtime::take` method (to exit the current runtime and return it to the user, keeping that same behavior of a stack if desired)
 - [ ] Investigate fullstack suspense