### PR TITLE
Feat: Re-Export `cargo_metadata` In `dioxus-dx-wire-format`

### DIFF
--- a/packages/dx-wire-format/src/lib.rs
+++ b/packages/dx-wire-format/src/lib.rs
@@ -2,6 +2,8 @@ use cargo_metadata::CompilerMessage;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub use cargo_metadata;
+
 /// The structured output for the CLI
 ///
 /// This is designed such that third party tools can reliably consume the output of the CLI when


### PR DESCRIPTION
This allows consumers of `dioxus-dx-wire-format` to use the same types, avoiding any version mismatches.