### PR TITLE
Remove dependency on atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,17 +614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auth-git2"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,7 +2432,6 @@ dependencies = [
  "ansi-to-html",
  "ansi-to-tui",
  "anyhow",
- "atty",
  "axum 0.7.5",
  "axum-extra",
  "axum-server",
@@ -4933,15 +4921,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -32,7 +32,6 @@ html_parser = { workspace = true }
 cargo_metadata = "0.18.1"
 tokio = { version = "1.16.1", features = ["fs", "sync", "rt", "macros", "process", "rt-multi-thread"] }
 tokio-stream = "0.1.15"
-atty = "0.2.14"
 chrono = "0.4.19"
 anyhow = "1"
 hyper = { workspace = true }

--- a/packages/cli/src/cli/translate.rs
+++ b/packages/cli/src/cli/translate.rs
@@ -1,4 +1,4 @@
-use std::process::exit;
+use std::{io::IsTerminal as _, process::exit};
 
 use dioxus_rsx::{BodyNode, CallBody, TemplateBody};
 
@@ -121,7 +121,7 @@ fn determine_input(file: Option<String>, raw: Option<String>) -> Result<String> 
     }
 
     // If neither exist, we try to read from stdin
-    if atty::is(atty::Stream::Stdin) {
+    if std::io::stdin().is_terminal() {
         return custom_error!("No input file, source, or stdin to translate from.");
     }
 


### PR DESCRIPTION
It is no longer maintained and has been replaced by functionality in the
stdlib (std::io::IsTerminal).

Removes two warnings from cargo-audit for being unmaintained and being
[potentially unsound](https://rustsec.org/advisories/RUSTSEC-2021-0145.html).
