### PR TITLE
fix: :lock: removed the line that exposes file structure of web server

### DIFF
--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -61,8 +61,6 @@ pub use hydration::*;
 /// wasm_bindgen_futures::spawn_local(app_fut);
 /// ```
 pub async fn run(mut virtual_dom: VirtualDom, web_config: Config) -> ! {
-    tracing::info!("Starting up");
-
     #[cfg(feature = "document")]
     virtual_dom.in_runtime(document::init_document);
 


### PR DESCRIPTION
in web/src/lib there is a line that says "Starting up" to the browser console. This is leaking information about server file structure. 

Related: https://github.com/DioxusLabs/dioxus/issues/3117