### PR TITLE
Fix event closure invoked recursively

### DIFF
--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -80,7 +80,10 @@ impl WebsysDom {
 
         let interpreter = Interpreter::default();
 
-        let handler: Closure<dyn FnMut(&Event)> = Closure::wrap(Box::new({
+        // The closure type we pass to the dom may be invoked recursively if one event triggers another. For example,
+        // one event could focus another element which triggers the focus event of the new element like inhttps://github.com/DioxusLabs/dioxus/issues/2882.
+        // The Closure<dyn Fn(_)> type can invoked recursively, but Closure<dyn FnMut()> cannot
+        let handler: Closure<dyn Fn(&Event)> = Closure::wrap(Box::new({
             let runtime = runtime.clone();
             move |web_sys_event: &web_sys::Event| {
                 let name = web_sys_event.type_();


### PR DESCRIPTION
We were using the `Closure<dyn FnMut>` type for the event handling closure. Events can be invoked recursively sometimes which is not allowed with `Closure<dyn FnMut>`. Switching to `Closure<dyn Fn>` fixes the issue

Fixes #2882