### PR TITLE
Ignore write while rendering warning in memo lazy recompute

### DIFF
--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -1,3 +1,4 @@
+use crate::warnings::{signal_read_and_write_in_reactive_scope, signal_write_in_component_body};
 use crate::write::Writable;
 use crate::{read::Readable, ReadableRef, Signal};
 use crate::{read_impls, GlobalMemo};
@@ -11,6 +12,7 @@ use std::{
 use dioxus_core::prelude::*;
 use futures_util::StreamExt;
 use generational_box::{AnyStorage, BorrowResult, UnsyncStorage};
+use warnings::Warning;
 
 struct UpdateInformation<T> {
     dirty: Arc<AtomicBool>,
@@ -179,7 +181,9 @@ where
         let result = if needs_update {
             drop(read);
             // We shouldn't be subscribed to the value here so we don't trigger the scope we are currently in to rerun even though that scope got the latest value because we synchronously update the value: https://github.com/DioxusLabs/dioxus/issues/2416
-            self.recompute();
+            signal_read_and_write_in_reactive_scope::allow(|| {
+                signal_write_in_component_body::allow(|| self.recompute())
+            });
             self.inner.inner.try_read_unchecked()
         } else {
             Ok(read)


### PR DESCRIPTION
Memos lazily recompute if they are read before async tasks are run in a component. Writing to the memos internal signal while rendering will cause the possible infinite rerender warning, but it is fine in this case because the write only happens conditionally