### PR TITLE
Fix mounted event after initial hydration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-playwright-fullstack-mounted-test"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "dioxus-playwright-fullstack-test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ members = [
     "packages/playwright-tests/liveview",
     "packages/playwright-tests/web",
     "packages/playwright-tests/fullstack",
+    "packages/playwright-tests/fullstack-mounted",
     "packages/playwright-tests/suspense-carousel",
     "packages/playwright-tests/nested-suspense",
 ]

--- a/packages/playwright-tests/fullstack-mounted.spec.js
+++ b/packages/playwright-tests/fullstack-mounted.spec.js
@@ -1,0 +1,10 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+test("hydration", async ({ page }) => {
+  await page.goto("http://localhost:7777");
+
+  // Expect the page to contain the pending text.
+  const main = page.locator("#main");
+  await expect(main).toContainText("The mounted event was triggered.");
+});

--- a/packages/playwright-tests/fullstack-mounted/Cargo.toml
+++ b/packages/playwright-tests/fullstack-mounted/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "dioxus-playwright-fullstack-mounted-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dioxus = { workspace = true, features = ["fullstack"] }
+serde = "1.0.159"
+tokio = { workspace = true, features = ["full"], optional = true }
+
+[features]
+default = []
+server = ["dioxus/server", "dep:tokio"]
+web = ["dioxus/web"]

--- a/packages/playwright-tests/fullstack-mounted/src/main.rs
+++ b/packages/playwright-tests/fullstack-mounted/src/main.rs
@@ -1,0 +1,23 @@
+// Regression test for https://github.com/DioxusLabs/dioxus/pull/3480
+
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::launch(App);
+}
+
+#[component]
+fn App() -> Element {
+    let mut mounted = use_signal(|| false);
+
+    rsx! {
+        div {
+            onmounted: move |_| {
+                mounted.set(true);
+            },
+            if mounted() {
+                "The mounted event was triggered."
+            }
+        }
+    }
+}

--- a/packages/playwright-tests/playwright.config.js
+++ b/packages/playwright-tests/playwright.config.js
@@ -103,6 +103,15 @@ module.exports = defineConfig({
       stdout: "pipe",
     },
     {
+      cwd: path.join(process.cwd(), "fullstack-mounted"),
+      command:
+        'cargo run --package dioxus-cli --release -- serve --force-sequential --platform web --addr "127.0.0.1" --port 7777',
+      port: 7777,
+      timeout: 50 * 60 * 1000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+    },
+    {
       cwd: path.join(process.cwd(), "suspense-carousel"),
       command:
         'cargo run --package dioxus-cli --release -- serve --force-sequential --platform web --addr "127.0.0.1" --port 4040',

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -105,6 +105,12 @@ pub async fn run(mut virtual_dom: VirtualDom, web_config: Config) -> ! {
 
             let rx = websys_dom.rehydrate(&virtual_dom).unwrap();
             hydration_receiver = Some(rx);
+
+            #[cfg(feature = "mounted")]
+            {
+                // Flush any mounted events that were queued up while hydrating
+                websys_dom.flush_queued_mounted_events();
+            }
         }
         #[cfg(not(feature = "hydrate"))]
         {

--- a/packages/web/src/mutations.rs
+++ b/packages/web/src/mutations.rs
@@ -59,7 +59,7 @@ impl WebsysDom {
     }
 
     #[cfg(feature = "mounted")]
-    fn flush_queued_mounted_events(&mut self) {
+    pub(crate) fn flush_queued_mounted_events(&mut self) {
         for id in self.queued_mounted_events.drain(..) {
             let node = self.interpreter.base().get_node(id.0 as u32);
             if let Some(element) = node.dyn_ref::<web_sys::Element>() {


### PR DESCRIPTION
The mounted event was not being triggered after hydration when no other edits were queued. This PR fixes that issue and adds a playwright test to prevent regressions