### PR TITLE
Update dx serve output: remove wrap in right-side paragraphs

### DIFF
--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -14,7 +14,7 @@ use crossterm::{
 };
 use ratatui::{
     prelude::*,
-    widgets::{Block, BorderType, Borders, LineGauge, Paragraph, Wrap},
+    widgets::{Block, BorderType, Borders, LineGauge, Paragraph},
     TerminalOptions, Viewport,
 };
 use std::{

--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -656,8 +656,7 @@ impl Output {
                 } else {
                     " ".dark_gray()
                 },
-            ]))
-            .wrap(Wrap { trim: false }),
+            ])),
             current_platform,
         );
 
@@ -677,8 +676,7 @@ impl Output {
                     "ServerFns at: ".gray()
                 },
                 address,
-            ]))
-            .wrap(Wrap { trim: false }),
+            ])),
             serve_address,
         );
     }
@@ -703,8 +701,7 @@ impl Output {
                 lines.push("]".yellow());
 
                 lines
-            }))
-            .wrap(Wrap { trim: false }),
+            })),
             area,
         );
     }


### PR DESCRIPTION
fix #3847 

Update "Platform", "App features" and "Serving at" paragraphs by removing wrapping.

ratatui's Wrap system causes text to disappear into an invisible 2nd line when paragraph content exceeds available space, which might confuse new users when terminal width is small. This PR removes wrapping entirely, using ratatui default behavior (truncation) instead, which is not optimal either (i.e. URL gets truncated) but possibly less confusing.

### before
```
╭────────────────────────────────────────────────────────────────────────── /:more ╮
│  App:     ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 0.4s      Platform: Web                 │
│  Bundle:  ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 3.7s      App features: ["web"]         │
│  Status:  Serving [_project_name_] 🚀 4.1s         Serving at:                   │
╰──────────────────────────────────────────────────────────────────────────────────╯

╭────────────────────────────────────────────────────────────── /:more ╮
│  App:     ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 0.4s      Platform: Web     │
│  Bundle:  ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 3.7s      App features:     │
│  Status:  Serving [_project_name_] 🚀 4.1s         Serving at:       │
╰──────────────────────────────────────────────────────────────────────╯
```

### after
```
╭────────────────────────────────────────────────────────────────────────── /:more ╮
│  App:     ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 0.4s      Platform: Web                 │
│  Bundle:  ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 3.7s      App features: ["web"]         │
│  Status:  Serving [_project_name_] 🚀 4.1s         Serving at: http://127.0.0.1  │
╰──────────────────────────────────────────────────────────────────────────────────╯

╭────────────────────────────────────────────────────────────── /:more ╮
│  App:     ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 0.4s      Platform: Web     │
│  Bundle:  ━━━━━━━━━━━━━━━━━━━━━━━━━━  🎉 3.7s      App features: ["  │
│  Status:  Serving [_project_name_] 🚀 4.1s         Serving at: http  │
╰──────────────────────────────────────────────────────────────────────╯
```

Note: an alternative would be to use non-breaking space `\u{00a0}` (which is honored by ratatui) instead of white-space, but it results in the same output as removing wrapping.