### PR TITLE
Feat: CLI Debug Warning

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -41,6 +41,10 @@ async fn main() {
     }
 
     let args = TraceController::initialize();
+    
+    #[cfg(debug_assertions)]
+    tracing::warn!("CLI was built with debug profile. Commands will run slower.");
+
     let result = match args.action {
         Commands::Translate(opts) => opts.translate(),
         Commands::New(opts) => opts.create(),


### PR DESCRIPTION
This PR adds a warning if the CLI was built and ran in debug.

Why? I've ran the CLI in debug without realizing it and wondered why the docsite took 6 minutes to copy 2 assets.