### PR TITLE
fixes: light qol fixes for ssg and logging on `dx run`

### DIFF
--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -693,7 +693,9 @@ impl AppBundle {
         }
 
         // Wait a second for the cache to be written by the server
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tracing::info!("Waiting a moment for isrg to propagate...");
+
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
         tracing::info!("SSG complete");
 

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{serve::ServeUpdate, BuildArgs, Builder, DioxusCrate, Result};
+use crate::{serve::ServeUpdate, BuildArgs, Builder, DioxusCrate, Platform, Result};
 
 /// Run the project with the given arguments
 #[derive(Clone, Debug, Parser)]
@@ -23,8 +23,12 @@ impl RunArgs {
             .finish()
             .await?;
 
-        let devserver_ip = "127.0.0.1:8080".parse().unwrap();
-        let fullstack_ip = "127.0.0.1:8081".parse().unwrap();
+        let devserver_ip = "127.0.0.1:8081".parse().unwrap();
+        let fullstack_ip = "127.0.0.1:8080".parse().unwrap();
+
+        if self.build_args.platform() == Platform::Web || self.build_args.fullstack {
+            tracing::info!("Serving at: {}", fullstack_ip);
+        }
 
         let mut runner = crate::serve::AppRunner::start(&krate);
         runner


### PR DESCRIPTION
We weren't giving SSG enough time to complete which made some pages not finish before we killed the server.

In the future we should have some better signaling system that doesn't necessarily require us to set up ssg.

Perhaps a server function itself could internally drive the router and only respond success if the site generates successfully?

Anyways, fixes that and also has better logging for web apps when launching from `dx run`