### PR TITLE
Fix the typo checking CI

### DIFF
--- a/packages/autofmt/src/indent.rs
+++ b/packages/autofmt/src/indent.rs
@@ -12,11 +12,11 @@ pub struct IndentOptions {
 }
 
 impl IndentOptions {
-    pub fn new(typ: IndentType, width: usize, split_line_attributes: bool) -> Self {
+    pub fn new(ty: IndentType, width: usize, split_line_attributes: bool) -> Self {
         assert_ne!(width, 0, "Cannot have an indent width of 0");
         Self {
             width,
-            indent_string: match typ {
+            indent_string: match ty {
                 IndentType::Tabs => "\t".into(),
                 IndentType::Spaces => " ".repeat(width),
             },


### PR DESCRIPTION
Typo checking CI has been failing for a couple PRs because a function accepts `typ`. This PR changes it to `ty` which we use elsewhere to mean type and doesn't trigger CI failure