### PR TITLE
fix(cli): filter out .lib files when targeting Android

### DIFF
--- a/packages/cli/src/cli/link.rs
+++ b/packages/cli/src/cli/link.rs
@@ -129,6 +129,10 @@ impl LinkAction {
 
         handle_linker_command_file(&mut args);
 
+        if self.triple.environment == target_lexicon::Environment::Android {
+            args.retain(|arg| !arg.ends_with(".lib"));
+        }
+
         // Write the linker args to a file for the main process to read
         // todo: we might need to encode these as escaped shell words in case newlines are passed
         std::fs::write(self.link_args_file, args.join("\n"))?;


### PR DESCRIPTION
This PR fixes a case that during multi-platform builds (e.g., when simultaneously targeting Windows and Android), Windows-specific .lib files from dependencies like `embed_resource` are incorrectly included in Android linker arguments, despite proper `#[cfg(windows)]` guards in both `build.rs` and `Cargo.toml`