### PR TITLE
feat: allow android apps with any name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
   "[toml]": {
     "editor.formatOnSave": false
   },
+  "[handlebars]": {
+    "editor.formatOnSave": false
+  },
   // "rust-analyzer.check.workspace": true,
   // "rust-analyzer.check.workspace": false,
   // "rust-analyzer.check.features": "all",

--- a/packages/cli/assets/android/MainActivity.kt
+++ b/packages/cli/assets/android/MainActivity.kt
@@ -1,3 +1,3 @@
-package com.example.androidfinal
+package dev.dioxus.main
 
 class MainActivity : WryActivity()

--- a/packages/cli/assets/android/gen/app/build.gradle.kts.hbs
+++ b/packages/cli/assets/android/gen/app/build.gradle.kts.hbs
@@ -4,10 +4,10 @@ plugins {
 }
 
 android {
-    namespace="com.example.androidfinal"
+    namespace="{{ application_id }}"
     compileSdk = 33
     defaultConfig {
-        applicationId = "com.example.androidfinal"
+        applicationId = "{{ application_id }}"
         minSdk = 24
         targetSdk = 33
         versionCode = 1

--- a/packages/cli/assets/android/gen/app/src/main/AndroidManifest.xml.hbs
+++ b/packages/cli/assets/android/gen/app/src/main/AndroidManifest.xml.hbs
@@ -5,7 +5,7 @@
     <application android:hasCode="true" android:supportsRtl="true" android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name" android:theme="@style/AppTheme">
         <activity android:configChanges="orientation|keyboardHidden" android:exported="true"
-            android:label="@string/app_name" android:name="com.example.androidfinal.MainActivity">
+            android:label="@string/app_name" android:name="dev.dioxus.main.MainActivity">
             <meta-data android:name="android.app.lib_name" android:value="androidfinal" />
             <meta-data android:name="android.app.func_name" android:value="ANativeActivity_onCreate" />
             <intent-filter>

--- a/packages/cli/assets/android/gen/app/src/main/res/values/strings.xml
+++ b/packages/cli/assets/android/gen/app/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Androidfinal</string>
-</resources>

--- a/packages/cli/assets/android/gen/app/src/main/res/values/strings.xml.hbs
+++ b/packages/cli/assets/android/gen/app/src/main/res/values/strings.xml.hbs
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">{{app_name}}</string>
+</resources>

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -636,18 +636,21 @@ impl DioxusCrate {
                 return toolchain_dir
                     .join("darwin-x86_64")
                     .join("bin")
-                    .join("clang");
+                    .join("aarch64-linux-android24-clang");
             }
 
             if cfg!(target_os = "linux") {
-                return toolchain_dir.join("linux-x86_64").join("bin").join("clang");
+                return toolchain_dir
+                    .join("linux-x86_64")
+                    .join("bin")
+                    .join("aarch64-linux-android24-clang");
             }
 
             if cfg!(target_os = "windows") {
                 return toolchain_dir
                     .join("windows-x86_64")
                     .join("bin")
-                    .join("clang.exe");
+                    .join("aarch64-linux-android24-clang.cmd");
             }
 
             unimplemented!("Unsupported target os for android toolchain auodetection")

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -596,6 +596,36 @@ impl DioxusCrate {
         PATH.clone()
     }
 
+    pub(crate) fn android_llvm_objcopy(&self) -> Option<PathBuf> {
+        self.android_ndk().map(|ndk| {
+            let toolchain_dir = ndk.join("toolchains").join("llvm").join("prebuilt");
+
+            if cfg!(target_os = "macos") {
+                // for whatever reason, even on aarch64 macos, the linker is under darwin-x86_64
+                return toolchain_dir
+                    .join("darwin-x86_64")
+                    .join("bin")
+                    .join("llvm-objcopy");
+            }
+
+            if cfg!(target_os = "windows") {
+                return toolchain_dir
+                    .join("windows-x86_64")
+                    .join("bin")
+                    .join("llvm-objcopy.cmd");
+            }
+
+            if cfg!(target_os = "linux") {
+                return toolchain_dir
+                    .join("linux-x86_64")
+                    .join("bin")
+                    .join("llvm-objcopy");
+            }
+
+            panic!("unsupported target os");
+        })
+    }
+
     pub(crate) fn android_linker(&self) -> Option<PathBuf> {
         // "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
         self.android_ndk().map(|ndk| {
@@ -622,6 +652,18 @@ impl DioxusCrate {
 
             unimplemented!("Unsupported target os for android toolchain auodetection")
         })
+    }
+
+    pub(crate) fn mobile_org(&self) -> String {
+        "com.example".to_string()
+    }
+
+    pub(crate) fn mobile_app_name(&self) -> String {
+        self.executable_name().to_string()
+    }
+
+    pub(crate) fn full_mobile_app_name(&self) -> String {
+        format!("{}.{}", self.mobile_org(), self.mobile_app_name())
     }
 }
 

--- a/packages/cli/src/serve/handle.rs
+++ b/packages/cli/src/serve/handle.rs
@@ -463,13 +463,19 @@ impl AppHandle {
             .output()
             .await?;
 
-        // adb shell am start -n com.example.androidfinal/com.example.androidfinal.MainActivity
+        // adb shell am start -n dev.dioxuslabs.hardcoded/dev.dioxuslabs.hardcoded.MainActivity
+        let activity_name = format!(
+            "{}/{}.MainActivity",
+            self.app.build.krate.full_mobile_app_name(),
+            self.app.build.krate.full_mobile_app_name(),
+        );
+
         let _output = Command::new("adb")
             .arg("shell")
             .arg("am")
             .arg("start")
             .arg("-n")
-            .arg("com.example.androidfinal/com.example.androidfinal.MainActivity")
+            .arg(activity_name)
             .envs(envs)
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())

--- a/packages/mobile/src/lib.rs
+++ b/packages/mobile/src/lib.rs
@@ -51,15 +51,8 @@ pub fn root() {
 #[no_mangle]
 #[inline(never)]
 pub extern "C" fn start_app() {
-    tao::android_binding!(
-        dev_dioxuslabs,
-        hardcoded,
-        WryActivity,
-        wry::android_setup,
-        root,
-        tao
-    );
-    wry::android_binding!(dev_dioxuslabs, hardcoded, wry);
+    tao::android_binding!(dev_dioxus, main, WryActivity, wry::android_setup, root, tao);
+    wry::android_binding!(dev_dioxus, main, wry);
 }
 
 /// Call our `main` function to initialize the rust runtime and set the launch binding trampoline

--- a/packages/mobile/src/lib.rs
+++ b/packages/mobile/src/lib.rs
@@ -52,14 +52,14 @@ pub fn root() {
 #[inline(never)]
 pub extern "C" fn start_app() {
     tao::android_binding!(
-        com_example,
-        androidfinal,
+        dev_dioxuslabs,
+        hardcoded,
         WryActivity,
         wry::android_setup,
         root,
         tao
     );
-    wry::android_binding!(com_example, androidfinal, wry);
+    wry::android_binding!(dev_dioxuslabs, hardcoded, wry);
 }
 
 /// Call our `main` function to initialize the rust runtime and set the launch binding trampoline


### PR DESCRIPTION
Enables android apps with any name, not just apps with a fixed name.
Does this by hardcoding the dioxus library itself and then importing ourselves into the main app.

- use llvm objcopy to rename syms
- use handlebars
