### PR TITLE
fix onload and onerror parsing error

### DIFF
--- a/packages/html/src/events/image.rs
+++ b/packages/html/src/events/image.rs
@@ -45,6 +45,7 @@ impl ImageData {
 /// A serialized version of ImageData
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Clone)]
 pub struct SerializedImageData {
+    #[cfg_attr(feature = "serialize", serde(default))]
     load_error: bool,
 }
 


### PR DESCRIPTION
regression error induced by 299b123 where serde default got removed from `load_error` attribute of `ImageData`.

```diff
pub struct ImageData {
-     #[cfg_attr(feature = "serialize", serde(default))]
-     pub load_error: bool,
+     inner: Box<dyn HasImageData>,
}

// ...

+ struct SerializedImageData {
+     load_error: bool,
+ }
```

Also, it seems like neither the `load` nor the `error` events are used in [`serializeEvent`](https://github.com/DioxusLabs/dioxus/blob/36353eb90b72668f0b4173d7f083d0ad67caf416/packages/interpreter/src/ts/serialize.ts#L13). This could be an issue when an `error` event goes unnoticed and the `load_error` attribute is still set to `false` as it is the default value for `bool`.

Something like this could do the trick but it might be out of scope for this PR.

```ts
if (event.type === "load") {
  extend({ load_error: false })
}
if (event.type === "error") {
  extend({ load_error: true })
}
```