### PR TITLE
Fix the test_stream function running after the stream is closed

### DIFF
--- a/examples/fullstack-streaming/src/main.rs
+++ b/examples/fullstack-streaming/src/main.rs
@@ -30,7 +30,10 @@ pub async fn test_stream() -> Result<TextStream, ServerFnError> {
         loop {
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
             dioxus::logger::tracing::info!("Sending new chunk!");
-            let _ = tx.unbounded_send(Ok("Hello, world!".to_string()));
+            if tx.unbounded_send(Ok("Hello, world!".to_string())).is_err() {
+                // If the channel is closed, stop sending chunks
+                break;
+            }
         }
     });
 


### PR DESCRIPTION
The fullstack streaming server function example spawns a task that sends values into the channel, but it doesn't quit when the channel closes. This caused the future to keep running even after the client disconnected.