### PR TITLE
Fix opened browser blocking `dx serve`

### DIFF
--- a/packages/cli/src/serve/handle.rs
+++ b/packages/cli/src/serve/handle.rs
@@ -356,7 +356,7 @@ impl AppHandle {
             Some(base_path) => format!("/{}", base_path.trim_matches('/')),
             None => "".to_owned(),
         };
-        _ = open::that(format!("{protocol}://{address}{base_path}"));
+        _ = open::that_detached(format!("{protocol}://{address}{base_path}"));
     }
 
     /// Use `xcrun` to install the app to the simulator


### PR DESCRIPTION
When opening a browser (firefox in my case) though pressing `o` and there wasn't an instance of firefox running yet. `dx serve` would hang until the instance was closed again. 

This wasn't the case when a firefox instance was already running and was only opening a new tab.
Opening the browser detached solves the issue.