### PR TITLE
Fix undefined param cause uncaught error when call atob() in JS code

### DIFF
--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -85,7 +85,7 @@ pub async fn run(mut virtual_dom: VirtualDom, web_config: Config) -> ! {
             // Get the initial hydration data from the client
             #[wasm_bindgen::prelude::wasm_bindgen(inline_js = r#"
                 export function get_initial_hydration_data() {
-                    const decoded = atob(window.initial_dioxus_hydration_data);
+                    const decoded = atob(window.initial_dioxus_hydration_data || "");
                     return Uint8Array.from(decoded, (c) => c.charCodeAt(0))
                 }
                 export function get_initial_hydration_debug_types() {


### PR DESCRIPTION
<img width="878" alt="image" src="https://github.com/user-attachments/assets/1ce45a6d-0bcd-45a8-9c91-e20edc55f5dc" />
