### PR TITLE
Add android sync lock to asset handler to avoid already borrowed errors on android

### DIFF
--- a/packages/desktop/src/assets.rs
+++ b/packages/desktop/src/assets.rs
@@ -33,6 +33,10 @@ impl AssetHandlerRegistry {
         responder: RequestAsyncResponder,
     ) {
         if let Some(handler) = self.handlers.borrow().get(name) {
+            // Avoid handler being already borrowed on android
+            #[cfg(target_os = "android")]
+            let _lock = crate::android_sync_lock::android_runtime_lock();
+
             // And run the handler in the scope of the component that created it
             handler.f.call((request, responder));
         }


### PR DESCRIPTION
Fixes #4005 