### PR TITLE
fix: window state preservation by soft-killing the process

### DIFF
--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -46,7 +46,7 @@ impl RunArgs {
                     tracing::info!("[{platform}]: {msg}")
                 }
                 ServeUpdate::ProcessExited { platform, status } => {
-                    runner.kill(platform);
+                    runner.kill(platform).await;
                     tracing::info!("[{platform}]: process exited with status: {status:?}");
                     break;
                 }

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -109,7 +109,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
 
                     // Kill any running executables on Windows
                     if cfg!(windows) {
-                        runner.kill_all();
+                        runner.kill_all().await;
                     }
 
                     // We're going to kick off a new build, interrupting the current build if it's ongoing
@@ -200,7 +200,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                     );
                 }
 
-                runner.kill(platform);
+                runner.kill(platform).await;
             }
 
             ServeUpdate::StdoutReceived { platform, msg } => {
@@ -223,7 +223,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
 
                 // Kill any running executables on Windows
                 if cfg!(windows) {
-                    runner.kill_all();
+                    runner.kill_all().await;
                 }
 
                 builder.rebuild(args.build_arguments.clone());


### PR DESCRIPTION
In the big CLI rewrite I accidentally removed the code for doing soft-kills on the desktop window.

This fixes that, fixing window state preservation.

Fixes #3355