### PR TITLE
Fix enable_out_of_order_streaming doc example and manganis macro remote example

### DIFF
--- a/packages/fullstack/src/serve_config.rs
+++ b/packages/fullstack/src/serve_config.rs
@@ -163,7 +163,7 @@ impl ServeConfigBuilder {
     ///
     /// It is equivalent to calling `streaming_mode(StreamingMode::OutOfOrder)`
     ///
-    /// /// ```rust, no_run
+    /// ```rust, no_run
     /// # use dioxus::prelude::*;
     /// # fn app() -> Element { todo!() }
     /// dioxus::LaunchBuilder::new()

--- a/packages/manganis/manganis-macro/src/lib.rs
+++ b/packages/manganis/manganis-macro/src/lib.rs
@@ -19,11 +19,6 @@ use linker::generate_link_section;
 /// # use manganis::{asset, Asset};
 /// const _: Asset = asset!("/assets/asset.txt");
 /// ```
-/// Or you can use URLs to read the asset at build time from a remote location
-/// ```rust
-/// # use manganis::{asset, Asset};
-/// const _: Asset = asset!("/assets/image.png");
-/// ```
 ///
 /// # Images
 ///


### PR DESCRIPTION
Fixes a typo in the enable_out_of_order_streaming documentation and removes the remote example from the manganis macro documentation

Closes #3316 