### PR TITLE
Fix hot reload diffing to empty rsx

### DIFF
--- a/packages/rsx-hotreload/src/diff.rs
+++ b/packages/rsx-hotreload/src/diff.rs
@@ -122,7 +122,10 @@ impl HotReloadResult {
         new: &TemplateBody,
         name: String,
     ) -> Option<Self> {
-        let full_rebuild_state = LastBuildState::new(full_rebuild_state, name);
+        // Normalize both the full rebuild state and the new state for rendering
+        let full_rebuild_state = full_rebuild_state.normalized();
+        let new = new.normalized();
+        let full_rebuild_state = LastBuildState::new(&full_rebuild_state, name);
         let mut s = Self {
             full_rebuild_state,
             templates: Default::default(),
@@ -131,7 +134,7 @@ impl HotReloadResult {
             literal_component_properties: Default::default(),
         };
 
-        s.hotreload_body::<Ctx>(new)?;
+        s.hotreload_body::<Ctx>(&new)?;
 
         Some(s)
     }

--- a/packages/rsx-hotreload/tests/hotreload_pattern.rs
+++ b/packages/rsx-hotreload/tests/hotreload_pattern.rs
@@ -468,6 +468,32 @@ fn invalid_cases() {
 }
 
 #[test]
+fn invalid_empty_rsx() {
+    let old_template = quote! {
+        div {
+            for item in vec![1, 2, 3, 4] {
+                div { "asasddasdasd" }
+                div { "123" }
+            }
+            for item in vec![4, 5, 6] {
+                span { "asasddasdasd" }
+                span { "123" }
+            }
+        }
+    };
+
+    // empty out the whole rsx block
+    let new_template = quote! {};
+
+    let location = "file:line:col:0";
+
+    let old_template: CallBody = syn::parse2(old_template).unwrap();
+    let new_template: CallBody = syn::parse2(new_template).unwrap();
+
+    assert!(hotreload_callbody::<Mock>(&old_template, &new_template).is_none());
+}
+
+#[test]
 fn attributes_reload() {
     let old = quote! {
         div {


### PR DESCRIPTION
Fixes hot reloading empty rsx nodes. When we see an empty rsx node, we replaced it with `rsx!{{()}}` in the `ToTokens` implementation, but not during hot reloading. Removing the last node is not hot reloadable because placeholder it creates is a dynamic node.

Fixes #3562 