### PR TITLE
Feat: Ability To Disable File Drop Handler

### DIFF
--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub(crate) background_color: Option<(u8, u8, u8, u8)>,
     pub(crate) last_window_close_behavior: WindowCloseBehaviour,
     pub(crate) custom_event_handler: Option<CustomEventHandler>,
+    pub(crate) disable_file_drop_handler: bool,
 }
 
 impl LaunchConfig for Config {}
@@ -108,6 +109,7 @@ impl Config {
             background_color: None,
             last_window_close_behavior: WindowCloseBehaviour::LastWindowExitsApp,
             custom_event_handler: None,
+            disable_file_drop_handler: false,
         }
     }
 
@@ -128,6 +130,13 @@ impl Config {
     /// Set whether or not the right-click context menu should be disabled.
     pub fn with_disable_context_menu(mut self, disable: bool) -> Self {
         self.disable_context_menu = disable;
+        self
+    }
+
+    /// Set whether or not the file drop handler should be disabled.
+    /// On Windows the drop handler must be disabled for HTML drag and drop APIs to work.
+    pub fn with_disable_drag_drop_handler(mut self, disable: bool) -> Self {
+        self.disable_file_drop_handler = disable;
         self
     }
 

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -359,8 +359,11 @@ impl WebviewInstance {
                 }
             }) // prevent all navigations
             .with_asynchronous_custom_protocol(String::from("dioxus"), request_handler)
-            .with_web_context(&mut web_context)
-            .with_drag_drop_handler(file_drop_handler);
+            .with_web_context(&mut web_context);
+
+        if !cfg.disable_file_drop_handler {
+            webview = webview.with_drag_drop_handler(file_drop_handler);
+        }
 
         if let Some(color) = cfg.background_color {
             webview = webview.with_background_color(color);


### PR DESCRIPTION
If the file drop handler isn't provided, files cannot be dropped. Unfortunately, this causes HTML drag-n-drop events to no longer fire on Windows. This is an upstream issue with Window's webview2. 

The solution for now is to allow disabling the drop handler to fit the dev's required use-case. 
Related Issue (\*does not fully solve\*): #2167