### PR TITLE
Deprecate relative asset paths, better warnings for asset!()

### DIFF
--- a/example-projects/ecommerce-site/src/components/loading.rs
+++ b/example-projects/ecommerce-site/src/components/loading.rs
@@ -5,7 +5,7 @@ pub(crate) fn ChildrenOrLoading(children: Element) -> Element {
     rsx! {
         document::Link {
             rel: "stylesheet",
-            href: asset!("./public/loading.css")
+            href: asset!("/public/loading.css")
         }
         SuspenseBoundary {
             fallback: |context: SuspenseContext| {

--- a/example-projects/ecommerce-site/src/main.rs
+++ b/example-projects/ecommerce-site/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
         rsx! {
             document::Link {
                 rel: "stylesheet",
-                href: asset!("./public/tailwind.css")
+                href: asset!("/public/tailwind.css")
             }
 
             ChildrenOrLoading {

--- a/example-projects/file-explorer/src/main.rs
+++ b/example-projects/file-explorer/src/main.rs
@@ -23,7 +23,7 @@ fn app() -> Element {
     rsx! {
         document::Link {
             rel: "stylesheet",
-            href: asset!("./assets/fileexplorer.css")
+            href: asset!("/assets/fileexplorer.css")
         }
         div {
             document::Link { href: "https://fonts.googleapis.com/icon?family=Material+Icons", rel: "stylesheet" }

--- a/example-projects/fullstack-hackernews/src/main.rs
+++ b/example-projects/fullstack-hackernews/src/main.rs
@@ -36,7 +36,7 @@ pub fn App() -> Element {
 #[component]
 fn Homepage(story: ReadOnlySignal<PreviewState>) -> Element {
     rsx! {
-        document::Link { rel: "stylesheet", href: asset!("./assets/hackernews.css") }
+        document::Link { rel: "stylesheet", href: asset!("/assets/hackernews.css") }
         div { display: "flex", flex_direction: "row", width: "100%",
             div {
                 width: "50%",

--- a/examples/calculator_mutable.rs
+++ b/examples/calculator_mutable.rs
@@ -31,7 +31,7 @@ fn app() -> Element {
     rsx! {
         document::Link {
             rel: "stylesheet",
-            href: asset!("./examples/assets/calculator.css"),
+            href: asset!("/examples/assets/calculator.css"),
         }
         div { id: "wrapper",
             div { class: "app",

--- a/examples/crm.rs
+++ b/examples/crm.rs
@@ -32,7 +32,7 @@ fn main() {
                 }
                 document::Link {
                     rel: "stylesheet",
-                    href: asset!("./examples/assets/crm.css"),
+                    href: asset!("/examples/assets/crm.css"),
                 }
                 h1 { "Dioxus CRM Example" }
                 Router::<Route> {}

--- a/examples/read_size.rs
+++ b/examples/read_size.rs
@@ -30,7 +30,7 @@ fn app() -> Element {
     rsx! {
         document::Link {
             rel: "stylesheet",
-            href: asset!("./examples/assets/read_size.css"),
+            href: asset!("/examples/assets/read_size.css"),
         }
         div {
             width: "50%",

--- a/examples/resize.rs
+++ b/examples/resize.rs
@@ -17,7 +17,7 @@ fn app() -> Element {
     rsx!(
         document::Link {
             rel: "stylesheet",
-            href: asset!("./examples/assets/read_size.css"),
+            href: asset!("/examples/assets/read_size.css"),
         }
         div {
             width: "50%",

--- a/packages/document/src/elements/link.rs
+++ b/packages/document/src/elements/link.rs
@@ -86,7 +86,7 @@ impl LinkProps {
 ///         // You can use the meta component to render a meta tag into the head of the page
 ///         // This meta tag will redirect the user to the dioxuslabs homepage in 10 seconds
 ///         document::Link {
-///             href: asset!("./assets/style.css"),
+///             href: asset!("/assets/style.css"),
 ///             rel: "stylesheet",
 ///         }
 ///     }

--- a/packages/document/src/elements/script.rs
+++ b/packages/document/src/elements/script.rs
@@ -74,7 +74,7 @@ impl ScriptProps {
 ///     rsx! {
 ///         // You can use the Script component to render a script tag into the head of the page
 ///         document::Script {
-///             src: asset!("./assets/script.js"),
+///             src: asset!("/assets/script.js"),
 ///         }
 ///     }
 /// }

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -19,13 +19,13 @@ impl Parse for AssetParser {
     //
     // This gives you the Asset type - it's generic and basically unrefined
     // ```
-    // asset!("myfile.png")
+    // asset!("/assets/myfile.png")
     // ```
     //
     // To narrow the type, use a method call to get the refined type
     // ```
     // asset!(
-    //     "myfile.png",
+    //     "/assets/myfile.png",
     //      asset::image()
     //        .format(ImageType::Jpg)
     //        .size(512, 512)
@@ -75,8 +75,15 @@ impl ToTokens for AssetParser {
         // 5. source tokens
         let option_source = &self.options;
 
+        // generate the asset::new method to deprecate the `./assets/blah.css` syntax
+        let method = if self.asset.input.is_relative() {
+            quote::quote! { new_relative }
+        } else {
+            quote::quote! { new }
+        };
+
         tokens.extend(quote! {
-            Asset::new(
+            Asset::#method(
                 {
                     #link_section
                     manganis::Asset {

--- a/packages/manganis/manganis/src/builder.rs
+++ b/packages/manganis/manganis/src/builder.rs
@@ -22,6 +22,16 @@ impl Asset {
         self
     }
 
+    /// Create a new asset but with a relative path
+    ///
+    /// This method is deprecated and will be removed in a future release.
+    #[deprecated(
+        note = "Relative asset!() paths are not supported. Use a path like `/assets/myfile.png` instead of `./assets/myfile.png`"
+    )]
+    pub const fn new_relative(self) -> Self {
+        self
+    }
+
     /// Get the path to the asset
     pub fn path(&self) -> PathBuf {
         PathBuf::from(self.input.to_string())


### PR DESCRIPTION
We currently don't support relative asset paths ie `asset!("./assets/blah.css")` but previously we instructed users to use that syntax since the "relative" portion is relative to the crate root.

However, in practice, we can only allow "absolute" paths like `/assets/blah.css` since, when publishing the crates.io, we need to force all assets to live under the `assets` folder *within the crate*.

We made this change in the last alpha, but did not deprecate the old syntax.

In the future we plan to properly support relative paths (ie relative to the current file) so the old syntax will conflict.

This cleans up errors with missing assets as well as adds a new_relative method to asset that the macro now uses to signal the deprecation warning.

<img width="1649" alt="Screenshot 2024-11-13 at 7 10 18 PM" src="https://github.com/user-attachments/assets/46a29e73-7b18-4fd3-aa59-33405da86f2d">
