### PR TITLE
Fix restarting coroutines

### DIFF
--- a/examples/popup.rs
+++ b/examples/popup.rs
@@ -12,7 +12,7 @@ fn app() -> Element {
     let mut emails_sent = use_signal(|| Vec::new() as Vec<String>);
 
     // Wait for responses to the compose channel, and then push them to the emails_sent signal.
-    let handle = use_coroutine(|mut rx: UnboundedReceiver<String>| async move {
+    let handle = use_coroutine(move |mut rx: UnboundedReceiver<String>| async move {
         use futures_util::StreamExt;
         while let Some(message) = rx.next().await {
             emails_sent.write().push(message);

--- a/packages/hooks/src/use_future.rs
+++ b/packages/hooks/src/use_future.rs
@@ -78,7 +78,7 @@ where
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 pub struct UseFuture {
     task: CopyValue<Task>,
     state: Signal<UseFutureState>,


### PR DESCRIPTION
This PR changes `use_coroutine` to re-use the stale closure and restart logic from `use_future`. `use_coroutine` is now just a version of `use_future` that creates a channel for you and adds itself through the context API

Fixes #3004