### PR TITLE
Fix: Flush Cargo Logs on Build Failure

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -249,6 +249,13 @@ impl Builder {
                     return Ok(bundle);
                 }
                 BuildUpdate::BuildFailed { err } => {
+                    // Flush remaining compiler messages
+                    while let Ok(Some(msg)) = self.rx.try_next() {
+                        if let BuildUpdate::CompilerMessage { message } = msg {
+                            tracing::info!(json = ?StructuredOutput::CargoOutput { message: message.clone() }, %message);
+                        }
+                    }
+
                     tracing::error!(?err, json = ?StructuredOutput::Error { message: err.to_string() });
                     return Err(err);
                 }


### PR DESCRIPTION
Using `dx build`, when Cargo fails, it early returns and doesn't process any remaining `BuildUpdate`s in the channel. This change flushes any `BuildUpdate::CompilerMessage` in the `BuildFailed` handler so that logs are outputted correctly.