### PR TITLE
Fix: CLI Release & Profile Conflict

### DIFF
--- a/packages/cli/src/builder/build.rs
+++ b/packages/cli/src/builder/build.rs
@@ -239,11 +239,25 @@ impl BuildRequest {
         // Set the target, profile and features that vary between the app and server builds
         if self.build.platform() == Platform::Server {
             cargo_args.push("--profile".to_string());
-            cargo_args.push(self.build.server_profile.to_string());
+            match self.build.release {
+                true => cargo_args.push("release".to_string()),
+                false => cargo_args.push(self.build.server_profile.to_string()),
+            };
         } else {
-            if let Some(custom_profile) = &self.build.profile {
+            // Add required profile flags. --release overrides any custom profiles.
+            let custom_profile = &self.build.profile.as_ref();
+            if custom_profile.is_some() || self.build.release {
                 cargo_args.push("--profile".to_string());
-                cargo_args.push(custom_profile.to_string());
+                match self.build.release {
+                    true => cargo_args.push("release".to_string()),
+                    false => {
+                        cargo_args.push(
+                            custom_profile
+                                .expect("custom_profile should have been checked by is_some")
+                                .to_string(),
+                        );
+                    }
+                };
             }
 
             // todo: use the right arch based on the current arch
@@ -269,9 +283,9 @@ impl BuildRequest {
             }
         }
 
-        if self.build.release {
-            cargo_args.push("--release".to_string());
-        }
+        // if self.build.release {
+        //     cargo_args.push("--release".to_string());
+        // }
 
         if self.build.verbose {
             cargo_args.push("--verbose".to_string());

--- a/packages/cli/src/builder/build.rs
+++ b/packages/cli/src/builder/build.rs
@@ -283,10 +283,6 @@ impl BuildRequest {
             }
         }
 
-        // if self.build.release {
-        //     cargo_args.push("--release".to_string());
-        // }
-
         if self.build.verbose {
             cargo_args.push("--verbose".to_string());
         } else {


### PR DESCRIPTION
Fixes the conflict of CLI providing `--release` and `--profile something` to Cargo, which isn't allowed. This fix makes `--release` have priority.

Re-implements functionality of #3078 since it was accidentally overwritten.