### PR TITLE
Fix authentication example

### DIFF
--- a/examples/fullstack-auth/Cargo.toml
+++ b/examples/fullstack-auth/Cargo.toml
@@ -48,7 +48,7 @@ optional = true
 [features]
 default = []
 server = [
-    "dioxus-fullstack/server",
+    "dioxus/server",
     "dep:dioxus-cli-config",
     "dep:axum",
     "dep:tokio",


### PR DESCRIPTION
The auth example never enabled the server feature of the dioxus crate which caused the endpoints to fail. This PR fixes that issue

Fixes #4135 