### PR TITLE
feat: some simple UI tweaks to CLI

### DIFF
--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -777,6 +777,8 @@ impl AppBundle {
     /// Run any final tools to produce apks or other artifacts we might need.
     async fn assemble(&self) -> Result<()> {
         if let Platform::Android = self.build.build.platform() {
+            self.build.status_running_gradle();
+
             // make sure we can execute the gradlew script
             #[cfg(unix)]
             {

--- a/packages/cli/src/build/progress.rs
+++ b/packages/cli/src/build/progress.rs
@@ -29,6 +29,12 @@ impl BuildRequest {
         });
     }
 
+    pub(crate) fn status_running_gradle(&self) {
+        _ = self.progress.unbounded_send(BuildUpdate::Progress {
+            stage: BuildStage::RunningGradle,
+        })
+    }
+
     pub(crate) fn status_build_diagnostic(&self, message: CompilerMessage) {
         _ = self
             .progress

--- a/packages/cli/src/cli/create.rs
+++ b/packages/cli/src/cli/create.rs
@@ -211,6 +211,7 @@ pub(crate) fn post_create(path: &Path) -> Result<()> {
     file.write_all(new_readme.as_bytes())?;
 
     tracing::info!(dx_src = ?TraceSrc::Dev, "Generated project at {}", path.display());
+    tracing::info!(dx_src = ?TraceSrc::Dev, "`cd` to your project and run `dx serve` to start developing. Build cool things! ✌️");
 
     Ok(())
 }

--- a/packages/cli/src/logging.rs
+++ b/packages/cli/src/logging.rs
@@ -95,6 +95,10 @@ impl TraceController {
                         return Ok(());
                     }
 
+                    if field.name() == "dx_src" && !args.verbosity.verbose {
+                        return Ok(());
+                    }
+
                     write!(writer, "{}", format_field(field.name(), value))
                 })
                 .delimited(" "),

--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -488,6 +488,7 @@ impl Output {
             }
             BuildStage::OptimizingWasm {} => lines.push("Optimizing wasm".yellow()),
             BuildStage::RunningBindgen {} => lines.push("Running wasm-bindgen".yellow()),
+            BuildStage::RunningGradle {} => lines.push("Running gradle assemble".yellow()),
             BuildStage::Bundling {} => lines.push("Bundling app".yellow()),
             BuildStage::CopyingAssets {
                 current,

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -66,7 +66,7 @@ impl App {
             webviews: HashMap::new(),
             control_flow: ControlFlow::Wait,
             unmounted_dom: Cell::new(Some(virtual_dom)),
-            float_all: !cfg!(debug_assertions),
+            float_all: false,
             show_devtools: false,
             cfg: Cell::new(Some(cfg)),
             shared: Rc::new(SharedContext {

--- a/packages/dx-wire-format/src/lib.rs
+++ b/packages/dx-wire-format/src/lib.rs
@@ -63,6 +63,7 @@ pub enum BuildStage {
         path: PathBuf,
     },
     Bundling,
+    RunningGradle,
     Success,
     Failed,
     Aborted,


### PR DESCRIPTION
- Add gradle status message
- Use cargo.toml for profiles, not .config/cargo.toml
- hide `dx_src` from logs when not running `--verbose` for build/bundle etc
- don't float desktop windows by default