### PR TITLE
doc: Fix spawn doc

### DIFF
--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -120,7 +120,7 @@ pub fn spawn_isomorphic(fut: impl Future<Output = ()> + 'static) -> Task {
     Runtime::with_current_scope(|cx| cx.spawn_isomorphic(fut)).unwrap()
 }
 
-/// Spawns the future but does not return the [`Task`]. This task will automatically be canceled when the component is dropped.
+/// Spawns the future and returns the [`Task`]. This task will automatically be canceled when the component is dropped.
 ///
 /// # Example
 /// ```rust


### PR DESCRIPTION
Fixes typo, clearly the function returns the task.