### PR TITLE
Make GenericRouterContext pub

### DIFF
--- a/packages/router/src/contexts/router.rs
+++ b/packages/router/src/contexts/router.rs
@@ -309,6 +309,7 @@ impl RouterContext {
     }
 }
 
+/// This context is set to the RouterConfig on_update method
 pub struct GenericRouterContext<R> {
     inner: RouterContext,
     _marker: std::marker::PhantomData<R>,

--- a/packages/router/src/lib.rs
+++ b/packages/router/src/lib.rs
@@ -38,7 +38,7 @@ mod contexts {
     pub(crate) mod router;
     pub use navigator::*;
     pub(crate) use router::*;
-    pub use router::{root_router, RouterContext};
+    pub use router::{root_router, GenericRouterContext, RouterContext};
 }
 
 mod router_cfg;


### PR DESCRIPTION
`RouterConfig` accepts a `on_default` callback. To be able to create types for this callback, you need access to `GenericRouterContext`. This PR just makes that type pub. 

Here is the customer use case:
```rust
/// requires type 
pub fn on_update_route<R>(state: GenericRouterContext<R>) -> Option<NavigationTarget<R>>
where
    R: Routable,
{
    None
}

rsx! {
  Router::<router::Route> {
    config: || {
      RouterConfig::default().on_update(on_update_route)
    }
   }
}
```