### PR TITLE
Add examples for LaunchBuilder methods

### DIFF
--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -1,4 +1,3 @@
-//! Launch helper macros for fullstack apps
 #![allow(clippy::new_without_default)]
 #![allow(unused)]
 use dioxus_config_macro::*;
@@ -131,6 +130,27 @@ impl LaunchBuilder {
 
 impl LaunchBuilder {
     /// Inject state into the root component's context that is created on the thread that the app is launched on.
+    ///
+    /// # Example
+    /// ```rust, no_run
+    /// use dioxus::prelude::*;
+    /// use std::any::Any;
+    ///
+    /// #[derive(Default)]
+    /// struct MyState {
+    ///     value: i32,
+    /// }
+    ///
+    /// fn app() -> Element {
+    ///     rsx! {
+    ///         div { "Hello, world!" }
+    ///     }
+    /// }
+    ///
+    /// dioxus::LaunchBuilder::new()
+    ///     .with_context_provider(|| Box::new(MyState { value: 42 }))
+    ///     .launch(app);
+    /// ```
     pub fn with_context_provider(
         mut self,
         state: impl Fn() -> Box<dyn Any> + Send + Sync + 'static,
@@ -140,6 +160,27 @@ impl LaunchBuilder {
     }
 
     /// Inject state into the root component's context.
+    ///
+    /// # Example
+    /// ```rust, no_run
+    /// use dioxus::prelude::*;
+    /// use std::any::Any;
+    ///
+    /// #[derive(Clone)]
+    /// struct MyState {
+    ///     value: i32,
+    /// }
+    ///
+    /// fn app() -> Element {
+    ///     rsx! {
+    ///         div { "Hello, world!" }
+    ///     }
+    /// }
+    ///
+    /// dioxus::LaunchBuilder::new()
+    ///     .with_context(MyState { value: 42 })
+    ///     .launch(app);
+    /// ```
     pub fn with_context(mut self, state: impl Any + Clone + Send + Sync + 'static) -> Self {
         self.contexts
             .push(Box::new(move || Box::new(state.clone())));
@@ -149,6 +190,22 @@ impl LaunchBuilder {
 
 impl LaunchBuilder {
     /// Provide a platform-specific config to the builder.
+    ///
+    /// # Example
+    /// ```rust, no_run
+    /// use dioxus::prelude::*;
+    /// use dioxus_desktop::Config;
+    ///
+    /// fn app() -> Element {
+    ///     rsx! {
+    ///         div { "Hello, world!" }
+    ///     }
+    /// }
+    ///
+    /// dioxus::LaunchBuilder::desktop()
+    ///     .with_cfg(Config::new().with_window(|w| w.with_title("My App")))
+    ///     .launch(app);
+    /// ```
     pub fn with_cfg(mut self, config: impl LaunchConfig) -> Self {
         self.configs.push(Box::new(config));
         self


### PR DESCRIPTION
Related to #3530

Add examples for `with_cfg`, `with_context`, and `with_context_provider` methods in the `LaunchBuilder` documentation.

* **with_context_provider**: Add an example demonstrating how to inject state into the root component's context created on the thread that the app is launched on.
* **with_context**: Add an example demonstrating how to inject state into the root component's context.
* **with_cfg**: Add an example demonstrating how to provide a platform-specific config to the builder.

