### PR TITLE
Create Helper Method For `ReadOnlySignal`

### DIFF
--- a/packages/signals/src/read_only_signal.rs
+++ b/packages/signals/src/read_only_signal.rs
@@ -26,6 +26,12 @@ impl<T: 'static> ReadOnlySignal<T> {
     pub fn new(signal: Signal<T>) -> Self {
         Self::new_maybe_sync(signal)
     }
+
+    /// Create a new read-only signal from a value.
+    #[track_caller]
+    pub fn create(value: T) -> Self {
+        Self::new(Signal::new(value))
+    }
 }
 
 impl<T: 'static, S: Storage<SignalData<T>>> ReadOnlySignal<T, S> {


### PR DESCRIPTION
Adds `ReadOnlySignal::create(T)` which is a shorthand for `ReadOnlySignal::new(Signal::new(T))`.

This helps with #3920

Seems like `Signal.into()` also currently works.