### PR TITLE
Fix: CLI Not Applying `no-default-features` When Specifying Platform

### DIFF
--- a/packages/cli/src/builder/build.rs
+++ b/packages/cli/src/builder/build.rs
@@ -289,6 +289,10 @@ impl BuildRequest {
             cargo_args.push("--quiet".to_string());
         }
 
+        if self.build.target_args.no_default_features {
+            cargo_args.push("--no-default-features".to_string());
+        }
+
         let features = self.target_features();
 
         if !features.is_empty() {


### PR DESCRIPTION
If you have a default platform in your `default` feature and want to specify a different platform with the `--platform` flag, the original feature would still be enabled.