### PR TITLE
Feat: Android Dynamic Arch Support

### DIFF
--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -748,7 +748,13 @@ impl AppBundle {
                 )?;
             }
 
-            let output = Command::new("./gradlew")
+            let gradle_exec_name = match cfg!(windows) {
+                true => "gradlew.bat",
+                false => "gradlew",
+            };
+            let gradle_exec = self.build.root_dir().join(gradle_exec_name);
+
+            let output = Command::new(gradle_exec)
                 .arg("assembleDebug")
                 .current_dir(self.build.root_dir())
                 .stderr(std::process::Stdio::piped())

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -114,10 +114,16 @@ impl BuildRequest {
         // We don't want to overwrite the user's .cargo/config.toml since that gets committed to git
         // and we want everyone's install to be the same.
         if self.build.platform() == Platform::Android {
-            let linker = self
+            let ndk = self
                 .krate
-                .android_linker()
+                .android_ndk()
                 .context("Could not autodetect android linker")?;
+            let linker = self
+                .build
+                .target_args
+                .arch
+                .unwrap_or_default()
+                .android_linker(&ndk);
 
             tracing::trace!("Using android linker: {linker:?}");
 

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -118,12 +118,7 @@ impl BuildRequest {
                 .krate
                 .android_ndk()
                 .context("Could not autodetect android linker")?;
-            let linker = self
-                .build
-                .target_args
-                .arch
-                .unwrap_or_default()
-                .android_linker(&ndk);
+            let linker = self.build.target_args.arch().android_linker(&ndk);
 
             tracing::trace!("Using android linker: {linker:?}");
 
@@ -258,13 +253,7 @@ impl BuildRequest {
                     Some(true) => Some("aarch64-apple-ios"),
                     _ => Some("aarch64-apple-ios-sim"),
                 },
-                Platform::Android => Some(
-                    self.build
-                        .target_args
-                        .arch
-                        .unwrap_or_default()
-                        .android_target_triplet(),
-                ),
+                Platform::Android => Some(self.build.target_args.arch().android_target_triplet()),
                 Platform::Server => None,
                 // we're assuming we're building for the native platform for now... if you're cross-compiling
                 // the targets here might be different
@@ -548,13 +537,7 @@ impl BuildRequest {
                 .join("src")
                 .join("main")
                 .join("jniLibs")
-                .join(
-                    self.build
-                        .target_args
-                        .arch
-                        .unwrap_or_default()
-                        .android_jnilib(),
-                ),
+                .join(self.build.target_args.arch().android_jnilib()),
 
             // these are all the same, I think?
             Platform::Windows

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -252,7 +252,13 @@ impl BuildRequest {
                     Some(true) => Some("aarch64-apple-ios"),
                     _ => Some("aarch64-apple-ios-sim"),
                 },
-                Platform::Android => Some("aarch64-linux-android"),
+                Platform::Android => Some(
+                    self.build
+                        .target_args
+                        .arch
+                        .unwrap_or_default()
+                        .android_target_triplet(),
+                ),
                 Platform::Server => None,
                 // we're assuming we're building for the native platform for now... if you're cross-compiling
                 // the targets here might be different
@@ -541,7 +547,13 @@ impl BuildRequest {
                 .join("src")
                 .join("main")
                 .join("jniLibs")
-                .join("arm64-v8a"),
+                .join(
+                    self.build
+                        .target_args
+                        .arch
+                        .unwrap_or_default()
+                        .android_jnilib(),
+                ),
 
             // these are all the same, I think?
             Platform::Windows

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -114,10 +114,17 @@ impl BuildRequest {
         // We don't want to overwrite the user's .cargo/config.toml since that gets committed to git
         // and we want everyone's install to be the same.
         if self.build.platform() == Platform::Android {
+            let linker = self
+                .krate
+                .android_linker()
+                .context("Could not autodetect android linker")?;
+
+            tracing::trace!("Using android linker: {linker:?}");
+
             cmd.env(
                 LinkAction::ENV_VAR_NAME,
                 LinkAction::LinkAndroid {
-                    linker: "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang".into(),
+                    linker,
                     extra_flags: vec![],
                 }
                 .to_json(),

--- a/packages/cli/src/build/verify.rs
+++ b/packages/cli/src/build/verify.rs
@@ -139,12 +139,7 @@ impl BuildRequest {
                 break 'a true;
             };
 
-            let linker = self
-                .build
-                .target_args
-                .arch
-                .unwrap_or_default()
-                .android_linker(&ndk);
+            let linker = self.build.target_args.arch().android_linker(&ndk);
 
             !linker.exists()
         };

--- a/packages/cli/src/build/verify.rs
+++ b/packages/cli/src/build/verify.rs
@@ -134,23 +134,20 @@ impl BuildRequest {
     /// will do its best to fill in the missing bits by exploring the sdk structure
     /// IE will attempt to use the Java installed from android studio if possible.
     pub(crate) async fn verify_android_tooling(&self, _rustup: RustupShow) -> Result<()> {
-        let failed = 'a: {
-            let Some(ndk) = self.krate.android_ndk() else {
-                break 'a true;
-            };
+        let result = self
+            .krate
+            .android_ndk()
+            .map(|ndk| self.build.target_args.arch().android_linker(&ndk));
 
-            let linker = self.build.target_args.arch().android_linker(&ndk);
-
-            !linker.exists()
-        };
-
-        if failed {
-            return Err(anyhow::anyhow!(
-                "Android linker not found. Please set the `ANDROID_NDK_HOME` environment variable to the root of your NDK installation."
-            ).into());
+        if let Some(path) = result {
+            if path.exists() {
+                return Ok(());
+            }
         }
 
-        Ok(())
+        Err(anyhow::anyhow!(
+            "Android linker not found. Please set the `ANDROID_NDK_HOME` environment variable to the root of your NDK installation."
+        ).into())
     }
 
     /// Ensure the right dependencies are installed for linux apps.

--- a/packages/cli/src/build/verify.rs
+++ b/packages/cli/src/build/verify.rs
@@ -134,6 +134,12 @@ impl BuildRequest {
     /// will do its best to fill in the missing bits by exploring the sdk structure
     /// IE will attempt to use the Java installed from android studio if possible.
     pub(crate) async fn verify_android_tooling(&self, _rustup: RustupShow) -> Result<()> {
+        if self.krate.android_linker().is_none() {
+            return Err(anyhow::anyhow!(
+                "Android linker not found. Please set the ANDROID_NDK_HOME environment variable to the root of your NDK installation."
+            ).into());
+        }
+
         Ok(())
     }
 
@@ -142,7 +148,7 @@ impl BuildRequest {
     ///
     /// Eventually, we want to check for the prereqs for wry/tao as outlined by tauri:
     ///     https://tauri.app/start/prerequisites/
-    pub(crate) async fn verify_linux_tooling(&self, _rustup: crate::RustupShow) -> Result<()> {
+    pub(crate) async fn verify_linux_tooling(&self, _rustup: RustupShow) -> Result<()> {
         Ok(())
     }
 }

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -63,7 +63,7 @@ impl BuildArgs {
         let krate =
             DioxusCrate::new(&self.target_args).context("Failed to load Dioxus workspace")?;
 
-        self.resolve(&krate)?;
+        self.resolve(&krate).await?;
 
         let bundle = Builder::start(&krate, self.clone())?.finish().await?;
 
@@ -79,7 +79,7 @@ impl BuildArgs {
     ///
     /// IE if they've specified "fullstack" as a feature on `dioxus`, then we want to build the
     /// fullstack variant even if they omitted the `--fullstack` flag.
-    pub(crate) fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
+    pub(crate) async fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
         let default_platform = krate.default_platform();
         let auto_platform = krate.autodetect_platform();
 
@@ -149,7 +149,7 @@ impl BuildArgs {
         if self.platform == Some(Platform::Android) && self.target_args.arch.is_none() {
             tracing::debug!("No android arch provided, attempting to auto detect.");
 
-            let arch = Arch::autodetect();
+            let arch = Arch::autodetect().await;
 
             // Some extra logs
             let arch = match arch {

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -1,5 +1,3 @@
-use once_cell::sync::OnceCell;
-
 use super::*;
 use crate::{Builder, DioxusCrate, Platform, PROFILE_SERVER};
 
@@ -62,10 +60,10 @@ impl BuildArgs {
     pub async fn run_cmd(mut self) -> Result<StructuredOutput> {
         tracing::info!("Building project...");
 
-        let mut krate =
+        let krate =
             DioxusCrate::new(&self.target_args).context("Failed to load Dioxus workspace")?;
 
-        self.resolve(&mut krate)?;
+        self.resolve(&krate)?;
 
         let bundle = Builder::start(&krate, self.clone())?.finish().await?;
 
@@ -81,7 +79,7 @@ impl BuildArgs {
     ///
     /// IE if they've specified "fullstack" as a feature on `dioxus`, then we want to build the
     /// fullstack variant even if they omitted the `--fullstack` flag.
-    pub(crate) fn resolve(&mut self, krate: &mut DioxusCrate) -> Result<()> {
+    pub(crate) fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
         let default_platform = krate.default_platform();
         let auto_platform = krate.autodetect_platform();
 
@@ -151,34 +149,7 @@ impl BuildArgs {
         if self.platform == Some(Platform::Android) && self.target_args.arch.is_none() {
             tracing::debug!("No android arch provided, attempting to auto detect.");
 
-            // Try auto detecting arch through adb.
-            static AUTO_ARCH: OnceCell<Option<Arch>> = OnceCell::new();
-
-            let arch = AUTO_ARCH.get_or_init(|| {
-                // TODO: Wire this up with --device flag. (add `-s serial`` flag before `shell` arg)
-                let output = std::process::Command::new("adb")
-                    .arg("shell")
-                    .arg("uname")
-                    .arg("-m")
-                    .output();
-
-                let out = match output {
-                    Ok(o) => o,
-                    Err(e) => {
-                        tracing::debug!("ADB command failed: {:?}", e);
-                        return None;
-                    }
-                };
-
-                let Ok(out) = String::from_utf8(out.stdout) else {
-                    tracing::debug!("ADB returned unexpected data.");
-                    return None;
-                };
-                let trimmed = out.trim().to_string();
-                tracing::trace!("ADB Returned: `{trimmed:?}`");
-
-                Arch::try_from(trimmed).ok()
-            });
+            let arch = Arch::autodetect();
 
             // Some extra logs
             let arch = match arch {
@@ -200,7 +171,6 @@ impl BuildArgs {
             };
 
             self.target_args.arch = Some(arch);
-            krate.arch = Some(arch);
         }
 
         Ok(())

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -41,12 +41,12 @@ impl Bundle {
     pub(crate) async fn bundle(mut self) -> Result<StructuredOutput> {
         tracing::info!("Bundling project...");
 
-        let krate = DioxusCrate::new(&self.build_arguments.target_args)
+        let mut krate = DioxusCrate::new(&self.build_arguments.target_args)
             .context("Failed to load Dioxus workspace")?;
 
         // We always use `release` mode for bundling
         self.build_arguments.release = true;
-        self.build_arguments.resolve(&krate)?;
+        self.build_arguments.resolve(&mut krate)?;
 
         tracing::info!("Building app...");
 

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -46,7 +46,7 @@ impl Bundle {
 
         // We always use `release` mode for bundling
         self.build_arguments.release = true;
-        self.build_arguments.resolve(&krate)?;
+        self.build_arguments.resolve(&krate).await?;
 
         tracing::info!("Building app...");
 

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -41,12 +41,12 @@ impl Bundle {
     pub(crate) async fn bundle(mut self) -> Result<StructuredOutput> {
         tracing::info!("Bundling project...");
 
-        let mut krate = DioxusCrate::new(&self.build_arguments.target_args)
+        let krate = DioxusCrate::new(&self.build_arguments.target_args)
             .context("Failed to load Dioxus workspace")?;
 
         // We always use `release` mode for bundling
         self.build_arguments.release = true;
-        self.build_arguments.resolve(&mut krate)?;
+        self.build_arguments.resolve(&krate)?;
 
         tracing::info!("Building app...");
 

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -14,7 +14,7 @@ impl RunArgs {
         let krate = DioxusCrate::new(&self.build_args.target_args)
             .context("Failed to load Dioxus workspace")?;
 
-        self.build_args.resolve(&krate)?;
+        self.build_args.resolve(&krate).await?;
 
         tracing::trace!("Building crate krate data: {:#?}", krate);
         tracing::trace!("Build args: {:#?}", self.build_args);

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -11,10 +11,10 @@ pub(crate) struct RunArgs {
 
 impl RunArgs {
     pub(crate) async fn run(mut self) -> Result<StructuredOutput> {
-        let mut krate = DioxusCrate::new(&self.build_args.target_args)
+        let krate = DioxusCrate::new(&self.build_args.target_args)
             .context("Failed to load Dioxus workspace")?;
 
-        self.build_args.resolve(&mut krate)?;
+        self.build_args.resolve(&krate)?;
 
         tracing::trace!("Building crate krate data: {:#?}", krate);
         tracing::trace!("Build args: {:#?}", self.build_args);

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -11,10 +11,10 @@ pub(crate) struct RunArgs {
 
 impl RunArgs {
     pub(crate) async fn run(mut self) -> Result<StructuredOutput> {
-        let krate = DioxusCrate::new(&self.build_args.target_args)
+        let mut krate = DioxusCrate::new(&self.build_args.target_args)
             .context("Failed to load Dioxus workspace")?;
 
-        self.build_args.resolve(&krate)?;
+        self.build_args.resolve(&mut krate)?;
 
         tracing::trace!("Building crate krate data: {:#?}", krate);
         tracing::trace!("Build args: {:#?}", self.build_args);

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -55,12 +55,12 @@ impl ServeArgs {
     }
 
     pub(crate) fn load_krate(&mut self) -> Result<DioxusCrate> {
-        let krate = DioxusCrate::new(&self.build_arguments.target_args)?;
-        self.resolve(&krate)?;
+        let mut krate = DioxusCrate::new(&self.build_arguments.target_args)?;
+        self.resolve(&mut krate)?;
         Ok(krate)
     }
 
-    pub(crate) fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
+    pub(crate) fn resolve(&mut self, krate: &mut DioxusCrate) -> Result<()> {
         // Enable hot reload.
         if self.hot_reload.is_none() {
             self.hot_reload = Some(krate.settings.always_hot_reload.unwrap_or(true));

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -54,13 +54,13 @@ impl ServeArgs {
         Ok(StructuredOutput::Success)
     }
 
-    pub(crate) fn load_krate(&mut self) -> Result<DioxusCrate> {
+    pub(crate) async fn load_krate(&mut self) -> Result<DioxusCrate> {
         let krate = DioxusCrate::new(&self.build_arguments.target_args)?;
-        self.resolve(&krate)?;
+        self.resolve(&krate).await?;
         Ok(krate)
     }
 
-    pub(crate) fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
+    pub(crate) async fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
         // Enable hot reload.
         if self.hot_reload.is_none() {
             self.hot_reload = Some(krate.settings.always_hot_reload.unwrap_or(true));
@@ -82,7 +82,7 @@ impl ServeArgs {
         }
 
         // Resolve the build arguments
-        self.build_arguments.resolve(krate)?;
+        self.build_arguments.resolve(krate).await?;
 
         Ok(())
     }

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -55,12 +55,12 @@ impl ServeArgs {
     }
 
     pub(crate) fn load_krate(&mut self) -> Result<DioxusCrate> {
-        let mut krate = DioxusCrate::new(&self.build_arguments.target_args)?;
-        self.resolve(&mut krate)?;
+        let krate = DioxusCrate::new(&self.build_arguments.target_args)?;
+        self.resolve(&krate)?;
         Ok(krate)
     }
 
-    pub(crate) fn resolve(&mut self, krate: &mut DioxusCrate) -> Result<()> {
+    pub(crate) fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
         // Enable hot reload.
         if self.hot_reload.is_none() {
             self.hot_reload = Some(krate.settings.always_hot_reload.unwrap_or(true));

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -51,6 +51,12 @@ pub(crate) struct TargetArgs {
     pub(crate) target: Option<String>,
 }
 
+impl TargetArgs {
+    pub(crate) fn arch(&self) -> Arch {
+        self.arch.unwrap_or_default()
+    }
+}
+
 #[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize, clap::ValueEnum)]
 #[non_exhaustive]
 pub(crate) enum Arch {

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -35,18 +35,71 @@ pub(crate) struct TargetArgs {
     #[clap(long)]
     pub(crate) no_default_features: bool,
 
-    /// The architecture to build for [default: "native"]
-    ///
-    /// Can either be `arm | arm64 | x86 | x86_64 | native`
-    #[clap(long)]
-    pub(crate) arch: Option<String>,
+    /// The architecture to build for.
+    #[clap(long, value_enum)]
+    pub(crate) arch: Option<Arch>,
 
-    /// Are we building for a device or just the simulator
-    /// If device is false, then we'll build for the simulator
+    /// Are we building for a device or just the simulator.
+    /// If simulator is false, then we'll build for the simulator
     #[clap(long)]
     pub(crate) device: Option<bool>,
 
     /// Rustc platform triple
     #[clap(long)]
     pub(crate) target: Option<String>,
+}
+
+#[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize, clap::ValueEnum)]
+#[non_exhaustive]
+pub enum Arch {
+    // Android: armv7l, armv7-linux-androideabi
+    Arm,
+    // Android: aarch64, aarch64-linux-android
+    #[default]
+    Arm64,
+    // Android: i386, i686-linux-android
+    X86,
+    // Android: x86_64, x86_64-linux-android
+    X64,
+}
+
+impl Arch {
+    pub fn android_target_triplet(&self) -> &'static str {
+        match self {
+            Arch::Arm => "armv7-linux-androideabi",
+            Arch::Arm64 => "aarch64-linux-android",
+            Arch::X86 => "i686-linux-android",
+            Arch::X64 => "x86_64-linux-android",
+        }
+    }
+
+    pub fn android_jnilib(&self) -> &'static str {
+        match self {
+            Arch::Arm => "armeabi-v7a",
+            Arch::Arm64 => "arm64-v8a",
+            Arch::X86 => "x86",
+            Arch::X64 => "x86_64",
+        }
+    }
+
+    pub fn android_clang_triplet(&self) -> &'static str {
+        match self {
+            Self::Arm => "armv7a-linux-androideabi",
+            _ => self.android_target_triplet(),
+        }
+    }
+}
+
+impl TryFrom<String> for Arch {
+    type Error = ();
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "armv7l" => Ok(Self::Arm),
+            "aarch64" => Ok(Self::Arm64),
+            "i386" => Ok(Self::X86),
+            "x86_64" => Ok(Self::X64),
+            _ => Err(()),
+        }
+    }
 }

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -1,8 +1,6 @@
-use std::path::Path;
-
-use once_cell::sync::OnceCell;
-
 use super::*;
+use once_cell::sync::OnceCell;
+use std::path::Path;
 
 /// Information about the target to build
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
@@ -44,7 +42,7 @@ pub(crate) struct TargetArgs {
     pub(crate) arch: Option<Arch>,
 
     /// Are we building for a device or just the simulator.
-    /// If simulator is false, then we'll build for the simulator
+    /// If device is false, then we'll build for the simulator
     #[clap(long)]
     pub(crate) device: Option<bool>,
 
@@ -55,7 +53,7 @@ pub(crate) struct TargetArgs {
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Deserialize, clap::ValueEnum)]
 #[non_exhaustive]
-pub enum Arch {
+pub(crate) enum Arch {
     // Android: armv7l, armv7-linux-androideabi
     Arm,
     // Android: aarch64, aarch64-linux-android
@@ -68,7 +66,7 @@ pub enum Arch {
 }
 
 impl Arch {
-    pub fn autodetect() -> Option<Self> {
+    pub(crate) fn autodetect() -> Option<Self> {
         // Try auto detecting arch through adb.
         static AUTO_ARCH: OnceCell<Option<Arch>> = OnceCell::new();
 
@@ -99,7 +97,7 @@ impl Arch {
         })
     }
 
-    pub fn android_target_triplet(&self) -> &'static str {
+    pub(crate) fn android_target_triplet(&self) -> &'static str {
         match self {
             Arch::Arm => "armv7-linux-androideabi",
             Arch::Arm64 => "aarch64-linux-android",
@@ -108,7 +106,7 @@ impl Arch {
         }
     }
 
-    pub fn android_jnilib(&self) -> &'static str {
+    pub(crate) fn android_jnilib(&self) -> &'static str {
         match self {
             Arch::Arm => "armeabi-v7a",
             Arch::Arm64 => "arm64-v8a",
@@ -117,7 +115,7 @@ impl Arch {
         }
     }
 
-    pub fn android_clang_triplet(&self) -> &'static str {
+    pub(crate) fn android_clang_triplet(&self) -> &'static str {
         match self {
             Self::Arm => "armv7a-linux-androideabi",
             _ => self.android_target_triplet(),

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -1,5 +1,5 @@
+use crate::CliSettings;
 use crate::{config::DioxusConfig, TargetArgs};
-use crate::{Arch, CliSettings};
 use crate::{Platform, Result};
 use anyhow::Context;
 use itertools::Itertools;
@@ -18,7 +18,6 @@ pub(crate) struct DioxusCrate {
     pub(crate) config: DioxusConfig,
     pub(crate) target: Target,
     pub(crate) settings: CliSettings,
-    pub(crate) arch: Option<Arch>,
 }
 
 pub(crate) static PROFILE_WASM: &str = "dioxus-wasm";
@@ -53,7 +52,7 @@ impl DioxusCrate {
             .unwrap_or(package_name);
 
         let main_package = &krates[package];
-        let crate_target = main_package
+        let target = main_package
             .targets
             .iter()
             .find(|target| {
@@ -68,9 +67,8 @@ impl DioxusCrate {
             krates: Arc::new(krates),
             package,
             config: dioxus_config,
-            target: crate_target,
+            target,
             settings,
-            arch: target.arch,
         })
     }
 
@@ -559,7 +557,7 @@ impl DioxusCrate {
         krates
     }
 
-    fn android_ndk(&self) -> Option<PathBuf> {
+    pub fn android_ndk(&self) -> Option<PathBuf> {
         // "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
         static PATH: once_cell::sync::Lazy<Option<PathBuf>> = once_cell::sync::Lazy::new(|| {
             use std::env::var;
@@ -596,42 +594,6 @@ impl DioxusCrate {
         });
 
         PATH.clone()
-    }
-
-    pub(crate) fn android_linker(&self) -> Option<PathBuf> {
-        // "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
-        self.android_ndk().map(|ndk| {
-            let toolchain_dir = ndk.join("toolchains").join("llvm").join("prebuilt");
-            let arch = self.arch.unwrap_or_default();
-            let triplet = arch.android_clang_triplet();
-            let clang_exec = format!("{}24-clang", triplet);
-
-            tracing::trace!("android linker: {}", clang_exec);
-
-            if cfg!(target_os = "macos") {
-                // for whatever reason, even on aarch64 macos, the linker is under darwin-x86_64
-                return toolchain_dir
-                    .join("darwin-x86_64")
-                    .join("bin")
-                    .join(clang_exec);
-            }
-
-            if cfg!(target_os = "linux") {
-                return toolchain_dir
-                    .join("linux-x86_64")
-                    .join("bin")
-                    .join(clang_exec);
-            }
-
-            if cfg!(target_os = "windows") {
-                return toolchain_dir
-                    .join("windows-x86_64")
-                    .join("bin")
-                    .join(format!("{}.cmd", clang_exec));
-            }
-
-            unimplemented!("Unsupported target os for android toolchain auodetection")
-        })
     }
 }
 

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -557,7 +557,7 @@ impl DioxusCrate {
         krates
     }
 
-    pub fn android_ndk(&self) -> Option<PathBuf> {
+    pub(crate) fn android_ndk(&self) -> Option<PathBuf> {
         // "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
         static PATH: once_cell::sync::Lazy<Option<PathBuf>> = once_cell::sync::Lazy::new(|| {
             use std::env::var;

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -2,6 +2,7 @@ use crate::CliSettings;
 use crate::{config::DioxusConfig, TargetArgs};
 use crate::{Platform, Result};
 use anyhow::Context;
+use itertools::Itertools;
 use krates::{cm::Target, KrateDetails};
 use krates::{cm::TargetKind, Cmd, Krates, NodeId};
 use std::path::PathBuf;
@@ -554,6 +555,73 @@ impl DioxusCrate {
         krates.dedup();
 
         krates
+    }
+
+    fn android_ndk(&self) -> Option<PathBuf> {
+        // "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
+        static PATH: once_cell::sync::Lazy<Option<PathBuf>> = once_cell::sync::Lazy::new(|| {
+            use std::env::var;
+            use tracing::debug;
+
+            fn var_or_debug(name: &str) -> Option<PathBuf> {
+                var(name)
+                    .inspect_err(|_| debug!("{name} not set"))
+                    .ok()
+                    .map(PathBuf::from)
+            }
+
+            // attempt to autodetect the ndk path from env vars (usually set by the shell)
+            let auto_detected_ndk =
+                var_or_debug("NDK_HOME").or_else(|| var_or_debug("ANDROID_NDK_HOME"));
+
+            if let Some(home) = auto_detected_ndk {
+                return Some(home);
+            }
+
+            let sdk = var_or_debug("ANDROID_SDK_ROOT")
+                .or_else(|| var_or_debug("ANDROID_SDK"))
+                .or_else(|| var_or_debug("ANDROID_HOME"))?;
+
+            let ndk = sdk.join("ndk");
+
+            ndk.read_dir()
+                .ok()?
+                .flatten()
+                .map(|dir| (dir.file_name(), dir.path()))
+                .sorted()
+                .last()
+                .map(|(_, path)| path.to_path_buf())
+        });
+
+        PATH.clone()
+    }
+
+    pub(crate) fn android_linker(&self) -> Option<PathBuf> {
+        // "/Users/jonkelley/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android24-clang"
+        self.android_ndk().map(|ndk| {
+            let toolchain_dir = ndk.join("toolchains").join("llvm").join("prebuilt");
+
+            if cfg!(target_os = "macos") {
+                // for whatever reason, even on aarch64 macos, the linker is under darwin-x86_64
+                return toolchain_dir
+                    .join("darwin-x86_64")
+                    .join("bin")
+                    .join("clang");
+            }
+
+            if cfg!(target_os = "linux") {
+                return toolchain_dir.join("linux-x86_64").join("bin").join("clang");
+            }
+
+            if cfg!(target_os = "windows") {
+                return toolchain_dir
+                    .join("windows-x86_64")
+                    .join("bin")
+                    .join("clang.exe");
+            }
+
+            unimplemented!("Unsupported target os for android toolchain auodetection")
+        })
     }
 }
 

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -42,7 +42,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
     let mut tracer = TraceController::redirect();
 
     // Load the krate and resolve the server args against it - this might log so do it after we turn on the tracer first
-    let krate = args.load_krate()?;
+    let krate = args.load_krate().await?;
 
     // Note that starting the builder will queue up a build immediately
     let mut builder = Builder::start(&krate, args.build_args())?;

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -158,7 +158,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                         screen.push_cargo_log(message);
                     }
                     BuildUpdate::BuildFailed { err } => {
-                        tracing::error!("Build failed: {}", err);
+                        tracing::error!("Build failed: {:?}", err);
                     }
                     BuildUpdate::BuildReady { bundle } => {
                         let handle = runner


### PR DESCRIPTION
Adds support for specifying an Android target arch with the `--arch` flag. If no `--arch` flag is included, the CLI will attempt to automatically detect the arch using `adb` and if that fails, the arch defaults to Arm64.