### PR TITLE
Perform a full rebuild when a hot reload is not possible

### DIFF
--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -169,6 +169,9 @@ impl AppRunner {
                     // todo(jon): don't hardcode this here
                     let asset_relative = PathBuf::from("/assets/").join(bundled_name);
                     assets.push(asset_relative);
+                } else {
+                    // This was not an asset that we could hot reload, perform a full rebuild
+                    return None;
                 }
             }
         }


### PR DESCRIPTION
The CLI currently tries to hot reload changes to your `Cargo.toml` even though it is not used as an asset in the application. It should trigger a full rebuild because it is not linked as an asset. Other build time assets like an external lalrpop grammar that drives a build script should also trigger a full rebuild