### PR TITLE
fix android serverfns

### DIFF
--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -159,8 +159,14 @@ impl LaunchBuilder {
         {
             use dioxus_fullstack::prelude::server_fn::client::{get_server_url, set_server_url};
             if get_server_url().is_empty() {
+                let ip = if cfg!(target_os = "android") {
+                    "10.0.2.2"
+                } else {
+                    "127.0.0.1"
+                };
+
                 let serverurl = format!(
-                    "http://127.0.0.1:{}",
+                    "http://{ip}:{}",
                     std::env::var("PORT").unwrap_or_else(|_| "8080".to_string())
                 )
                 .leak();


### PR DESCRIPTION
set the endpoint url to 10.0.2.2 to follow loopback config for android emulator
<img width="512" alt="Screenshot 2024-11-17 at 1 56 48 AM" src="https://github.com/user-attachments/assets/611f81ab-07d1-4267-a5df-947230fa0983">
