### PR TITLE
Fix: CLI Windows Write `exe` Errors

### DIFF
--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -107,6 +107,9 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                 } else if runner.should_full_rebuild {
                     tracing::info!(dx_src = ?TraceSrc::Dev, "Full rebuild: {}", file);
 
+                    // Kill runnning executables
+                    runner.kill_all();
+
                     // We're going to kick off a new build, interrupting the current build if it's ongoing
                     builder.rebuild(args.build_arguments.clone());
 
@@ -214,7 +217,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                 // `Full rebuild:` to line up with
                 // `Hotreloading:` to keep the alignment during long edit sessions
                 tracing::info!("Full rebuild: triggered manually");
-
+                runner.kill_all();
                 builder.rebuild(args.build_arguments.clone());
                 runner.file_map.force_rebuild();
                 devserver.start_build().await

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -107,7 +107,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                 } else if runner.should_full_rebuild {
                     tracing::info!(dx_src = ?TraceSrc::Dev, "Full rebuild: {}", file);
 
-                    // Kill runnning executables
+                    // Kill any running executables
                     runner.kill_all();
 
                     // We're going to kick off a new build, interrupting the current build if it's ongoing

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -107,8 +107,10 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                 } else if runner.should_full_rebuild {
                     tracing::info!(dx_src = ?TraceSrc::Dev, "Full rebuild: {}", file);
 
-                    // Kill any running executables
-                    runner.kill_all();
+                    // Kill any running executables on Windows
+                    if cfg!(windows) {
+                        runner.kill_all();
+                    }
 
                     // We're going to kick off a new build, interrupting the current build if it's ongoing
                     builder.rebuild(args.build_arguments.clone());
@@ -217,7 +219,12 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                 // `Full rebuild:` to line up with
                 // `Hotreloading:` to keep the alignment during long edit sessions
                 tracing::info!("Full rebuild: triggered manually");
-                runner.kill_all();
+
+                // Kill any running executables on Windows
+                if cfg!(windows) {
+                    runner.kill_all();
+                }
+
                 builder.rebuild(args.build_arguments.clone());
                 runner.file_map.force_rebuild();
                 devserver.start_build().await

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -141,6 +141,10 @@ impl AppRunner {
         self.running.remove(&platform);
     }
 
+    pub(crate) fn kill_all(&mut self) {
+        self.running.clear();
+    }
+
     /// Open an existing app bundle, if it exists
     pub(crate) async fn open_existing(&self, devserver: &WebServer) {
         if let Some(address) = devserver.server_address() {


### PR DESCRIPTION
The CLI fails to write the new executable on Windows because the old one is still running during rebuilds.

This PR introduces a `kill_all()` method on the `AppRunner`. Ideally, the app would be killed right before the bundler starts, but I wasn't sure how to best get a handle down to the bundler. Instead, I opted for this simpler, but perhaps slightly less DX solution (since the app is closed during rebuilds and the dev can't admire their desktop app or interact with serverfns).