### PR TITLE
fix(cli): get ip addr & port number from config

### DIFF
--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -688,7 +688,9 @@ impl AppBundle {
         use futures_util::StreamExt;
         use tokio::process::Command;
 
-        const PORT: u16 = 9999;
+        let fullstack_address = dioxus_cli_config::fullstack_address_or_localhost();
+        let address = fullstack_address.ip().to_string();
+        let port = fullstack_address.port().to_string();
 
         tracing::info!("Running SSG");
 
@@ -697,8 +699,8 @@ impl AppBundle {
             self.server_exe()
                 .context("Failed to find server executable")?,
         )
-        .env(dioxus_cli_config::SERVER_PORT_ENV, PORT.to_string())
-        .env(dioxus_cli_config::SERVER_IP_ENV, "127.0.0.1")
+        .env(dioxus_cli_config::SERVER_PORT_ENV, port.clone())
+        .env(dioxus_cli_config::SERVER_IP_ENV, address.clone())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(true)
@@ -710,7 +712,7 @@ impl AppBundle {
         // Get the routes from the `/static_routes` endpoint
         let mut routes = reqwest::Client::builder()
             .build()?
-            .post(format!("http://127.0.0.1:{PORT}/api/static_routes"))
+            .post(format!("http://{address}:{port}/api/static_routes"))
             .send()
             .await
             .context("Failed to get static routes from server")?
@@ -720,14 +722,18 @@ impl AppBundle {
             .inspect(|text| tracing::debug!("Got static routes: {text:?}"))
             .context("Failed to parse static routes from server")?
             .into_iter()
-            .map(|line| async move {
-                tracing::info!("SSG: {line}");
-                reqwest::Client::builder()
-                    .build()?
-                    .get(format!("http://127.0.0.1:{PORT}{line}"))
-                    .header("Accept", "text/html")
-                    .send()
-                    .await
+            .map(|line| {
+                let port = port.clone();
+                let address = address.clone();
+                async move {
+                    tracing::info!("SSG: {line}");
+                    reqwest::Client::builder()
+                        .build()?
+                        .get(format!("http://{address}:{port}{line}"))
+                        .header("Accept", "text/html")
+                        .send()
+                        .await
+                }
             })
             .collect::<FuturesUnordered<_>>();
 


### PR DESCRIPTION
[I have been experimenting with Dioxus SSG recently](https://github.com/opensass/opensass/pull/22) and noticed that the port number and IP address are hardcoded. The port is set to `9999` instead of retrieving the values from the configuration.

With these changes, the port is now set to the env var value at compile time (defaults to 8080):

```sh
PORT=3000 dx serve --ssg 
```