### PR TITLE
fix: bump futures-channel to prevent locked versions from conflicting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "anymap2"
@@ -3990,7 +3990,6 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "pretty_env_logger",
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
@@ -9558,16 +9557,6 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
-]
-
-[[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger 0.10.2",
- "log",
 ]
 
 [[package]]
@@ -15313,7 +15302,6 @@ dependencies = [
  "dioxus",
  "futures",
  "futures-channel",
- "pretty_env_logger",
  "tokio",
  "wifiscanner",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,8 +162,8 @@ toml = "0.8"
 tokio = "1.40"
 slab = "0.4.2"
 slotmap = { version = "1.0.7", features = ["serde"] }
-futures = "0.3.30"
-futures-channel = "0.3.21"
+futures = "0.3.31"
+futures-channel = "0.3.31"
 futures-util = { version = "0.3", default-features = false }
 rustc-hash = "1.1.0"
 wasm-bindgen = "0.2.99"
@@ -298,7 +298,7 @@ ouroboros = { version = "*", optional = true }
 [dev-dependencies]
 dioxus = { workspace = true, features = ["router"] }
 dioxus-ssr = { workspace = true }
-futures-util = "0.3.21"
+futures-util = "0.3.31"
 separator = "0.4.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ warnings = { version = "0.2.1" }
 
 # a fork of pretty please for tests - let's get off of this if we can!
 prettier-please = { version = "0.3.0", features = ["verbatim"]}
+anyhow = "1.0.95"
 clap = { version = "4.5.7" }
 askama_escape = "0.10.3"
 tracing = "0.1.37"

--- a/example-projects/wifi-scanner/Cargo.toml
+++ b/example-projects/wifi-scanner/Cargo.toml
@@ -7,10 +7,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.52"
-pretty_env_logger = "0.5.0"
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 dioxus = { workspace = true, features = ["desktop"] }
+futures-channel = { workspace = true }
+futures = { workspace = true }
 wifiscanner = "0.5.1"
-futures-channel = "0.3.19"
-futures = "0.3.19"

--- a/examples/fullstack-auth/Cargo.toml
+++ b/examples/fullstack-auth/Cargo.toml
@@ -27,9 +27,9 @@ sqlx = { version = "0.7.0", features = [
 http = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
 
-serde = "1.0.159"
 execute = "0.2.12"
-anyhow = "1.0.71"
+serde = { workspace = true }
+anyhow = { workspace = true }
 
 [dependencies.axum_session]
 workspace = true

--- a/packages/cli-opt/Cargo.toml
+++ b/packages/cli-opt/Cargo.toml
@@ -10,7 +10,7 @@ description = "CLI optimizations for dioxus-cli"
 keywords = ["dom", "ui", "gui", "react"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 manganis-core = { workspace = true }
 object = {version="0.36.0", features=["wasm"]}
 serde = { workspace = true, features = ["derive"] }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -39,7 +39,7 @@ cargo_metadata = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = "0.1.15"
 chrono = "0.4.19"
-anyhow = "1"
+anyhow = { workspace = true }
 hyper = { workspace = true }
 hyper-util = "0.1.3"
 hyper-rustls = { workspace = true }

--- a/packages/liveview/Cargo.toml
+++ b/packages/liveview/Cargo.toml
@@ -36,7 +36,6 @@ generational-box = { workspace = true }
 axum = { workspace = true, optional = true, features = ["ws"] }
 
 [dev-dependencies]
-pretty_env_logger = { version = "0.5.0" }
 tokio = { workspace = true, features = ["full"] }
 axum = { workspace = true, features = ["ws"] }
 tower = { workspace = true }

--- a/packages/liveview/examples/axum.rs
+++ b/packages/liveview/examples/axum.rs
@@ -15,7 +15,7 @@ fn app() -> Element {
 
 #[tokio::main]
 async fn main() {
-    pretty_env_logger::init();
+    dioxus::logger::initialize_default();
 
     let addr: std::net::SocketAddr = ([127, 0, 0, 1], 3030).into();
 

--- a/packages/liveview/examples/axum_stress.rs
+++ b/packages/liveview/examples/axum_stress.rs
@@ -21,7 +21,7 @@ fn app() -> Element {
 
 #[tokio::main]
 async fn main() {
-    pretty_env_logger::init();
+    dioxus::logger::initialize_default();
 
     let addr: std::net::SocketAddr = ([127, 0, 0, 1], 3030).into();
 


### PR DESCRIPTION
Fixes https://github.com/DioxusLabs/dioxus/issues/3053 by bumping our `futures-*` crates.

Also does some light cleanup on version hosting and uses `dioxus::logger::initialize_default()` instead of pretty_env_logger for the liveview examples