### PR TITLE
Fix later-attached wry event handlers not getting called

### DIFF
--- a/packages/desktop/src/event_handlers.rs
+++ b/packages/desktop/src/event_handlers.rs
@@ -56,7 +56,7 @@ impl WindowEventHandlers {
             // if this event does not apply to the window this listener cares about, return
             if let Event::WindowEvent { window_id, .. } = event {
                 if *window_id != handler.window_id {
-                    return;
+                    continue;
                 }
             }
             (handler.handler)(event, target)


### PR DESCRIPTION
Fixes #3907.

The issue is caused by a simple logic error: instead of aborting the entire loop when we find a window that doesn't match our id, we should just skip the current iteration.