### PR TITLE
Fix windows CI by removing virtual file system cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,7 +311,7 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       - name: "Install Rust toolchain"
-        run: rm -rf E:/.rustup && rustup default stable && rustup component add clippy,rustfmt
+        run: rd /s /q E:/.rustup && rustup default stable && rustup component add clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,9 +310,8 @@ jobs:
         run: |
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
-      - uses: dtolnay/rust-toolchain@1.84.0
-        with:
-          components: rustfmt, clippy
+      - name: "Install Rust toolchain"
+        run: rustup component add clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,7 +311,7 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       - name: "Install Rust toolchain"
-        run: rd /s /q E:/.rustup && rustup default stable && rustup component add clippy,rustfmt
+        run: Remove-Item -Path E:/.rustup -Recurse -Force && rustup default stable && rustup component add clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,7 +311,7 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       - name: "Install Rust toolchain"
-        run: Remove-Item -Path E:/.rustup -Recurse -Force && rustup default stable && rustup component add clippy,rustfmt
+        run: rustup toolchain uninstall stable && rustup toolchain install stable && rustup default stable && rustup component add clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,7 +311,7 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       - name: "Install Rust toolchain"
-        run: rustup default stable && rustup component add clippy,rustfmt
+        run: rm -rf E:/.rustup && rustup default stable && rustup component add clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,13 +302,13 @@ jobs:
     name: "cargo test | windows"
     steps:
       - uses: actions/checkout@v4
-      # - name: Create Dev Drive using ReFS
-      #   run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+      - name: Create Dev Drive using ReFS
+        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
-      # # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
-      # - name: Copy Git Repo to Dev Drive
-      #   run: |
-      #     Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
+      # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
+      - name: Copy Git Repo to Dev Drive
+        run: |
+          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       - uses: dtolnay/rust-toolchain@1.84.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,6 +301,7 @@ jobs:
       labels: "windows-latest"
     name: "cargo test | windows"
     steps:
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.84.0
         with:
           components: rustfmt, clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,13 +311,13 @@ jobs:
           Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
       - name: "Install Rust toolchain"
-        run: rustup component add clippy,rustfmt
+        run: rustup default stable && rustup component add clippy,rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}
           cache-all-crates: "true"
 
-      - name: "Install Rust toolchain"
+      - name: "Show Rust toolchain"
         working-directory: ${{ env.UV_WORKSPACE }}
         run: rustup show
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,15 +301,6 @@ jobs:
       labels: "windows-latest"
     name: "cargo test | windows"
     steps:
-      - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
-
-      # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
-      - name: Copy Git Repo to Dev Drive
-        run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
-
       - uses: dtolnay/rust-toolchain@1.84.0
         with:
           components: rustfmt, clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,22 +302,23 @@ jobs:
     name: "cargo test | windows"
     steps:
       - uses: actions/checkout@v4
-      - name: Create Dev Drive using ReFS
-        run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
+      # - name: Create Dev Drive using ReFS
+      #   run: ${{ github.workspace }}/.github/workflows/setup-dev-drive.ps1
 
-      # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
-      - name: Copy Git Repo to Dev Drive
-        run: |
-          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
+      # # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
+      # - name: Copy Git Repo to Dev Drive
+      #   run: |
+      #     Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.UV_WORKSPACE }}" -Recurse
 
-      - name: "Install Rust toolchain"
-        run: rustup toolchain uninstall stable && rustup toolchain install stable && rustup default stable && rustup component add clippy,rustfmt
+      - uses: dtolnay/rust-toolchain@1.84.0
+        with:
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ${{ env.UV_WORKSPACE }}
           cache-all-crates: "true"
 
-      - name: "Show Rust toolchain"
+      - name: "Install Rust toolchain"
         working-directory: ${{ env.UV_WORKSPACE }}
         run: rustup show
 

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -15,11 +15,6 @@ $Tmp = "$($Drive)/uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
-New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
-if (Test-Path "C:/Users/runneradmin/.cargo") {
-    Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
-}
-
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `
 	"TMP=$($Tmp)" `

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -15,10 +15,10 @@ $Tmp = "$($Drive)/uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
-New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
-if (Test-Path "C:/Users/runneradmin/.cargo") {
-    Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
-}
+# New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
+# if (Test-Path "C:/Users/runneradmin/.cargo") {
+#     Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+# }
 
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -15,6 +15,8 @@ $Tmp = "$($Drive)/uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
+Remove-Item -Recurse -Force "C:/Users/runneradmin/.cargo"
+Remove-Item -Recurse -Force "C:/Users/runneradmin/.rustup"
 New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
 if (Test-Path "C:/Users/runneradmin/.cargo") {
     Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -15,6 +15,7 @@ $Tmp = "$($Drive)/uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
+New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
 if (Test-Path "C:/Users/runneradmin/.cargo") {
     Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
 }

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -15,6 +15,10 @@ $Tmp = "$($Drive)/uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
+if (Test-Path "C:/Users/runneradmin/.cargo") {
+    Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+}
+
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `
 	"TMP=$($Tmp)" `

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -15,10 +15,10 @@ $Tmp = "$($Drive)/uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
-# New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
-# if (Test-Path "C:/Users/runneradmin/.cargo") {
-#     Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
-# }
+New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
+if (Test-Path "C:/Users/runneradmin/.cargo") {
+    Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force
+}
 
 Write-Output `
 	"DEV_DRIVE=$($Drive)" `

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -15,8 +15,6 @@ $Tmp = "$($Drive)/uv-tmp"
 # Create the directory ahead of time in an attempt to avoid race-conditions
 New-Item $Tmp -ItemType Directory
 
-Remove-Item -Recurse -Force "C:/Users/runneradmin/.cargo"
-Remove-Item -Recurse -Force "C:/Users/runneradmin/.rustup"
 New-Item -Path "$($Drive)/.cargo/bin" -ItemType Directory -Force
 if (Test-Path "C:/Users/runneradmin/.cargo") {
     Copy-Item -Path "C:/Users/runneradmin/.cargo/*" -Destination "$($Drive)/.cargo/" -Recurse -Force

--- a/.github/workflows/setup-dev-drive.ps1
+++ b/.github/workflows/setup-dev-drive.ps1
@@ -27,4 +27,5 @@ Write-Output `
 	"RUSTUP_HOME=$($Drive)/.rustup" `
 	"CARGO_HOME=$($Drive)/.cargo" `
 	"UV_WORKSPACE=$($Drive)/uv" `
+	"PATH=$($Drive)/.cargo/bin;$env:PATH" `
 	>> $env:GITHUB_ENV


### PR DESCRIPTION
This just disables the vfs logic in windows CI. This will make the CI slower, but it does fix the caching issue. [matrix_test (x86_64-apple-darwin, macos-13, 1.84.0, false, test, --all --tests)](https://github.com/DioxusLabs/dioxus/actions/runs/14091293751/job/39468383837#logs) runs at a similar speed so the overall slowdown is only ~2m. The underlying issue might be related to https://github.com/rust-lang/rustup/issues/2417 which could be fixed by clearing the rustup cache, but I can't find the cache for windows CI in `gh cache list`

I tried copying uv's CI setup as closely as I could, but that also does not fix the issue