### PR TITLE
fix: too much padding for small frames

### DIFF
--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -1003,10 +1003,7 @@ impl Output {
 
                 // Create the ansi -> raw string line with a width of either the viewport width or the max width
                 let line_length = line.styled_graphemes(Style::default()).count();
-                lines.push(
-                    AnsiStringLine::new(line_length.max(VIEWPORT_MAX_WIDTH.into()) as _)
-                        .render(&line),
-                );
+                lines.push(AnsiStringLine::new(line_length as _).render(&line));
             }
         }
 


### PR DESCRIPTION
This fixes an issue with the frame width calculations that always reserved extra space to the max_term_width even if we didn't need that space, causing extra lines to bleed over:
<img width="828" alt="Screenshot 2025-01-21 at 11 11 06 AM" src="https://github.com/user-attachments/assets/b0f91b3a-47ba-4b64-a0db-b12b21b9ede2" />

This is now fixed:
<img width="819" alt="Screenshot 2025-01-21 at 11 11 17 AM" src="https://github.com/user-attachments/assets/652fd4fd-77fc-40e9-bf05-95f413f062bc" />

We didn't need that `.max()` at all since we never print empty lines anyways.