### PR TITLE
feat: android bundling, red/blue exe names, session cache

### DIFF
--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -67,6 +67,7 @@ pub const APP_TITLE_ENV: &str = "DIOXUS_APP_TITLE";
 #[deprecated(since = "0.6.0", note = "The CLI currently does not set this.")]
 #[doc(hidden)]
 pub const OUT_DIR: &str = "DIOXUS_OUT_DIR";
+pub const SESSION_CACHE_DIR: &str = "DIOXUS_SESSION_CACHE_DIR";
 
 /// Reads an environment variable at runtime in debug mode or at compile time in
 /// release mode. When bundling in release mode, we will not be running under the
@@ -276,4 +277,16 @@ pub fn out_dir() -> Option<PathBuf> {
     {
         std::env::var(OUT_DIR).ok().map(PathBuf::from)
     }
+}
+
+/// Get the directory where this app can write to for this session that's guaranteed to be stable
+/// between reloads of the same app. This is useful for emitting state like window position and size
+/// so the app can restore it when it's next opened.
+///
+/// Note that this cache dir is really only useful for platforms that can access it. Web/Android
+/// don't have access to this directory, so it's not useful for them.
+///
+/// This is designed with desktop executables in mind.
+pub fn session_cache_dir() -> Option<PathBuf> {
+    std::env::var(SESSION_CACHE_DIR).ok().map(PathBuf::from)
 }

--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -730,23 +730,7 @@ impl AppBundle {
         if let Platform::Android = self.build.build.platform() {
             self.build.status_running_gradle();
 
-            // make sure we can execute the gradlew script
-            #[cfg(unix)]
-            {
-                use std::os::unix::prelude::PermissionsExt;
-                std::fs::set_permissions(
-                    self.build.root_dir().join("gradlew"),
-                    std::fs::Permissions::from_mode(0o755),
-                )?;
-            }
-
-            let gradle_exec_name = match cfg!(windows) {
-                true => "gradlew.bat",
-                false => "gradlew",
-            };
-            let gradle_exec = self.build.root_dir().join(gradle_exec_name);
-
-            let output = Command::new(gradle_exec)
+            let output = Command::new(self.gradle_exe()?)
                 .arg("assembleDebug")
                 .current_dir(self.build.root_dir())
                 .stderr(std::process::Stdio::piped())
@@ -760,6 +744,62 @@ impl AppBundle {
         }
 
         Ok(())
+    }
+
+    /// Run bundleRelease and return the path to the `.aab` file
+    ///
+    /// https://stackoverflow.com/questions/57072558/whats-the-difference-between-gradlewassemblerelease-gradlewinstallrelease-and
+    pub(crate) async fn android_gradle_bundle(&self) -> Result<PathBuf> {
+        let output = Command::new(self.gradle_exe()?)
+            .arg("bundleRelease")
+            .current_dir(self.build.root_dir())
+            .output()
+            .await
+            .context("Failed to run gradle bundleRelease")?;
+
+        if !output.status.success() {
+            return Err(anyhow::anyhow!("Failed to bundleRelease: {output:?}").into());
+        }
+
+        let app_release = self
+            .build
+            .root_dir()
+            .join("app")
+            .join("build")
+            .join("outputs")
+            .join("bundle")
+            .join("release");
+
+        // Rename it to Name-arch.aab
+        let from = app_release.join("app-release.aab");
+        let to = app_release.join(format!(
+            "{}-{}.aab",
+            self.build.krate.bundled_app_name(),
+            self.build.build.target_args.arch()
+        ));
+
+        std::fs::rename(&from, &to).context("Failed to rename aab")?;
+
+        Ok(to)
+    }
+
+    fn gradle_exe(&self) -> Result<PathBuf> {
+        // make sure we can execute the gradlew script
+        #[cfg(unix)]
+        {
+            use std::os::unix::prelude::PermissionsExt;
+            std::fs::set_permissions(
+                self.build.root_dir().join("gradlew"),
+                std::fs::Permissions::from_mode(0o755),
+            )?;
+        }
+
+        let gradle_exec_name = match cfg!(windows) {
+            true => "gradlew.bat",
+            false => "gradlew",
+        };
+
+        Ok(self.build.root_dir().join(gradle_exec_name))
     }
 
     pub(crate) fn apk_path(&self) -> PathBuf {

--- a/packages/cli/src/build/bundle.rs
+++ b/packages/cli/src/build/bundle.rs
@@ -778,7 +778,7 @@ impl AppBundle {
             self.build.build.target_args.arch()
         ));
 
-        std::fs::rename(&from, &to).context("Failed to rename aab")?;
+        std::fs::rename(from, &to).context("Failed to rename aab")?;
 
         Ok(to)
     }

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -76,11 +76,12 @@ impl Bundle {
             Platform::Server => bundles.push(bundle.build.root_dir()),
             Platform::Liveview => bundles.push(bundle.build.root_dir()),
 
-            // todo(jon): we can technically create apks (already do...) just need to expose it
             Platform::Android => {
-                return Err(Error::UnsupportedFeature(
-                    "Android bundles are not yet supported".into(),
-                ));
+                let aab = bundle
+                    .android_gradle_bundle()
+                    .await
+                    .context("Failed to run gradle bundleRelease")?;
+                bundles.push(aab);
             }
         };
 

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -46,7 +46,7 @@ impl RunArgs {
                     tracing::info!("[{platform}]: {msg}")
                 }
                 ServeUpdate::ProcessExited { platform, status } => {
-                    runner.kill(platform).await;
+                    runner.cleanup().await;
                     tracing::info!("[{platform}]: process exited with status: {status:?}");
                     break;
                 }

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -217,3 +217,15 @@ impl TryFrom<String> for Arch {
         }
     }
 }
