### PR TITLE
add helpful message for obscure cargo failures

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -210,7 +210,7 @@ impl BuildRequest {
                 Message::BuildFinished(finished) => {
                     if !finished.success {
                         return Err(anyhow::anyhow!(
-                            "Cargo build failed, signaled by the compiler"
+                            "Cargo build failed, signaled by the compiler. Toggle tracing mode (press `t`) for more information."
                         )
                         .into());
                     }
@@ -220,7 +220,7 @@ impl BuildRequest {
         }
 
         if output_location.is_none() {
-            tracing::error!("Cargo build failed - no output location");
+            tracing::error!("Cargo build failed - no output location. Toggle tracing mode (press `t`) for more information.");
         }
 
         let out_location = output_location.context("Build did not return an executable")?;

--- a/packages/fullstack/src/hooks/server_future.rs
+++ b/packages/fullstack/src/hooks/server_future.rs
@@ -72,8 +72,6 @@ where
     // If this is the first run and we are on the web client, the data might be cached
     #[cfg(feature = "web")]
     let initial_web_result = use_hook(|| {
-        tracing::info!("First run of use_server_future");
-
         std::rc::Rc::new(std::cell::RefCell::new(Some(
             dioxus_web::take_server_data::<T>(),
         )))


### PR DESCRIPTION
If `cargo build` ends in a weird state, we were previously swallowing logs (which has been fixed).

However, we should still point people to enabling trace mode in these cases since there might be useful information.

This also removes a latent `info!()` log that isn't helpful.