### PR TITLE
Make test_github_install only run on platforms with prebuilt binaries

### DIFF
--- a/packages/cli/src/wasm_bindgen.rs
+++ b/packages/cli/src/wasm_bindgen.rs
@@ -438,6 +438,13 @@ mod test {
     const VERSION: &str = "0.2.99";
 
     /// Test the github installer.
+    #[cfg(any(
+        all(
+            any(target_os = "windows", target_os = "linux", target_os = "macos"),
+            target_arch = "x86_64"
+        ),
+        all(any(target_os = "linux", target_os = "macos"), target_arch = "aarch64"),
+    ))]
     #[tokio::test]
     async fn test_github_install() {
         let binary = WasmBindgen::new(VERSION);


### PR DESCRIPTION
This allows tests to pass on all platforms (in my case riscv64gc-unknown-linux-gnu).