### PR TITLE
Fix compiler error in examples/fullstack-auth

### DIFF
--- a/packages/web/Cargo.toml
+++ b/packages/web/Cargo.toml
@@ -54,6 +54,7 @@ features = [
     "CustomEvent",
     "DataTransfer",
     "Document",
+    "DomRectReadOnly",
     "DragEvent",
     "FocusEvent",
     "History",


### PR DESCRIPTION
Running `dx serve --fullstack` in fullstack-auth returns several compiler errors:
```
[cargo] error[E0432]: unresolved import `web_sys::DomRectReadOnly`
  --> packages/web/src/events/visible.rs:11:28
   |
11 | use web_sys::{CustomEvent, DomRectReadOnly, Event, IntersectionObserverEntry};
   |                            ^^^^^^^^^^^^^^^ no `DomRectReadOnly` in the root
 ```
 This feature activation of web-sys should resolve the issue.