### PR TITLE
Inline the TailwindCLI into dx and run it during serve

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -657,8 +657,6 @@ impl AppBuilder {
             None => self.build.asset_dir(),
         };
 
-        tracing::debug!("Hotreloading asset {changed_file:?} in target {asset_dir:?}");
-
         // Canonicalize the path as Windows may use long-form paths "\\\\?\\C:\\".
         let changed_file = dunce::canonicalize(changed_file)
             .inspect_err(|e| tracing::debug!("Failed to canonicalize hotreloaded asset: {e}"))
@@ -667,6 +665,8 @@ impl AppBuilder {
         // The asset might've been renamed thanks to the manifest, let's attempt to reload that too
         let resource = artifacts.assets.assets.get(&changed_file)?;
         let output_path = asset_dir.join(resource.bundled_path());
+
+        tracing::debug!("Hotreloading asset {changed_file:?} in target {asset_dir:?}");
 
         // Remove the old asset if it exists
         _ = std::fs::remove_file(&output_path);
@@ -1310,6 +1310,6 @@ We checked the folder: {}
 
     /// Check if the queued build is blocking hotreloads
     pub(crate) fn can_receive_hotreloads(&self) -> bool {
-        matches!(&self.stage, BuildStage::Success)
+        matches!(&self.stage, BuildStage::Success | BuildStage::Failed)
     }
 }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -3758,4 +3758,14 @@ r#" <script>
             trimmed_path
         }
     }
+
+    /// Get the path to the package manifest directory
+    pub(crate) fn package_manifest_dir(&self) -> PathBuf {
+        self.workspace.krates[self.crate_package]
+            .manifest_path
+            .parent()
+            .unwrap()
+            .to_path_buf()
+            .into()
+    }
 }

