### PR TITLE
docs: improved issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve Dioxus
+labels: bug
 ---
 
 **Problem**
@@ -24,14 +25,16 @@ Steps to reproduce the behavior:
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Environment:**
- - Dioxus version:  <!-- e.g. v0.17, `master` -->
- - Rust version:    <!-- e.g. 1.43.0, `nightly` -->
- - OS info:         <!-- e.g. MacOS -->
- - App platform:    <!-- e.g. `web`, `desktop` -->
+
+- Dioxus version:  <!-- e.g., v0.17, main -->
+- Rust version:    <!-- e.g., 1.123.0, nightly -->
+- OS info:         <!-- e.g., macOS, NixOS 25.05 -->
+- App platform:    <!-- e.g., web, desktop -->
 
 **Questionnaire**
-<!-- If you feel up to the challenge, please uncomment one of the lines below: -->
 
-<!-- I'm interested in fixing this myself but don't know where to start -->
-<!-- I would like to fix and I have a solution -->
-<!-- I don't have time to fix this right now, but maybe later -->
+<!-- If you feel up to the challenge, please uncomment applicable lines below: -->
+
+<!-- I'm interested in fixing this myself but don't know where to start. -->
+<!-- I would like to fix and I have a solution. -->
+<!-- I don't have time to fix this right now, but maybe later. -->

--- a/.github/ISSUE_TEMPLATE/feature_requst.md
+++ b/.github/ISSUE_TEMPLATE/feature_requst.md
@@ -1,19 +1,19 @@
 ---
 name: Feature Request
 about: If you have any interesting advice, you can tell us.
+labels: enhancement
 ---
 
 ## Feature Request
 
 <!--
-Describe the issue in detail and why we should add it. To help us out, please poke through our issue tracker and make sure it's not a duplicate issue.
-
-
-Please add the corresponding labels to the issue.
+Describe the issue in detail and why we should add it. To help us out,
+please poke through our issue tracker and make sure it's not a duplicate issue.
 -->
 
 ## Implement Suggestion
 
 <!--
-If you have any suggestions on how to design this feature or any prior art, list them here.
+If you have any suggestions on how to design this feature or any prior art,
+list them here.
 -->


### PR DESCRIPTION
The "Please add the corresponding labels to the issue." line started the chain reaction (issue OP can't add labels), and now I just overall polished the current templates.

From [the docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), the non-YAML templates are considered legacy templates, but the documentation for them is [still up](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository). I'm not user if we should switch. But Typst uses them and I didn't have any problems with them.
