### PR TITLE
Assume the virtual dom is not rendering while not diffing components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,6 +4051,8 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-wasm",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/packages/core/src/effect.rs
+++ b/packages/core/src/effect.rs
@@ -1,5 +1,4 @@
 use crate::innerlude::ScopeOrder;
-use crate::Runtime;
 use std::borrow::Borrow;
 use std::cell::RefCell;
 use std::collections::VecDeque;
@@ -29,13 +28,11 @@ impl Effect {
         self.effect.borrow_mut().push_back(Box::new(f));
     }
 
-    pub(crate) fn run(&self, runtime: &Runtime) {
-        runtime.rendering.set(false);
+    pub(crate) fn run(&self) {
         let mut effect = self.effect.borrow_mut();
         while let Some(f) = effect.pop_front() {
             f();
         }
-        runtime.rendering.set(true);
     }
 }
 

--- a/packages/core/src/tasks.rs
+++ b/packages/core/src/tasks.rs
@@ -275,7 +275,6 @@ impl Runtime {
 
         // poll the future with the scope on the stack
         let poll_result = self.with_scope_on_stack(task.scope, || {
-            self.rendering.set(false);
             self.current_task.set(Some(id));
 
             let poll_result = task.task.borrow_mut().as_mut().poll(&mut cx);
@@ -293,7 +292,6 @@ impl Runtime {
 
             poll_result
         });
-        self.rendering.set(true);
         self.current_task.set(None);
 
         poll_result

--- a/packages/playwright-tests/web.spec.js
+++ b/packages/playwright-tests/web.spec.js
@@ -119,8 +119,8 @@ test("onmounted", async ({ page }) => {
 test("web-sys closure", async ({ page }) => {
   await page.goto("http://localhost:9999");
   // wait until the div is mounted
-  await page.waitForSelector("div#web-sys-closure-div");
-  await page.keyboard.press("Enter");
   const scrollDiv = page.locator("div#web-sys-closure-div");
+  await scrollDiv.waitFor({ state: "attached" });
+  await page.keyboard.press("Enter");
   await expect(scrollDiv).toHaveText("the keydown event was triggered");
 });

--- a/packages/playwright-tests/web.spec.js
+++ b/packages/playwright-tests/web.spec.js
@@ -115,3 +115,12 @@ test("onmounted", async ({ page }) => {
   const mountedDiv = page.locator("div.onmounted-div");
   await expect(mountedDiv).toHaveText("onmounted was called 1 times");
 });
+
+test("web-sys closure", async ({ page }) => {
+  await page.goto("http://localhost:9999");
+  // wait until the div is mounted
+  await page.waitForSelector("div#web-sys-closure-div");
+  await page.keyboard.press("Enter");
+  const scrollDiv = page.locator("div#web-sys-closure-div");
+  await expect(scrollDiv).toHaveText("the keydown event was triggered");
+});

--- a/packages/playwright-tests/web/Cargo.toml
+++ b/packages/playwright-tests/web/Cargo.toml
@@ -11,3 +11,5 @@ dioxus = { workspace = true, features = ["web"]}
 serde_json = "1.0.96"
 tracing.workspace = true
 tracing-wasm = "0.2.1"
+wasm-bindgen.workspace = true
+web-sys = { workspace = true, features = ["Element", "Window"] }

--- a/packages/playwright-tests/web/src/main.rs
+++ b/packages/playwright-tests/web/src/main.rs
@@ -1,6 +1,7 @@
 // This test is used by playwright configured in the root of the repo
 
 use dioxus::prelude::*;
+use wasm_bindgen::prelude::*;
 
 fn app() -> Element {
     let mut num = use_signal(|| 0);
@@ -53,6 +54,7 @@ fn app() -> Element {
         div { class: "eval-result", "{eval_result}" }
         PreventDefault {}
         OnMounted {}
+        WebSysClosure {}
     }
 }
 
@@ -82,6 +84,49 @@ fn OnMounted() -> Element {
                 mounted_triggered_count += 1;
             },
             "onmounted was called {mounted_triggered_count} times"
+        }
+    }
+}
+
+// This component tests attaching an event listener to the document with a web-sys closure
+// and effect
+#[component]
+fn WebSysClosure() -> Element {
+    static TRIGGERED: GlobalSignal<bool> = GlobalSignal::new(|| false);
+    use_effect(|| {
+        let window = web_sys::window().expect("window not available");
+
+        // Assert the component contents have been mounted
+        window
+            .document()
+            .unwrap()
+            .get_element_by_id("web-sys-closure-div")
+            .expect("Effects should only be run after all contents have bene mounted to the dom");
+
+        // Make sure passing the runtime into the closure works
+        let callback = Callback::new(|_| {
+            assert!(!dioxus::dioxus_core::vdom_is_rendering());
+            *TRIGGERED.write() = true;
+        });
+        let closure: Closure<dyn Fn()> = Closure::new({
+            move || {
+                callback(());
+            }
+        });
+
+        window
+            .add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref())
+            .expect("Failed to add keydown event listener");
+
+        closure.forget();
+    });
+
+    rsx! {
+        div {
+            id: "web-sys-closure-div",
+            if TRIGGERED() {
+                "the keydown event was triggered"
+            }
         }
     }
 }


### PR DESCRIPTION
We currently assume everything except tasks, events, and effects happens while the vdom is rendering. This causes issues with external callbacks in the dom like a scroll handler attached to the window. The rendering flag is used both for warnings and to determine if signals should subscribe to components

This PR fixes those issues by only setting the rendering boolean while rendering and assuming everything else happens when the vdom is not rendering. It also adds a playwright test to check this behavior

Closes #3399