### PR TITLE
fix the downcast for formdata try_as_web_event

### DIFF
--- a/packages/web/src/events/form.rs
+++ b/packages/web/src/events/form.rs
@@ -18,7 +18,7 @@ impl WebEventExt for dioxus_html::FormData {
 
     #[inline(always)]
     fn try_as_web_event(&self) -> Option<Self::WebEvent> {
-        self.downcast::<WebFormData>().map(|e| e.raw.clone())
+        self.downcast::<Event>().cloned()
     }
 }
 


### PR DESCRIPTION
Demo app to prove this change:
```rust
use dioxus::prelude::*;
use dioxus_logger::tracing::{info, Level};
use dioxus::web::WebEventExt;

fn main() {
    dioxus_logger::init(Level::INFO).expect("failed to init logger");
    info!("starting app");
    launch(App);
}

#[component]
fn App() -> Element {
    rsx! {
        input {
            type: "file",
            onchange: move |evt| {
                info!("onchange");
                if let Some(evt) = evt.try_as_web_event() {
                    info!("web event");
                }
            },
        }
    }
}
```

Before my change, selecting a file would only log "onchange". After my change you get both "onchange" and "web event" as you would expect.

I suspect this is a parallel problem to https://github.com/DioxusLabs/dioxus/pull/3137 and possibly needs to be updated in more places as well.