### PR TITLE
Move web.resource.style log to a warning

### DIFF
--- a/packages/cli/src/build/web.rs
+++ b/packages/cli/src/build/web.rs
@@ -179,7 +179,7 @@ impl BuildRequest {
             ResourceType::Script => "web.resource.script",
         };
 
-        tracing::debug!(
+        tracing::warn!(
             "{RESOURCE_DEPRECATION_MESSAGE}\nTo migrate to head components, remove `{section_name}` and include the following rsx in your root component:\n```rust\n{replacement_components}\n```"
         );
     }


### PR DESCRIPTION
The deprecation warning was at the `debug` level which only gets logged if customize the logging level manually when serving (turning on trace mode once the CLI is running does not show any debug logs). Alternatively, we could move the warning to `dx check`