### PR TITLE
Add server context to suspense resolution

### DIFF
--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -221,7 +221,10 @@ impl SsrRendererPool {
             // If streaming is disabled, wait for the virtual dom to finish all suspense work
             // before rendering anything
             if streaming_mode == StreamingMode::Disabled {
-                virtual_dom.wait_for_suspense().await;
+                ProvideServerContext::new(
+                    virtual_dom.wait_for_suspense(),
+                    server_context.clone(),
+                ).await
             }
 
             // Render the initial frame with loading placeholders

--- a/packages/fullstack/src/render.rs
+++ b/packages/fullstack/src/render.rs
@@ -221,10 +221,8 @@ impl SsrRendererPool {
             // If streaming is disabled, wait for the virtual dom to finish all suspense work
             // before rendering anything
             if streaming_mode == StreamingMode::Disabled {
-                ProvideServerContext::new(
-                    virtual_dom.wait_for_suspense(),
-                    server_context.clone(),
-                ).await
+                ProvideServerContext::new(virtual_dom.wait_for_suspense(), server_context.clone())
+                    .await
             }
 
             // Render the initial frame with loading placeholders


### PR DESCRIPTION
While this was done correctly in the streaming case, non-streaming suspense resolution didn't recieve the server context.  This meant that anything that required the context after the point of suspension would find it missing.

This resolves #3500 