### PR TITLE
Fix opening fullstack and server crash logging in the CLI

### DIFF
--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -79,7 +79,7 @@ impl AppRunner {
                     },
                     Some(status) = OptionFuture::from(handle.server_child.as_mut().map(|f| f.wait())) => {
                         match status {
-                            Ok(status) => ProcessExited { status, platform: Platform::Server },
+                            Ok(status) => ProcessExited { status, platform },
                             Err(_err) => todo!("handle error in process joining?"),
                         }
                     }


### PR DESCRIPTION
Fixes #3295 and Fixes #3477 which was caused by the CLI opening a new instance of the server every time the open shortcut is used

Fixes #3296 which was caused by the CLI trying to close the `Server` platform instead of the platform the server is launched under (generally `Web` or `Desktop`)