+
+impl std::fmt::Display for Arch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Arch::Arm => "armv7l",
+            Arch::Arm64 => "aarch64",
+            Arch::X86 => "i386",
+            Arch::X64 => "x86_64",
+        }
+        .fmt(f)
+    }
+}

--- a/packages/cli/src/dioxus_crate.rs
+++ b/packages/cli/src/dioxus_crate.rs
@@ -149,6 +149,16 @@ impl DioxusCrate {
         files
     }
 
+    /// Get the directory where this app can write to for this session that's guaranteed to be stable
+    /// for the same app. This is useful for emitting state like window position and size.
+    ///
+    /// The directory is specific for this app and might be
+    pub(crate) fn session_cache_dir(&self) -> PathBuf {
+        self.internal_out_dir()
+            .join(self.executable_name())
+            .join("session-cache")
+    }
+
     /// Get the outdir specified by the Dioxus.toml, relative to the crate directory.
     /// We don't support workspaces yet since that would cause a collision of bundles per project.
     pub(crate) fn crate_out_dir(&self) -> Option<PathBuf> {

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -33,6 +33,7 @@ pub(crate) enum Error {
     #[error("Failed to bundle project: {0}")]
     BundleFailed(#[from] tauri_bundler::Error),
 
+    #[allow(unused)]
     #[error("Unsupported feature: {0}")]
     UnsupportedFeature(String),
 

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -107,11 +107,6 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                 } else if runner.should_full_rebuild {
                     tracing::info!(dx_src = ?TraceSrc::Dev, "Full rebuild: {}", file);
 
-                    // Kill any running executables on Windows
-                    if cfg!(windows) {
-                        runner.kill_all().await;
-                    }
-
                     // We're going to kick off a new build, interrupting the current build if it's ongoing
                     builder.rebuild(args.build_arguments.clone());
 
@@ -221,11 +216,6 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                 // `Hotreloading:` to keep the alignment during long edit sessions
                 tracing::info!("Full rebuild: triggered manually");
 
-                // Kill any running executables on Windows
-                if cfg!(windows) {
-                    runner.kill_all().await;
-                }
-
                 builder.rebuild(args.build_arguments.clone());
                 runner.file_map.force_rebuild();
                 devserver.send_reload_start().await;
@@ -261,6 +251,7 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
         }
     };
 
+    _ = runner.shutdown().await;
     _ = devserver.shutdown().await;
     _ = screen.shutdown();
     builder.abort_all();

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -194,8 +194,6 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
                - To exit the server, press `ctrl+c`"#
                     );
                 }
