### PR TITLE
Fix: Link Checker

### DIFF
--- a/examples/dog_app.rs
+++ b/examples/dog_app.rs
@@ -11,10 +11,11 @@ use dioxus::prelude::*;
 use std::collections::HashMap;
 
 fn main() {
-    dioxus::launch(app);
+    dioxus::launch(App);
 }
 
-fn app() -> Element {
+#[component]
+fn App() -> Element {
     // Breed is a signal that will be updated when the user clicks a breed in the list
     // `shiba` is just a default that we know will exist. We could also use a `None` instead
     let mut breed = use_signal(|| "shiba".to_string());

--- a/lychee.toml
+++ b/lychee.toml
@@ -4,3 +4,5 @@ exclude_path = ['target']
 no_progress = false
 cache = true
 max_cache_age = "10d"
+# accept 404 as github pages returns it for invalid (server) but valid (client) dioxuslabs.com routes.
+accept = ["200", "404"]


### PR DESCRIPTION
GitHub Pages `404.html` returns HTTP 404 on the new docsite site but didn't previously(?).

This drastically reduces the effectiveness of having a link checker.