### PR TITLE
Fix diffing cloned rsx nodes by deep cloning nodes before mounting them

### DIFF
--- a/packages/core/src/error_boundary.rs
+++ b/packages/core/src/error_boundary.rs
@@ -459,6 +459,14 @@ impl CapturedError {
             Some(std::result::Result::Ok(self.render.clone()))
         }
     }
+
+    /// Create a deep clone of this error
+    pub(crate) fn deep_clone(&self) -> Self {
+        Self {
+            render: self.render.deep_clone(),
+            ..self.clone()
+        }
+    }
 }
 
 impl PartialEq for CapturedError {

--- a/packages/core/src/events.rs
+++ b/packages/core/src/events.rs
@@ -425,8 +425,8 @@ impl<Args, Ret> Clone for Callback<Args, Ret> {
 }
 
 impl<Args: 'static, Ret: 'static> PartialEq for Callback<Args, Ret> {
-    fn eq(&self, _: &Self) -> bool {
-        true
+    fn eq(&self, other: &Self) -> bool {
+        self.callback.ptr_eq(&other.callback) && self.origin == other.origin
     }
 }
 
@@ -469,6 +469,14 @@ impl<Args: 'static, Ret: 'static> Callback<Args, Ret> {
             Location::caller(),
         );
         Self { callback, origin }
+    }
+
+    /// Leak a new reference to the [`Callback`] that will not be dropped unless the callback is dropped manually
+    pub(crate) fn leak_reference(&self) -> generational_box::BorrowResult<Callback<Args, Ret>> {
+        Ok(Callback {
+            callback: self.callback.leak_reference()?,
+            origin: self.origin,
+        })
     }
 
     /// Call this callback with the appropriate argument type

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -132,11 +132,22 @@ impl From<Element> for VNode {
 pub(crate) trait AsVNode {
     /// Get the vnode for this element
     fn as_vnode(&self) -> &VNode;
+
+    /// Create a deep clone of this VNode
+    fn deep_clone(&self) -> Self;
 }
 
 impl AsVNode for Element {
     fn as_vnode(&self) -> &VNode {
         AsRef::as_ref(self)
+    }
+
+    fn deep_clone(&self) -> Self {
+        match self {
+            Ok(node) => Ok(node.deep_clone()),
+            Err(RenderError::Aborted(err)) => Err(RenderError::Aborted(err.deep_clone())),
+            Err(RenderError::Suspended(fut)) => Err(RenderError::Suspended(fut.deep_clone())),
+        }
     }
 }
 
@@ -287,6 +298,38 @@ impl VNode {
             .mounted_attributes
             .get(dynamic_attribute_idx)
             .copied()
+    }
+
+    /// Create a deep clone of this VNode
+    pub(crate) fn deep_clone(&self) -> Self {
+        Self {
+            vnode: Rc::new(VNodeInner {
+                key: self.vnode.key.clone(),
+                template: self.vnode.template.clone(),
+                dynamic_nodes: self
+                    .vnode
+                    .dynamic_nodes
+                    .iter()
+                    .map(|node| match node {
+                        DynamicNode::Fragment(nodes) => DynamicNode::Fragment(
+                            nodes.iter().map(|node| node.deep_clone()).collect(),
+                        ),
+                        other => other.clone(),
+                    })
+                    .collect(),
+                dynamic_attrs: self
+                    .vnode
+                    .dynamic_attrs
+                    .iter()
+                    .map(|attr| {
+                        attr.iter()
+                            .map(|attribute| attribute.deep_clone())
+                            .collect()
+                    })
+                    .collect(),
+            }),
+            mount: Default::default(),
+        }
     }
 }
 
@@ -737,6 +780,21 @@ impl Attribute {
             value: value.into_value(),
         }
     }
+
+    /// Create a new deep clone of this attribute
+    pub(crate) fn deep_clone(&self) -> Self {
+        Attribute {
+            name: self.name,
+            namespace: self.namespace.clone(),
+            volatile: self.volatile,
+            value: match &self.value {
+                AttributeValue::Listener(listener) => {
+                    AttributeValue::Listener(listener.leak_reference().unwrap())
+                }
+                value => value.clone(),
+            },
+        }
+    }
 }
 
 /// Any of the built-in values that the Dioxus VirtualDom supports as dynamic attributes on elements
@@ -812,7 +870,7 @@ impl PartialEq for AttributeValue {
             (Self::Float(l0), Self::Float(r0)) => l0 == r0,
             (Self::Int(l0), Self::Int(r0)) => l0 == r0,
             (Self::Bool(l0), Self::Bool(r0)) => l0 == r0,
-            (Self::Listener(_), Self::Listener(_)) => true,
+            (Self::Listener(l0), Self::Listener(r0)) => l0 == r0,
             (Self::Any(l0), Self::Any(r0)) => l0.as_ref().any_cmp(r0.as_ref()),
             (Self::None, Self::None) => true,
             _ => false,

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -305,7 +305,7 @@ impl VNode {
         Self {
             vnode: Rc::new(VNodeInner {
                 key: self.vnode.key.clone(),
-                template: self.vnode.template.clone(),
+                template: self.vnode.template,
                 dynamic_nodes: self
                     .vnode
                     .dynamic_nodes
@@ -785,7 +785,7 @@ impl Attribute {
     pub(crate) fn deep_clone(&self) -> Self {
         Attribute {
             name: self.name,
-            namespace: self.namespace.clone(),
+            namespace: self.namespace,
             volatile: self.volatile,
             value: match &self.value {
                 AttributeValue::Listener(listener) => {

--- a/packages/core/src/suspense/mod.rs
+++ b/packages/core/src/suspense/mod.rs
@@ -70,6 +70,15 @@ impl SuspendedFuture {
     pub fn task(&self) -> Task {
         self.task
     }
+
+    /// Create a deep clone of this suspended future
+    pub(crate) fn deep_clone(&self) -> Self {
+        Self {
+            task: self.task,
+            placeholder: self.placeholder.deep_clone(),
+            origin: self.origin,
+        }
+    }
 }
 
 /// A context with information about suspended components


### PR DESCRIPTION
This PR fixes diffing after hot reloading the rsx inside of the resource in the dog app example. The resource was returning a cloned version of the rsx from the previous run which was mounted. We should never have mounted VNodes in components so that cloning VNodes works as expected. This PR fixes the issue by performing a deep clone of the VNode before diffing so the version of the vnode that lives in diffing/core doesn't share the same `Cell<Mount>` as the version of the vnode that lives in the component.