### PR TITLE
fix(fullstack): Allow configuration of the public_path

### DIFF
--- a/packages/fullstack/src/serve_config.rs
+++ b/packages/fullstack/src/serve_config.rs
@@ -215,6 +215,10 @@ impl TryInto<ServeConfig> for ServeConfigBuilder {
 
 /// Get the path to the public assets directory to serve static files from
 pub(crate) fn public_path() -> PathBuf {
+    if let Ok(path) = std::env::var("DIOXUS_PUBLIC_PATH") {
+        return PathBuf::from(path);
+    }
+
     // The CLI always bundles static assets into the exe/public directory
     std::env::current_exe()
         .expect("Failed to get current executable path")


### PR DESCRIPTION
This was annoying me. I don't think the default is always sensible.

I ran the tests and they passed, but haven't yet tried running the code.