### PR TITLE
Expose Outlet Context

### DIFF
--- a/packages/router/src/components/router.rs
+++ b/packages/router/src/components/router.rs
@@ -47,11 +47,10 @@ where
 
     use_hook(|| {
         provide_router_context(RouterContext::new(props.config.call(())));
+    });
 
-        provide_context(OutletContext::<R> {
-            current_level: 0,
-            _marker: std::marker::PhantomData,
-        });
+    use_hook(|| {
+        provide_context(OutletContext::<R>::new());
     });
 
     rsx! { Outlet::<R> {} }

--- a/packages/router/src/contexts/outlet.rs
+++ b/packages/router/src/contexts/outlet.rs
@@ -10,7 +10,7 @@ use crate::{routable::Routable, utils::use_router_internal::use_router_internal}
 /// # Type Parameters
 ///
 /// * `R` - The routable type that implements the routing logic
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct OutletContext<R> {
     current_level: usize,
     _marker: std::marker::PhantomData<R>,

--- a/packages/router/src/contexts/outlet.rs
+++ b/packages/router/src/contexts/outlet.rs
@@ -20,7 +20,7 @@ impl<R> OutletContext<R> {
     /// Creates a new outlet context starting at level 1
     pub fn new() -> Self {
         Self {
-            current_level: 1,
+            current_level: 0,
             _marker: std::marker::PhantomData,
         }
     }

--- a/packages/router/src/contexts/outlet.rs
+++ b/packages/router/src/contexts/outlet.rs
@@ -2,7 +2,7 @@ use dioxus_lib::prelude::*;
 
 use crate::{routable::Routable, utils::use_router_internal::use_router_internal};
 
-pub(crate) struct OutletContext<R> {
+pub struct OutletContext<R> {
     pub current_level: usize,
     pub _marker: std::marker::PhantomData<R>,
 }
@@ -16,7 +16,7 @@ impl<R> Clone for OutletContext<R> {
     }
 }
 
-pub(crate) fn use_outlet_context<R: 'static>() -> OutletContext<R> {
+pub fn use_outlet_context<R: 'static>() -> OutletContext<R> {
     use_hook(|| {
         try_consume_context().unwrap_or(OutletContext::<R> {
             current_level: 1,

--- a/packages/router/src/contexts/outlet.rs
+++ b/packages/router/src/contexts/outlet.rs
@@ -2,8 +2,34 @@ use dioxus_lib::prelude::*;
 
 use crate::{routable::Routable, utils::use_router_internal::use_router_internal};
 
+/// A context that manages nested routing levels for outlet components.
+///
+/// The outlet context keeps track of the current nesting level of routes and helps
+/// manage the hierarchical structure of nested routes in the application.
+///
+/// # Type Parameters
+///
+/// * `R` - The routable type that implements the routing logic
+///
+/// # Fields
+///
+/// * `current_level` - The current nesting level of the route
+/// * `_marker` - Phantom data to hold the generic type parameter
+///
+/// # Examples
+///
+/// ```rust
+/// let outlet = OutletContext {
+///     current_level: 1,
+///     _marker: std::marker::PhantomData,
+/// };
+/// ```
 pub struct OutletContext<R> {
+    /// The current nesting level of the route in the outlet hierarchy.
+    /// Level 0 represents the root route, and each nested route increases the level by 1.
     pub current_level: usize,
+    /// Phantom data marker to hold the generic type parameter `R`.
+    /// This field is not used at runtime and has zero size.
     pub _marker: std::marker::PhantomData<R>,
 }
 
@@ -15,7 +41,25 @@ impl<R> Clone for OutletContext<R> {
         }
     }
 }
-
+/// Returns the current outlet context from the component hierarchy.
+///
+/// This hook retrieves the outlet context from the current component scope. If no context is found,
+/// it creates a new context with a default level of 1.
+///
+/// # Type Parameters
+///
+/// * `R` - The routable type that implements the routing logic
+///
+/// # Returns
+///
+/// Returns an [`OutletContext<R>`] containing the current nesting level information.
+///
+/// # Examples
+///
+/// ```rust
+/// let outlet_ctx = use_outlet_context::<MyRouter>();
+/// println!("Current nesting level: {}", outlet_ctx.current_level);
+/// ```
 pub fn use_outlet_context<R: 'static>() -> OutletContext<R> {
     use_hook(|| {
         try_consume_context().unwrap_or(OutletContext::<R> {

--- a/packages/router/src/lib.rs
+++ b/packages/router/src/lib.rs
@@ -35,6 +35,7 @@ pub mod components {
 mod contexts {
     pub(crate) mod navigator;
     pub(crate) mod outlet;
+    pub use outlet::{use_outlet_context, OutletContext};
     pub(crate) mod router;
     pub use navigator::*;
     pub(crate) use router::*;


### PR DESCRIPTION
AI Description

Here are the key reasons for exposing `OutletContext`:

- **Custom Route Rendering**
  - Implement custom outlet rendering logic
  - Control how nested routes are displayed
  - Override default outlet behavior when needed

- **Advanced Use Cases**
  - Build middleware that needs route depth information
  - Implement route-based caching strategies
  - Create nested loading states with different behaviors

- **Component Libraries**
  - Build reusable navigation components
  - Create layout systems that adapt to route depth
  - Implement smart containers that respond to routing context

These use cases justify exposing `OutletContext` as part of the public API, allowing developers to build more sophisticated routing-aware features.

My Description:
Outlet is handling nested routing and levels, and gives the level to the router to render with the level. So without OutletContext and having Somekind of animation between page route components will miss the Layout component during the animation period. 

Current Example Gif:
![ezgif-8dca0cb88546e6](https://github.com/user-attachments/assets/146d70d2-0e01-4867-96ae-f6b2935565b1)

In the gif above, Blog Layout is disappearing, and i can't apply custom rendering based on any levels.

If i can increment level during the animation phase as well
```rust
    provide_context({
        OutletContext::<R> {
            current_level: current_level + 1,
            _marker: std::marker::PhantomData,
        }
    });
```
My custom component can mimic as an Outlet which have all the goodies that dioxus Outlet provides and i can do custom rendering with the level and the router.

New Example Gif:
![ezgif-8f73855265bb9f](https://github.com/user-attachments/assets/1d486a1d-42c9-4c99-ad5d-5aaad23034cd)

We still have super tight coupling of Rendering with Router. Eventually we might want to decouple things a bit, so other developers can use different rendering ways for their use case. Like i want to render just the layout without any child route, which is not easy for the time being. Maybe in future we can add some stuffs here

```rust
pub trait Routable: FromStr + Display + Clone + 'static {
    /// The error that can occur when parsing a route.
    const SITE_MAP: &'static [SiteMapSegment];

    /// Render the route at the given level
    fn render(&self, level: usize) -> Element;

    /// Render the layout only at the given level
    fn render_layout(&self, level: usize) -> Element;

    /// Render the child route only at the given level
    fn render_child_route(&self, level: usize) -> Element;
```

To have more flexibility for the devs to build more complex animations or rendering strategies 
