### PR TITLE
Make `Routable` derive macro hygienic

### DIFF
--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -257,13 +257,15 @@ pub fn routable(input: TokenStream) -> TokenStream {
     let routable_impl = route_enum.routable_impl();
 
     (quote! {
-        #error_type
+        const _: () = {
+            #error_type
 
-        #display_impl
+            #display_impl
 
-        #routable_impl
+            #routable_impl
 
-        #parse_impl
+            #parse_impl
+        };
     })
     .into()
 }


### PR DESCRIPTION
Makes the `Routable` derive macro hygienic by wrapping the output in an anonymous scope.

This allows multiple routers to be defined in the same scope if necessary (e.g. for testing purposes, macro generation, etc.).