### PR TITLE
fix: never cache spanless expressions in autofmt

### DIFF
--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -437,10 +437,6 @@ impl<'a> Writer<'a> {
             self.out.indent_level += 1;
 
             if !props_same_line {
-                // match attr {
-                //     AttrType::Attr(attr) => panic!("writing comment {:?}", attr),
-                //     AttrType::Spread(attr) => panic!("writing comment {:?}", attr.expr),
-                // };
                 self.write_attr_comments(
                     brace,
                     match attr {

--- a/packages/autofmt/tests/samples/attributes.rsx
+++ b/packages/autofmt/tests/samples/attributes.rsx
@@ -7,6 +7,8 @@ rsx! {
         class: "asd",
         class: "asd",
         class: "asd",
+        src: asset!("/123.png"),
+        src: asset!("/456.png"),
         blah: 123,
         onclick: move |_| {
             let blah = 120;

--- a/packages/autofmt/tests/srcless.rs
+++ b/packages/autofmt/tests/srcless.rs
@@ -1,17 +1,29 @@
 use dioxus_rsx::CallBody;
-use proc_macro2::TokenStream as TokenStream2;
+use syn::parse_quote;
+
+macro_rules! test_case {
+    (
+        $path:literal
+    ) => {
+        works(include!($path), include_str!($path))
+    };
+}
 
 /// Ensure we can write RSX blocks without a source file
 ///
 /// Useful in code generation use cases where we still want formatted code.
 #[test]
 fn write_block_out() {
-    let src = include_str!("./srcless/basic_expr.rsx");
+    test_case!("./srcless/basic_expr.rsx");
+    test_case!("./srcless/asset.rsx");
+}
 
-    let tokens: TokenStream2 = syn::parse_str(src).unwrap();
-    let parsed: CallBody = syn::parse2(tokens).unwrap();
-
+fn works(parsed: CallBody, src: &str) {
     let block = dioxus_autofmt::write_block_out(&parsed).unwrap();
+    let src = src
+        .trim()
+        .trim_start_matches("parse_quote! {")
+        .trim_end_matches("}");
 
     // normalize line endings for windows tests to pass
     pretty_assertions::assert_eq!(

--- a/packages/autofmt/tests/srcless.rs
+++ b/packages/autofmt/tests/srcless.rs
@@ -23,7 +23,7 @@ fn works(parsed: CallBody, src: &str) {
     let src = src
         .trim()
         .trim_start_matches("parse_quote! {")
-        .trim_end_matches("}");
+        .trim_end_matches('}');
 
     // normalize line endings for windows tests to pass
     pretty_assertions::assert_eq!(

--- a/packages/autofmt/tests/srcless/asset.rsx
+++ b/packages/autofmt/tests/srcless/asset.rsx
@@ -1,0 +1,5 @@
+parse_quote! {
+    img { src: asset!("/assets/logos/123.png") }
+    img { src: asset!("/assets/logos/456.png") }
+    img { src: asset!("/assets/logos/789.png") }
+}

--- a/packages/autofmt/tests/srcless/basic_expr.rsx
+++ b/packages/autofmt/tests/srcless/basic_expr.rsx
@@ -1,3 +1,4 @@
+parse_quote! {
     div {
         "hi"
         {children}
@@ -37,6 +38,23 @@
             let b = 40;
             let c = 50;
         },
+        src1: asset!("/123.png"),
+        src2: asset!("/456.png"),
+        src3: asset!("/789.png"),
+        src4: asset!("/101112.png", WithOptions),
         "hi"
     }
+    p {
+        img {
+            src: asset!("/example-book/assets1/logo.png", ImageAssetOptions::new().with_avif()),
+            alt: "some_local1",
+            title: "",
+        }
+        img {
+            src: asset!("/example-book/assets2/logo.png", ImageAssetOptions::new().with_avif()),
+            alt: "some_local2",
+            title: "",
+        }
+    }
     div { class: "asd", "Jon" }
+}


### PR DESCRIPTION
Autofmt was returning the same expression every time when being used for codegen (IE on the docsite) and some documentation was just wrong.

Apparently our "spanless" test was actually generating spans and thus we weren't catching it.

If the span is unreliable (in this case, row=1, col=0), then we shouldn't cache it at all.

This fixes that, fixing some docs.