### PR TITLE
fix: cli pakage name search

### DIFF
--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -45,13 +45,36 @@ impl DioxusCrate {
             TargetKind::Bin
         };
 
+        let main_package = &krates[package];
+
         let target_name = target
             .example
             .clone()
             .or(target.bin.clone())
+            .or_else(|| {
+                if let Some(default_run) = &main_package.default_run {
+                    return Some(default_run.to_string());
+                }
+
+                let bin_count = main_package
+                    .targets
+                    .iter()
+                    .filter(|x| x.kind.contains(&target_kind))
+                    .count();
+                if bin_count != 1 {
+                    return None;
+                }
+
+                main_package.targets.iter().find_map(|x| {
+                    if x.kind.contains(&target_kind) {
+                        Some(x.name.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
             .unwrap_or(package_name);
 
-        let main_package = &krates[package];
         let target = main_package
             .targets
             .iter()


### PR DESCRIPTION
Resolves https://github.com/DioxusLabs/dioxus/issues/3546

Now, if `bin` param not specified for dx it firstly fallback `default-run` target, secondly to single bin target thirdly to package name.

`default-run` case:
![image](https://github.com/user-attachments/assets/0f1ba561-b15f-46da-b809-a8461850ed9f)
![image](https://github.com/user-attachments/assets/5505d2bd-e79c-4956-b1d1-575e3e74a5c3)

single bin case:
![image](https://github.com/user-attachments/assets/71579e73-cf90-4d7e-b042-66aa87ef3f22)
![image](https://github.com/user-attachments/assets/98280eb3-aa82-490d-b742-1d16228bfa65)
