### PR TITLE
update Leptos example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,23 +295,25 @@ fn Counters() -> Element {
 ```rust
 fn Counters() -> impl IntoView {
     let counters = RwSignal::new(vec![0; 10]);
-
+    
     view! {
-        <button on:click=move |_| counters.update(|n| n.push(n.len()))>"Add Counter"</button>
-        <For
-            each=move || 0..counters.with(Vec::len)
-            key=|idx| *idx
-            let:idx
-        >
-            <li>
-                <button on:click=move |_| counters.update(|n| n[idx] += 1)>
-                    {Memo::new(move |_| counters.with(|n| n[idx]))}
-                </button>
-                <button on:click=move |_| counters.update(|n| { n.remove(idx); })>
-                    "Remove"
-                </button>
-            </li>
-        </For>
+        <button on:click=move |_| counters.update(|c| c.push(c.len()))>"Add Counter"</button>
+        <ul>
+            {move || (0..(counters.read().len())).map(|idx| {
+                view! {
+                    <li>
+                        <button on:click=move |_| counters.write()[idx] += 1>
+                            {counters.read()[idx]}
+                        </button>
+                        <button on:click=move |_| {
+                            counters.write().remove(idx);
+                        }>
+                            "Remove"
+                        </button>
+                    </li>
+                }
+            }).collect_view()}
+        </ul>
     }
 }
 ```


### PR DESCRIPTION
As of 0.7, Leptos supports the same kind of unkeyed, VDOM-like diff that Dioxus does in the comparison example given in the README.

I only updated the example, but the changes to the example mean that the rest of the surrounding text no longer makes sense.

Personally, I'd suggest just removing it; Leptos does provide a (keyed) For component helper, but the unkeyed behavior is now identical with the Dioxus unkeyed behavior, the only real difference between the two examples being that the Leptos one uses an iterator and the Dioxus one uses its special rsx `for` syntax, so the comments about losing reactivity and special control-flow components being required are not particularly accurate.