### PR TITLE
fix: autodetect android install

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -119,6 +119,8 @@ impl BuildRequest {
                 .android_linker()
                 .context("Could not autodetect android linker")?;
 
+            tracing::trace!("Using android linker: {linker:?}");
+
             cmd.env(
                 LinkAction::ENV_VAR_NAME,
                 LinkAction::LinkAndroid {

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -114,10 +114,15 @@ impl BuildRequest {
         // We don't want to overwrite the user's .cargo/config.toml since that gets committed to git
         // and we want everyone's install to be the same.
         if self.build.platform() == Platform::Android {
+            let linker = self
+                .krate
+                .android_linker()
+                .context("Could not autodetect android linker")?;
+
             cmd.env(
                 LinkAction::ENV_VAR_NAME,
                 LinkAction::LinkAndroid {
-                    linker: "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang".into(),
+                    linker,
                     extra_flags: vec![],
                 }
                 .to_json(),

--- a/packages/cli/src/build/verify.rs
+++ b/packages/cli/src/build/verify.rs
@@ -134,6 +134,12 @@ impl BuildRequest {
     /// will do its best to fill in the missing bits by exploring the sdk structure
     /// IE will attempt to use the Java installed from android studio if possible.
     pub(crate) async fn verify_android_tooling(&self, _rustup: RustupShow) -> Result<()> {
+        if self.krate.android_linker().is_none() {
+            return Err(anyhow::anyhow!(
+                "Android linker not found. Please set the ANDROID_NDK_HOME environment variable to the root of your NDK installation."
+            ).into());
+        }
+
         Ok(())
     }
 
@@ -142,7 +148,7 @@ impl BuildRequest {
     ///
     /// Eventually, we want to check for the prereqs for wry/tao as outlined by tauri:
     ///     https://tauri.app/start/prerequisites/
-    pub(crate) async fn verify_linux_tooling(&self, _rustup: crate::RustupShow) -> Result<()> {
+    pub(crate) async fn verify_linux_tooling(&self, _rustup: RustupShow) -> Result<()> {
         Ok(())
     }
 }

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -601,8 +601,7 @@ impl DioxusCrate {
         self.android_ndk().map(|ndk| {
             let toolchain_dir = ndk.join("toolchains").join("llvm").join("prebuilt");
 
-            #[cfg(target_os = "macos")]
-            {
+            if cfg!(target_os = "macos") {
                 // for whatever reason, even on aarch64 macos, the linker is under darwin-x86_64
                 return toolchain_dir
                     .join("darwin-x86_64")
@@ -610,18 +609,18 @@ impl DioxusCrate {
                     .join("clang");
             }
 
-            #[cfg(target_os = "linux")]
-            {
+            if cfg!(target_os = "linux") {
                 return toolchain_dir.join("linux-x86_64").join("bin").join("clang");
             }
 
-            #[cfg(target_os = "windows")]
-            {
+            if cfg!(target_os = "windows") {
                 return toolchain_dir
                     .join("windows-x86_64")
                     .join("bin")
                     .join("clang.exe");
             }
+
+            unimplemented!("Unsupported target os for android toolchain auodetection")
         })
     }
 }

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -597,6 +597,7 @@ impl DioxusCrate {
     }
 
     pub(crate) fn android_linker(&self) -> Option<PathBuf> {
+        // "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
         self.android_ndk().map(|ndk| {
             let toolchain_dir = ndk.join("toolchains").join("llvm").join("prebuilt");
 
@@ -606,15 +607,12 @@ impl DioxusCrate {
                 return toolchain_dir
                     .join("darwin-x86_64")
                     .join("bin")
-                    .join("aarch64-apple-darwin-clang");
+                    .join("clang");
             }
 
             #[cfg(target_os = "linux")]
             {
-                return toolchain_dir
-                    .join("linux-x86_64")
-                    .join("bin")
-                    .join("aarch64-linux-android24-clang");
+                return toolchain_dir.join("linux-x86_64").join("bin").join("clang");
             }
 
             #[cfg(target_os = "windows")]
@@ -622,7 +620,7 @@ impl DioxusCrate {
                 return toolchain_dir
                     .join("windows-x86_64")
                     .join("bin")
-                    .join("aarch64-linux-android24-clang.exe");
+                    .join("clang.exe");
             }
         })
     }


### PR DESCRIPTION
No longer hardcodes the internal android linker and instead uses the system's installation if available.