### PR TITLE
Labelled hooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,6 +3745,7 @@ dependencies = [
  "dioxus-core-types",
  "dioxus-html",
  "dioxus-ssr",
+ "dyn-hash",
  "futures-channel",
  "futures-util",
  "generational-box",
@@ -4623,6 +4624,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-hash"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15401da73a9ed8c80e3b2d4dc05fe10e7b72d7243b9f614e516a44fa99986e88"
 
 [[package]]
 name = "eax"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -24,6 +24,7 @@ tracing = { workspace = true }
 warnings = { workspace = true }
 futures-util = { workspace = true, default-features = false, features = ["alloc", "std"] }
 serde = { workspace = true, optional = true, features = ["derive"] }
+dyn-hash = "0.2.2"
 
 [dev-dependencies]
 dioxus = { workspace = true }

--- a/packages/core/label.rs
+++ b/packages/core/label.rs
@@ -1,0 +1,22 @@
+use std::any::Any;
+use dyn_hash::DynHash;
+
+pub trait HookLabel: DynEq + DynHash + Send + Sync{}
+impl<T: DynEq + DynHash + Send + Sync> HookLabel for T {}
+pub trait DynEq: Any {
+	fn dyn_eq(&self, other: &dyn DynEq) -> bool;
+}
+
+impl PartialEq for dyn HookLabel {
+	fn eq(&self, other: &dyn HookLabel) -> bool {
+		(self as &dyn DynEq).dyn_eq(other as &dyn DynEq)
+	}
+}
+impl Eq for dyn HookLabel {}
+dyn_hash::hash_trait_object!(HookLabel);
+
+impl<T: Any + Eq + 'static> DynEq for T {
+	fn dyn_eq(&self, other: &dyn DynEq) -> bool {
+		(other as &dyn Any).downcast_ref::<T>().filter(|other| PartialEq::eq(self, other)).is_some()
+	}
+}

--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -1,6 +1,6 @@
 use crate::prelude::SuspenseContext;
 use crate::runtime::RuntimeError;
-use crate::{innerlude::SuspendedFuture, runtime::Runtime, CapturedError, Element, ScopeId, Task};
+use crate::{innerlude::{SuspendedFuture, HookLabel}, runtime::Runtime, CapturedError, Element, ScopeId, Task};
 use std::future::Future;
 use std::sync::Arc;
 
@@ -308,6 +308,12 @@ pub fn remove_future(id: Task) {
 #[track_caller]
 pub fn use_hook<State: Clone + 'static>(initializer: impl FnOnce() -> State) -> State {
     Runtime::with_current_scope(|cx| cx.use_hook(initializer)).unwrap()
+}
+
+// Does track_caller conflict with using hooks in loops?
+#[track_caller]
+pub fn use_hook_with_label<Label: HookLabel, State: Clone + 'static>(label: Label, initializer: impl FnOnce() -> State) -> State {
+    Runtime::with_current_scope(|cx| cx.use_hook_with_label(label, initializer)).unwrap()
 }
 
 /// Get the current render since the inception of this component

--- a/packages/core/src/label.rs
+++ b/packages/core/src/label.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use dyn_hash::DynHash;
 
