### PR TITLE
Fix: Only Resize WebView Associated With Window

### DIFF
--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -226,14 +226,14 @@ impl App {
         }
     }
 
-    pub fn resize_window(&self, size: PhysicalSize<u32>) {
+    pub fn resize_window(&self, id: WindowId, size: PhysicalSize<u32>) {
         // TODO: the app layer should avoid directly manipulating the webview webview instance internals.
         // Window creation and modification is the responsibility of the webview instance so it makes sense to
         // encapsulate that there.
-        self.webviews.values().for_each(|webview_instance| {
+        if let Some(webview) = self.webviews.get(&id) {
             use wry::Rect;
 
-            webview_instance
+            webview
                 .desktop_context
                 .webview
                 .set_bounds(Rect {
@@ -244,7 +244,7 @@ impl App {
                     )),
                 })
                 .unwrap();
-        });
+        }
     }
 
     pub fn handle_start_cause_init(&mut self) {

--- a/packages/desktop/src/launch.rs
+++ b/packages/desktop/src/launch.rs
@@ -32,7 +32,7 @@ pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, mut desktop_config: 
             } => match event {
                 WindowEvent::CloseRequested => app.handle_close_requested(window_id),
                 WindowEvent::Destroyed { .. } => app.window_destroyed(window_id),
-                WindowEvent::Resized(new_size) => app.resize_window(new_size),
+                WindowEvent::Resized(new_size) => app.resize_window(window_id, new_size),
                 _ => {}
             },
 


### PR DESCRIPTION
When resizing a window, Dioxus previously accidentally resized every single webview to the dimensions of the window that just got resized. This fixes it so only the webview that is associated with the window is resized.


https://github.com/user-attachments/assets/515aaeb5-aa9c-4ab0-9d95-559689312e53

