### PR TITLE
Fix: Asset Cache On Windows & Asset Status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "dioxus-rsx-hotreload",
  "dioxus-rsx-rosetta",
  "dirs",
+ "dunce",
  "env_logger 0.11.5",
  "escargot",
  "flate2",
@@ -7766,6 +7767,7 @@ dependencies = [
 name = "manganis-macro"
 version = "0.6.1"
 dependencies = [
+ "dunce",
  "manganis",
  "manganis-core",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,7 +230,7 @@ wry = { version = "0.45.0", default-features = false }
 tao = { version = "0.30.8", features = ["rwh_05"] }
 webbrowser = "1.0.1"
 infer = "0.16.0"
-dunce = "1.0.2"
+dunce = "1.0.5"
 urlencoding = "2.1.2"
 global-hotkey = "0.6.0"
 rfd = { version = "0.14", default-features = false }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -61,6 +61,7 @@ syn = { workspace = true, features = ["full", "extra-traits", "visit", "visit-mu
 
 headers = "0.4.0"
 walkdir = "2"
+dunce = { workspace = true }
 
 # tools download
 dirs = { workspace = true }

--- a/packages/cli/src/serve/handle.rs
+++ b/packages/cli/src/serve/handle.rs
@@ -2,7 +2,6 @@ use crate::{AppBundle, Platform, Result};
 use anyhow::Context;
 use dioxus_cli_opt::process_file_to;
 use std::{
-    fs,
     net::SocketAddr,
     path::{Path, PathBuf},
     process::Stdio,
@@ -190,7 +189,7 @@ impl AppHandle {
         }
 
         // Canonicalize the path as Windows may use long-form paths "\\\\?\\C:\\".
-        let changed_file = fs::canonicalize(changed_file)
+        let changed_file = dunce::canonicalize(changed_file)
             .inspect_err(|e| tracing::debug!("Failed to canonicalize hotreloaded asset: {e}"))
             .ok()?;
 

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { workspace = true, features = [
 ], optional = true }
 webbrowser = "0.8.0"
 infer = "0.11.0"
-dunce = "1.0.2"
+dunce = { workspace = true }
 slab = { workspace = true }
 rustc-hash = { workspace = true }
 dioxus-hooks = { workspace = true }

--- a/packages/manganis/manganis-macro/Cargo.toml
+++ b/packages/manganis/manganis-macro/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["full", "extra-traits"] }
 manganis-core = { workspace = true }
+dunce = { workspace = true }
 
 [features]
 default = []

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -17,11 +17,12 @@ fn resolve_path(raw: &str) -> Result<PathBuf, AssetParseError> {
     // /users/dioxus/dev/app/
     // is the root of
     // /users/dioxus/dev/app/assets/blah.css
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .map(PathBuf::from)
-        .unwrap()
-        .canonicalize()
-        .unwrap();
+    let manifest_dir = dunce::canonicalize(
+        std::env::var("CARGO_MANIFEST_DIR")
+            .map(PathBuf::from)
+            .unwrap(),
+    )
+    .unwrap();
 
     // 1. the input file should be a pathbuf
     let input = PathBuf::from(raw);
@@ -34,7 +35,7 @@ fn resolve_path(raw: &str) -> Result<PathBuf, AssetParseError> {
     };
 
     // 3. Ensure the path exists
-    let Ok(path) = path.canonicalize() else {
+    let Ok(path) = dunce::canonicalize(path) else {
         return Err(AssetParseError::AssetDoesntExist {
             path: input.clone(),
         });


### PR DESCRIPTION
**Problem**
Due to Windows' long-form path variants, cached assets were being deleted causing long rebuilds for apps with lots of assets e.g. docsite.

The asset status would jump around a lot in terms of progress.

**Fixes**
We use the `dunce` crate to canonicalize assets in a few places, replacing `fs::canonicalize`. The changes work well on Windows, but it would be good to test other platforms. There may be other places we should canonicalize.

The asset status now tracks the completed assets instead of the current asset.