### PR TITLE
improve `use_drop` documentation

### DIFF
--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -310,6 +310,9 @@ pub fn schedule_update_any() -> Arc<dyn Fn(ScopeId) + Send + Sync> {
 /// This can be used to clean up side effects from the component
 /// (created with [`use_effect`](dioxus::prelude::use_effect)).
 ///
+/// Note:
+/// Effects do not run on the server, but use_drop **DOES**. It runs any time the component is dropped including during SSR rendering on the server. If your clean up logic targets web, the logic has to be gated by a feature, see the below example for details.
+///
 /// Example:
 /// ```rust
 /// use dioxus::prelude::*;
@@ -346,9 +349,12 @@ pub fn schedule_update_any() -> Arc<dyn Fn(ScopeId) + Send + Sync> {
 ///     });
 ///
 ///     use_drop(move || {
-///         /// restore scroll to the top of the page
-///         let window = web_sys::window().unwrap();
-///         window.scroll_with_x_and_y(original_scroll_position(), 0.0);
+///         // This only make sense to web and hence the `web!` macro
+///         web! {
+///             /// restore scroll to the top of the page
+///             let window = web_sys::window().unwrap();
+///             window.scroll_with_x_and_y(original_scroll_position(), 0.0);
+///         }
 ///     });
 ///
 ///     rsx! {


### PR DESCRIPTION
Partially(or fully?) addressing https://github.com/DioxusLabs/dioxus/issues/3002

Basically added the important info about use_drop to the doc.

Preview
![screencapture-file-home-chung-repos-dioxus-target-doc-dioxus-core-prelude-fn-use-drop-html-2024-10-02-10_30_59](https://github.com/user-attachments/assets/f70ca0b5-c447-4da2-90f0-48774ec2e960)
