### PR TITLE
fix: throw error when asset is empty

### DIFF
--- a/examples/custom_assets.rs
+++ b/examples/custom_assets.rs
@@ -13,8 +13,6 @@ fn main() {
 }
 
 fn app() -> Element {
-    let a = asset!("/../ecosystem-dioxus/docsite/assets/06assets/355903878-ebcb5872-acf7-4e29-8acb-5b183b0617ca.png");
-    let b = asset!("");
     rsx! {
         div {
             h1 { "This should show an image:" }

--- a/examples/custom_assets.rs
+++ b/examples/custom_assets.rs
@@ -13,6 +13,8 @@ fn main() {
 }
 
 fn app() -> Element {
+    let a = asset!("/../ecosystem-dioxus/docsite/assets/06assets/355903878-ebcb5872-acf7-4e29-8acb-5b183b0617ca.png");
+    let b = asset!("");
     rsx! {
         div {
             h1 { "This should show an image:" }

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -11,12 +11,6 @@ use syn::{
 };
 
 fn resolve_path(raw: &str) -> Result<PathBuf, AssetParseError> {
-    if raw.is_empty() {
-        return Err(AssetParseError::InvalidPath {
-            path: PathBuf::new(),
-        });
-    }
-
     // Get the location of the root of the crate which is where all assets are relative to
     //
     // IE

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -31,7 +31,7 @@ fn resolve_path(raw: &str) -> Result<PathBuf, AssetParseError> {
         });
     };
 
-    // 3. Ensure the path doesn't escape the workspace
+    // 3. Ensure the path doesn't escape the crate dir
     if path == manifest_dir || !path.starts_with(manifest_dir) {
         return Err(AssetParseError::InvalidPath { path });
     }


### PR DESCRIPTION
While working on the docsite I found that if you passed `asset!("")` on accident, then we'd end up copying the entire current directory over. This is not good. It also causes new `dx serve` to hang infinitely since we get stuck on clearing the assets dir.

This fixes that by throwing an error if the path is empty and ensuring the final path is a child of the crate.