### PR TITLE
fix(server): Provide GoogleBot compatibility.

### DIFF
--- a/packages/fullstack/src/server/mod.rs
+++ b/packages/fullstack/src/server/mod.rs
@@ -374,16 +374,7 @@ impl RenderHandleState {
 pub async fn render_handler(
     State(state): State<RenderHandleState>,
     request: Request<Body>,
-) -> impl IntoResponse {
-    // Only respond to requests for HTML
-    if let Some(mime) = request.headers().get("Accept") {
-        let mime = mime.to_str().map(|mime| mime.to_ascii_lowercase());
-        match mime {
-            Ok(accepts) if accepts.contains("text/html") => {}
-            _ => return Err(StatusCode::NOT_ACCEPTABLE),
-        }
-    }
-
+) -> Result<http::Response<axum::body::Body>, StatusCode> {
     let cfg = &state.config;
     let ssr_state = state.ssr_state();
     let build_virtual_dom = {


### PR DESCRIPTION
- Actually, GoogleBot will crawl as below command.
```
curl -A GoogleBot 'http://localhost:8080'
```
- However, dioxus `render_handler` rejects GoogleBot crawl.
  - It DOES mean dioxus webapp can't be indexed by GoogleBot properly.
- I removed accept checking instead of optional parameter.
  - Because all dioxus app based fullstack will be desired to be crawl and proper SEO.

- Before this PR, it only allows requests including `accept`, however it allows all requests

- I would say that its part doesn't need to provide backward compatibility
because SEO capability is a crucial issue.
  - It means it can make starters confusion why they can't check their page on
  google inspection.
  - So I propose that it SHOULD provide SEO feature by default.