--- a/packages/cli/src/config/app.rs
+++ b/packages/cli/src/config/app.rs
@@ -10,4 +10,10 @@ pub(crate) struct ApplicationConfig {
 
     #[serde(default)]
     pub(crate) out_dir: Option<PathBuf>,
+
+    #[serde(default)]
+    pub(crate) tailwind_input: Option<PathBuf>,
+
+    #[serde(default)]
+    pub(crate) tailwind_output: Option<PathBuf>,
 }

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -22,6 +22,8 @@ impl Default for DioxusConfig {
                 asset_dir: None,
                 sub_package: None,
                 out_dir: None,
+                tailwind_input: None,
+                tailwind_output: None,
             },
             web: WebConfig {
                 app: WebAppConfig {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -17,6 +17,7 @@ mod platform;
 mod rustcwrapper;
 mod serve;
 mod settings;
+mod tailwind;
 mod wasm_bindgen;
 mod wasm_opt;
 mod workspace;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -32,6 +32,7 @@ pub(crate) use logging::*;
 pub(crate) use platform::*;
 pub(crate) use rustcwrapper::*;
 pub(crate) use settings::*;
+pub(crate) use tailwind::*;
 pub(crate) use wasm_bindgen::*;
 pub(crate) use workspace::*;
 

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -72,7 +72,6 @@ pub(crate) async fn serve_all(args: ServeArgs, tracer: &mut TraceController) -> 
                     continue;
                 }
 
-                tracing::debug!("Starting hotpatching: {:?}", files);
                 builder.handle_file_change(&files, &mut devserver).await;
             }
 

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -72,6 +72,9 @@ pub(crate) struct AppServer {
     pub(crate) devserver_bind_ip: IpAddr,
     pub(crate) proxied_port: Option<u16>,
     pub(crate) cross_origin_policy: bool,
+
+    // Additional plugin-type tools
+    pub(crate) tw_watcher: Option<tokio::process::Child>,
 }
 
 pub(crate) struct CachedFile {
@@ -148,6 +151,8 @@ impl AppServer {
             .map(|server| AppBuilder::start(&server, build_mode))
             .transpose()?;
 
+        let tw_watcher = None;
+
         tracing::debug!("Proxied port: {:?}", proxied_port);
 
         // Create the runner
@@ -174,6 +179,7 @@ impl AppServer {
             _force_sequential: force_sequential,
             cross_origin_policy,
             fullstack,
+            tw_watcher,
         };
 
         // Only register the hot-reload stuff if we're watching the filesystem

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -151,7 +151,12 @@ impl AppServer {
             .map(|server| AppBuilder::start(&server, build_mode))
             .transpose()?;
 
-        let tw_watcher = None;
+        let pkg_dir = client.build.package_manifest_dir();
+        tracing::debug!("pkgdir: {:?}", pkg_dir);
+        let tw_watcher = crate::tailwind::TailwindCli::autodetect(&pkg_dir)
+            .and_then(|tw| tw.watch(&pkg_dir, None, None).ok());
+
+        tracing::debug!("Tailwind watcher: {:?}", tw_watcher);
 
         tracing::debug!("Proxied port: {:?}", proxied_port);
 

--- a/packages/cli/src/settings.rs
+++ b/packages/cli/src/settings.rs
@@ -124,7 +124,7 @@ impl CliSettings {
 
     /// Check if we should prefer to use the no-downloads feature
     pub(crate) fn prefer_no_downloads() -> bool {
-        if cfg!(feature = "no-downloads") {
+        if cfg!(feature = "no-downloads") && !cfg!(debug_assertions) {
             return true;
         }
 

--- a/packages/cli/src/tailwind.rs
+++ b/packages/cli/src/tailwind.rs
@@ -1,4 +1,4 @@
-use crate::{Result, Workspace};
+use crate::{CliSettings, Result, Workspace};
 use anyhow::{anyhow, Context};
 use std::{
     path::{Path, PathBuf},
@@ -100,13 +100,13 @@ impl TailwindCli {
     }
 
     fn get_binary_path(&self) -> anyhow::Result<PathBuf> {
-        // if CliSettings::prefer_no_downloads() {
-        //     which::which("tailwindcss").map_err(|_| anyhow!("Missing tailwindcss@{}", self.version))
-        // } else {
-        let installed_name = self.installed_bin_name();
-        let install_dir = self.install_dir()?;
-        Ok(install_dir.join(installed_name))
-        // }
+        if CliSettings::prefer_no_downloads() {
+            which::which("tailwindcss").map_err(|_| anyhow!("Missing tailwindcss@{}", self.version))
+        } else {
+            let installed_name = self.installed_bin_name();
+            let install_dir = self.install_dir()?;
+            Ok(install_dir.join(installed_name))
+        }
     }
 
     fn installed_bin_name(&self) -> String {

--- a/packages/cli/src/tailwind.rs
+++ b/packages/cli/src/tailwind.rs
@@ -1,0 +1,149 @@
+use crate::{CliSettings, Result};
+use anyhow::{anyhow, Context};
+use flate2::read::GzDecoder;
+use std::{
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+use tar::Archive;
+use tempfile::TempDir;
+use tokio::{fs, process::Command};
+
+pub(crate) struct TailwindCli {
+    version: String,
+}
+
+impl TailwindCli {
+    const VERSION: &'static str = "v4.1.5";
+
+    pub(crate) fn new(version: String) -> Self {
+        Self { version }
+    }
+
+    pub(crate) async fn watch(
+        &self,
+        input_path: &PathBuf,
+        output_path: &PathBuf,
+    ) -> Result<tokio::process::Child> {
+        let binary_path = self.get_binary_path().await?;
+        let mut cmd = Command::new(binary_path);
+        let proc = cmd
+            .arg("--watch")
+            .arg(input_path)
+            .arg("--output")
+            .arg(output_path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .spawn()?;
+
+        Ok(proc)
+    }
+    pub(crate) fn run(&self) {}
+
+    async fn get_binary_path(&self) -> anyhow::Result<PathBuf> {
+        if CliSettings::prefer_no_downloads() {
+            which::which("tailwindcss")
+                .map_err(|_| anyhow!("Missing wasm-bindgen-cli@{}", self.version))
+        } else {
+            let installed_name = self.installed_bin_name();
+            let install_dir = self.install_dir().await?;
+            Ok(install_dir.join(installed_name))
+        }
+    }
+
+    fn installed_bin_name(&self) -> String {
+        let mut name = format!("tailwindcss-{}", self.version);
+        if cfg!(windows) {
+            name = format!("{name}.exe");
+        }
+        name
+    }
+
+    async fn install_github(&self) -> anyhow::Result<()> {
+        tracing::debug!(
+            "Attempting to install wasm-bindgen-cli@{} from GitHub",
+            self.version
+        );
+
+        let url = self.git_install_url().ok_or_else(|| {
+            anyhow!(
+                "no available GitHub binary for wasm-bindgen-cli@{}",
+                self.version
+            )
+        })?;
+
+        // Get the final binary location.
+        let binary_path = self.get_binary_path().await?;
+
+        // Download then extract wasm-bindgen-cli.
+        let bytes = reqwest::get(url).await?.bytes().await?;
+
+        // Unpack the first tar entry to the final binary location
+        Archive::new(GzDecoder::new(bytes.as_ref()))
+            .entries()?
+            .find(|entry| {
+                entry
+                    .as_ref()
+                    .map(|e| {
+                        e.path_bytes()
+                            .ends_with(self.downloaded_bin_name().as_bytes())
+                    })
+                    .unwrap_or(false)
+            })
+            .context("Failed to find entry")??
+            .unpack(&binary_path)
+            .context("failed to unpack wasm-bindgen-cli binary")?;
+
+        Ok(())
+    }
+
+    fn downloaded_bin_name(&self) -> &'static str {
+        if cfg!(windows) {
+            "tailwindcss.exe"
+        } else {
+            "tailwindcss"
+        }
+    }
+
+    async fn install_dir(&self) -> anyhow::Result<PathBuf> {
+        let bindgen_dir = dirs::data_local_dir()
+            .expect("user should be running on a compatible operating system")
+            .join("dioxus/wasm-bindgen/");
+
+        fs::create_dir_all(&bindgen_dir).await?;
+        Ok(bindgen_dir)
+    }
+
+    fn git_install_url(&self) -> Option<String> {
+        let platform = match target_lexicon::HOST.operating_system {
+            target_lexicon::OperatingSystem::Linux => "linux",
+            target_lexicon::OperatingSystem::Darwin(_) => "macos",
+            target_lexicon::OperatingSystem::Windows => "windows",
+            _ => return None,
+        };
+
+        let arch = match target_lexicon::HOST.architecture {
+            target_lexicon::Architecture::X86_64 if platform == "windows" => "x64.exe",
+            target_lexicon::Architecture::X86_64 => "x64",
+            target_lexicon::Architecture::Aarch64(_) => "arm64",
+            _ => return None,
+        };
+
+        // eg:
+        //
+        // https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.5/tailwindcss-linux-arm64
+        //
+        // tailwindcss-linux-arm64
+        // tailwindcss-linux-x64
+        // tailwindcss-macos-arm64
+        // tailwindcss-macos-x64
+        // tailwindcss-windows-x64.exe
+        // tailwindcss-linux-arm64-musl
+        // tailwindcss-linux-x64-musl
+        Some(format!(
+            "https://github.com/tailwindlabs/tailwindcss/releases/download/{}/tailwind-{}-{}.tar.gz",
+            self.version, platform, arch
+        ))
+    }
+}

--- a/packages/cli/src/wasm_bindgen.rs
+++ b/packages/cli/src/wasm_bindgen.rs
@@ -1,4 +1,4 @@
-use crate::{CliSettings, Result};
+use crate::{CliSettings, Result, Workspace};
 use anyhow::{anyhow, Context};
 use flate2::read::GzDecoder;
 use std::path::{Path, PathBuf};
@@ -402,10 +402,7 @@ impl WasmBindgen {
     }
 
     async fn install_dir(&self) -> anyhow::Result<PathBuf> {
-        let bindgen_dir = dirs::data_local_dir()
-            .expect("user should be running on a compatible operating system")
-            .join("dioxus/wasm-bindgen/");
-
+        let bindgen_dir = Workspace::dioxus_home_dir().join("wasm-bindgen/");
         fs::create_dir_all(&bindgen_dir).await?;
         Ok(bindgen_dir)
     }

--- a/packages/cli/src/workspace.rs
+++ b/packages/cli/src/workspace.rs
@@ -369,6 +369,13 @@ impl Workspace {
                 .context("Failed to find dx")?,
         )
     }
+
+    /// Returns the path to the dioxus home directory, used to install tools and other things
+    pub(crate) fn dioxus_home_dir() -> PathBuf {
+        dirs::data_local_dir()
+            .map(|f| f.join("dioxus/"))
+            .unwrap_or_else(|| dirs::home_dir().unwrap().join(".dioxus"))
+    }
 }
 
 impl std::fmt::Debug for Workspace {


### PR DESCRIPTION
This PR adds support for inline tailwind css, drastically simplifying how dioxus users interact with tailwind.

See the tailwind blogpost talking about tailwind standalone:

https://tailwindcss.com/blog/standalone-cli

We'll be able to detect the tailwind.css file and then automatically hot-reload it for you when the CLI is serving.

The tailwind binaries are quite large (70-100mb) but that shouldn't be a huge problem in practice.

We could also look at depending on encre directly https://gitlab.com/encre-org/encre-css