### PR TITLE
fix: don't accidentally generate .d.ts files with wasm-bindgen

### DIFF
--- a/packages/cli/src/wasm_bindgen.rs
+++ b/packages/cli/src/wasm_bindgen.rs
@@ -52,6 +52,9 @@ impl WasmBindgen {
             args.push("--remove-producers-section");
         }
 
+        // wbg generates typescript bindnings by default - we don't want those
+        args.push("--no-typescript");
+
         // Out name
         args.push("--out-name");
         args.push(&self.out_name);
@@ -308,10 +311,10 @@ impl WasmBindgenBuilder {
     pub fn new(version: String) -> Self {
         Self {
             version,
+            target: String::new(),
             input_path: PathBuf::new(),
             out_dir: PathBuf::new(),
             out_name: String::new(),
-            target: String::new(),
             debug: true,
             keep_debug: true,
             demangle: true,

--- a/packages/cli/src/wasm_bindgen.rs
+++ b/packages/cli/src/wasm_bindgen.rs
@@ -311,10 +311,10 @@ impl WasmBindgenBuilder {
     pub fn new(version: String) -> Self {
         Self {
             version,
-            target: String::new(),
             input_path: PathBuf::new(),
             out_dir: PathBuf::new(),
             out_name: String::new(),
+            target: String::new(),
             debug: true,
             keep_debug: true,
             demangle: true,


### PR DESCRIPTION
We were accidentally generating typescript files with wasm-bindgen which we don't need to be doing.

Seems to be the only flag we're missing?
```
Usage: wasm-bindgen [OPTIONS] <INPUT>

Arguments:
  <INPUT>  

Options:
      --nodejs                    Deprecated, use `--target nodejs`
      --browser                   Hint that JS should only be compatible with a browser
      --web                       Deprecated, use `--target web`
      --no-modules                Deprecated, use `--target no-modules`
      --typescript                Output a TypeScript definition file (on by default)
      --no-typescript             Don't emit a *.d.ts file
      --omit-imports              Don't emit imports in generated JavaScript
      --out-dir <DIR>             Output directory
      --out-name <VAR>            Set a custom output filename (Without extension. Defaults to crate name)
      --debug                     Include otherwise-extraneous debug checks in output
      --no-demangle               Don't demangle Rust symbol names
      --no-modules-global <VAR>   Name of the global variable to initialize
      --remove-name-section       Remove the debugging `name` section of the file
      --remove-producers-section  Remove the telemetry `producers` section
      --weak-refs                 Deprecated, is runtime-detected
      --reference-types           Deprecated, use `-Ctarget-feature=+reference-types`
      --keep-lld-exports          Keep exports synthesized by LLD
      --keep-debug                Keep debug sections in Wasm files
      --encode-into <MODE>        Whether or not to use TextEncoder#encodeInto, valid values are [test, always, never]
      --target <TARGET>           What type of output to generate, valid
                                  values are [web, bundler, nodejs, no-modules, deno, experimental-nodejs-module],
                                  and the default is [bundler]
      --omit-default-module-path  Don't add WebAssembly fallback imports in generated JavaScript
      --split-linked-modules      Split linked modules out into their own files. Recommended if possible.
                                  If a bundler is used, it needs to be set up accordingly.
  -h, --help                      Print help
  -V, --version                   Print version

Additional documentation: https://rustwasm.github.io/wasm-bindgen/reference/cli.html
```