### PR TITLE
Fix span locations in ifmt and components

### DIFF
--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -19,7 +19,7 @@
 use crate::innerlude::*;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2_diagnostics::SpanDiagnosticExt;
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
 use std::{collections::HashSet, vec};
 use syn::{
     parse::{Parse, ParseStream},
@@ -211,11 +211,16 @@ impl Component {
 
         let name = &self.name;
         let generics = &self.generics;
+        let inner_scope_span = self
+            .brace
+            .as_ref()
+            .map(|b| b.span.join())
+            .unwrap_or(self.name.span());
 
         let mut tokens = if let Some(props) = manual_props.as_ref() {
-            quote! { let mut __manual_props = #props; }
+            quote_spanned! { props.span() => let mut __manual_props = #props; }
         } else {
-            quote! { fc_to_builder(#name #generics) }
+            quote_spanned! { self.name.span() => fc_to_builder(#name #generics) }
         };
 
         tokens.append_all(self.add_fields_to_builder(
@@ -225,16 +230,19 @@ impl Component {
         if !self.children.is_empty() {
             let children = &self.children;
             if manual_props.is_some() {
-                tokens.append_all(quote! { __manual_props.children = { #children }; })
+                tokens.append_all(
+                    quote_spanned! { inner_scope_span => __manual_props.children = { #children }; },
+                )
             } else {
-                tokens.append_all(quote! { .children( { #children } ) })
+                tokens.append_all(quote_spanned! { inner_scope_span => .children( { #children } ) })
             }
         }
 
         if manual_props.is_some() {
             tokens.append_all(quote! { __manual_props })
         } else {
-            tokens.append_all(quote! { .build() })
+            // If this does fail to build, point the compiler error at the Prop braces
+            tokens.append_all(quote_spanned! { inner_scope_span => .build() })
         }
 
         tokens

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -232,11 +232,11 @@ impl Component {
             // If the props don't accept children, attach the error to the first child
             if manual_props.is_some() {
                 tokens.append_all(
-                    quote_spanned! { children.first_root_span() => __manual_props.children = { #children }; },
+                    quote_spanned! { children.first_root_span() => __manual_props.children = #children; },
                 )
             } else {
                 tokens.append_all(
-                    quote_spanned! { children.first_root_span() => .children( { #children } ) },
+                    quote_spanned! { children.first_root_span() => .children( #children ) },
                 )
             }
         }

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -229,12 +229,15 @@ impl Component {
 
         if !self.children.is_empty() {
             let children = &self.children;
+            // If the props don't accept children, attach the error to the first child
             if manual_props.is_some() {
                 tokens.append_all(
-                    quote_spanned! { inner_scope_span => __manual_props.children = { #children }; },
+                    quote_spanned! { children.first_root_span() => __manual_props.children = { #children }; },
                 )
             } else {
-                tokens.append_all(quote_spanned! { inner_scope_span => .children( { #children } ) })
+                tokens.append_all(
+                    quote_spanned! { children.first_root_span() => .children( { #children } ) },
+                )
             }
         }
 

--- a/packages/rsx/src/template_body.rs
+++ b/packages/rsx/src/template_body.rs
@@ -56,7 +56,7 @@
 use self::location::DynIdx;
 use crate::innerlude::Attribute;
 use crate::*;
-use proc_macro2::TokenStream as TokenStream2;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use proc_macro2_diagnostics::SpanDiagnosticExt;
 use syn::parse_quote;
 
@@ -384,6 +384,14 @@ impl TemplateBody {
                 vec![ #( #component_values ),* ],
                 __TEMPLATE_ROOTS,
             )
+        }
+    }
+
+    /// Get the span of the first root of this template
+    pub(crate) fn first_root_span(&self) -> Span {
+        match self.roots.first() {
+            Some(root) => root.span(),
+            _ => Span::call_site(),
         }
     }
 }


### PR DESCRIPTION
We were not forwarding the span of the litstr when parsing ifmt from a macro call which causes the error messages to blame the whole call span. This PR fixes that issue