### PR TITLE
fix copy assets progress by moving fetch_add out of trace!().

### DIFF
--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -447,10 +447,9 @@ impl AppBundle {
             assets_to_transfer
                 .par_iter()
                 .try_for_each(|(from, to, options)| {
-                    tracing::trace!(
-                        "Starting asset copy {current}/{asset_count} from {from:?}",
-                        current = current_asset.fetch_add(1, std::sync::atomic::Ordering::SeqCst),
-                    );
+                    let current = current_asset.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+                    tracing::trace!("Starting asset copy {current}/{asset_count} from {from:?}");
 
                     let res = process_file_to(options, from, to);
 
@@ -460,7 +459,7 @@ impl AppBundle {
 
                     BuildRequest::status_copied_asset(
                         &progress,
-                        current_asset.fetch_add(0, std::sync::atomic::Ordering::SeqCst),
+                        current,
                         asset_count,
                         from.to_path_buf(),
                     );


### PR DESCRIPTION
before this PR:
(note the six `(0/6)`)

```
  15.509s  INFO Bundling app...
  15.536s  INFO Running wasm-bindgen...
  15.790s  INFO Copying asset (0/6): C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\header.svg
  15.791s  INFO Copying asset (0/6): \\?\C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\main.css
  15.792s  INFO Copying asset (0/6): C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\favicon.ico
  15.794s  INFO Copying asset (0/6): \\?\C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\favicon.ico
  15.795s  INFO Copying asset (0/6): \\?\C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\header.svg
  15.797s  INFO Copying asset (0/6): C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\main.css
  19.87s  INFO Copying app to output directory...
  ```

after this PR:
  ```
  1258.16s  INFO Bundling app...
1258.18s  INFO Running wasm-bindgen...
1260.72s  INFO Copying asset (1/6): C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\favicon.ico
1260.73s  INFO Copying asset (0/6): \\?\C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\favicon.ico
1260.75s  INFO Copying asset (4/6): C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\header.svg
1260.76s  INFO Copying asset (2/6): \\?\C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\main.css
1260.76s  INFO Copying asset (5/6): C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\main.css
1260.77s  INFO Copying asset (3/6): \\?\C:\Users\liigo\tmp\hidx06\Bare-Bones\assets\header.svg
1283. 2s  INFO Copying app to output directory...
```
