### PR TITLE
Remove the todo list from the examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -99,17 +99,3 @@ cargo run --example hello_world
 [dog_app](./dog_app.rs) - Accesses dog API
 
 [todomvc](./todomvc.rs) - Todo task list example
-
-# TODO
-Missing Features
-- Fine-grained reactivity
-- Refs - imperative handles to elements
-- Function-driven children: Pass functions to make VNodes
-
-Missing examples
-- Shared state
-- Root-less element groups
-- Custom elements
-- Component Children: Pass children into child components
-- Render To string: Render a mounted virtualdom to a string
-- Testing and Debugging


### PR DESCRIPTION
Most of the todo list items were already added to the examples folder. For the items that haven't been added, it might be easier to track them in issues. These are the remaining items:
- Shared state example: This is covered in the [state essentials guide](https://dioxuslabs.com/learn/0.6/essentials/state/#passing-context) and the [guide](https://dioxuslabs.com/learn/0.6/guide/state#global-state-with-context), but we don't have any examples in the folder (#3612)
- Custom elements example (#3611)
- Testing and Debugging: This seems like a better topic for a guide on the docsite (https://github.com/DioxusLabs/docsite/issues/374)
