### PR TITLE
subsecond: Typed HotFn pointer

### DIFF
--- a/packages/core/src/properties.rs
+++ b/packages/core/src/properties.rs
@@ -155,7 +155,7 @@ where
     }
 
     fn fn_ptr(&self) -> usize {
-        subsecond::HotFn::current(self.clone()).ptr_address() as usize
+        subsecond::HotFn::current(self.clone()).ptr_address().0 as usize
     }
 }
 
@@ -170,7 +170,7 @@ where
     }
 
     fn fn_ptr(&self) -> usize {
-        subsecond::HotFn::current(self.clone()).ptr_address() as usize
+        subsecond::HotFn::current(self.clone()).ptr_address().0 as usize
     }
 }
 

--- a/packages/server/src/launch.rs
+++ b/packages/server/src/launch.rs
@@ -163,7 +163,7 @@ async fn serve_server(
                                 }
 
                                 let hot_root = subsecond::HotFn::current(original_root);
-                                let new_root_addr = hot_root.ptr_address() as usize as *const ();
+                                let new_root_addr = hot_root.ptr_address().0 as usize as *const ();
                                 let new_root = unsafe {
                                     std::mem::transmute::<*const (), fn() -> Element>(new_root_addr)
                                 };


### PR DESCRIPTION
- Type the pointer you can get from `ptr_address`
- Add a method to reuse a saved pointer instead of checking the jump table