### PR TITLE
Fix client side liveview links

### DIFF
--- a/packages/liveview/src/adapters/axum_adapter.rs
+++ b/packages/liveview/src/adapters/axum_adapter.rs
@@ -62,6 +62,13 @@ impl LiveviewRouter for Router {
         };
 
         let app = Arc::new(app);
+        // Add an extra catch all segment to the route
+        let mut route = route.trim_matches('/').to_string();
+        if route.is_empty() {
+            route = "/*route".to_string();
+        } else {
+            route = format!("/{route}/*route");
+        }
 
         self.route(
             &ws_path,
@@ -75,7 +82,7 @@ impl LiveviewRouter for Router {
             }),
         )
         .route(
-            route,
+            &route,
             get(move || async move { index_page_with_glue(&interpreter_glue(&ws_path)) }),
         )
     }

--- a/packages/liveview/src/history.rs
+++ b/packages/liveview/src/history.rs
@@ -342,6 +342,10 @@ impl History for LiveviewHistory {
         let mut updater_callback = self.updater_callback.write().unwrap();
         *updater_callback = callback;
     }
+
+    fn include_prevent_default(&self) -> bool {
+        true
+    }
 }
 
 mod routes {


### PR DESCRIPTION
This PR fixes the prevent default behavior of Links in liveview. Without this change, every link requires a full page reload.