### PR TITLE
Fix serving desktop+fullstack apps that have not set a server url

### DIFF
--- a/examples/fullstack-desktop/src/main.rs
+++ b/examples/fullstack-desktop/src/main.rs
@@ -3,6 +3,8 @@ use dioxus::prelude::*;
 
 fn main() {
     // Set the url of the server where server functions are hosted.
+    #[cfg(not(feature = "server"))]
+    dioxus::fullstack::prelude::server_fn::client::set_server_url("http://127.0.0.1:8080");
     dioxus::launch(app);
 }
 

--- a/examples/fullstack-desktop/src/main.rs
+++ b/examples/fullstack-desktop/src/main.rs
@@ -3,8 +3,6 @@ use dioxus::prelude::*;
 
 fn main() {
     // Set the url of the server where server functions are hosted.
-    #[cfg(not(feature = "server"))]
-    dioxus::fullstack::prelude::server_fn::client::set_server_url("http://127.0.0.1:8080");
     dioxus::launch(app);
 }
 

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -220,8 +220,10 @@ impl LaunchBuilder {
             use dioxus_fullstack::prelude::server_fn::client::{get_server_url, set_server_url};
             if get_server_url().is_empty() {
                 let serverurl = format!(
-                    "http://127.0.0.1:{}",
-                    std::env::var("PORT").unwrap_or_else(|_| "8080".to_string())
+                    "http://{}:{}",
+                    std::env::var("DIOXUS_DEVSERVER_IP")
+                        .unwrap_or_else(|_| "127.0.0.1".to_string()),
+                    std::env::var("DIOXUS_DEVSERVER_PORT").unwrap_or_else(|_| "8080".to_string())
                 )
                 .leak();
                 set_server_url(serverurl);


### PR DESCRIPTION
The CLI was pointing the desktop application to the fullstack backend server url instead of the url the devserver proxied the backend on. This PR use the CLI proxy address instead

Fixes #3674