### PR TITLE
Rewrite all the `dioxus_elements` logic for more modular `hotreload` support

### DIFF
--- a/packages/cli/src/elements_metadata.rs
+++ b/packages/cli/src/elements_metadata.rs
@@ -1,0 +1,37 @@
+use manganis_core::linker::LinkSection;
+use manganis_core::BundledMetadata;
+use object::{read::archive::ArchiveFile, File as ObjectFile, Object, ObjectSection};
+use serde::{Deserialize, Serialize};
+
+/// Fill this manifest with whatever tables might come from the object file
+fn collect_elements_metadata(&mut self, obj: &ObjectFile) -> anyhow::Result<HasMap<ConstStr, ConstStr>> {
+    for section in obj.sections() {
+        let Ok(section_name) = section.name() else {
+            continue;
+        };
+
+        // Check if the link section matches the asset section for one of the platforms we support. This may not be the current platform if the user is cross compiling
+        let matches = LinkSection::ALL
+            .iter()
+            .any(|x| x.link_section == section_name);
+
+        if !matches {
+            continue;
+        }
+
+        let bytes = section
+            .uncompressed_data()
+            .context("Could not read uncompressed data from object file")?;
+
+        let mut buffer = const_serialize::ConstReadBuffer::new(&bytes);
+        while let Some((remaining_buffer, asset)) =
+            const_serialize::deserialize_const!(BundledMetadata, buffer)
+        {
+            self.assets
+                .insert(asset.absolute_source_path().into(), asset);
+            buffer = remaining_buffer;
+        }
+    }
+
+    Ok(())
+}

--- a/packages/manganis/manganis-core/src/metadata.rs
+++ b/packages/manganis/manganis-core/src/metadata.rs
@@ -1,0 +1,63 @@
+use const_serialize::{ConstStr, SerializeConst};
+use std::path::PathBuf;
+
+#[derive(
+    Debug,
+    PartialEq,
+    PartialOrd,
+    Clone,
+    Copy,
+    Hash,
+    SerializeConst,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct BundledMetadata {
+    pub key: ConstStr,
+    pub value: ConstStr,
+}
+
+impl BundledMetadata {
+    #[doc(hidden)]
+    /// This should only be called from the macro
+    /// Create a new asset
+    pub const fn new(
+        absolute_source_path: &'static str,
+        bundled_path: &'static str,
+        options: AssetOptions,
+    ) -> Self {
+        Self {
+            absolute_source_path: ConstStr::new(absolute_source_path),
+            bundled_path: ConstStr::new(bundled_path),
+            options,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct MetaData {
+    /// The bundled metadata
+    bundled: BundledMetadata,
+    /// The link section for the metadata
+    keep_link_section: fn() -> u8,
+}
+
+
+
+impl Metadata {
+    #[doc(hidden)]
+    /// This should only be called from the macro
+    /// Create a new metadata
+    pub const fn new(key: &'static str, value: &'static str, keep_link_section: fn() -> u8) -> Self {
+        Self {
+            key: ConstStr::new(key),
+            value: ConstStr::new(value),
+            keep_link_section,
+        }
+    }
+
+    /// Get the bundled metadata
+    pub const fn bundled(&self) -> &BundledMetadata {
+        &self.bundled
+    }
+}


### PR DESCRIPTION
It is very much a draft.
For now, this channel is mainly a way for me to write down my reasoning about what has to be done.

The final goal of this PR is to get to a state where:
- the knowledge about the elements is not baked into the cli
- the user can easily add or change (and maybe delete) the elements we wants to use in the rsx
- the rsx hotreload and the compilation does not take more time
- maybe use a trait-based element definition to allow the user to add it's own element without having `dioxus_elements` in scope
- the code for hotreload is simpler (no `HotReloadCtx` trait)


I also have a different PR #3274 that generates the elements spec with codegen, and this work is almost usable right now. I will have to merge the 2 at one point.