### PR TITLE
Fix(cli) preserve server child process in open.

### DIFF
--- a/packages/cli/src/serve/handle.rs
+++ b/packages/cli/src/serve/handle.rs
@@ -94,20 +94,22 @@ impl AppHandle {
             envs.push((dioxus_cli_config::SERVER_PORT_ENV, addr.port().to_string()));
         }
 
-        // Launch the server if we have one and consume its stdout/stderr
-        if let Some(server) = self.app.server_exe() {
-            tracing::debug!("Launching server from path: {server:?}");
-            let mut child = Command::new(server)
-                .envs(envs.clone())
-                .stderr(Stdio::piped())
-                .stdout(Stdio::piped())
-                .kill_on_drop(true)
-                .spawn()?;
-            let stdout = BufReader::new(child.stdout.take().unwrap());
-            let stderr = BufReader::new(child.stderr.take().unwrap());
-            self.server_stdout = Some(stdout.lines());
-            self.server_stderr = Some(stderr.lines());
-            self.server_child = Some(child);
+        if self.server_child.is_none() {
+            // Launch the server if we have one and consume its stdout/stderr
+            if let Some(server) = self.app.server_exe() {
+                tracing::debug!("Launching server from path: {server:?}");
+                let mut child = Command::new(server)
+                    .envs(envs.clone())
+                    .stderr(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .kill_on_drop(true)
+                    .spawn()?;
+                let stdout = BufReader::new(child.stdout.take().unwrap());
+                let stderr = BufReader::new(child.stderr.take().unwrap());
+                self.server_stdout = Some(stdout.lines());
+                self.server_stderr = Some(stderr.lines());
+                self.server_child = Some(child);
+            }
         }
 
         // We try to use stdin/stdout to communicate with the app


### PR DESCRIPTION
Fixes  #3477.

Currently opening the app from the cli replaces the server child process, creating a conflict if there is an existing one. This PR preserves the current process. 

Can be tested with the fullstack-hello-world example:

```
cd examples/fullstack-hello-world
cargo run -p dioxus-cli -- serve
o
```