+/// Type erased value that acts as a label for a hook
 pub trait HookLabel: DynEq + DynHash + Send + Sync{}
 impl<T: DynEq + DynHash + Send + Sync> HookLabel for T {}
 pub trait DynEq: Any {

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -29,6 +29,7 @@ mod tasks;
 mod virtual_dom;
 
 mod hotreload_utils;
+mod label;
 
 /// Items exported from this module are used in macros and should not be used directly.
 #[doc(hidden)]

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -69,6 +69,7 @@ pub(crate) mod innerlude {
     pub use crate::suspense::*;
     pub use crate::tasks::*;
     pub use crate::virtual_dom::*;
+	pub use crate::label::*;
 
     /// An [`Element`] is a possibly-none [`VNode`] created by calling `render` on [`ScopeId`] or [`ScopeState`].
     ///
@@ -85,7 +86,7 @@ pub use crate::innerlude::{
     Element, ElementId, Event, Fragment, HasAttributes, IntoDynNode, LaunchConfig, MarkerWrapper,
     Mutation, Mutations, NoOpMutations, Ok, Properties, Result, Runtime, ScopeId, ScopeState,
     SpawnIfAsync, Task, Template, TemplateAttribute, TemplateNode, VComponent, VNode, VNodeInner,
-    VPlaceholder, VText, VirtualDom, WriteMutations,
+    VPlaceholder, VText, VirtualDom, WriteMutations, HookLabel,
 };
 
 /// The purpose of this module is to alleviate imports of many common types

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -86,7 +86,7 @@ pub use crate::innerlude::{
     Element, ElementId, Event, Fragment, HasAttributes, IntoDynNode, LaunchConfig, MarkerWrapper,
     Mutation, Mutations, NoOpMutations, Ok, Properties, Result, Runtime, ScopeId, ScopeState,
     SpawnIfAsync, Task, Template, TemplateAttribute, TemplateNode, VComponent, VNode, VNodeInner,
-    VPlaceholder, VText, VirtualDom, WriteMutations, HookLabel,
+    VPlaceholder, VText, VirtualDom, WriteMutations, HookLabel, use_hook_with_label,
 };
 
 /// The purpose of this module is to alleviate imports of many common types
@@ -99,7 +99,7 @@ pub mod prelude {
         provide_context, provide_error_boundary, provide_root_context, queue_effect, remove_future,
         schedule_update, schedule_update_any, spawn, spawn_forever, spawn_isomorphic, suspend,
         suspense_context, throw_error, try_consume_context, use_after_render, use_before_render,
-        use_drop, use_hook, use_hook_with_cleanup, with_owner, AnyValue, Attribute, Callback,
+        use_drop, use_hook, use_hook_with_label, use_hook_with_cleanup, with_owner, AnyValue, Attribute, Callback,
         Component, ComponentFunction, Context, Element, ErrorBoundary, ErrorContext, Event,
         EventHandler, Fragment, HasAttributes, IntoAttributeValue, IntoDynNode,
         OptionStringFromMarker, Properties, ReactiveContext, RenderError, Runtime, RuntimeGuard,

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -105,7 +105,7 @@ pub mod prelude {
         OptionStringFromMarker, Properties, ReactiveContext, RenderError, Runtime, RuntimeGuard,
         ScopeId, ScopeState, SuperFrom, SuperInto, SuspendedFuture, SuspenseBoundary,
         SuspenseBoundaryProps, SuspenseContext, SuspenseExtension, Task, Template,
-        TemplateAttribute, TemplateNode, VNode, VNodeInner, VirtualDom,
+        TemplateAttribute, TemplateNode, VNode, VNodeInner, VirtualDom, HookLabel,
     };
 }
 

--- a/packages/hooks/src/use_signal.rs
+++ b/packages/hooks/src/use_signal.rs
@@ -98,7 +98,7 @@ pub fn use_signal_sync_with_label<Label: HookLabel, T: Send + Sync + 'static>(
 	label: Label, 
 	f: impl FnOnce() -> T
 ) -> Signal<T, SyncStorage> {
-    use_maybe_signal_sync(f)
+    use_maybe_signal_sync_with_label(label, f)
 }
 
 #[must_use]


### PR DESCRIPTION
# Description
MVP for labelled hooks to allow hooks to be used in conditional statements and loops. I've only implemented hooks and signals so far, because i wanted to see if there would be any issues with the simplest version first.

# Changes
- added labelled_hooks field to `dioxus_core::Scope`
- added use_hook_with_label method to `dioxus_core::Scope`
- added `use_hook_with_label`, `use_(maybe_)signal_(sync_)with_label`, functions available through `dioxus::prelude`

# Notes 
```rust 
let mut len = use_signal(|| 0_usize);
*len.write() += 1;
(0..len()).for_each(|i| {
    use_hook_with_label(i, || info!(i));
});
// More hooks below    
```
I inserted the above code into an existing codebase of mine and it worked flawlessly. 
However, signals had a slight hitch. 

If a signal with a particular label is skipped during a render pass, then the next time it is called, it gets reset to its original value.
Since such a situation was disallowed previously, it never caused an issue. But that would have to be fixed now.

[Discussion](https://github.com/DioxusLabs/dioxus/discussions/4048) page about this.