### PR TITLE
feat: android asset hotreloading

### DIFF
--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -91,7 +91,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
 
                 // if change is hotreloadable, hotreload it
                 // and then send that update to all connected clients
-                if let Some(hr) = runner.attempt_hot_reload(files) {
+                if let Some(hr) = runner.attempt_hot_reload(files).await {
                     // Only send a hotreload message for templates and assets - otherwise we'll just get a full rebuild
                     if hr.templates.is_empty()
                         && hr.assets.is_empty()

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -157,7 +157,7 @@ impl AppRunner {
         Ok(())
     }
 
-    pub(crate) fn attempt_hot_reload(
+    pub(crate) async fn attempt_hot_reload(
         &mut self,
         modified_files: Vec<PathBuf>,
     ) -> Option<HotReloadMsg> {
@@ -183,7 +183,7 @@ impl AppRunner {
 
             // Otherwise, it might be an asset and we should look for it in all the running apps
             for runner in self.running.values() {
-                if let Some(bundled_name) = runner.hotreload_bundled_asset(&path) {
+                if let Some(bundled_name) = runner.hotreload_bundled_asset(&path).await {
                     // todo(jon): don't hardcode this here
                     let asset_relative = PathBuf::from("/assets/").join(bundled_name);
                     assets.push(asset_relative);


### PR DESCRIPTION
This fixes android asset hot-reloading. We were running into permissions issues earlier that I realized don't exist with the `tmp` directory.

https://github.com/user-attachments/assets/1c945758-422b-4d4f-937e-a0f6484b594a

