### PR TITLE
Improve the second example in the read write same scope warning

### DIFF
--- a/packages/signals/src/warnings.rs
+++ b/packages/signals/src/warnings.rs
@@ -121,7 +121,7 @@ fn app() -> Element {
     let mut count2 = use_signal(|| 0);
 
     use_effect(move || {
-        count1.write(count2());
+        count1.set(count2());
     });
 }
 2) Reading and Writing to the same signal in different scopes:
@@ -134,7 +134,7 @@ fn app() -> Element {
     use_effect(move || {
         // This effect both reads and writes to count
         println!("{}", count());
-        count.write(count());
+        count.set(1);
     });
 }
 
@@ -145,7 +145,7 @@ fn app() -> Element {
     let mut count = use_signal(|| 0);
 
     use_effect(move || {
-        count.write(count());
+        count.set(1);
     });
     use_effect(move || {
         println!("{}", count());


### PR DESCRIPTION
The second example in the help section for reading and writing the same signal in a reactive scope contains the line `count.write(count());` which sets the signal to itself and doesn't make sense for any real app. This PR just sets the signal to a constant instead