### PR TITLE
fix(cli): Updated logic to resolve out_dir paths relative to workspace

### DIFF
--- a/packages/cli/src/config/app.rs
+++ b/packages/cli/src/config/app.rs
@@ -8,8 +8,15 @@ pub(crate) struct ApplicationConfig {
 
     #[serde(default)]
     pub(crate) sub_package: Option<String>,
+
+    #[serde(default = "out_dir_default")]
+    pub(crate) out_dir: PathBuf,
 }
 
 pub(crate) fn asset_dir_default() -> PathBuf {
     PathBuf::from("assets")
+}
+
+pub(crate) fn out_dir_default() -> PathBuf {
+    PathBuf::from("dist")  
 }

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -24,6 +24,7 @@ impl Default for DioxusConfig {
             application: ApplicationConfig {
                 asset_dir: asset_dir_default(),
                 sub_package: None,
+                out_dir: out_dir_default(),
             },
             web: WebConfig {
                 app: WebAppConfig {

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -97,9 +97,21 @@ impl DioxusCrate {
     /// is "distributed" after building an application (configurable in the
     /// `Dioxus.toml`).
     fn out_dir(&self) -> PathBuf {
-        let dir = self.workspace_dir().join("target").join("dx");
-        std::fs::create_dir_all(&dir).unwrap();
-        dir
+        // Resolve the out_dir based on the configuration or default
+        let out_dir_config = self.config.application.out_dir.clone();
+        // Resolve relative paths against the workspace root
+        let resolved_out_dir = if out_dir_config.is_relative() {
+            self.workspace_dir().join(out_dir_config)
+        } else {
+            out_dir_config
+        };
+
+        // Create the directory and handle potential errors
+        if let Err(e) = std::fs::create_dir_all(&resolved_out_dir) {
+            tracing::error!("Failed to create output directory: {}", e);
+        }
+
+        resolved_out_dir
     }
 
     /// Create a workdir for the given platform

--- a/packages/cli/src/wasm_bindgen.rs
+++ b/packages/cli/src/wasm_bindgen.rs
@@ -57,10 +57,14 @@ impl WasmBindgen {
         args.push(&self.out_name);
 
         // Out dir
-        let out_dir = self
+        let canonical_out_dir = self
             .out_dir
+            .canonicalize()
+            .expect("out_dir should resolve to a valid path");
+
+        let out_dir = canonical_out_dir
             .to_str()
-            .expect("input_path should be valid utf8");
+            .expect("out_dir should be valid UTF-8");
 
         args.push("--out-dir");
         args.push(out_dir);
@@ -342,11 +346,9 @@ impl WasmBindgenBuilder {
         }
     }
 
-    pub fn out_dir(self, out_dir: &Path) -> Self {
-        Self {
-            out_dir: out_dir.to_path_buf(),
-            ..self
-        }
+    pub fn out_dir(mut self, out_dir: &Path) -> Self {
+        self.out_dir = out_dir.canonicalize().expect("Invalid out_dir path");
+        self
     }
 
     pub fn out_name(self, out_name: &str) -> Self {


### PR DESCRIPTION
This fix ensures the out_dir configuration in Dioxus.toml is respected for web builds, allowing users to specify custom output directories. Key updates include:

- Added out_dir handling to resolve both relative and absolute paths.
- Ensured the directory is created if missing, with error logging.
- Introduced an out_dir field in ApplicationConfig (default: "dist") and integrated it into DioxusConfig for backward compatibility.
Users can now customize the build output directory seamlessly.