### PR TITLE
Return None in autodetect_on_cargo_feature on other platforms

### DIFF
--- a/packages/cli/src/platform.rs
+++ b/packages/cli/src/platform.rs
@@ -173,6 +173,11 @@ impl Platform {
                 {
                     Some(Platform::Linux)
                 }
+                // Possibly need a something for freebsd? Maybe default to Linux?
+                #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+                {
+                    None
+                }
             }
             "mobile" => None,
             "liveview" => Some(Platform::Liveview),


### PR DESCRIPTION
A user in the discord tried to compile the cli on FreeBSD, but it failed due to nothing being returned inside autodetect_on_cargo_feature due to freebsd not being covered. As they wanted just to compile for web, returning None might work, but maybe an additional check for freebsd and returning Linux might be needed?