### PR TITLE
fix: Use as_value() to properly serialize form values in login example

### DIFF
--- a/examples/login_form.rs
+++ b/examples/login_form.rs
@@ -17,8 +17,8 @@ fn app() -> Element {
         let resp = reqwest::Client::new()
             .post("http://localhost:8080/login")
             .form(&[
-                ("username", &evt.values()["username"]),
-                ("password", &evt.values()["password"]),
+                ("username", evt.values()["username"].as_value()),
+                ("password", evt.values()["password"].as_value()),
             ])
             .send()
             .await;


### PR DESCRIPTION
This fix is for issue: https://github.com/DioxusLabs/dioxus/issues/3783

The login form example was trying to directly use FormValue in reqwest's form method, which doesn't implement Serialize. This change extracts the actual string values using as_value() before sending them to the server.