### PR TITLE
fix: don't panic while reading file in hotreload

### DIFF
--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -188,7 +188,13 @@ impl AppRunner {
             };
 
             // And grabout the contents
-            let contents = std::fs::read_to_string(&rust_file).unwrap();
+            let Ok(contents) = std::fs::read_to_string(&rust_file) else {
+                tracing::debug!(
+                    "Failed to read rust file while hotreloading: {:?}",
+                    rust_file
+                );
+                continue;
+            };
 
             match self.file_map.update_rsx::<HtmlCtx>(path, contents) {
                 HotreloadResult::Rsx(new) => templates.extend(new),


### PR DESCRIPTION
Fixes: https://github.com/DioxusLabs/dioxus/issues/3141

I think this is because some editors might use `.bk` files but I'm not exactly sure why a file wouldn't show up.

I can't replicate this locally on my mac.