### PR TITLE
Fix compiler errors in examples/fullstack-auth

### DIFF
--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -54,6 +54,7 @@ features = [
     "CustomEvent",
     "DataTransfer",
     "Document",
+    "DomRectReadOnly",
     "DragEvent",
     "FocusEvent",
     "History",
@@ -101,9 +102,16 @@ file_engine = [
     "dep:async-trait",
     "web-sys/File",
     "web-sys/FileList",
-    "web-sys/FileReader"
+    "web-sys/FileReader",
 ]
-devtools = ["web-sys/MessageEvent", "web-sys/WebSocket", "web-sys/Location", "dep:serde_json", "dep:serde", "dioxus-core/serialize"]
+devtools = [
+    "web-sys/MessageEvent",
+    "web-sys/WebSocket",
+    "web-sys/Location",
+    "dep:serde_json",
+    "dep:serde",
+    "dioxus-core/serialize",
+]
 document = ["dep:serde-wasm-bindgen", "dep:serde_json", "dep:serde"]
 
 [dev-dependencies]


### PR DESCRIPTION
Fix compiler errors in the example fullstack-auth when running `dx serve --fullstack`