### PR TITLE
feat: Reexport the `Warning` trait in dioxus-signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3404,6 +3404,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "warnings",
 ]
 
 [[package]]
@@ -3963,6 +3964,7 @@ dependencies = [
  "dioxus-html",
  "dioxus-rsx",
  "dioxus-signals",
+ "warnings",
 ]
 
 [[package]]

--- a/packages/dioxus-lib/Cargo.toml
+++ b/packages/dioxus-lib/Cargo.toml
@@ -20,16 +20,18 @@ dioxus-config-macro = { workspace = true, optional = true }
 dioxus-hooks = { workspace = true, optional = true }
 dioxus-rsx = { workspace = true, optional = true }
 dioxus-signals = { workspace = true, optional = true }
+warnings = { workspace = true, optional = true }
 
 [dev-dependencies]
 dioxus = { workspace = true }
 
 [features]
-default = ["macro", "html", "signals", "hooks"]
+default = ["macro", "html", "signals", "hooks", "warnings"]
 signals = ["dep:dioxus-signals"]
 macro = ["dep:dioxus-core-macro", "dep:dioxus-rsx", "dep:dioxus-config-macro"]
 html = ["dep:dioxus-html", "dep:dioxus-document", "dep:dioxus-history"]
 hooks = ["dep:dioxus-hooks"]
+warnings = ["dep:warnings"]
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/packages/dioxus-lib/src/lib.rs
+++ b/packages/dioxus-lib/src/lib.rs
@@ -28,6 +28,9 @@ pub use dioxus_rsx as rsx;
 #[cfg(feature = "macro")]
 pub use dioxus_core_macro as core_macro;
 
+#[cfg(feature = "warnings")]
+pub use warnings;
+
 pub mod prelude {
     #[cfg(feature = "html")]
     #[cfg_attr(docsrs, doc(cfg(feature = "html")))]

--- a/packages/dioxus/Cargo.toml
+++ b/packages/dioxus/Cargo.toml
@@ -28,6 +28,7 @@ dioxus-liveview = { workspace = true, optional = true }
 dioxus-ssr = { workspace = true, optional = true }
 manganis = { workspace = true, features = ["dioxus"], optional = true }
 dioxus-logger = { workspace = true, optional = true }
+warnings = { workspace = true, optional = true }
 
 serde = { workspace = true, optional = true }
 dioxus-cli-config = { workspace = true, optional = true }
@@ -36,7 +37,7 @@ dioxus-cli-config = { workspace = true, optional = true }
 dioxus-devtools = { workspace = true, optional = true }
 
 [features]
-default = ["macro", "html", "signals", "hooks", "launch",  "mounted", "file_engine", "document", "asset", "devtools", "logger"]
+default = ["macro", "html", "signals", "hooks", "launch",  "mounted", "file_engine", "document", "asset", "devtools", "logger", "warnings"]
 minimal = ["macro", "html", "signals", "hooks", "launch"]
 signals = ["dep:dioxus-signals"]
 macro = ["dep:dioxus-core-macro"]
@@ -48,6 +49,7 @@ file_engine = ["dioxus-web?/file_engine"]
 asset = ["dep:manganis"]
 document = ["dioxus-web?/document", "dep:dioxus-document", "dep:dioxus-history"]
 logger = ["dep:dioxus-logger"]
+warnings = ["dep:warnings"]
 
 launch = ["dep:dioxus-config-macro"]
 router = ["dep:dioxus-router"]
@@ -89,7 +91,8 @@ features = [
     "hooks",
     "html",
     "liveview",
-    "server"
+    "server",
+    "warnings"
 ]
 targets = [
     "wasm32-unknown-unknown",

--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -163,3 +163,7 @@ pub use dioxus_liveview as liveview;
 #[cfg(feature = "ssr")]
 #[cfg_attr(docsrs, doc(cfg(feature = "ssr")))]
 pub use dioxus_ssr as ssr;
+
+#[cfg(feature = "warnings")]
+#[cfg_attr(docsrs, doc(cfg(feature = "warnings")))]
+pub use warnings;

--- a/packages/signals/src/warnings.rs
+++ b/packages/signals/src/warnings.rs
@@ -1,6 +1,7 @@
 //! Warnings that can be triggered by suspicious usage of signals
 
 use warnings::warning;
+pub use warnings::Warning;
 
 /// A warning that is triggered when a copy value is used in a higher scope that it is owned by
 #[warning]

--- a/packages/signals/src/warnings.rs
+++ b/packages/signals/src/warnings.rs
@@ -1,7 +1,6 @@
 //! Warnings that can be triggered by suspicious usage of signals
 
 use warnings::warning;
-pub use warnings::Warning;
 
 /// A warning that is triggered when a copy value is used in a higher scope that it is owned by
 #[warning]


### PR DESCRIPTION
feat: Reexport the `Warning` trait in dioxus-signals to allow the use of `::allow()` without pulling the warnings crate

fixes: #3513