### PR TITLE
feature(cli): dioxus-cli as lib

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -141,6 +141,9 @@ wasm-opt = ["dep:wasm-opt"]
 path = "src/main.rs"
 name = "dx"
 
+[lib]
+path = "src/lib.rs"
+
 [dev-dependencies]
 escargot = "0.5"
 

--- a/packages/cli/src/cli/autoformat.rs
+++ b/packages/cli/src/cli/autoformat.rs
@@ -10,35 +10,35 @@ use std::{borrow::Cow, fs, path::Path};
 
 /// Format some rsx
 #[derive(Clone, Debug, Parser)]
-pub(crate) struct Autoformat {
+pub struct Autoformat {
     /// Format rust code before the formatting the rsx macros
     #[clap(long)]
-    pub(crate) all_code: bool,
+    pub all_code: bool,
 
     /// Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits
     /// with 1 and prints a diff if formatting is required.
     #[clap(short, long)]
-    pub(crate) check: bool,
+    pub check: bool,
 
     /// Input rsx (selection)
     #[clap(short, long)]
-    pub(crate) raw: Option<String>,
+    pub raw: Option<String>,
 
     /// Input file
     #[clap(short, long)]
-    pub(crate) file: Option<String>,
+    pub file: Option<String>,
 
     /// Split attributes in lines or not
     #[clap(short, long, default_value = "false")]
-    pub(crate) split_line_attributes: bool,
+    pub split_line_attributes: bool,
 
     /// The package to build
     #[clap(short, long)]
-    pub(crate) package: Option<String>,
+    pub package: Option<String>,
 }
 
 impl Autoformat {
-    pub(crate) fn autoformat(self) -> Result<StructuredOutput> {
+    pub fn autoformat(self) -> Result<StructuredOutput> {
         let Autoformat {
             check,
             raw,

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -5,62 +5,62 @@ use crate::{Builder, DioxusCrate, Platform, PROFILE_SERVER};
 ///
 /// Produces a final output bundle designed to be run on the target platform.
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
-pub(crate) struct BuildArgs {
+pub struct BuildArgs {
     /// Build in release mode [default: false]
     #[clap(long, short)]
     #[serde(default)]
-    pub(crate) release: bool,
+    pub release: bool,
 
     /// This flag only applies to fullstack builds. By default fullstack builds will run the server and client builds in parallel. This flag will force the build to run the server build first, then the client build. [default: false]
     #[clap(long)]
     #[serde(default)]
-    pub(crate) force_sequential: bool,
+    pub force_sequential: bool,
 
     /// Build the app with custom a profile
     #[clap(long)]
-    pub(crate) profile: Option<String>,
+    pub profile: Option<String>,
 
     /// Build with custom profile for the fullstack server
     #[clap(long, default_value_t = PROFILE_SERVER.to_string())]
-    pub(crate) server_profile: String,
+    pub server_profile: String,
 
     /// Build platform: support Web & Desktop [default: "default_platform"]
     #[clap(long, value_enum)]
-    pub(crate) platform: Option<Platform>,
+    pub platform: Option<Platform>,
 
     /// Build the fullstack variant of this app, using that as the fileserver and backend
     ///
     /// This defaults to `false` but will be overridden to true if the `fullstack` feature is enabled.
     #[clap(long)]
-    pub(crate) fullstack: bool,
+    pub fullstack: bool,
 
     /// Run the ssg config of the app and generate the files
     #[clap(long)]
-    pub(crate) ssg: bool,
+    pub ssg: bool,
 
     /// Skip collecting assets from dependencies [default: false]
     #[clap(long)]
     #[serde(default)]
-    pub(crate) skip_assets: bool,
+    pub skip_assets: bool,
 
     /// Extra arguments passed to cargo build
     #[clap(last = true)]
-    pub(crate) cargo_args: Vec<String>,
+    pub cargo_args: Vec<String>,
 
     /// Inject scripts to load the wasm and js files for your dioxus app if they are not already present [default: true]
     #[clap(long, default_value_t = true)]
-    pub(crate) inject_loading_scripts: bool,
+    pub inject_loading_scripts: bool,
 
     /// Generate debug symbols for the wasm binary [default: true]
     ///
     /// This will make the binary larger and take longer to compile, but will allow you to debug the
     /// wasm binary
     #[clap(long, default_value_t = true)]
-    pub(crate) debug_symbols: bool,
+    pub debug_symbols: bool,
 
     /// Information about the target to build
     #[clap(flatten)]
-    pub(crate) target_args: TargetArgs,
+    pub target_args: TargetArgs,
 }
 
 impl BuildArgs {

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -34,11 +34,11 @@ pub struct Bundle {
 
     /// The arguments for the dioxus build
     #[clap(flatten)]
-    pub(crate) build_arguments: BuildArgs,
+    pub build_arguments: BuildArgs,
 }
 
 impl Bundle {
-    pub(crate) async fn bundle(mut self) -> Result<StructuredOutput> {
+    pub async fn bundle(mut self) -> Result<StructuredOutput> {
         tracing::info!("Bundling project...");
 
         let krate = DioxusCrate::new(&self.build_arguments.target_args)

--- a/packages/cli/src/cli/check.rs
+++ b/packages/cli/src/cli/check.rs
@@ -11,19 +11,19 @@ use std::path::Path;
 
 /// Check the Rust files in the project for issues.
 #[derive(Clone, Debug, Parser)]
-pub(crate) struct Check {
+pub struct Check {
     /// Input file
     #[clap(short, long)]
-    pub(crate) file: Option<PathBuf>,
+    pub file: Option<PathBuf>,
 
     /// Information about the target to check
     #[clap(flatten)]
-    pub(crate) target_args: TargetArgs,
+    pub target_args: TargetArgs,
 }
 
 impl Check {
     // Todo: check the entire crate
-    pub(crate) async fn check(self) -> Result<StructuredOutput> {
+    pub async fn check(self) -> Result<StructuredOutput> {
         match self.file {
             // Default to checking the project
             None => {

--- a/packages/cli/src/cli/clean.rs
+++ b/packages/cli/src/cli/clean.rs
@@ -5,11 +5,11 @@ use crate::Result;
 ///
 /// Simlpy runs `cargo clean`
 #[derive(Clone, Debug, Parser)]
-pub(crate) struct Clean {}
+pub struct Clean {}
 
 impl Clean {
     /// todo(jon): we should add a config option that just wipes target/dx and target/dioxus-client instead of doing a full clean
-    pub(crate) async fn clean(self) -> Result<StructuredOutput> {
+    pub async fn clean(self) -> Result<StructuredOutput> {
         let output = tokio::process::Command::new("cargo")
             .arg("clean")
             .stdout(Stdio::piped())

--- a/packages/cli/src/cli/config.rs
+++ b/packages/cli/src/cli/config.rs
@@ -4,7 +4,7 @@ use crate::{metadata::crate_root, CliSettings};
 
 /// Dioxus config file controls
 #[derive(Clone, Debug, Deserialize, Subcommand)]
-pub(crate) enum Config {
+pub enum Config {
     /// Init `Dioxus.toml` for project/folder.
     Init {
         /// Init project name
@@ -35,7 +35,7 @@ pub(crate) enum Config {
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Subcommand)]
-pub(crate) enum Setting {
+pub enum Setting {
     /// Set the value of the always-hot-reload setting.
     AlwaysHotReload { value: BoolValue },
     /// Set the value of the always-open-browser setting.
@@ -60,7 +60,7 @@ impl Display for Setting {
 // Clap complains if we use a bool directly and I can't find much info about it.
 // "Argument 'value` is positional and it must take a value but action is SetTrue"
 #[derive(Debug, Clone, Copy, Deserialize, clap::ValueEnum)]
-pub(crate) enum BoolValue {
+pub enum BoolValue {
     True,
     False,
 }
@@ -75,7 +75,7 @@ impl From<BoolValue> for bool {
 }
 
 impl Config {
-    pub(crate) fn config(self) -> Result<StructuredOutput> {
+    pub fn config(self) -> Result<StructuredOutput> {
         let crate_root = crate_root()?;
         match self {
             Config::Init {

--- a/packages/cli/src/cli/link.rs
+++ b/packages/cli/src/cli/link.rs
@@ -14,18 +14,18 @@ pub enum LinkAction {
 }
 
 impl LinkAction {
-    pub(crate) const ENV_VAR_NAME: &'static str = "dx_magic_link_file";
+    pub const ENV_VAR_NAME: &'static str = "dx_magic_link_file";
 
     /// Should we write the input arguments to a file (aka act as a linker subprocess)?
     ///
     /// Just check if the magic env var is set
-    pub(crate) fn from_env() -> Option<Self> {
+    pub fn from_env() -> Option<Self> {
         std::env::var(Self::ENV_VAR_NAME)
             .ok()
             .map(|var| serde_json::from_str(&var).expect("Failed to parse magic env var"))
     }
 
-    pub(crate) fn to_json(&self) -> String {
+    pub fn to_json(&self) -> String {
         serde_json::to_string(self).unwrap()
     }
 
@@ -38,7 +38,7 @@ impl LinkAction {
     ///
     /// hmmmmmmmm tbh I'd rather just pass the object files back and do the parsing here, but the interface
     /// is nicer to just bounce back the args and let the host do the parsing/canonicalization
-    pub(crate) fn run(self) {
+    pub fn run(self) {
         match self {
             // Literally just run the android linker :)
             LinkAction::LinkAndroid {

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -17,7 +17,16 @@ pub mod verbosity;
 pub use build::*;
 pub use serve::*;
 pub use target::*;
+pub use translate::*;
 pub use verbosity::*;
+pub use init::*;
+pub use clean::*;
+pub use bundle::*;
+pub use autoformat::*;
+pub use check::*;
+pub use run::*;
+pub use doctor::*;
+pub use config::*;
 
 use crate::{error::Result, Error, StructuredOutput};
 use anyhow::Context;

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -1,23 +1,23 @@
-pub(crate) mod autoformat;
-pub(crate) mod build;
-pub(crate) mod bundle;
-pub(crate) mod check;
-pub(crate) mod clean;
-pub(crate) mod config;
-pub(crate) mod create;
-pub(crate) mod doctor;
-pub(crate) mod init;
-pub(crate) mod link;
-pub(crate) mod run;
-pub(crate) mod serve;
-pub(crate) mod target;
-pub(crate) mod translate;
-pub(crate) mod verbosity;
+pub mod autoformat;
+pub mod build;
+pub mod bundle;
+pub mod check;
+pub mod clean;
+pub mod config;
+pub mod create;
+pub mod doctor;
+pub mod init;
+pub mod link;
+pub mod run;
+pub mod serve;
+pub mod target;
+pub mod translate;
+pub mod verbosity;
 
-pub(crate) use build::*;
-pub(crate) use serve::*;
-pub(crate) use target::*;
-pub(crate) use verbosity::*;
+pub use build::*;
+pub use serve::*;
+pub use target::*;
+pub use verbosity::*;
 
 use crate::{error::Result, Error, StructuredOutput};
 use anyhow::Context;
@@ -36,16 +36,16 @@ use std::{
 /// Build, Bundle & Ship Dioxus Apps.
 #[derive(Parser)]
 #[clap(name = "dioxus", version = VERSION.as_str())]
-pub(crate) struct Cli {
+pub struct Cli {
     #[command(subcommand)]
-    pub(crate) action: Commands,
+    pub action: Commands,
 
     #[command(flatten)]
-    pub(crate) verbosity: Verbosity,
+    pub verbosity: Verbosity,
 }
 
 #[derive(Subcommand)]
-pub(crate) enum Commands {
+pub enum Commands {
     /// Build the Dioxus project and all of its assets.
     #[clap(name = "build")]
     Build(build::BuildArgs),

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -3,14 +3,14 @@ use crate::{serve::ServeUpdate, BuildArgs, Builder, DioxusCrate, Platform, Resul
 
 /// Run the project with the given arguments
 #[derive(Clone, Debug, Parser)]
-pub(crate) struct RunArgs {
+pub struct RunArgs {
     /// Information about the target to build
     #[clap(flatten)]
-    pub(crate) build_args: BuildArgs,
+    pub build_args: BuildArgs,
 }
 
 impl RunArgs {
-    pub(crate) async fn run(mut self) -> Result<StructuredOutput> {
+    pub async fn run(mut self) -> Result<StructuredOutput> {
         let krate = DioxusCrate::new(&self.build_args.target_args)
             .context("Failed to load Dioxus workspace")?;
 

--- a/packages/cli/src/cli/serve.rs
+++ b/packages/cli/src/cli/serve.rs
@@ -4,43 +4,43 @@ use crate::{AddressArguments, BuildArgs, DioxusCrate, Platform};
 /// Serve the project
 #[derive(Clone, Debug, Default, Parser)]
 #[command(group = clap::ArgGroup::new("release-incompatible").multiple(true).conflicts_with("release"))]
-pub(crate) struct ServeArgs {
+pub struct ServeArgs {
     /// The arguments for the address the server will run on
     #[clap(flatten)]
-    pub(crate) address: AddressArguments,
+    pub address: AddressArguments,
 
     /// Open the app in the default browser [default: true - unless cli settings are set]
     #[arg(long, default_missing_value="true", num_args=0..=1)]
-    pub(crate) open: Option<bool>,
+    pub open: Option<bool>,
 
     /// Enable full hot reloading for the app [default: true - unless cli settings are set]
     #[clap(long, group = "release-incompatible")]
-    pub(crate) hot_reload: Option<bool>,
+    pub hot_reload: Option<bool>,
 
     /// Configure always-on-top for desktop apps [default: true - unless cli settings are set]
     #[clap(long, default_missing_value = "true")]
-    pub(crate) always_on_top: Option<bool>,
+    pub always_on_top: Option<bool>,
 
     /// Set cross-origin-policy to same-origin [default: false]
     #[clap(name = "cross-origin-policy")]
     #[clap(long)]
-    pub(crate) cross_origin_policy: bool,
+    pub cross_origin_policy: bool,
 
     /// Additional arguments to pass to the executable
     #[clap(long)]
-    pub(crate) args: Vec<String>,
+    pub args: Vec<String>,
 
     /// Sets the interval in seconds that the CLI will poll for file changes on WSL.
     #[clap(long, default_missing_value = "2")]
-    pub(crate) wsl_file_poll_interval: Option<u16>,
+    pub wsl_file_poll_interval: Option<u16>,
 
     /// Run the server in interactive mode
     #[arg(long, default_missing_value="true", num_args=0..=1, short = 'i')]
-    pub(crate) interactive: Option<bool>,
+    pub interactive: Option<bool>,
 
     /// Arguments for the build itself
     #[clap(flatten)]
-    pub(crate) build_arguments: BuildArgs,
+    pub build_arguments: BuildArgs,
 }
 
 impl ServeArgs {
@@ -48,19 +48,19 @@ impl ServeArgs {
     ///
     /// Make sure not to do any intermediate logging since our tracing infra has now enabled much
     /// higher log levels
-    pub(crate) async fn serve(self) -> Result<StructuredOutput> {
+    pub async fn serve(self) -> Result<StructuredOutput> {
         crate::serve::serve_all(self).await?;
 
         Ok(StructuredOutput::Success)
     }
 
-    pub(crate) async fn load_krate(&mut self) -> Result<DioxusCrate> {
+    pub async fn load_krate(&mut self) -> Result<DioxusCrate> {
         let krate = DioxusCrate::new(&self.build_arguments.target_args)?;
         self.resolve(&krate).await?;
         Ok(krate)
     }
 
-    pub(crate) async fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
+    pub async fn resolve(&mut self, krate: &DioxusCrate) -> Result<()> {
         // Enable hot reload.
         if self.hot_reload.is_none() {
             self.hot_reload = Some(krate.settings.always_hot_reload.unwrap_or(true));
@@ -87,20 +87,20 @@ impl ServeArgs {
         Ok(())
     }
 
-    pub(crate) fn should_hotreload(&self) -> bool {
+    pub fn should_hotreload(&self) -> bool {
         self.hot_reload.unwrap_or(true)
     }
 
-    pub(crate) fn build_args(&self) -> BuildArgs {
+    pub fn build_args(&self) -> BuildArgs {
         self.build_arguments.clone()
     }
 
-    pub(crate) fn is_interactive_tty(&self) -> bool {
+    pub fn is_interactive_tty(&self) -> bool {
         use crossterm::tty::IsTty;
         std::io::stdout().is_tty() && self.interactive.unwrap_or(true)
     }
 
-    pub(crate) fn should_proxy_build(&self) -> bool {
+    pub fn should_proxy_build(&self) -> bool {
         match self.build_arguments.platform() {
             Platform::Server => true,
             _ => self.build_arguments.fullstack,

--- a/packages/cli/src/cli/translate.rs
+++ b/packages/cli/src/cli/translate.rs
@@ -4,27 +4,27 @@ use dioxus_rsx::{BodyNode, CallBody, TemplateBody};
 
 /// Translate some source file into Dioxus code
 #[derive(Clone, Debug, Parser)]
-pub(crate) struct Translate {
+pub struct Translate {
     /// Activate debug mode
     // short and long flags (-d, --debug) will be deduced from the field's name
     #[clap(short, long)]
-    pub(crate) component: bool,
+    pub component: bool,
 
     /// Input file
     #[clap(short, long)]
-    pub(crate) file: Option<String>,
+    pub file: Option<String>,
 
     /// Input file
     #[clap(short, long)]
-    pub(crate) raw: Option<String>,
+    pub raw: Option<String>,
 
     /// Output file, stdout if not present
     #[arg(short, long)]
-    pub(crate) output: Option<PathBuf>,
+    pub output: Option<PathBuf>,
 }
 
 impl Translate {
-    pub(crate) fn translate(self) -> Result<StructuredOutput> {
+    pub fn translate(self) -> Result<StructuredOutput> {
         // Get the right input for the translation
         let contents = determine_input(self.file, self.raw)?;
 

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error as ThisError;
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(ThisError, Debug)]
-pub(crate) enum Error {
+pub enum Error {
     /// Used when errors need to propagate but are too unique to be typed
     #[error("{0}")]
     Unique(String),

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -1,7 +1,7 @@
 use crate::metadata::CargoError;
 use thiserror::Error as ThisError;
 
-pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(ThisError, Debug)]
 pub enum Error {

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1,0 +1,33 @@
+#![doc = include_str!("../README.md")]
+#![doc(html_logo_url = "https://avatars.githubusercontent.com/u/79236386")]
+#![doc(html_favicon_url = "https://avatars.githubusercontent.com/u/79236386")]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod build;
+mod bundle_utils;
+mod cli;
+mod config;
+mod dioxus_crate;
+mod dx_build_info;
+mod error;
+mod fastfs;
+mod filemap;
+mod logging;
+mod metadata;
+mod platform;
+mod rustup;
+mod serve;
+mod settings;
+mod wasm_bindgen;
+
+pub use build::*;
+pub use cli::*;
+pub use config::*;
+pub use dioxus_crate::*;
+pub use dioxus_dx_wire_format::*;
+pub use error::*;
+pub use filemap::*;
+pub use logging::*;
+pub use platform::*;
+pub use rustup::*;
+pub use settings::*;

--- a/packages/cli/src/logging.rs
+++ b/packages/cli/src/logging.rs
@@ -50,7 +50,7 @@ static TUI_ACTIVE: AtomicBool = AtomicBool::new(false);
 static TUI_TX: OnceCell<UnboundedSender<TraceMsg>> = OnceCell::new();
 pub static VERBOSITY: OnceCell<Verbosity> = OnceCell::new();
 
-pub(crate) struct TraceController {
+pub struct TraceController {
     pub(crate) tui_rx: UnboundedReceiver<TraceMsg>,
 }
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -3,34 +3,7 @@
 #![doc(html_favicon_url = "https://avatars.githubusercontent.com/u/79236386")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-mod build;
-mod bundle_utils;
-mod cli;
-mod config;
-mod dioxus_crate;
-mod dx_build_info;
-mod error;
-mod fastfs;
-mod filemap;
-mod logging;
-mod metadata;
-mod platform;
-mod rustup;
-mod serve;
-mod settings;
-mod wasm_bindgen;
-
-pub(crate) use build::*;
-pub(crate) use cli::*;
-pub(crate) use config::*;
-pub(crate) use dioxus_crate::*;
-pub(crate) use dioxus_dx_wire_format::*;
-pub(crate) use error::*;
-pub(crate) use filemap::*;
-pub(crate) use logging::*;
-pub(crate) use platform::*;
-pub(crate) use rustup::*;
-pub(crate) use settings::*;
+pub use dioxus_cli::*;
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
### Problem

While it is possible to wrap dx using std::process::Command, a more flexible and programmable approach would be to reuse dioxus-cli as a library. Publishing dioxus-cli as a library would greatly enhance its usability.

### Solution

This PR exposes `dioxus-cli` as a library, making it possible to reuse `dx` instead of redirecting cli commands to it.

A good example is how `bolt-cli` uses `anchor-cli` as a library.
https://github.com/magicblock-labs/bolt/blob/main/crates/bolt-cli/src/lib.rs