### PR TITLE
Use &Event for Vdom::handle_event

### DIFF
--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -290,7 +290,7 @@ impl Runtime {
     ///
     /// If you have multiple events, you can call this method multiple times before calling "render_with_deadline"
     #[instrument(skip(self, event), level = "trace", name = "Runtime::handle_event")]
-    pub fn handle_event(self: &Rc<Self>, name: &str, event: Event<dyn Any>, element: ElementId) {
+    pub fn handle_event(self: &Rc<Self>, name: &str, event: &Event<dyn Any>, element: ElementId) {
         let _runtime = RuntimeGuard::new(self.clone());
         let elements = self.elements.borrow();
 
@@ -329,7 +329,7 @@ impl Runtime {
         level = "trace",
         name = "VirtualDom::handle_bubbling_event"
     )]
-    fn handle_bubbling_event(&self, parent: ElementRef, name: &str, uievent: Event<dyn Any>) {
+    fn handle_bubbling_event(&self, parent: ElementRef, name: &str, uievent: &Event<dyn Any>) {
         let mounts = self.mounts.borrow();
 
         // If the event bubbles, we traverse through the tree until we find the target element.
@@ -396,7 +396,7 @@ impl Runtime {
         level = "trace",
         name = "VirtualDom::handle_non_bubbling_event"
     )]
-    fn handle_non_bubbling_event(&self, node: ElementRef, name: &str, uievent: Event<dyn Any>) {
+    fn handle_non_bubbling_event(&self, node: ElementRef, name: &str, uievent: &Event<dyn Any>) {
         let mounts = self.mounts.borrow();
         let Some(mount) = mounts.get(node.mount.0) else {
             // If the node is suspended and not mounted, we can just ignore the event

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -735,7 +735,7 @@ impl VirtualDom {
     #[deprecated = "Use [VirtualDom::runtime().handle_event] instead"]
     pub fn handle_event(&self, name: &str, event: Rc<dyn Any>, element: ElementId, bubbling: bool) {
         let event = crate::Event::new(event, bubbling);
-        self.runtime().handle_event(name, event, element);
+        self.runtime().handle_event(name, &event, element);
     }
 }
 

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -309,10 +309,10 @@ impl App {
 
         let event = dioxus_core::Event::new(data as Rc<dyn Any>, event_bubbles);
         if event_name == "change&input" {
-            view.dom.runtime().handle_event("input", event.clone(), id);
-            view.dom.runtime().handle_event("change", event, id);
+            view.dom.runtime().handle_event("input", &event, id);
+            view.dom.runtime().handle_event("change", &event, id);
         } else {
-            view.dom.runtime().handle_event(event_name, event, id);
+            view.dom.runtime().handle_event(event_name, &event, id);
         }
     }
 

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -114,7 +114,7 @@ impl WebviewEdits {
         };
 
         let event = dioxus_core::Event::new(as_any, bubbles);
-        self.runtime.handle_event(&name, event.clone(), element);
+        self.runtime.handle_event(&name, &event, element);
 
         // Get the response from the event
         SynchronousEventResponse::new(!event.default_action_enabled())

--- a/packages/liveview/src/pool.rs
+++ b/packages/liveview/src/pool.rs
@@ -192,7 +192,7 @@ pub async fn run(mut vdom: VirtualDom, ws: impl LiveViewSocket) -> Result<(), Li
                                     };
                                     vdom.runtime().handle_event(
                                         &evt.name,
-                                        event,
+                                        &event,
                                         evt.element,
                                     );
                                 }

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -94,7 +94,7 @@ impl WebsysDom {
                 let data = virtual_event_from_websys_event(web_sys_event.clone(), target);
 
                 let event = dioxus_core::Event::new(Rc::new(data) as Rc<dyn Any>, bubbles);
-                runtime.handle_event(name.as_str(), event.clone(), element);
+                runtime.handle_event(name.as_str(), &event, element);
 
                 // Prevent the default action if the user set prevent default on the event
                 let prevent_default = !event.default_action_enabled();

--- a/packages/web/src/mutations.rs
+++ b/packages/web/src/mutations.rs
@@ -70,7 +70,7 @@ impl WebsysDom {
                     false,
                 );
                 let name = "mounted";
-                self.runtime.handle_event(name, event, id)
+                self.runtime.handle_event(name, &event, id)
             }
         }
     }


### PR DESCRIPTION
This removes the need for an `Rc` and allows code calling `handle_event` to access the `prevent_default` and `stop_propagation` status without a clone