### PR TITLE
Fix initialising tray icons on the macos desktop platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,7 +3702,7 @@ dependencies = [
  "infer 0.11.0",
  "jni",
  "lazy-js-bundle",
- "muda 0.11.5",
+ "muda",
  "ndk",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
@@ -8007,24 +8007,6 @@ dependencies = [
  "dunce",
  "libc",
  "nasm-rs",
-]
-
-[[package]]
-name = "muda"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c47e7625990fc1af2226ea4f34fb2412b03c12639fcb91868581eb3a6893453"
-dependencies = [
- "cocoa 0.25.0",
- "crossbeam-channel",
- "gtk",
- "keyboard-types",
- "libxdo",
- "objc",
- "once_cell",
- "png",
- "thiserror 1.0.69",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14331,7 +14313,7 @@ dependencies = [
  "crossbeam-channel",
  "dirs",
  "libappindicator",
- "muda 0.15.3",
+ "muda",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,7 +234,7 @@ dunce = "1.0.2"
 urlencoding = "2.1.2"
 global-hotkey = "0.6.0"
 rfd = { version = "0.14", default-features = false }
-muda = "0.14.0"
+muda = "0.15.3"
 cocoa = "0.26"
 core-foundation = "0.10.0"
 objc = { version = "0.2.7", features = ["exception"] }

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -71,7 +71,7 @@ wry = { workspace = true, features = [
 [target.'cfg(any(target_os = "windows",target_os = "macos",target_os = "linux",target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
 global-hotkey = "0.5.0"
 rfd = { version = "0.14", default-features = false, features = ["xdg-portal", "tokio"] }
-muda = "0.11.3"
+muda = { workspace = true }
 
 [target.'cfg(any(target_os = "windows",target_os = "macos",target_os = "linux"))'.dependencies]
 tray-icon = { workspace = true }


### PR DESCRIPTION
Depending on multiple versions of the `muda` crate - one directly and one via a transitive dependency in the tray-icon crate - leads to the following error when attempting to initialize a tray icon on the desktop platform, specifically on MacOS:

```
   6.858s  INFO Build completed successfully in 2882ms, launching app! 💫   7.871s  INFO [macos]: 2025-01-10 00:16:01.736 dimsum[19111:45581742] +[IMKClient subclass]: chose IMKClient_Modern
   7.876s  INFO [macos]:   7.876s  INFO [macos]: thread 'main' panicked at /Users/philippherzog/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/muda-0.15.3/src/platform_impl/macos/mod.rs:934:1:
   7.876s  INFO [macos]: could not create new class MudaMenuItem. Perhaps a class with that name already exists?
```

Without any prior knowledge on how the `muda` crate or MacOS tray icons work, it appears that `muda` generates some sort of class definition for MacOS whose identifier needs to be unique. Multiple versions of the crate will then lead to duplicate definitions and thereby the above crash at runtime. 

Since this only breaks at runtime and only on the MacOS target it's far from trivial to add a test to ensure this doesn't break again on the next `cargo update`. I'll open a related ticket in the muda repository, maybe they can think of a more robust solution.