### PR TITLE
Allow Missing Prop Docs

### DIFF
--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -47,6 +47,7 @@ impl ToTokens for ComponentBody {
                 let props_struct = self.props_struct();
                 quote! {
                     #[doc = #doc]
+                    #[allow(missing_docs)]
                     #props_struct
                 }
             }

--- a/translations/pt-br/README.md
+++ b/translations/pt-br/README.md
@@ -167,7 +167,7 @@ Para mais informações sobre quais funções estão atualmente disponíveis e p
 
 Quer adentrar e ajudar a construir o futuro do frontend em Rust? Há um vasto número de lugares em que você pode contribuir e fazer uma grande diferença:
 
-- [Ferramentas CLI](https://github.com/dioxusLabs/cli)
+- [Ferramentas CLI](https://github.com/DioxusLabs/dioxus/tree/main/packages/cli)
 - [Documentação e Exemplos de Projeto](https://github.com/dioxusLabs/docsite)
 - LiveView e Servidor Web
 - Sistema de Componentes prontos


### PR DESCRIPTION
Adds `#[allow(missing_docs)]` for the auto-generated props struct. We could also generate the docs but I'm not sure what we would generate.

Fixes #3690 