### PR TITLE
feat(examples): add Context API state management example 

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -52,6 +52,8 @@ cargo run --example hello_world
 
 ### State Management
 
+[context_api](./context_api.rs) - Cross-component state sharing via Context API
+
 ### Async
 
 [login_form](./login_form.rs) - Login endpoint example

--- a/examples/assets/context_api.css
+++ b/examples/assets/context_api.css
@@ -1,0 +1,43 @@
+.main-container {
+  font-family: system-ui, sans-serif;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 2rem;
+}
+
+.light-theme {
+  background: #ffffff;
+  color: #1a1a1a;
+  border: 1px solid #e0e0e0;
+}
+
+.dark-theme {
+  background: #1a1a1a;
+  color: #ffffff;
+  border: 1px solid #333;
+}
+
+.controls {
+  display: flex;
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.btn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.btn:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.display {
+  padding: 2rem;
+  border-radius: 8px;
+  margin-top: 2rem;
+}

--- a/examples/context_api.rs
+++ b/examples/context_api.rs
@@ -49,22 +49,21 @@ impl Theme {
 
 #[component]
 fn ThemeControls() -> Element {
-    let mut theme = try_use_context::<Signal<Theme>>()
-        .expect("Theme context not found. Wrap components in <App>");
-
+    let mut theme = use_theme_context();
+    let current_theme = *theme.read();
     rsx! {
         div {
             class: "controls",
             button {
                 class: "btn",
                 onclick: move |_| theme.set(Theme::Light),
-                disabled: *theme.read() == Theme::Light,
+                disabled: current_theme== Theme::Light,
                 "Switch to Light"
             }
             button {
                 class: "btn",
                 onclick: move |_| theme.set(Theme::Dark),
-                disabled: *theme.read() == Theme::Dark,
+                disabled: current_theme == Theme::Dark,
                 "Switch to Dark"
             }
         }
@@ -73,8 +72,7 @@ fn ThemeControls() -> Element {
 
 #[component]
 fn ThemeDisplay() -> Element {
-    let theme = try_use_context::<Signal<Theme>>()
-        .expect("Theme context not found. Wrap components in <App>");
+    let theme = use_theme_context();
 
     rsx! {
         div {
@@ -83,4 +81,9 @@ fn ThemeDisplay() -> Element {
             p { "Try switching themes using the buttons above!" }
         }
     }
+}
+
+fn use_theme_context() -> Signal<Theme> {
+    try_use_context::<Signal<Theme>>()
+        .expect("Theme context not found. Ensure <App> is the root component.")
 }

--- a/examples/context_api.rs
+++ b/examples/context_api.rs
@@ -1,0 +1,86 @@
+//! Demonstrates cross-component state sharing using Dioxus' Context API
+//!
+//! Features:
+//! - Context provider initialization
+//! - Nested component consumption
+//! - Reactive state updates
+//! - Error handling for missing context
+//! - Platform-agnostic implementation
+
+use dioxus::prelude::*;
+
+const STYLE: Asset = asset!("/examples/assets/context_api.css");
+
+fn main() {
+    launch(app);
+}
+
+#[component]
+fn app() -> Element {
+    // Provide theme context at root level
+    use_context_provider(|| Signal::new(Theme::Light));
+
+    rsx! {
+        document::Link { rel: "stylesheet", href: STYLE }
+        main {
+            class: "main-container",
+
+            h1 { "Theme Switcher" }
+            ThemeControls {}
+            ThemeDisplay {}
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+enum Theme {
+    Light,
+    Dark,
+}
+
+impl Theme {
+    fn stylesheet(&self) -> &'static str {
+        match self {
+            Theme::Light => "light-theme",
+            Theme::Dark => "dark-theme",
+        }
+    }
+}
+
+#[component]
+fn ThemeControls() -> Element {
+    let mut theme = try_use_context::<Signal<Theme>>()
+        .expect("Theme context not found. Wrap components in <App>");
+
+    rsx! {
+        div {
+            class: "controls",
+            button {
+                class: "btn",
+                onclick: move |_| theme.set(Theme::Light),
+                disabled: *theme.read() == Theme::Light,
+                "Switch to Light"
+            }
+            button {
+                class: "btn",
+                onclick: move |_| theme.set(Theme::Dark),
+                disabled: *theme.read() == Theme::Dark,
+                "Switch to Dark"
+            }
+        }
+    }
+}
+
+#[component]
+fn ThemeDisplay() -> Element {
+    let theme = try_use_context::<Signal<Theme>>()
+        .expect("Theme context not found. Wrap components in <App>");
+
+    rsx! {
+        div {
+            class: "display {theme.read().stylesheet()}",
+            p { "Current theme: {theme:?}" }
+            p { "Try switching themes using the buttons above!" }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Resolves #3612  
Adds a comprehensive example demonstrating Context API with:
- Cross-component state sharing via `use_context_provider`/`use_context`
- Reactive theme switching using Signals
- Error handling for missing context providers
- External CSS styling patterns
- Platform-agnostic implementation

## Changes

```diff
+ examples/context_api.rs
+ examples/assets/context_api.css
+ examples/README.md (documentation update)