### PR TITLE
Fix the event handler memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3641,6 +3641,7 @@ dependencies = [
  "serde",
  "slab",
  "slotmap",
+ "sysinfo",
  "tokio",
  "tracing",
  "tracing-fluent-assertions",
@@ -8249,6 +8250,15 @@ dependencies = [
  "serde",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -13413,6 +13423,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15090,8 +15114,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.58.0",
  "windows-core 0.58.0",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
 ]
 
 [[package]]
@@ -15323,6 +15347,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -15342,15 +15376,38 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
  "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -15358,6 +15415,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15381,7 +15449,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
@@ -15392,8 +15460,17 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafa604f2104cf5ae2cc2db1dee84b7e6a5d11b05f737b60def0ffdc398cbc0a"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -15412,7 +15489,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -34,6 +34,7 @@ reqwest = { workspace = true }
 tracing-subscriber = { workspace = true, default-features = true }
 tracing-fluent-assertions = "0.3.0"
 pretty_assertions = "1.3.0"
+sysinfo = "0.33.1"
 
 [dev-dependencies.web-sys]
 version = "0.3.56"

--- a/packages/core/tests/memory_leak.rs
+++ b/packages/core/tests/memory_leak.rs
@@ -30,7 +30,26 @@ async fn test_for_memory_leaks() {
                     div {
                         onclick: move |_| { println!("click"); },
                     }
+                    AcceptsEventHandlerAndReadOnlySignal {
+                        event_handler: move |_| { println!("click"); },
+                        signal: el,
+                    }
                 }
+            }
+        }
+    }
+
+    // Event handlers and ReadOnlySignals have extra logic on component boundaries that has caused memory leaks
+    // in the past
+    #[component]
+    fn AcceptsEventHandlerAndReadOnlySignal(
+        event_handler: EventHandler<MouseEvent>,
+        signal: ReadOnlySignal<i32>,
+    ) -> Element {
+        rsx! {
+            div {
+                onclick: event_handler,
+                "{signal}"
             }
         }
     }

--- a/packages/core/tests/memory_leak.rs
+++ b/packages/core/tests/memory_leak.rs
@@ -1,0 +1,73 @@
+#![allow(non_snake_case)]
+use dioxus::prelude::dioxus_core::NoOpMutations;
+use dioxus::prelude::*;
+use sysinfo::{ProcessRefreshKind, RefreshKind, System};
+
+// Regression test for https://github.com/DioxusLabs/dioxus/issues/3421
+#[tokio::test]
+async fn test_for_memory_leaks() {
+    fn app() -> Element {
+        let mut count = use_signal(|| 0);
+
+        use_hook(|| {
+            spawn(async move {
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
+                    let val = *count.peek_unchecked();
+                    if val == 70 {
+                        count.set(0);
+                    } else {
+                        count.set(val + 1);
+                    }
+                }
+            })
+        });
+
+        rsx! {
+            for el in 0..*count.read() {
+                div {
+                    key: "{el}",
+                    div {
+                        onclick: move |_| { println!("click"); },
+                    }
+                }
+            }
+        }
+    }
+
+    // create the vdom, the real_dom, and the binding layer between them
+    let mut vdom = VirtualDom::new(app);
+
+    vdom.rebuild(&mut NoOpMutations);
+
+    let pid = sysinfo::get_current_pid().expect("failed to get PID");
+
+    let refresh =
+        RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing().with_memory());
+    let mut system = System::new_with_specifics(refresh);
+
+    let mut get_memory_usage = || {
+        system.refresh_specifics(refresh);
+        let this_process = system.process(pid).expect("failed to get process");
+        this_process.memory()
+    };
+
+    let initial_memory_usage = get_memory_usage();
+
+    // we need to run the vdom in a async runtime
+    for i in 0..=10000 {
+        // wait for the vdom to update
+        vdom.wait_for_work().await;
+
+        // get the mutations from the vdom
+        vdom.render_immediate(&mut NoOpMutations);
+
+        if i % 1000 == 0 {
+            let new_memory_usage = get_memory_usage();
+            println!("iteration: {} memory usage: {}", i, new_memory_usage);
+
+            // Memory usage might increase as arenas fill up, but it shouldn't double from the initial render
+            assert!(new_memory_usage < initial_memory_usage * 2);
+        }
+    }
+}


### PR DESCRIPTION
The event handler into implementation uses the current owner which defaults to the current scope. That causes a memory leak when repeatedly creating new event handlers on the same scope. This PR fixes the issue by overriding the owner to the closure

Fixes #3421