### PR TITLE
Fix JS deprecation warning in wasm init

### DIFF
--- a/packages/cli/src/build/web.rs
+++ b/packages/cli/src/build/web.rs
@@ -148,7 +148,7 @@ r#" <script>
       window.__wasm_split_main_initSync = initSync;
 
       // Actually perform the load
-      init("/{base_path}/{wasm_path}").then((wasm) => {
+      init({module_or_path: "/{base_path}/{wasm_path}"}).then((wasm) => {
         if (wasm.__wbindgen_start == undefined) {
             wasm.main();
         }


### PR DESCRIPTION
Fix #3831 

Applying change documented by @paul-hansen at https://github.com/DioxusLabs/dioxus/issues/3831#issuecomment-2741258327

### Test

Rebuild the CLI (`packages/cli`):
```shell
cargo install --path .
```

Rebuild any Dioxus web project:
```shell
dx serve
```

=> JS deprecation warning gone