### PR TITLE
drop reference types due to deprecation, pin browserlist (fix ci)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "axum-extra",
  "axum-server",
  "brotli 6.0.0",
+ "browserslist-rs",
  "built",
  "cargo-config2",
  "cargo-generate",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -158,6 +158,7 @@ swc_trace_macro = { version = "=0.1.3", default-features = false }
 swc_transform_common = { version = "=0.1.1", default-features = false }
 swc_typescript = { version = "=0.5.0", default-features = false }
 swc_visit = { version = "=0.6.2", default-features = false }
+browserslist-rs = { version = "=0.16.0" }
 
 tracing-subscriber = { version = "0.3.18", features = ["std", "env-filter", "json"] }
 console-subscriber = { version = "0.3.0", optional = true }

--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -604,7 +604,6 @@ impl AppBundle {
         let input_path = input_path.to_path_buf();
         let bindgen_outdir = bindgen_outdir.to_path_buf();
         let name = self.build.krate.executable_name().to_string();
-        let reference_types = self.build.krate.config.web.wasm_opt.reference_types;
         let keep_debug =
             // if we're in debug mode, or we're generating debug symbols, keep debug info
             (self.build.krate.config.web.wasm_opt.debug || self.build.build.debug_symbols)
@@ -620,7 +619,6 @@ impl AppBundle {
                 .debug(keep_debug)
                 .demangle(keep_debug)
                 .keep_debug(keep_debug)
-                .reference_types(keep_debug || reference_types)
                 .remove_name_section(!keep_debug)
                 .remove_producers_section(!keep_debug)
                 .out_name(&name)

--- a/packages/cli/src/config/web.rs
+++ b/packages/cli/src/config/web.rs
@@ -58,10 +58,6 @@ pub(crate) struct WasmOptConfig {
     /// Keep debug symbols in the wasm file
     #[serde(default = "false_bool")]
     pub(crate) debug: bool,
-
-    /// Enable reference types
-    #[serde(default = "false_bool")]
-    pub(crate) reference_types: bool,
 }
 
 /// The wasm-opt level to use for release web builds [default: 4]


### PR DESCRIPTION
wasm-bindgen now moved reference types to a -C flag which can be set via rustflags, so we no longer need to manually support it.