### PR TITLE
Specialize `HistoryProvider::on_update` for web

### DIFF
--- a/packages/liveview/src/history.rs
+++ b/packages/liveview/src/history.rs
@@ -1,10 +1,11 @@
 use dioxus_core::prelude::spawn;
 use dioxus_document::Eval;
-use dioxus_history::History;
+use dioxus_history::{History, HistoryCallback};
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 use std::sync::{Mutex, RwLock};
 use std::{collections::BTreeMap, sync::Arc};
+use tracing::warn;
 
 /// A [`HistoryProvider`] that evaluates history through JS.
 pub(crate) struct LiveviewHistory {
@@ -338,9 +339,13 @@ impl History for LiveviewHistory {
             })
     }
 
-    fn updater(&self, callback: Arc<dyn Fn() + Send + Sync>) {
-        let mut updater_callback = self.updater_callback.write().unwrap();
-        *updater_callback = callback;
+    fn updater(&self, callback: HistoryCallback) {
+        if let HistoryCallback::Shared(callback) = callback {
+            let mut updater_callback = self.updater_callback.write().unwrap();
+            *updater_callback = callback;
+        } else {
+            warn!("LiveviewHistory only supports shared callbacks");
+        };
     }
 }
 

--- a/packages/router/src/contexts/router.rs
+++ b/packages/router/src/contexts/router.rs
@@ -135,17 +135,6 @@ impl RouterContext {
 
         let inner = CopyValue::new_in_scope(myself, ScopeId::ROOT);
 
-        #[cfg(target_arch = "wasm32")]
-        inner
-            .write_unchecked()
-            .history
-            .updater(HistoryCallback::Local(Rc::new(move || {
-                for &id in subscribers.read().unwrap().iter() {
-                    (mark_dirty)(id);
-                }
-                me.change_route();
-            })));
-
         // Set the updater callback.
 
         // On web this is a local callback to ensure the `popstate` event is handled correctly.

--- a/packages/web/src/history/mod.rs
+++ b/packages/web/src/history/mod.rs
@@ -1,3 +1,4 @@
+use dioxus_history::HistoryCallback;
 use scroll::ScrollPosition;
 use std::path::PathBuf;
 use wasm_bindgen::JsCast;
@@ -208,13 +209,14 @@ impl dioxus_history::History for WebHistory {
         self.navigate_external(url)
     }
 
-    fn updater(&self, callback: std::sync::Arc<dyn Fn() + Send + Sync>) {
+    fn updater(&self, callback: HistoryCallback) {
         let w = self.window.clone();
         let h = self.history.clone();
         let d = self.do_scroll_restoration;
 
         let function = Closure::wrap(Box::new(move |_| {
-            (*callback)();
+            callback.run();
+
             if d {
                 if let Some([x, y]) = get_current(&h) {
                     ScrollPosition { x, y }.scroll_to(w.clone())


### PR DESCRIPTION
Removes the need for `Send + Sync` bounds by specializing the `HistoryProvider::on_update` for `!Send` `!Sync`.

Fixes https://github.com/DioxusLabs/dioxus/issues/1657 by triggering `switch_route` on the `popstate` event.

```rs
/// Callback for history updates.
pub enum HistoryCallback {
    /// Local callback.
    ///
    /// This callback is only used for `dioxus-web`.
    Local(Rc<dyn Fn()>),
    /// Shared callback.
    ///
    /// This callback is used for all other Dioxus platforms to enable multi-threaded callbacks.
    Shared(Arc<dyn Fn() + Send + Sync>),
}
```