### PR TITLE
Fix additional attributes for js renderers

### DIFF
--- a/packages/document/src/elements/link.rs
+++ b/packages/document/src/elements/link.rs
@@ -28,6 +28,7 @@ impl LinkProps {
     /// Get all the attributes for the link tag
     pub fn attributes(&self) -> Vec<(&'static str, String)> {
         let mut attributes = Vec::new();
+        extend_attributes(&mut attributes, &self.additional_attributes);
         if let Some(rel) = &self.rel {
             attributes.push(("rel", rel.clone()));
         }

--- a/packages/document/src/elements/meta.rs
+++ b/packages/document/src/elements/meta.rs
@@ -19,6 +19,7 @@ impl MetaProps {
     /// Get all the attributes for the meta tag
     pub fn attributes(&self) -> Vec<(&'static str, String)> {
         let mut attributes = Vec::new();
+        extend_attributes(&mut attributes, &self.additional_attributes);
         if let Some(property) = &self.property {
             attributes.push(("property", property.clone()));
         }

--- a/packages/document/src/elements/mod.rs
+++ b/packages/document/src/elements/mod.rs
@@ -124,3 +124,26 @@ impl DeduplicationContext {
         }
     }
 }
+
+/// Extend a list of string attributes with a list of dioxus attribute
+pub(crate) fn extend_attributes(
+    attributes: &mut Vec<(&'static str, String)>,
+    additional_attributes: &[Attribute],
+) {
+    for additional_attribute in additional_attributes {
+        let attribute_value_as_string = match &additional_attribute.value {
+            dioxus_core::AttributeValue::Text(v) => v.to_string(),
+            dioxus_core::AttributeValue::Float(v) => v.to_string(),
+            dioxus_core::AttributeValue::Int(v) => v.to_string(),
+            dioxus_core::AttributeValue::Bool(v) => v.to_string(),
+            dioxus_core::AttributeValue::Listener(_) | dioxus_core::AttributeValue::Any(_) => {
+                tracing::error!("document::* elements do not support event listeners or any value attributes. Expected displayable attribute, found {:?}", additional_attribute.value);
+                continue;
+            }
+            dioxus_core::AttributeValue::None => {
+                continue;
+            }
+        };
+        attributes.push((additional_attribute.name, attribute_value_as_string));
+    }
+}

--- a/packages/document/src/elements/script.rs
+++ b/packages/document/src/elements/script.rs
@@ -25,6 +25,7 @@ impl ScriptProps {
     /// Get all the attributes for the script tag
     pub fn attributes(&self) -> Vec<(&'static str, String)> {
         let mut attributes = Vec::new();
+        extend_attributes(&mut attributes, &self.additional_attributes);
         if let Some(defer) = &self.defer {
             attributes.push(("defer", defer.to_string()));
         }

--- a/packages/document/src/elements/style.rs
+++ b/packages/document/src/elements/style.rs
@@ -20,6 +20,7 @@ impl StyleProps {
     /// Get all the attributes for the style tag
     pub fn attributes(&self) -> Vec<(&'static str, String)> {
         let mut attributes = Vec::new();
+        extend_attributes(&mut attributes, &self.additional_attributes);
         if let Some(href) = &self.href {
             attributes.push(("href", href.clone()));
         }

--- a/packages/fullstack/src/document/server.rs
+++ b/packages/fullstack/src/document/server.rs
@@ -88,7 +88,7 @@ impl Document for ServerDocument {
                 http_equiv: props.http_equiv,
                 content: props.content,
                 property: props.property,
-                ..props.additional_attributes
+                ..props.additional_attributes,
             }
         });
     }
@@ -142,6 +142,7 @@ impl Document for ServerDocument {
                 integrity: props.integrity,
                 r#type: props.r#type,
                 blocking: props.blocking,
+                ..props.additional_attributes,
             }
         })
     }

--- a/packages/playwright-tests/fullstack.spec.js
+++ b/packages/playwright-tests/fullstack.spec.js
@@ -37,3 +37,34 @@ test("hydration", async ({ page }) => {
   const mountedDiv = page.locator("div.onmounted-div");
   await expect(mountedDiv).toHaveText("onmounted was called 1 times");
 });
+
+test("document elements", async ({ page }) => {
+  await page.goto("http://localhost:9999");
+  // wait until the meta element is mounted
+  const meta = page.locator("meta#meta-head[name='testing']");
+  await meta.waitFor({ state: "attached" });
+  await expect(meta).toHaveAttribute("data", "dioxus-meta-element");
+
+  const link = page.locator("link#link-head[rel='stylesheet']");
+  await link.waitFor({ state: "attached" });
+  await expect(link).toHaveAttribute(
+    "href",
+    "https://fonts.googleapis.com/css?family=Roboto+Mono"
+  );
+
+  const stylesheet = page.locator("link#stylesheet-head[rel='stylesheet']");
+  await stylesheet.waitFor({ state: "attached" });
+  await expect(stylesheet).toHaveAttribute(
+    "href",
+    "https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic"
+  );
+
+  const script = page.locator("script#script-head");
+  await script.waitFor({ state: "attached" });
+  await expect(script).toHaveAttribute("async", "true");
+
+  const style = page.locator("style#style-head");
+  await style.waitFor({ state: "attached" });
+  const main = page.locator("#main");
+  await expect(main).toHaveCSS("font-family", "Roboto");
+});

--- a/packages/playwright-tests/fullstack/src/main.rs
+++ b/packages/playwright-tests/fullstack/src/main.rs
@@ -41,6 +41,7 @@ fn app() -> Element {
             Errors {}
         }
         OnMounted {}
+        DocumentElements {}
     }
 }
 
