### PR TITLE
feat: add keep-symbols flag, change ssg format to Vec<String>

### DIFF
--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -51,6 +51,13 @@ pub(crate) struct BuildArgs {
     #[clap(long, default_value_t = true)]
     pub(crate) inject_loading_scripts: bool,
 
+    /// Generate debug symbols for the wasm binary [default: true]
+    ///
+    /// This will make the binary larger and take longer to compile, but will allow you to debug the
+    /// wasm binary
+    #[clap(long, default_value_t = true)]
+    pub(crate) debug_symbols: bool,
+
     /// Information about the target to build
     #[clap(flatten)]
     pub(crate) target_args: TargetArgs,

--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -175,7 +175,6 @@ impl SsrRendererPool {
             virtual_dom.provide_root_context(document.clone() as std::rc::Rc<dyn Document>);
 
             // poll the future, which may call server_context()
-            tracing::info!("Rebuilding vdom");
             with_server_context(server_context.clone(), || virtual_dom.rebuild_in_place());
 
             let mut pre_body = String::new();


### PR DESCRIPTION
Instead of always purging debug symbols unless the dioxus.toml is set, expose a flag that allows you to disable symbols.

Also change the format of ssg to be Vec<String> for the static routes instead of String to make it easier to teach the static_routes server function.