### PR TITLE
File explorer example was moved from `examples` to `example-projects`. Update related files. 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -98,8 +98,6 @@ cargo run --example hello_world
 
 [dog_app](./dog_app.rs) - Accesses dog API
 
-[file_explorer](./file_explorer.rs) - File browser that uses `use_ref` to interact with the model
-
 [todomvc](./todomvc.rs) - Todo task list example
 
 # TODO

--- a/packages/desktop/build.rs
+++ b/packages/desktop/build.rs
@@ -73,11 +73,6 @@ path = "../../examples/errors.rs"
 doc-scrape-examples = true
 
 [[example]]
-name = "file_explorer"
-path = "../../examples/file_explorer.rs"
-doc-scrape-examples = true
-
-[[example]]
 name = "future"
 path = "../../examples/future.rs"
 doc-scrape-examples = true


### PR DESCRIPTION
Since the File Explorer example moved from `examples` to `example-projects`, I think these lines should be removed?