### PR TITLE
fix: don't emit hash fragment for internal links if hash is empty

### DIFF
--- a/packages/router-macro/src/hash.rs
+++ b/packages/router-macro/src/hash.rs
@@ -25,7 +25,12 @@ impl HashFragment {
     pub fn write(&self) -> TokenStream2 {
         let ident = &self.ident;
         quote! {
-            write!(f, "#{}", #ident)?;
+            {
+                let __hash = #ident.to_string();
+                if !__hash.is_empty() {
+                    write!(f, "#{}", __hash)?;
+                }
+            }
         }
     }
 

--- a/packages/router/tests/via_ssr/link.rs
+++ b/packages/router/tests/via_ssr/link.rs
@@ -431,3 +431,31 @@ fn with_child_route() {
         "<h1>App</h1><a href=\"/test\">Parent Link</a><a href=\"/child/this-is-a-child-route\">Child Link 1</a><a href=\"/child/this-is-a-child-route\">Child Link 2</a>"
     );
 }
+
+#[test]
+fn with_hash_segment() {
+    #[derive(Routable, Clone)]
+    enum Route {
+        #[route("/#:data")]
+        Root { data: String },
+    }
+
+    #[component]
+    fn Root(data: String) -> Element {
+        rsx! {
+            Link {
+                to: Route::Root { data: "test".to_string() },
+                "Link"
+            }
+            Link {
+                to: Route::Root { data: "".to_string() },
+                "Empty"
+            }
+        }
+    }
+
+    assert_eq!(
+        prepare_at::<Route>("/#test"),
+        "<h1>App</h1><a href=\"/#test\" aria-current=\"page\">Link</a><a href=\"/\">Empty</a>"
+    );
+}


### PR DESCRIPTION
The docsite is emitting extra `#` for empty hash fragments which we shouldn't do.

Fixes #3658