### PR TITLE
Add a nix devShell for webapp development

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
         "type": "github"
       },
       "original": {
@@ -18,13 +18,56 @@
         "type": "github"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1733346208,
+        "narHash": "sha256-a4WZp1xQkrnA4BbnKrzJNr+dYoQr5Xneh2syJoddFyE=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "378614f37a6bee5a3f2ef4f825a73d948d3ae921",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724395761,
-        "narHash": "sha256-zRkDV/nbrnp3Y8oCADf5ETl1sDrdmAW6/bBVJ8EbIdQ=",
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
+        "path": "/nix/store/yw6kg4rb9v8s3ypjbpspig5r81m4lr5s-source",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1733096140,
+        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1734435836,
+        "narHash": "sha256-kMBQ5PRiFLagltK0sH+08aiNt3zGERC2297iB6vrvlU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae815cee91b417be55d43781eb4b73ae1ecc396c",
+        "rev": "4989a246d7a390a859852baddb1013f825435cee",
         "type": "github"
       },
       "original": {
@@ -34,25 +77,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
+    "nixpkgs_3": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1718428119,
-        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -65,21 +96,22 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay",
         "systems": "systems"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1724638882,
-        "narHash": "sha256-ap2jIQi/FuUHR6HCht6ASWhoz8EiB99XmI8Esot38VE=",
+        "lastModified": 1734834660,
+        "narHash": "sha256-bm8V+Cu8rWJA+vKQnc94mXTpSDgvedyoDKxTVi/uJfw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "19b70f147b9c67a759e35824b241f1ed92e46694",
+        "rev": "b070e6030118680977bc2388868c4b3963872134",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
+    naersk.url = "github:nix-community/naersk";
 
     rust-overlay.url = "github:oxalica/rust-overlay";
     # crane.url = "github:ipetkov/crane";
@@ -43,13 +44,21 @@
           # This is useful when building crates as packages
           # Note that it does require a `Cargo.lock` which this repo does not have
           # craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
-        in
+        in rec
         {
           _module.args.pkgs = import inputs.nixpkgs {
             inherit system;
             overlays = [
               inputs.rust-overlay.overlays.default
             ];
+          };
+
+          packages.dx = let
+            naersk' = pkgs.callPackage inputs.naersk {};
+          in naersk'.buildPackage {
+            name = "dioxus-cli";
+            src = ./.;
+            cargoBuildOptions = prev: prev ++ [ "-p" "dioxus-cli" ];
           };
 
           devShells.default = pkgs.mkShell {
@@ -64,6 +73,35 @@
               export RUST_SRC_PATH="${rustToolchain}/lib/rustlib/src/rust/library";
             '';
           };
+
+          devShells.web = pkgs.mkShell {
+            name = "dioxus-web-devShell";
+            buildInputs = with pkgs; [
+              openssl
+              pkg-config
+              cacert
+
+              (rust-bin.stable.latest.default.override {
+                extensions = [ "rust-src" "rust-analyzer" "rust-std" ];
+                targets = [ "wasm32-unknown-unknown" ];
+              })
+              (pkgs.writeShellApplication {
+                name = "rustup";
+                text = ''
+                    #!/bin/sh
+                    echo "installed targets for active toolchain"
+                    echo "--------------------------------------"
+                    echo "wasm32-unknown-unknown"
+                    echo "x86_64-unknown-linux-gnu"
+                '';
+              }) # mock rustup to pass dx toolchain verification
+              packages.dx
+            ];
+            shellHook = ''
+
+            '';
+          };
+
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,10 @@
             name = "dioxus-cli";
             src = ./.;
             cargoBuildOptions = prev: prev ++ [ "-p" "dioxus-cli" ];
+
+            meta = {
+              mainProgram = "dx";
+            };
           };
 
           devShells.default = pkgs.mkShell {


### PR DESCRIPTION
In addition to the existing nix devShell config, which is for developing `dioxus` itself, this pull request adds a `web` devShell for developing web applications with dioxus.

Although `dioxus-cli` is available in nixpkgs, it does not update with main branch and it doesn't integrate well with versioned rust environment (due to the missing or non-functioning `rustup`). The new devShell config builds `dx` based on the repo and inserts a mock-up `rustup` to bypass `dx`'s toolchain verification process, allowing it to automatically install the corresponding versioned `wasm-bindgen` (I couldn't come up with a better way to make it use a `wasm-bindgen` provided by the flake, other than wrapping `dx` with modified `$XDG_STATE_HOME`, which would also interfere with other parts of the program using related envvars).

Fixes https://github.com/DioxusLabs/dioxus/issues/3083 (sort of?)