### PR TITLE
Fix: WindowCloseBehaviour

### DIFF
--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -9,7 +9,7 @@ use dioxus::desktop::*;
 use dioxus::prelude::*;
 fn main() {
     dioxus::LaunchBuilder::desktop()
-        .with_cfg(Config::new().with_close_behaviour(WindowCloseBehaviour::LastWindowHides))
+        .with_cfg(Config::new().with_close_behaviour(WindowCloseBehaviour::WindowHides))
         .launch(app);
 }
 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,28 +1,35 @@
-//! Multiwindow example
+//! Multiwindow with tray icon example
 //!
 //! This example shows how to implement a simple multiwindow application using dioxus.
 //! This works by spawning a new window when the user clicks a button. We have to build a new virtualdom which has its
 //! own context, root elements, etc.
 
+use dioxus::desktop::trayicon::*;
+use dioxus::desktop::*;
 use dioxus::prelude::*;
-
 fn main() {
-    dioxus::LaunchBuilder::desktop().launch(app);
+    dioxus::LaunchBuilder::desktop()
+        .with_cfg(Config::new().with_close_behaviour(WindowCloseBehaviour::LastWindowHides))
+        .launch(app);
 }
 
 fn app() -> Element {
-    let onclick = move |_| {
+    // new window needs to be in async, otherwise it freezes
+    let onclick = move |_| async move {
         let dom = VirtualDom::new(popup);
         dioxus::desktop::window().new_window(dom, Default::default());
     };
-
+    init_tray_icon(default_tray_icon(), None);
     rsx! {
+        //"{TRAY.peek().id().0}"
         button { onclick, "New Window" }
     }
 }
 
 fn popup() -> Element {
     rsx! {
-        div { "This is a popup window!" }
+        div {
+            //"{TRAY.peek().id().0}"
+            "This is a popup window!" }
     }
 }

--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -23,8 +23,10 @@ type CustomEventHandler = Box<
 pub enum WindowCloseBehaviour {
     /// Default behaviour, closing the last window exits the app
     LastWindowExitsApp,
-    /// Closing the last window will not actually close it, just hide it
+    /// Closes all windows, except for the last window which will get hidden
     LastWindowHides,
+    /// All windows will just hide on close
+    WindowHides,
     /// Closing the last window will close it but the app will keep running so that new windows can be opened
     CloseWindow,
 }


### PR DESCRIPTION
Closes: #3113
Fixes window not hiding for WindowCloseBehaviour:LastWindowHides, 

WindowCloseBehaviour:LastWindowHides had a comment "Closing the last window will not actually close it, just hide it" but it was implemented in a way that hides all the windows so I added WindowCloseBehaviour:WindowHides that does that, and changed LastWindowHides so that it only hides on the last one, and removes the rest.

Changed multiwindow example to include tray icon & WindowCloseBehaviour:WindowHides

Temporary fix for new window not closing #3342 or at least I think that there is something else going on here and hiding the closed window is just a temporary solution to this problem since it worked in 0.5 without that.

I also changed multiwindow example to use async move, if you don't use it it gets stuck on 
https://github.com/DioxusLabs/dioxus/blob/30f760ca1503a10694fee1cd345de8d0174d14c5/packages/desktop/src/webview.rs#L383