### PR TITLE
Fixed asset path resolver to use the second segment instead of first.

### DIFF
--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -57,7 +57,7 @@ pub(super) fn desktop_handler(
     }
 
     // todo: we want to move the custom assets onto a different protocol or something
-    if let Some(name) = request.uri().path().split('/').next() {
+    if let Some(name) = request.uri().path().split('/').nth(1) {
         if asset_handlers.has_handler(name) {
             let _name = name.to_string();
             return asset_handlers.handle_request(&_name, request, responder);


### PR DESCRIPTION
In the dynamic path example

```rust
fn app() -> Element {
    use_asset_handler("logos", |request, response| {
        // We get the original path - make sure you handle that!
        if request.uri().path() != "/logos/logo.png" {
            return;
        }

        response.respond(Response::new(include_bytes!("./assets/logo.png").to_vec()));
    });

    rsx! {
        document::Link { rel: "stylesheet", href: STYLE }
        h1 { "Dynamic Assets" }
        img { src: "/logos/logo.png" }
    }
}

```

The expected behavior is that because `/logos/logo.png` has first  path segment "logos" that it would match the use asset handler with the name argument of "logos"
except this code

```rust
 // todo: we want to move the custom assets onto a different protocol or something
    if let Some(name) = request.uri().path().split('/').next() {
        if asset_handlers.has_handler(name) {
            let _name = name.to_string();
            return asset_handlers.handle_request(&_name, request, responder);
        }
    }
 ```
 
 Doesn't do that.
Given a uri path of "/logos/logo.png" the first element of the array of the split method is the segment before the first '/' thus "" which is not the first path segment but the first skip result.
The expected behavior is that this would be the second element of the skip result.
I added `.nth(1)` to satisfy this.