### PR TITLE
Use SuperInto and correct Owner for props defaults

### DIFF
--- a/packages/core-macro/tests/rsx.rs
+++ b/packages/core-macro/tests/rsx.rs
@@ -49,8 +49,50 @@ mod test_default_into {
         pub some_data: bool,
 
         pub some_other_data: bool,
+
+        // Test default values for signals
+        #[props(default)]
+        read_only_w_default: ReadOnlySignal<bool>,
+
+        #[props(default = true)]
+        read_only_w_default_val: ReadOnlySignal<bool>,
+
+        #[props(default = ReadOnlySignal::new(Signal::new(true)))]
+        read_only_w_default_val_explicit: ReadOnlySignal<bool>,
+
+        // Test default values for callbacks/event handlers
+        #[props(default)]
+        callback_w_default: Callback,
+
+        #[props(default = move |_| {})]
+        callback_w_default_val_closure: Callback,
+
+        #[props(default = {
+            fn test(_: ()) {}
+            test
+        })]
+        callback_w_default_val_expr_fn: Callback,
+
+        #[props(default = Callback::new(move |_: ()| {}))]
+        callback_w_default_val_explicit: Callback,
+
+        #[props(default)]
+        event_handler_w_default: EventHandler<KeyboardEvent>,
+
+        #[props(default = move |_| {})]
+        event_handler_w_default_val_closure: EventHandler<KeyboardEvent>,
+
+        #[props(default = {
+            fn test(_: KeyboardEvent) {}
+            test
+        })]
+        event_handler_w_default_val_expr_fn: EventHandler<KeyboardEvent>,
+
+        #[props(default = EventHandler::new(move |_: KeyboardEvent| {}))]
+        event_handler_w_default_val_explicit: EventHandler<KeyboardEvent>,
     }
 }
+
 /// This test ensures that read-only signals that contain an option (`Signal<Option<u16>>`)
 /// are correctly created as default when not provided.
 ///


### PR DESCRIPTION
This PR updates the generated props `build()` to use SuperInto and the props Owner for defaults of props that are child owned types (ReadOnlySignal/Callback), matching the behavior when the prop is set explicitly with its builder method.

Compile-time tests were added to assert that both existing default assignments and less-verbose defaults work.

Closes [3920](https://github.com/DioxusLabs/dioxus/issues/3920)