### PR TITLE
Make the asset collection keep track of all of the destinations (#3467)

### DIFF
--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -385,7 +385,7 @@ impl AppBundle {
             .assets
             .assets
             .values()
-            .map(|a| asset_dir.join(a.bundled_path()))
+            .flat_map(|a| a.keys().cloned())
             .collect();
         // one possible implementation of walking a directory only visiting files
         fn remove_old_assets<'a>(
@@ -422,11 +422,12 @@ impl AppBundle {
         let mut assets_to_transfer = vec![];
 
         // Queue the bundled assets
-        for (asset, bundled) in &self.app.assets.assets {
-            let from = asset.clone();
-            let to = asset_dir.join(bundled.bundled_path());
-            tracing::debug!("Copying asset {from:?} to {to:?}");
-            assets_to_transfer.push((from, to, *bundled.options()));
+        for (from, bundled) in &self.app.assets.assets {
+            for (bundled_path, bundled) in bundled.iter() {
+                let to = asset_dir.join(bundled_path);
+                tracing::debug!("Copying asset {from:?} to {to:?}");
+                assets_to_transfer.push((from.clone(), to, *bundled.options()));
+            }
         }
 
         // And then queue the legacy assets

--- a/packages/cli/src/serve/handle.rs
+++ b/packages/cli/src/serve/handle.rs
@@ -195,10 +195,12 @@ impl AppHandle {
 
         // The asset might've been renamed thanks to the manifest, let's attempt to reload that too
         if let Some(resource) = self.app.app.assets.assets.get(&changed_file).as_ref() {
-            let res = std::fs::copy(&changed_file, asset_dir.join(resource.bundled_path()));
-            bundled_name = Some(PathBuf::from(resource.bundled_path()));
-            if let Err(e) = res {
-                tracing::debug!("Failed to hotreload asset {e}");
+            for bundled_path in resource.keys() {
+                let res = std::fs::copy(&changed_file, asset_dir.join(bundled_path));
+                bundled_name = Some(bundled_path.clone());
+                if let Err(e) = res {
+                    tracing::debug!("Failed to hotreload asset {e}");
+                }
             }
         }
 


### PR DESCRIPTION
This fixes the issue I mentioned in #3467, where the use of two asset! macro usages was not being treated correctly by the handler.

BEFORE you merge: Please notice that the code at: packages/cli/src/serve/handle.rs is ""wrong"" (and it was wrong before as well). It does a simple file copy without checking if it needs to be processed in any way, which is likely to lead to issues when dealing with images. I have not encountered this problem though and I don't know what purpose it serves. If you consider this to be an issue, I'd encourage you to make an issue about it.