### PR TITLE
Fix as web event

### DIFF
--- a/packages/web/src/events/animation.rs
+++ b/packages/web/src/events/animation.rs
@@ -26,7 +26,6 @@ impl WebEventExt for dioxus_html::AnimationData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::AnimationEvent> {
-        self.downcast::<Synthetic<web_sys::AnimationEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::AnimationEvent>().cloned()
     }
 }

--- a/packages/web/src/events/clipboard.rs
+++ b/packages/web/src/events/clipboard.rs
@@ -20,7 +20,6 @@ impl WebEventExt for dioxus_html::ClipboardData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::Event>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::Event>().cloned()
     }
 }

--- a/packages/web/src/events/composition.rs
+++ b/packages/web/src/events/composition.rs
@@ -18,7 +18,6 @@ impl WebEventExt for dioxus_html::CompositionData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::CompositionEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::CompositionEvent>().cloned()
     }
 }

--- a/packages/web/src/events/drag.rs
+++ b/packages/web/src/events/drag.rs
@@ -101,7 +101,6 @@ impl WebEventExt for dioxus_html::DragData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::DragEvent> {
-        self.downcast::<Synthetic<DragEvent>>()
-            .map(|data| data.event.clone())
+        self.downcast::<DragEvent>().cloned()
     }
 }

--- a/packages/web/src/events/focus.rs
+++ b/packages/web/src/events/focus.rs
@@ -13,7 +13,6 @@ impl WebEventExt for dioxus_html::FocusData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::FocusEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::FocusEvent>().cloned()
     }
 }

--- a/packages/web/src/events/keyboard.rs
+++ b/packages/web/src/events/keyboard.rs
@@ -61,7 +61,6 @@ impl WebEventExt for dioxus_html::KeyboardData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::KeyboardEvent> {
-        self.downcast::<Synthetic<web_sys::KeyboardEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::KeyboardEvent>().cloned()
     }
 }

--- a/packages/web/src/events/media.rs
+++ b/packages/web/src/events/media.rs
@@ -12,7 +12,6 @@ impl WebEventExt for dioxus_html::MediaData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::Event>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::Event>().cloned()
     }
 }

--- a/packages/web/src/events/mounted.rs
+++ b/packages/web/src/events/mounted.rs
@@ -120,7 +120,6 @@ impl WebEventExt for MountedData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::Element> {
-        self.downcast::<Synthetic<web_sys::Element>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::Element>().cloned()
     }
 }

--- a/packages/web/src/events/mouse.rs
+++ b/packages/web/src/events/mouse.rs
@@ -73,7 +73,6 @@ impl WebEventExt for dioxus_html::MouseData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::MouseEvent> {
-        self.downcast::<Synthetic<web_sys::MouseEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::MouseEvent>().cloned()
     }
 }

--- a/packages/web/src/events/pointer.rs
+++ b/packages/web/src/events/pointer.rs
@@ -113,7 +113,6 @@ impl WebEventExt for dioxus_html::PointerData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::PointerEvent> {
-        self.downcast::<Synthetic<web_sys::PointerEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::PointerEvent>().cloned()
     }
 }

--- a/packages/web/src/events/resize.rs
+++ b/packages/web/src/events/resize.rs
@@ -39,8 +39,7 @@ impl WebEventExt for dioxus_html::ResizeData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::ResizeObserverEntry> {
-        self.downcast::<Synthetic<web_sys::ResizeObserverEntry>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::ResizeObserverEntry>().cloned()
     }
 }
 

--- a/packages/web/src/events/selection.rs
+++ b/packages/web/src/events/selection.rs
@@ -12,7 +12,6 @@ impl WebEventExt for dioxus_html::SelectionData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::Event>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::Event>().cloned()
     }
 }

--- a/packages/web/src/events/toggle.rs
+++ b/packages/web/src/events/toggle.rs
@@ -12,7 +12,6 @@ impl WebEventExt for dioxus_html::ToggleData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::Event>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::Event>().cloned()
     }
 }

--- a/packages/web/src/events/touch.rs
+++ b/packages/web/src/events/touch.rs
@@ -105,7 +105,6 @@ impl WebEventExt for dioxus_html::TouchData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<web_sys::TouchEvent> {
-        self.downcast::<Synthetic<web_sys::TouchEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::TouchEvent>().cloned()
     }
 }

--- a/packages/web/src/events/wheel.rs
+++ b/packages/web/src/events/wheel.rs
@@ -94,8 +94,7 @@ impl WebEventExt for dioxus_html::ScrollData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::Event>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::Event>().cloned()
     }
 }
 
@@ -104,7 +103,6 @@ impl WebEventExt for dioxus_html::WheelData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<Synthetic<web_sys::WheelEvent>>()
-            .map(|e| e.event.clone())
+        self.downcast::<web_sys::WheelEvent>().cloned()
     }
 }


### PR DESCRIPTION
https://github.com/DioxusLabs/dioxus/pull/3137 made as_any return the inner event directly instead of the synthetic event, but the as_web_event implementation of many events were still trying to downcast to the synthetic version of the event. This PR changes the as_web_event implementation for all events to always downcast to the web-sys version of the event directly

Fixes https://github.com/DioxusLabs/dioxus/issues/3177