### PR TITLE
Fix rsx expression autocomplete

### DIFF
--- a/packages/rsx/src/expr_node.rs
+++ b/packages/rsx/src/expr_node.rs
@@ -26,8 +26,13 @@ impl Parse for ExprNode {
 impl ToTokens for ExprNode {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let expr = &self.expr;
+        let doc = format!("{:?}", self.span());
         tokens.append_all(quote! {
-            { let ___nodes = (#expr).into_dyn_node(); ___nodes }
+            {
+                #doc;
+                let ___nodes = (#expr).into_dyn_node();
+                ___nodes
+            }
         })
     }
 }
@@ -38,6 +43,19 @@ fn no_commas() {
     let input = quote! {
         div {
             {label("Hello, world!")},
+        }
+    };
+
+    let _expr: crate::BodyNode = syn::parse2(input).unwrap();
+    println!("{}", _expr.to_token_stream().pretty_unparse());
+}
+
+#[test]
+fn autocomplete() {
+    use prettier_please::PrettyUnparse;
+    let input = quote! {
+        div {
+            {label(xy)},
         }
     };
 

--- a/packages/rsx/src/expr_node.rs
+++ b/packages/rsx/src/expr_node.rs
@@ -26,13 +26,8 @@ impl Parse for ExprNode {
 impl ToTokens for ExprNode {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let expr = &self.expr;
-        let doc = format!("{:?}", self.span());
         tokens.append_all(quote! {
-            {
-                #doc;
-                let ___nodes = (#expr).into_dyn_node();
-                ___nodes
-            }
+            { let ___nodes = (#expr).into_dyn_node(); ___nodes }
         })
     }
 }
@@ -43,19 +38,6 @@ fn no_commas() {
     let input = quote! {
         div {
             {label("Hello, world!")},
-        }
-    };
-
-    let _expr: crate::BodyNode = syn::parse2(input).unwrap();
-    println!("{}", _expr.to_token_stream().pretty_unparse());
-}
-
-#[test]
-fn autocomplete() {
-    use prettier_please::PrettyUnparse;
-    let input = quote! {
-        div {
-            {label(xy)},
         }
     };
 


### PR DESCRIPTION
We were expanding dynamic nodes and attributes in both the debug and release blocks of the macro. That caused rust analyzer to get confused and not autocomplete expressions. This PR pulls out those items into a shared scope

Fixes #3558