### PR TITLE
Add some CLI docs for stdin file input to fmt command

### DIFF
--- a/packages/cli/src/cli/autoformat.rs
+++ b/packages/cli/src/cli/autoformat.rs
@@ -24,7 +24,7 @@ pub(crate) struct Autoformat {
     #[clap(short, long)]
     pub(crate) raw: Option<String>,
 
-    /// Input file
+    /// Input file at path (set to "-" to read file from stdin, and output formatted file to stdout)
     #[clap(short, long)]
     pub(crate) file: Option<String>,
 


### PR DESCRIPTION
This just adds a little more detail to the `--file` flag to let devs know they can pass "-" as the file path to the `fmt` command and pass the file in via stdin (functionality added in #1529)

```
Automatically format RSX

Usage: dx fmt [OPTIONS]

Options:
      --all-code               Format rust code before the formatting the rsx macros
  -c, --check                  Run in 'check' mode. Exits with 0 if input is formatted correctly. Exits with 1 and prints a diff if formatting is required
  -r, --raw <RAW>              Input rsx (selection)
  -f, --file <FILE>            Input file at path (set to "-" to read file from stdin, and output formatted file to stdout)
  -s, --split-line-attributes  Split attributes in lines or not
  -p, --package <PACKAGE>      The package to build
      --verbose                Use verbose output [default: false]
      --trace                  Use trace output [default: false]
      --json-output            Output logs in JSON format
  -h, --help                   Print help
  ```