### PR TITLE
Fix: unwraps while ignoring log lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.31.1",
+ "gimli",
 ]
 
 [[package]]
@@ -3529,7 +3529,6 @@ dependencies = [
  "unicode-segmentation",
  "uuid",
  "walkdir",
- "walrus",
  "wasm-opt",
 ]
 
@@ -4760,12 +4759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
 name = "faster-hex"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5393,17 +5386,6 @@ checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
 dependencies = [
  "color_quant",
  "weezl",
-]
-
-[[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-dependencies = [
- "fallible-iterator",
- "indexmap 1.9.3",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -6126,7 +6108,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -6674,15 +6655,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.90",
-]
-
-[[package]]
-name = "id-arena"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
-dependencies = [
- "rayon",
 ]
 
 [[package]]
@@ -7388,12 +7360,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "lebe"
@@ -8625,7 +8591,7 @@ dependencies = [
  "flate2",
  "memchr",
  "ruzstd 0.7.3",
- "wasmparser 0.218.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -14814,35 +14780,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "walrus"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031bc51853697a6a01731f1c2d6d56989c3a742d63316f59918c90b709a6edd9"
-dependencies = [
- "anyhow",
- "gimli 0.26.2",
- "id-arena",
- "leb128",
- "log",
- "rayon",
- "walrus-macro",
- "wasm-encoder",
- "wasmparser 0.214.0",
-]
-
-[[package]]
-name = "walrus-macro"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14984,15 +14921,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.214.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
-dependencies = [
- "leb128",
-]
-
-[[package]]
 name = "wasm-opt"
 version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15043,20 +14971,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.214.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
-dependencies = [
- "ahash 0.8.11",
- "bitflags 2.6.0",
- "hashbrown 0.14.5",
- "indexmap 2.7.0",
- "semver 1.0.23",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,6 @@ trybuild = "1.0"
 dirs = "5.0.1"
 cargo-config2 = "0.1.26"
 criterion = { version = "0.5" }
-walrus = "0.23.2"
 cargo_metadata = "0.18.1"
 parking_lot = "0.12.1"
 tracing-wasm = "0.2.1"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -61,7 +61,6 @@ syn = { workspace = true, features = ["full", "extra-traits", "visit", "visit-mu
 
 headers = "0.4.0"
 walkdir = "2"
-walrus = { workspace = true, features = ["parallel"] }
 
 # tools download
 dirs = { workspace = true }

--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -414,6 +414,8 @@ impl AppBundle {
                 Ok(())
             })
         }
+
+        tracing::debug!("Removing old assets");
         remove_old_assets(&asset_dir, &bundled_output_paths).await?;
 
         // todo(jon): we also want to eventually include options for each asset's optimization and compression, which we currently aren't

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -174,10 +174,9 @@ impl BuildRequest {
                 else => break,
             };
 
-            let message = Message::parse_stream(std::io::Cursor::new(line))
-                .next()
-                .unwrap()
-                .unwrap();
+            let Some(Ok(message)) = Message::parse_stream(std::io::Cursor::new(line)).next() else {
+                continue;
+            };
 
             match message {
                 Message::BuildScriptExecuted(_) => units_compiled += 1,

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -77,7 +77,7 @@ impl Bundle {
                 for bundle in bundles {
                     for src in bundle.bundle_paths {
                         let src = if let Some(outdir) = &self.outdir {
-                            let dest = outdir.join(src.file_name().unwrap());
+                            let dest = outdir.join(src.file_name().expect("Filename to exist"));
                             crate::fastfs::copy_asset(&src, &dest)?;
                             dest
                         } else {
@@ -177,7 +177,7 @@ impl Bundle {
 
         for entry in std::fs::read_dir(bundle.build.asset_dir())?.flatten() {
             let old = entry.path().canonicalize()?;
-            let new = PathBuf::from("assets").join(old.file_name().unwrap());
+            let new = PathBuf::from("assets").join(old.file_name().expect("Filename to exist"));
             tracing::debug!("Bundled asset: {old:?} -> {new:?}");
 
             bundle_settings


### PR DESCRIPTION
- Removes walrus from our deps since we don't need it anymore
- Changes .unwrap() to let-else 
- Annotates some final `.unwrap()` calls as `.expect` 