### PR TITLE
Provide `HotkeyState` on Global Shortcut Events 

### DIFF
--- a/examples/overlay.rs
+++ b/examples/overlay.rs
@@ -6,7 +6,7 @@
 //! We also add a global shortcut to toggle the overlay on and off, so you could build a raycast-type app with this.
 
 use dioxus::desktop::{
-    tao::dpi::PhysicalPosition, use_global_shortcut, LogicalSize, WindowBuilder,
+    tao::dpi::PhysicalPosition, use_global_shortcut, HotKeyState, LogicalSize, WindowBuilder,
 };
 use dioxus::prelude::*;
 
@@ -19,7 +19,11 @@ fn main() {
 fn app() -> Element {
     let mut show_overlay = use_signal(|| true);
 
-    _ = use_global_shortcut("cmd+g", move || show_overlay.toggle());
+    _ = use_global_shortcut("cmd+g", move |state| {
+        if state == HotKeyState::Pressed {
+            show_overlay.toggle();
+        }
+    });
 
     rsx! {
         document::Link {

--- a/examples/shortcut.rs
+++ b/examples/shortcut.rs
@@ -5,7 +5,7 @@
 //!
 //! These are *global* shortcuts, so they will work even if your app is not in focus.
 
-use dioxus::desktop::use_global_shortcut;
+use dioxus::desktop::{use_global_shortcut, HotKeyState};
 use dioxus::prelude::*;
 
 fn main() {
@@ -15,7 +15,11 @@ fn main() {
 fn app() -> Element {
     let mut toggled = use_signal(|| false);
 
-    _ = use_global_shortcut("ctrl+s", move || toggled.toggle());
+    _ = use_global_shortcut("ctrl+s", move |state| {
+        if state == HotKeyState::Pressed {
+            toggled.toggle();
+        }
+    });
 
     rsx!("toggle: {toggled}")
 }

--- a/packages/desktop/src/desktop_context.rs
+++ b/packages/desktop/src/desktop_context.rs
@@ -4,7 +4,7 @@ use crate::{
     file_upload::NativeFileHover,
     ipc::UserWindowEvent,
     query::QueryEngine,
-    shortcut::{HotKey, ShortcutHandle, ShortcutRegistryError},
+    shortcut::{HotKey, HotKeyState, ShortcutHandle, ShortcutRegistryError},
     webview::WebviewInstance,
     AssetRequest, Config, WryEventHandler,
 };
@@ -214,7 +214,7 @@ impl DesktopService {
     pub fn create_shortcut(
         &self,
         hotkey: HotKey,
-        callback: impl FnMut() + 'static,
+        callback: impl FnMut(HotKeyState) + 'static,
     ) -> Result<ShortcutHandle, ShortcutRegistryError> {
         self.shared
             .shortcut_manager

--- a/packages/desktop/src/lib.rs
+++ b/packages/desktop/src/lib.rs
@@ -51,5 +51,5 @@ pub use config::{Config, WindowCloseBehaviour};
 pub use desktop_context::{window, DesktopContext, DesktopService, WeakDesktopContext};
 pub use event_handlers::WryEventHandler;
 pub use hooks::*;
-pub use shortcut::{ShortcutHandle, ShortcutRegistryError};
+pub use shortcut::{HotKeyState, ShortcutHandle, ShortcutRegistryError};
 pub use wry::RequestAsyncResponder;

--- a/packages/desktop/src/mobile_shortcut.rs
+++ b/packages/desktop/src/mobile_shortcut.rs
@@ -78,6 +78,16 @@ impl fmt::Display for HotkeyError {
 
 pub struct GlobalHotKeyEvent {
     pub id: u32,
+    pub state: HotKeyState,
+}
+
+/// Describes the state of the hotkey.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HotKeyState {
+    /// The hotkey is pressed.
+    Pressed,
+    /// The hotkey is released.
+    Released,
 }
 
 pub(crate) type Code = dioxus_html::input_data::keyboard_types::Code;

--- a/packages/desktop/src/shortcut.rs
+++ b/packages/desktop/src/shortcut.rs
@@ -66,9 +66,13 @@ impl ShortcutRegistry {
 
     #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
     pub(crate) fn call_handlers(&self, id: GlobalHotKeyEvent) {
-        if let Some(ShortcutInner { callbacks, .. }) = self.shortcuts.borrow_mut().get_mut(&id.id) {
-            for (_, callback) in callbacks.iter_mut() {
-                (callback)();
+        if id.state == global_hotkey::HotKeyState::Pressed {
+            if let Some(ShortcutInner { callbacks, .. }) =
+                self.shortcuts.borrow_mut().get_mut(&id.id)
+            {
+                for (_, callback) in callbacks.iter_mut() {
+                    (callback)();
+                }
             }
         }
     }


### PR DESCRIPTION
This state is now provided as an argument to the event handler, such that the user can decide whether to react to the global shortcut being released or not.