### PR TITLE
Add missing optional dependency to web feature

### DIFF
--- a/examples/fullstack-auth/Cargo.toml
+++ b/examples/fullstack-auth/Cargo.toml
@@ -57,4 +57,4 @@ server = [
     "http",
     "tower",
 ]
-web = ["dioxus-web"]
+web = ["dioxus/web", "dioxus-web"]


### PR DESCRIPTION
The 'web' feature in Cargo.toml listed `dioxus-web` as a dependency but it also needed to have `dioxus/web` in order to compile properly.