### PR TITLE
Fix links with set base_path & make external links usable without modifier

### DIFF
--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -264,11 +264,15 @@ pub fn Link(props: LinkProps) -> Element {
     let do_default = onclick.is_none() || !onclick_only;
 
     let action = move |event: MouseEvent| {
+        // Only handle internal links
+        if is_external {
+            return;
+        }
         // Only handle events without modifiers
         if !event.modifiers().is_empty() {
             return;
         }
-        // only handle left clicks
+        // Only handle left clicks
         if event.trigger_button() != Some(dioxus_elements::input_data::MouseButton::Primary) {
             return;
         }

--- a/packages/router/src/contexts/router.rs
+++ b/packages/router/src/contexts/router.rs
@@ -135,7 +135,7 @@ impl RouterContext {
             failure_external_navigation: cfg.failure_external_navigation,
 
             any_route_to_string: |route| {
-                route
+                let path = route
                     .downcast_ref::<R>()
                     .unwrap_or_else(|| {
                         panic!(
@@ -144,8 +144,13 @@ impl RouterContext {
                             route.type_id(),
                             std::any::TypeId::of::<R>()
                         )
-                    })
-                    .to_string()
+                    });
+
+                if let Some(base_path) = dioxus_cli_config::BASE_PATH {
+                    format!("/{base_path}{path}")
+                } else {
+                    path.to_string()
+                }
             },
 
             site_map: R::SITE_MAP,


### PR DESCRIPTION
This pull request addresses the following issues:

- **Internal Links:** When a `base_path` is set in `Dioxus.toml`, internal links only worked with a simple left click; CTRL + left click failed because the `href` only contained the absolute path to the next page without the `base_url`.
- **External Links:** External links required CTRL + left click due to the set `action` overwriting the normal left click behavior. This issue is independent of the `base_path`.

Additionally, I noticed that [this commit](https://github.com/DioxusLabs/dioxus/commit/3fb1f739d13967da9ee8db9f17a91fea321c9df2) broke base paths in general, but this pull request does not address that issue.

This is one of my first pull requests, so please let me know if there are any changes or improvements needed. Thank you!