### PR TITLE
fix: print `error: ` messages and their contents from cargo

### DIFF
--- a/packages/cli/src/build/progress.rs
+++ b/packages/cli/src/build/progress.rs
@@ -41,6 +41,10 @@ impl BuildRequest {
             .unbounded_send(BuildUpdate::CompilerMessage { message });
     }
 
+    pub(crate) fn status_build_error(&self, line: String) {
+        tracing::error!(dx_src = ?TraceSrc::Cargo, "{line}");
+    }
+
     pub(crate) fn status_build_message(&self, line: String) {
         tracing::trace!(dx_src = ?TraceSrc::Cargo, "{line}");
     }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -163,6 +163,7 @@ impl BuildRequest {
         let mut stdout = stdout.lines();
         let mut stderr = stderr.lines();
         let mut units_compiled = 0;
+        let mut emitting_error = false;
 
         loop {
             use cargo_metadata::Message;
@@ -173,15 +174,28 @@ impl BuildRequest {
                 else => break,
             };
 
-            let mut deserializer = serde_json::Deserializer::from_str(line.trim());
-            deserializer.disable_recursion_limit();
-
-            let message =
-                Message::deserialize(&mut deserializer).unwrap_or(Message::TextLine(line));
+            let message = Message::parse_stream(std::io::Cursor::new(line))
+                .next()
+                .unwrap()
+                .unwrap();
 
             match message {
                 Message::BuildScriptExecuted(_) => units_compiled += 1,
-                Message::TextLine(line) => self.status_build_message(line),
+                Message::TextLine(line) => {
+                    // For whatever reason, if there's an error while building, we still receive the TextLine
+                    // instead of an "error" message. However, the following messages *also* tend to
+                    // be the error message, and don't start with "error:". So we'll check if we've already
+                    // emitted an error message and if so, we'll emit all following messages as errors too.
+                    if line.trim_start().starts_with("error:") {
+                        emitting_error = true;
+                    }
+
+                    if emitting_error {
+                        self.status_build_error(line);
+                    } else {
+                        self.status_build_message(line)
+                    }
+                }
                 Message::CompilerMessage(msg) => self.status_build_diagnostic(msg),
                 Message::CompilerArtifact(artifact) => {
                     units_compiled += 1;

--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -265,12 +265,7 @@ impl Output {
     pub fn push_cargo_log(&mut self, message: cargo_metadata::CompilerMessage) {
         use cargo_metadata::diagnostic::DiagnosticLevel;
 
-        if self.trace
-            || matches!(
-                message.message.level,
-                DiagnosticLevel::Error | DiagnosticLevel::FailureNote
-            )
-        {
+        if self.trace || !matches!(message.message.level, DiagnosticLevel::Note) {
             self.push_log(TraceMsg::cargo(message));
         }
     }


### PR DESCRIPTION
I noticed in https://github.com/DioxusLabs/dioxus/issues/3298 that many users are running into opaque cargo issues because we're swallowing cargo's output in some scenarios.

Apparently most build errors aren't covered by any of the cargo metadata variants:

https://github.com/oli-obk/cargo_metadata/issues/168

This implements some basic heuristics to discover when cargo is emitting TextLine messages that are actually errors and ensures those make it to the user.