### PR TITLE
fix: pin cargo-msrv to older version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           cache-all-crates: "true"
       # https://github.com/foresterre/cargo-msrv/blob/4345edfe3f4fc91cc8ae6c7d6804c0748fae92ae/.github/workflows/msrv.yml
       - name: install_cargo_msrv
-        run: cargo install cargo-msrv --all-features --version 0.16.3
+        run: cargo install cargo-msrv --all-features --version 0.16.3 --locked
       - name: version_of_cargo_msrv
         run: cargo msrv --version
       - name: run_cargo_msrv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
           cache-all-crates: "true"
       # https://github.com/foresterre/cargo-msrv/blob/4345edfe3f4fc91cc8ae6c7d6804c0748fae92ae/.github/workflows/msrv.yml
       - name: install_cargo_msrv
-        run: cargo install cargo-msrv --all-features
+        run: cargo install cargo-msrv --all-features --version 0.16.3
       - name: version_of_cargo_msrv
         run: cargo msrv --version
       - name: run_cargo_msrv


### PR DESCRIPTION
The [cargo-msrv](https://crates.io/crates/cargo-msrv) crate released a new version which does not compile on Rust > 1.81 which breaks our msrv (1.79). This pins cargo-msrv to a fixed version keeping its msrv down.