@@ -115,5 +116,21 @@ pub fn ThrowsError() -> Element {
         .map_err(|err| RenderError::Aborted(CapturedError::from_display(err)))?;
     rsx! {
         "success"
+    }
+}
+
+/// This component tests the document::* elements pre-rendered on the server
+#[component]
+fn DocumentElements() -> Element {
+    rsx! {
+        document::Meta { id: "meta-head", name: "testing", data: "dioxus-meta-element" }
+        document::Link {
+            id: "link-head",
+            rel: "stylesheet",
+            href: "https://fonts.googleapis.com/css?family=Roboto+Mono"
+        }
+        document::Stylesheet { id: "stylesheet-head", href: "https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic" }
+        document::Script { id: "script-head", async: true, "console.log('hello world');" }
+        document::Style { id: "style-head", "body {{ font-family: 'Roboto'; }}" }
     }
 }

--- a/packages/playwright-tests/web.spec.js
+++ b/packages/playwright-tests/web.spec.js
@@ -124,3 +124,34 @@ test("web-sys closure", async ({ page }) => {
   await page.keyboard.press("Enter");
   await expect(scrollDiv).toHaveText("the keydown event was triggered");
 });
+
+test("document elements", async ({ page }) => {
+  await page.goto("http://localhost:9999");
+  // wait until the meta element is mounted
+  const meta = page.locator("meta#meta-head[name='testing']");
+  await meta.waitFor({ state: "attached" });
+  await expect(meta).toHaveAttribute("data", "dioxus-meta-element");
+
+  const link = page.locator("link#link-head[rel='stylesheet']");
+  await link.waitFor({ state: "attached" });
+  await expect(link).toHaveAttribute(
+    "href",
+    "https://fonts.googleapis.com/css?family=Roboto+Mono"
+  );
+
+  const stylesheet = page.locator("link#stylesheet-head[rel='stylesheet']");
+  await stylesheet.waitFor({ state: "attached" });
+  await expect(stylesheet).toHaveAttribute(
+    "href",
+    "https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic"
+  );
+
+  const script = page.locator("script#script-head");
+  await script.waitFor({ state: "attached" });
+  await expect(script).toHaveAttribute("async", "true");
+
+  const style = page.locator("style#style-head");
+  await style.waitFor({ state: "attached" });
+  const main = page.locator("#main");
+  await expect(main).toHaveCSS("font-family", "Roboto");
+});

--- a/packages/playwright-tests/web/src/main.rs
+++ b/packages/playwright-tests/web/src/main.rs
@@ -55,6 +55,7 @@ fn app() -> Element {
         PreventDefault {}
         OnMounted {}
         WebSysClosure {}
+        DocumentElements {}
     }
 }
 
@@ -128,6 +129,22 @@ fn WebSysClosure() -> Element {
                 "the keydown event was triggered"
             }
         }
+    }
+}
+
+/// This component tests the document::* elements
+#[component]
+fn DocumentElements() -> Element {
+    rsx! {
+        document::Meta { id: "meta-head", name: "testing", data: "dioxus-meta-element" }
+        document::Link {
+            id: "link-head",
+            rel: "stylesheet",
+            href: "https://fonts.googleapis.com/css?family=Roboto+Mono"
+        }
+        document::Stylesheet { id: "stylesheet-head", href: "https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic" }
+        document::Script { id: "script-head", async: true, "console.log('hello world');" }
+        document::Style { id: "style-head", "body {{ font-family: 'Roboto'; }}" }
     }
 }
 


### PR DESCRIPTION
Additional attributes on the head elements were only being applied in ssr in dioxus-fullstack. This PR applies them in desktop and web as well and adds a playwright test for fullstack and web to test for regressions.

Fixes #3623 