### PR TITLE
remove version pin on tao

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13469,9 +13469,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.31.0"
+version = "0.30.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b53216f32e60efc27dfa111268481e4dfba53e553e4cdebcaed9db36c11bb"
+checksum = "6682a07cf5bab0b8a2bd20d0a542917ab928b5edb75ebd4eda6b05cbaab872da"
 dependencies = [
  "bitflags 2.6.0",
  "cocoa 0.26.0",
@@ -13484,6 +13484,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
+ "instant",
  "jni",
  "lazy_static",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13469,9 +13469,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a93f2c6b8fdaeb7f417bda89b5bc767999745c3052969664ae1fa65892deb7e"
+checksum = "cc6b53216f32e60efc27dfa111268481e4dfba53e553e4cdebcaed9db36c11bb"
 dependencies = [
  "bitflags 2.6.0",
  "cocoa 0.26.0",
@@ -13484,7 +13484,6 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "instant",
  "jni",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ console_error_panic_hook = "0.1.7"
 
 # desktop
 wry = { version = "0.45.0", default-features = false }
-tao = { version = "0.30.0", features = ["rwh_05"] }
+tao = { version = "0.30.8", features = ["rwh_05"] }
 webbrowser = "1.0.1"
 infer = "0.16.0"
 dunce = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ console_error_panic_hook = "0.1.7"
 
 # desktop
 wry = { version = "0.45.0", default-features = false }
-tao = { version = "=0.31.0", features = ["rwh_05"] }
+tao = { version = "0.30.0", features = ["rwh_05"] }
 webbrowser = "1.0.1"
 infer = "0.16.0"
 dunce = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ console_error_panic_hook = "0.1.7"
 
 # desktop
 wry = { version = "0.45.0", default-features = false }
-tao = { version = "=0.30.0", features = ["rwh_05"] }
+tao = { version = "=0.31.0", features = ["rwh_05"] }
 webbrowser = "1.0.1"
 infer = "0.16.0"
 dunce = "1.0.2"


### PR DESCRIPTION
Version 0.30.3 of tao includes the fix for the window resize issue on Wayland.

Fixes #3314