### PR TITLE
Fix typo in router example

### DIFF
--- a/examples/router.rs
+++ b/examples/router.rs
@@ -123,6 +123,6 @@ fn PageNotFound(route: Vec<String>) -> Element {
     rsx! {
         h1 { "Page not found" }
         p { "We are terribly sorry, but the page you requested doesn't exist." }
-        pre { color: "red", "log:\nattemped to navigate to: {route:?}" }
+        pre { color: "red", "log:\nattempted to navigate to: {route:?}" }
     }
 }


### PR DESCRIPTION
Fixes typo in `examples/router.rs`.