### PR TITLE
remove `value` attr from HTML select tag

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1553,8 +1553,6 @@ builder_constructors! {
     /// [`<select>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)
     /// element.
     select None {
-        // defined below
-        // value: String,
         autocomplete: String DEFAULT,
         autofocus: Bool DEFAULT,
         disabled: Bool DEFAULT,
@@ -1563,7 +1561,6 @@ builder_constructors! {
         name: Id DEFAULT,
         required: Bool DEFAULT,
         size: usize DEFAULT,
-        value: String volatile,
     };
 
     /// Build a


### PR DESCRIPTION
`value` was added in [c961bf0779](https://github.com/DioxusLabs/dioxus/commit/c961bf0779#diff-e62d9776cc79c4b0ce740fbc99604b53f028061d209aa30ef8990c9a0ed7f441R1073). It is not a valid (attribute)[https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes] to the select tag.

The attribute doesn't do anything but only cause confusion to users as the only correct way to set a value natively is via the selected attr in option
```html
<select>
    <option value="1">Something</option>
    <option value="2" selected="selected">Something else</option>
</select>
```