### PR TITLE
fix(cli, breaking): Align Android applicationId with user's `bundle.identifier`

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -1136,7 +1136,7 @@ We checked the folder: {}
     ) -> Result<()> {
         let apk_path = self.build.debug_apk_path();
         let session_cache = self.build.session_cache_dir();
-        let full_mobile_app_name = self.build.full_mobile_app_name();
+        let application_id = self.build.bundle_identifier();
         let adb = self.build.workspace.android_tools()?.adb.clone();
 
         // Start backgrounded since .open() is called while in the arm of the top-level match
@@ -1194,7 +1194,7 @@ We checked the folder: {}
 
             // eventually, use the user's MainActivity, not our MainActivity
             // adb shell am start -n dev.dioxus.main/dev.dioxus.main.MainActivity
-            let activity_name = format!("{}/dev.dioxus.main.MainActivity", full_mobile_app_name,);
+            let activity_name = format!("{}/dev.dioxus.main.MainActivity", application_id,);
 
             if let Err(e) = Command::new(&adb)
                 .arg("shell")


### PR DESCRIPTION
This PR stems from my questions regarding issue #4098. In my opinion, if a user explicitly specifies an identifier, modifying it during APK build would be unreasonable.

If there is indeed a valid reason for altering the Android applicationId, I’ll close this PR—apologies for any inconvenience caused to the Dioxus team.

This commit fixes the Android `applicationId` generation to accurately reflect the user-configured `bundle.identifier` when provided. It also refactors the logic by removing the `full_mobile_app_name` function, with `bundle_identifier` now being the direct source for the Android `applicationId`.

The `bundle_identifier` function now operates as follows:
1. If `bundle.identifier` is explicitly set by the user:
    - It validates that the identifier has at least three segments (e.g., `com.example.app`).
    - The user's `identifier` is then returned and used directly as the Android `applicationId`.
2. If `config.bundle.identifier` is not set by the user:
    - It defaults to `com.example.{PascalCaseExecutableName}`. The `executable_name` (e.g., "my-app" derived from a project name like "MyApp") is converted to `PascalCase` (e.g., "MyApp") for this default.

**BREAKING CHANGE**:

This change primarily affects Android builds and may alter the final `applicationId` for users who had a custom `bundle.identifier` set, particularly if its casing or final segment differed from the PascalCased `executable_name`.

- **Previous Behavior**:

    The Android `applicationId` was derived from `full_mobile_app_name`. This function effectively used the first two segments of the `bundle_identifier` (user-configured or default) but then **always** appended a PascalCased version of the `executable_name` as the final segment.

    Example Scenario:
    - User project name: "MyApp" (CLI set `executable_name` to "my-app")
    - User configured `bundle.identifier` in Dioxus config: `"com.custom.myapp"`
    - `bundled_app_name()` (from "my-app"): "MyApp"
    - Old `applicationId` (via `full_mobile_app_name`): `"com.custom.MyApp"`

- **New Behavior**:

    With the same user configuration (`"com.custom.myapp"`), the `applicationId` will now be: `"com.custom.myapp"`

This change ensures the `applicationId` respects the user's explicit `bundle.identifier` string. However, if users were unknowingly relying on the previous behavior where the last segment was always a PascalCased version of the `executable_name` (potentially mismatching their intended lowercase final segment in `bundle.identifier`), their `applicationId` will change upon updating the CLI.

According to Google's Android documentation, the `applicationId` must not be changed after an app is published, as this causes Google Play to treat it as a new application. Users who have published Android apps and utilized custom `bundle.identifier` configurations should meticulously verify their `applicationId` after this update to ensure it remains consistent with their published versions or to take appropriate action if a change is detected.