### PR TITLE
fix(cli): addr parameter of dx serve

### DIFF
--- a/packages/cli/src/serve/server.rs
+++ b/packages/cli/src/serve/server.rs
@@ -82,7 +82,7 @@ impl WebServer {
             .then(|| get_available_port(devserver_ip))
             .flatten();
 
-        let proxied_address = proxied_port.map(|port| SocketAddr::new(devserver_ip, port));
+        let proxied_address = proxied_port.map(|port| SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), port));
 
         // Set up the router with some shared state that we'll update later to reflect the current state of the build
         let build_status = SharedStatus::new_with_starting_build();

--- a/packages/cli/src/serve/server.rs
+++ b/packages/cli/src/serve/server.rs
@@ -82,7 +82,8 @@ impl WebServer {
             .then(|| get_available_port(devserver_ip))
             .flatten();
 
-        let proxied_address = proxied_port.map(|port| SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), port));
+        let proxied_address = proxied_port
+            .map(|port| SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)), port));
 
         // Set up the router with some shared state that we'll update later to reflect the current state of the build
         let build_status = SharedStatus::new_with_starting_build();


### PR DESCRIPTION
When I run `dx serve --addr 0.0.0.0` in order to receive requests from any ip address, then currently the dev server tries to forward this request to 0.0.0.0, however since the proxied server is always started on the same machine, I believe that the request should always be forwarded to localhost.

Is that correct, or am I misunderstanding how the addr parameter should work?

I was also considering changing the address to localhost in the proxied_server_address function as well, so that also the proxied server would always only listen to localhost, but then I thought it might be useful to be able to reach it directly as well, when specifying the address as 0.0.0.0 and calling from another host.