### PR TITLE
Fix: CLI Fullstack Executable File Extension

### DIFF
--- a/packages/cli/src/builder/bundle.rs
+++ b/packages/cli/src/builder/bundle.rs
@@ -601,12 +601,18 @@ impl AppBundle {
 
     pub(crate) fn server_exe(&self) -> Option<PathBuf> {
         if let Some(_server) = &self.server {
-            return Some(
-                self.build
-                    .krate
-                    .build_dir(Platform::Server, self.build.build.release)
-                    .join("server"),
-            );
+            let mut path = self
+                .build
+                .krate
+                .build_dir(Platform::Server, self.build.build.release);
+
+            if cfg!(windows) {
+                path.push("server.exe");
+            } else {
+                path.push("server");
+            }
+
+            return Some(path);
         }
 
         None


### PR DESCRIPTION
CLI did not add `.exe` extension to the `server` file copied to the target-dist folder.