### PR TITLE
fix: add additional lock when calling wait_for_work on android

### DIFF
--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -445,6 +445,8 @@ impl WebviewInstance {
             }
 
             {
+                // lock the hack-ed in lock sync wry has some thread-safety issues with event handlers and async tasks
+                let _lock = crate::android_sync_lock::android_runtime_lock();
                 let fut = self.dom.wait_for_work();
                 pin_mut!(fut);
 
@@ -454,13 +456,15 @@ impl WebviewInstance {
                 }
             }
 
-            // lock the hack-ed in lock sync wry has some thread-safety issues with event handlers
-            let _lock = crate::android_sync_lock::android_runtime_lock();
+            {
+                // lock the hack-ed in lock sync wry has some thread-safety issues with event handlers
+                let _lock = crate::android_sync_lock::android_runtime_lock();
 
-            self.edits
-                .wry_queue
-                .with_mutation_state_mut(|f| self.dom.render_immediate(f));
-            self.edits.wry_queue.send_edits();
+                self.edits
+                    .wry_queue
+                    .with_mutation_state_mut(|f| self.dom.render_immediate(f));
+                self.edits.wry_queue.send_edits();
+            }
         }
     }
 

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -456,15 +456,13 @@ impl WebviewInstance {
                 }
             }
 
-            {
-                // lock the hack-ed in lock sync wry has some thread-safety issues with event handlers
-                let _lock = crate::android_sync_lock::android_runtime_lock();
+            // lock the hack-ed in lock sync wry has some thread-safety issues with event handlers
+            let _lock = crate::android_sync_lock::android_runtime_lock();
 
-                self.edits
-                    .wry_queue
-                    .with_mutation_state_mut(|f| self.dom.render_immediate(f));
-                self.edits.wry_queue.send_edits();
-            }
+            self.edits
+                .wry_queue
+                .with_mutation_state_mut(|f| self.dom.render_immediate(f));
+            self.edits.wry_queue.send_edits();
         }
     }
 


### PR DESCRIPTION
The `android_runtime_lock` function helps paper over an issue in wry where event handlers are allowed to be ran concurrently across multiple threads even though the API takes single-threaded structures.

We need to lock the mutex when we call "wait_for_work" since that operation might poll async tasks still stuck in the queue.

Fixes #3464

I would like to get tests here at some point but that will require a proper android test harness