-
-                runner.kill(platform).await;
             }
 
             ServeUpdate::StdoutReceived { platform, msg } => {
@@ -251,10 +249,10 @@ pub(crate) async fn serve_all(mut args: ServeArgs) -> Result<()> {
         }
     };
 
-    _ = runner.shutdown().await;
+    _ = runner.cleanup().await;
     _ = devserver.shutdown().await;
-    _ = screen.shutdown();
     builder.abort_all();
+    _ = screen.shutdown();
 
     if let Err(err) = err {
         eprintln!("Exiting with error: {}", err);

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -5,17 +5,16 @@ use crate::{
 use dioxus_core::internal::TemplateGlobalKey;
 use dioxus_devtools_types::HotReloadMsg;
 use dioxus_html::HtmlCtx;
-use futures_util::{future::OptionFuture, stream::FuturesUnordered};
+use futures_util::future::OptionFuture;
 use ignore::gitignore::Gitignore;
 use std::{
     collections::{HashMap, HashSet},
     net::SocketAddr,
     path::PathBuf,
 };
-use tokio_stream::StreamExt;
 
 pub(crate) struct AppRunner {
-    pub(crate) running: HashMap<Platform, AppHandle>,
+    pub(crate) running: Option<AppHandle>,
     pub(crate) krate: DioxusCrate,
     pub(crate) file_map: HotreloadFilemap,
     pub(crate) ignore: Gitignore,
@@ -44,52 +43,47 @@ impl AppRunner {
             runner.fill_filemap(krate);
         }
 
+        // Ensure the session cache dir exists and is empty
+        runner.flush_session_cache();
+
         runner
     }
 
     pub(crate) async fn wait(&mut self) -> ServeUpdate {
         // If there are no running apps, we can just return pending to avoid deadlocking
-        if self.running.is_empty() {
+        let Some(handle) = self.running.as_mut() else {
             return futures_util::future::pending().await;
-        }
+        };
 
-        self.running
-            .iter_mut()
-            .map(|(platform, handle)| async {
-                use ServeUpdate::*;
-                let platform = *platform;
-                tokio::select! {
-                    Some(Ok(Some(msg))) = OptionFuture::from(handle.app_stdout.as_mut().map(|f| f.next_line())) => {
-                        StdoutReceived { platform, msg }
-                    },
-                    Some(Ok(Some(msg))) = OptionFuture::from(handle.app_stderr.as_mut().map(|f| f.next_line())) => {
-                        StderrReceived { platform, msg }
-                    },
-                    Some(status) = OptionFuture::from(handle.app_child.as_mut().map(|f| f.wait())) => {
-                        match status {
-                            Ok(status) => ProcessExited { status, platform },
-                            Err(_err) => todo!("handle error in process joining?"),
-                        }
-                    }
-                    Some(Ok(Some(msg))) = OptionFuture::from(handle.server_stdout.as_mut().map(|f| f.next_line())) => {
-                        StdoutReceived { platform: Platform::Server, msg }
-                    },
-                    Some(Ok(Some(msg))) = OptionFuture::from(handle.server_stderr.as_mut().map(|f| f.next_line())) => {
-                        StderrReceived { platform: Platform::Server, msg }
-                    },
-                    Some(status) = OptionFuture::from(handle.server_child.as_mut().map(|f| f.wait())) => {
-                        match status {
-                            Ok(status) => ProcessExited { status, platform },
-                            Err(_err) => todo!("handle error in process joining?"),
-                        }
-                    }
-                    else => futures_util::future::pending().await
+        use ServeUpdate::*;
+        let platform = handle.app.build.build.platform();
+        tokio::select! {
+            Some(Ok(Some(msg))) = OptionFuture::from(handle.app_stdout.as_mut().map(|f| f.next_line())) => {
+                StdoutReceived { platform, msg }
+            },
+            Some(Ok(Some(msg))) = OptionFuture::from(handle.app_stderr.as_mut().map(|f| f.next_line())) => {
+                StderrReceived { platform, msg }
+            },
+            Some(status) = OptionFuture::from(handle.app_child.as_mut().map(|f| f.wait())) => {
+                match status {
+                    Ok(status) => ProcessExited { status, platform },
+                    Err(_err) => todo!("handle error in process joining?"),
                 }
-            })
-            .collect::<FuturesUnordered<_>>()
-            .next()
-            .await
-            .expect("Stream to pending if not empty")
+            }
+            Some(Ok(Some(msg))) = OptionFuture::from(handle.server_stdout.as_mut().map(|f| f.next_line())) => {
+                StdoutReceived { platform: Platform::Server, msg }
+            },
+            Some(Ok(Some(msg))) = OptionFuture::from(handle.server_stderr.as_mut().map(|f| f.next_line())) => {
+                StderrReceived { platform: Platform::Server, msg }
+            },
+            Some(status) = OptionFuture::from(handle.server_child.as_mut().map(|f| f.wait())) => {
+                match status {
+                    Ok(status) => ProcessExited { status, platform },
+                    Err(_err) => todo!("handle error in process joining?"),
+                }
+            }
+            else => futures_util::future::pending().await
+        }
     }
 
     /// Finally "bundle" this app and return a handle to it
@@ -100,16 +94,9 @@ impl AppRunner {
         fullstack_address: Option<SocketAddr>,
         should_open_web: bool,
     ) -> Result<&AppHandle> {
-        let platform = app.build.build.platform();
-
         // Drop the old handle
-        // todo(jon): we should instead be sending the kill signal rather than dropping the process
-        // This would allow a more graceful shutdown and fix bugs like desktop not retaining its size
-        self.kill(platform).await;
-
-        // wait a tiny sec for the processes to die so we don't have fullstack servers on top of each other
-        // todo(jon): we should allow rebinding to the same port in fullstack itself
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // This is a more forceful kill than soft_kill since the app entropy will be wiped
+        self.cleanup().await;
 
         // Add some cute logging
         if self.builds_opened == 0 {
@@ -132,38 +119,30 @@ impl AppRunner {
             .await?;
 
         self.builds_opened += 1;
-        self.running.insert(platform, handle);
+        self.running = Some(handle);
 
-        Ok(self.running.get(&platform).unwrap())
-    }
-
-    /// Gracefully kill the process and all of its children
-    pub(crate) async fn kill(&mut self, platform: Platform) {
-        if let Some(mut process) = self.running.remove(&platform) {
-            process.cleanup().await;
-        };
-    }
-
-    pub(crate) async fn kill_all(&mut self) {
-        let keys = self.running.keys().cloned().collect::<Vec<_>>();
-        for platform in keys {
-            self.kill(platform).await;
-        }
+        Ok(self.running.as_ref().unwrap())
     }
 
     /// Open an existing app bundle, if it exists
     pub(crate) async fn open_existing(&mut self, devserver: &WebServer) -> Result<()> {
         let fullstack_address = devserver.proxied_server_address();
 
-        if let Some((_, app)) = self
-            .running
-            .iter_mut()
-            .find(|(platform, _)| **platform != Platform::Server)
-        {
-            app.open(devserver.devserver_address(), fullstack_address, true)
+        if let Some(runner) = self.running.as_mut() {
+            runner.soft_kill().await;
+            runner
+                .open(devserver.devserver_address(), fullstack_address, true)
                 .await?;
         }
+
         Ok(())
+    }
+
+    /// Shutdown all the running processes
+    pub(crate) async fn cleanup(&mut self) {
+        if let Some(mut process) = self.running.take() {
+            process.cleanup().await;
+        }
     }
 
     pub(crate) async fn attempt_hot_reload(
@@ -196,7 +175,7 @@ impl AppRunner {
             }
 
             // Otherwise, it might be an asset and we should look for it in all the running apps
-            for runner in self.running.values() {
+            if let Some(runner) = self.running.as_mut() {
                 if let Some(bundled_name) = runner.hotreload_bundled_asset(&path).await {
                     // todo(jon): don't hardcode this here
                     let asset_relative = PathBuf::from("/assets/").join(bundled_name);
@@ -288,27 +267,29 @@ impl AppRunner {
     }
 
     pub(crate) async fn client_connected(&mut self) {
-        for (platform, runner) in self.running.iter_mut() {
-            // Assign the runtime asset dir to the runner
-            if *platform == Platform::Ios {
-                // xcrun simctl get_app_container booted com.dioxuslabs
-                let res = tokio::process::Command::new("xcrun")
-                    .arg("simctl")
-                    .arg("get_app_container")
-                    .arg("booted")
-                    .arg(runner.app.build.krate.bundle_identifier())
-                    .output()
-                    .await;
+        let Some(handle) = self.running.as_mut() else {
+            return;
+        };
 
-                if let Ok(res) = res {
-                    tracing::trace!("Using runtime asset dir: {:?}", res);
+        // Assign the runtime asset dir to the runner
+        if handle.app.build.build.platform() == Platform::Ios {
+            // xcrun simctl get_app_container booted com.dioxuslabs
+            let res = tokio::process::Command::new("xcrun")
+                .arg("simctl")
+                .arg("get_app_container")
+                .arg("booted")
+                .arg(handle.app.build.krate.bundle_identifier())
+                .output()
+                .await;
 
-                    if let Ok(out) = String::from_utf8(res.stdout) {
-                        let out = out.trim();
+            if let Ok(res) = res {
+                tracing::trace!("Using runtime asset dir: {:?}", res);
 
-                        tracing::trace!("Setting Runtime asset dir: {out:?}");
-                        runner.runtime_asst_dir = Some(PathBuf::from(out));
-                    }
+                if let Ok(out) = String::from_utf8(res.stdout) {
+                    let out = out.trim();
+
+                    tracing::trace!("Setting Runtime asset dir: {out:?}");
+                    handle.runtime_asst_dir = Some(PathBuf::from(out));
                 }
             }
         }
@@ -348,8 +329,9 @@ impl AppRunner {
         }
     }
 
-    /// Shutdown all the running processes
-    pub(crate) async fn shutdown(&mut self) {
-        self.kill_all().await;
+    fn flush_session_cache(&self) {
+        let cache_dir = self.krate.session_cache_dir();
+        _ = std::fs::remove_dir_all(&cache_dir);
+        _ = std::fs::create_dir_all(&cache_dir);
     }
 }

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -593,6 +593,6 @@ fn hide_last_window(window: &Window) {
 
 /// Return the location of a tempfile with our window state in it such that we can restore it later
 fn restore_file() -> std::path::PathBuf {
-    let dir = dioxus_cli_config::session_cache_dir().unwrap_or_else(|| std::env::temp_dir());
+    let dir = dioxus_cli_config::session_cache_dir().unwrap_or_else(std::env::temp_dir);
     dir.join("window-state.json")
 }

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -593,20 +593,6 @@ fn hide_last_window(window: &Window) {
 
 /// Return the location of a tempfile with our window state in it such that we can restore it later
 fn restore_file() -> std::path::PathBuf {
-    /// Get the name of the program or default to "dioxus" so we can hash it
-    fn get_prog_name_or_default() -> Option<String> {
-        Some(
-            std::env::current_exe()
-                .ok()?
-                .file_name()?
-                .to_str()?
-                .to_string(),
-        )
-    }
-
-    let name = get_prog_name_or_default().unwrap_or_else(|| "dioxus".to_string());
-    let hashed_id = name.chars().map(|c| c as usize).sum::<usize>();
-    let mut path = std::env::temp_dir();
-    path.push(format!("{}-window-state.json", hashed_id));
-    path
+    let dir = dioxus_cli_config::session_cache_dir().unwrap_or_else(|| std::env::temp_dir());
+    dir.join("window-state.json")
 }


### PR DESCRIPTION
Implements `dx bundle` for android to generate `.aab` files for uploading to the playstore.

You can de-compose a `.aab` to get a raw `.apk` in the event you want to manually sign it yourself instead of uploading to the play store.

Closes #3548

---

Also adds a bit of entropy to exe names so we can have multiple, concurrent versions of the same app making the iteration process a bit nicer.

Takes a similar strategy to #3323 but is more general for all platforms.

---

Implements a session cache since the entropy features breaks the way we do window state restoration