### PR TITLE
Use the launch builder instead of web launch in the fullstack auth example

### DIFF
--- a/examples/fullstack-auth/src/main.rs
+++ b/examples/fullstack-auth/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
 
     #[cfg(feature = "web")]
     // Hydrate the application on the client
-    dioxus_web::launch::launch_cfg(app, dioxus_web::Config::new().hydrate(true));
+    LaunchBuilder::web().launch(app);
 
     #[cfg(feature = "server")]
     {


### PR DESCRIPTION
The fullstack auth example uses the raw web launch function which doesn't include all of the hydration logic for head elements. It doesn't cause any issues in that example, but it can cause issues when people start modifying the example like #3636. This PR switches to the launchbuilder which calls into the fullstack version if fullstack is enabled