### PR TITLE
fix: add missing `img` attrs

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1103,7 +1103,10 @@ builder_constructors! {
         usemap: String DEFAULT, // FIXME should be a fragment starting with '#'
         width: usize DEFAULT,
         referrerpolicy: String DEFAULT,
-        // sizes: SpacedList<String>, // FIXME it's not really just a string
+        sizes: String DEFAULT, // FIXME
+        elementtiming: String DEFAULT,
+        fetchpriority: String DEFAULT,
+        attributionsrc: String DEFAULT,
     };
 
     /// Build a


### PR DESCRIPTION
While adding support for Dioxus in [`image-rs`](https://github.com/opensass/image-rs), i noticed some of the `img` tag attrs are missing. So, i added them.

Also, I have a question: how can we attach a node reference to a tag? I don't see any tags that accept the `ref` attr. Why tho?