### PR TITLE
Fix parsing of braced expressions followed by a method

### DIFF
--- a/packages/rsx/src/raw_expr.rs
+++ b/packages/rsx/src/raw_expr.rs
@@ -1,4 +1,4 @@
-use proc_macro2::{TokenStream as TokenStream2, TokenTree};
+use proc_macro2::{Delimiter, TokenStream as TokenStream2, TokenTree};
 use quote::ToTokens;
 use std::hash;
 use syn::{parse::Parse, spanned::Spanned, token::Brace, Expr};
@@ -15,32 +15,18 @@ pub struct PartialExpr {
 
 impl Parse for PartialExpr {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        // Trying to find if input includes a method call
-        let has_method_call = input
-            .fork()
-            .step(|cursor| {
-                let mut rest = *cursor;
-                while let Some((tt, next)) = rest.token_tree() {
-                    if let TokenTree::Punct(punct) = &tt {
-                        if punct.as_char() == ',' {
-                            return Ok((false, next));
-                        }
-                    }
-                    if let TokenTree::Group(_) = &tt {
-                        if let Some((tt2, _)) = next.punct() {
-                            if tt2.as_char() == '.' {
-                                return Ok((true, next));
-                            }
-                        }
-                    }
-                    rest = next;
-                }
-                Ok((false, rest))
-            })
-            .unwrap_or(false);
+        // Input is considered a braced expression if it's a braced group
+        // followed by a comma or the end of the stream
+        let mut is_braced = false;
+        if let Some((TokenTree::Group(group), next)) = input.fork().cursor().token_tree() {
+            let next_char_is_a_comma = next.punct().is_some_and(|(tt, _)| tt.as_char() == ',');
+            if group.delimiter() == Delimiter::Brace && (next.eof() || next_char_is_a_comma) {
+                is_braced = true
+            }
+        };
 
-        // Parse as an expression if there is no brace or there is a method call
-        if !input.peek(syn::token::Brace) || has_method_call {
+        // Parse as an expression if it's not braced
+        if !is_braced {
             let expr = input.parse::<syn::Expr>()?;
             return Ok(Self {
                 brace: None,

--- a/packages/rsx/src/raw_expr.rs
+++ b/packages/rsx/src/raw_expr.rs
@@ -16,11 +16,14 @@ pub struct PartialExpr {
 impl Parse for PartialExpr {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         // Input is considered a braced expression if it's a braced group
-        // followed by a comma or the end of the stream
+        // followed by a comma, the end of the stream, or another braced expression
         let mut is_braced = false;
         if let Some((TokenTree::Group(group), next)) = input.fork().cursor().token_tree() {
             let next_char_is_a_comma = next.punct().is_some_and(|(tt, _)| tt.as_char() == ',');
-            if group.delimiter() == Delimiter::Brace && (next.eof() || next_char_is_a_comma) {
+            let next_is_a_braced_exp = next.group(Delimiter::Brace).is_some();
+            if group.delimiter() == Delimiter::Brace
+                && (next.eof() || next_char_is_a_comma || next_is_a_braced_exp)
+            {
                 is_braced = true
             }
         };

--- a/packages/rsx/src/raw_expr.rs
+++ b/packages/rsx/src/raw_expr.rs
@@ -15,14 +15,26 @@ pub struct PartialExpr {
 
 impl Parse for PartialExpr {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        // Input is considered a braced expression if it's a braced group
-        // followed by a comma, the end of the stream, or another braced expression
+        // Input is a braced expression if it's a braced group
+        // followed by either of the following:
+        // - the end of the stream
+        // - a comma
+        // - another braced group
+        // - an identifier
+        // - a string literal
         let mut is_braced = false;
         if let Some((TokenTree::Group(group), next)) = input.fork().cursor().token_tree() {
             let next_char_is_a_comma = next.punct().is_some_and(|(tt, _)| tt.as_char() == ',');
             let next_is_a_braced_exp = next.group(Delimiter::Brace).is_some();
+            let next_is_an_ident = next.ident().is_some();
+            let next_is_a_string_literal = next.literal().is_some();
+
             if group.delimiter() == Delimiter::Brace
-                && (next.eof() || next_char_is_a_comma || next_is_a_braced_exp)
+                && (next.eof()
+                    || next_char_is_a_comma
+                    || next_is_a_braced_exp
+                    || next_is_an_ident
+                    || next_is_a_string_literal)
             {
                 is_braced = true
             }

--- a/packages/rsx/tests/parsing.rs
+++ b/packages/rsx/tests/parsing.rs
@@ -71,6 +71,7 @@ fn complex_kitchen_sink() {
         // complex_carry
         button {
             class: "flex items-center pl-3 py-3 pr-2 text-gray-500 hover:bg-indigo-50 rounded",
+            width: {"100%"}.to_string(),
             onclick: move |evt| {
                 show_user_menu.set(!show_user_menu.get());
                 evt.cancel_bubble();

--- a/packages/rsx/tests/parsing.rs
+++ b/packages/rsx/tests/parsing.rs
@@ -72,7 +72,6 @@ fn complex_kitchen_sink() {
         button {
             class: "flex items-center pl-3 py-3 pr-2 text-gray-500 hover:bg-indigo-50 rounded",
             width: {"100%"}.to_string(),
-            width: {|| "100%"}(),
             onclick: move |evt| {
                 show_user_menu.set(!show_user_menu.get());
                 evt.cancel_bubble();
@@ -168,4 +167,28 @@ fn key_cannot_be_static() {
     let parsed = syn::parse2::<CallBody>(item).unwrap();
     println!("{:?}", parsed.body.diagnostics);
     assert!(!parsed.body.diagnostics.is_empty());
+}
+
+#[test]
+fn braced_expressions() {
+    let item = quote::quote! {
+        div {
+            width: {100} - 50,
+            width: {"100%"}.to_string(),
+            width: {|| "100%"}(),
+        }
+        // Partial expressions in braces rsx should be allowed and output as-is
+        // for autocomplete
+        {partial.}
+        div {}
+        {partial.}
+        // Comments should be ignored
+        div {}
+        {partial.}
+        "hello world"
+        {partial.}
+        if true {}
+    };
+
+    let _cb: CallBody = syn::parse2(item).unwrap();
 }

--- a/packages/rsx/tests/parsing.rs
+++ b/packages/rsx/tests/parsing.rs
@@ -72,6 +72,7 @@ fn complex_kitchen_sink() {
         button {
             class: "flex items-center pl-3 py-3 pr-2 text-gray-500 hover:bg-indigo-50 rounded",
             width: {"100%"}.to_string(),
+            width: {|| "100%"}(),
             onclick: move |evt| {
                 show_user_menu.set(!show_user_menu.get());
                 evt.cancel_bubble();


### PR DESCRIPTION
This is an attempt at solving issue [https://github.com/DioxusLabs/dioxus/issues/3945](https://github.com/DioxusLabs/dioxus/issues/3945) when parsing attributes.
I added code that checks if there is a TokenTree::Group followed by a dot.  If it finds it, it parses the whole attribute as an expression. It stops if it finds a comma, signaling the end of the attribute.
I added the example in the original issue to the "complex_kitchen_sink" test, and everything passed.