### PR TITLE
use main exe name without extension for bundler on windows

### DIFF
--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -153,7 +153,7 @@ impl Bundle {
 
         let binaries = vec![
             // We use the name of the exe but it has to be in the same directory
-            BundleBinary::new(name.display().to_string(), true)
+            BundleBinary::new(krate.executable_name().to_string(), true)
                 .set_src_path(Some(bundle.app.exe.display().to_string())),
         ];
 


### PR DESCRIPTION
fixes msi & nsis bundles having `.exe.exe` extension in installer created shortcuts [as mentioned here](https://github.com/DioxusLabs/dioxus/issues/3233#issuecomment-2637001313).

Haven't tested on other platforms.