### PR TITLE
fix: escape backslashes in debug locations for HTMLData serialization

### DIFF
--- a/packages/fullstack-protocol/src/lib.rs
+++ b/packages/fullstack-protocol/src/lib.rs
@@ -359,7 +359,13 @@ impl HTMLData {
             #[cfg(debug_assertions)]
             debug_types: format_js_list_of_strings(&self.debug_types),
             #[cfg(debug_assertions)]
-            debug_locations: format_js_list_of_strings(&self.debug_locations),
+            debug_locations: format_js_list_of_strings(
+                &self
+                    .debug_locations
+                    .iter()
+                    .map(|s| Some(s.as_ref().unwrap().replace("\\", "\\\\").to_string()))
+                    .collect::<Vec<_>>(),
+            ),
         }
     }
 }


### PR DESCRIPTION
PR for #4112, hopefully fixes issue when on windows. Most of a middleman fix than a solution for the root cause.