### PR TITLE
Get server address from cli in fullstack-auth example. 

### DIFF
--- a/examples/fullstack-auth/Cargo.toml
+++ b/examples/fullstack-auth/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 dioxus-web = { workspace = true, features = ["hydrate"], optional = true }
 dioxus = { features = ["fullstack"], workspace = true }
 dioxus-fullstack = { workspace = true }
+dioxus-cli-config = { workspace = true, optional = true }
 axum = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["full"], optional = true }
 tower-http = { workspace = true, features = ["auth"], optional = true }
@@ -43,5 +44,17 @@ optional = true
 
 [features]
 default = []
-server = ["axum", "tokio", "dioxus-fullstack/axum", "tower-http", "async-trait", "sqlx", "axum_session", "axum_session_auth", "http", "tower"]
+server = [
+    "dioxus-cli-config",
+    "axum",
+    "tokio",
+    "dioxus-fullstack/axum",
+    "tower-http",
+    "async-trait",
+    "sqlx",
+    "axum_session",
+    "axum_session_auth",
+    "http",
+    "tower",
+]
 web = ["dioxus-web"]

--- a/examples/fullstack-auth/src/main.rs
+++ b/examples/fullstack-auth/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
                     .layer(axum_session::SessionLayer::new(session_store));
 
                 // run it
-                let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3000));
+                let addr = dioxus_cli_config::fullstack_address_or_localhost();
                 let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
 
                 axum::serve(listener, app.into_make_service())


### PR DESCRIPTION
Fixes #3363.

The example is served to a hardcoded port 3000, while the cli expects to connect to 8080 by default. Using `dioxus_cli_config::fullstack_address_or_localhost`,  the proper address can be used by the server. This is consistent with the documentation for [dioxus-fullstack](https://github.com/DioxusLabs/dioxus/tree/main/packages/fullstack#axum-integration).

Note that because of the issue fixed in #3359, what works is `dx serve --client-features dioxus-web/mounted --open`, where the `mounted` feature enables the web-sys feature `DomRect`, which enables `DomRectReadOnly`. 