### PR TITLE
Remove: `default_platform` in `Dioxus.toml`

### DIFF
--- a/packages/cli/Dioxus.toml
+++ b/packages/cli/Dioxus.toml
@@ -3,9 +3,6 @@
 # App name
 name = "project_name"
 
-# The Dioxus platform to default to
-default_platform = "web"
-
 # `build` & `serve` output path
 out_dir = "dist"
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -33,12 +33,6 @@ Note: The CLI will fail to build projects in debug profile. This is currently un
 cargo install --path .
 ```
 
-### Developing The CLI
-It's faster to build the CLI using the `cli-dev` profile when testing changes.
-```shell
-cargo build --profile cli-dev
-```
-
 ## Get started
 
 Use `dx new` to initialize a new Dioxus project.

--- a/packages/cli/src/config/app.rs
+++ b/packages/cli/src/config/app.rs
@@ -1,21 +1,13 @@
-use crate::Platform;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ApplicationConfig {
-    #[serde(default = "default_platform")]
-    pub(crate) default_platform: Platform,
-
     #[serde(default = "asset_dir_default")]
     pub(crate) asset_dir: PathBuf,
 
     #[serde(default)]
     pub(crate) sub_package: Option<String>,
-}
-
-pub(crate) fn default_platform() -> Platform {
-    Platform::Web
 }
 
 pub(crate) fn asset_dir_default() -> PathBuf {

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -22,7 +22,6 @@ impl Default for DioxusConfig {
     fn default() -> Self {
         Self {
             application: ApplicationConfig {
-                default_platform: default_platform(),
                 asset_dir: asset_dir_default(),
                 sub_package: None,
             },


### PR DESCRIPTION
Removes the `default_platform` field in `Dioxus.toml` in favor of using default `Cargo.toml` features.