### PR TITLE
fix: fixed wasm and js paths in release mode

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -3148,11 +3148,8 @@ impl BuildRequest {
         // In release mode, we make the wasm and bindgen files into assets so they get bundled with max
         // optimizations.
         let wasm_path = if self.release && !should_bundle_split {
-            // Register the main.js with the asset system so it bundles in the snippets and optimizes
-            let name = assets.register_asset(
-                &self.wasm_bindgen_js_output_file(),
-                AssetOptions::Js(JsAssetOptions::new().with_minify(true).with_preload(true)),
-            )?;
+            // Make sure to register the main wasm file with the asset system
+            let name = assets.register_asset(&post_bindgen_wasm, AssetOptions::Unknown)?;
             format!("assets/{}", name.bundled_path())
         } else {
             let asset = self.wasm_bindgen_wasm_output_file();
@@ -3160,8 +3157,11 @@ impl BuildRequest {
         };
 
         let js_path = if self.release && !should_bundle_split {
-            // Make sure to register the main wasm file with the asset system
-            let name = assets.register_asset(&post_bindgen_wasm, AssetOptions::Unknown)?;
+            // Register the main.js with the asset system so it bundles in the snippets and optimizes
+            let name = assets.register_asset(
+                &self.wasm_bindgen_js_output_file(),
+                AssetOptions::Js(JsAssetOptions::new().with_minify(true).with_preload(true)),
+            )?;
             format!("assets/{}", name.bundled_path())
         } else {
             let asset = self.wasm_bindgen_js_output_file();


### PR DESCRIPTION
Hi!
When playing with the bleeding edge of Dioxus, I noticed that in the release mode, the JS file and the WASM file were imported in wrong places on accident (WASM file was imported instead of JS and vice versa). This rendered the app unusable in the web build.
<img width="691" alt="obraz" src="https://github.com/user-attachments/assets/7a7bde1d-83eb-48a0-9270-e3db8bfde866" />
<img width="1214" alt="obraz" src="https://github.com/user-attachments/assets/8e6cbd03-a0c8-4f33-8001-a10079cbc143" />
This simple pull request fixes this mistake.