### PR TITLE
Fix hydration race condition

### DIFF
--- a/packages/interpreter/src/unified_bindings.rs
+++ b/packages/interpreter/src/unified_bindings.rs
@@ -44,9 +44,6 @@ mod js {
     #[extends(BaseInterpreter)]
     pub struct Interpreter;
 
-    fn mount_to_root() {
-        "{this.appendChildren(0, this.stack.length-1);}"
-    }
     fn push_root(root: u32) {
         "{this.pushRoot(this.nodes[$root$]);}"
     }

--- a/packages/interpreter/src/unified_bindings.rs
+++ b/packages/interpreter/src/unified_bindings.rs
@@ -45,7 +45,7 @@ mod js {
     pub struct Interpreter;
 
     fn mount_to_root() {
-        "{this.appendChildren(this.root, this.stack.length-1);}"
+        "{this.appendChildren(0, this.stack.length-1);}"
     }
     fn push_root(root: u32) {
         "{this.pushRoot(this.nodes[$root$]);}"

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -134,10 +134,6 @@ impl WebsysDom {
             suspense_hydration_ids: Default::default(),
         }
     }
-
-    pub fn mount(&mut self) {
-        self.interpreter.mount_to_root();
-    }
 }
 
 fn walk_event_for_id(event: &web_sys::Event) -> Option<(ElementId, web_sys::Element)> {

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -121,9 +121,6 @@ pub async fn run(mut virtual_dom: VirtualDom, web_config: Config) -> ! {
         websys_dom.flush_edits();
     }
 
-    // the mutations come back with nothing - we need to actually mount them
-    websys_dom.mount();
-
     loop {
         // if virtual dom has nothing, wait for it to have something before requesting idle time
         // if there is work then this future resolves immediately.


### PR DESCRIPTION
Fixes #2926

I fixed the issue by removing Interpreter::mount_to_root because its implementation either does nothing or throws the type error, effectively making it dead code.

`mount_to_root` had passed `Node` instead of `NodeId` to `appendChildren(id: NodeId, many: number)`.