### PR TITLE
fix windows subsecond, add `DX_LINKER` and `DX_HOST_LINKER` env var overrides

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1718,6 +1718,20 @@ impl BuildRequest {
     /// cause issues with a custom linker setup. In theory, rust translates most flags to the right
     /// linker format.
     fn select_linker(&self) -> Result<PathBuf, Error> {
+        // Use a custom linker for non-crosscompile and crosscompile targets
+        if matches!(
+            self.triple.operating_system,
+            OperatingSystem::Darwin(_) | OperatingSystem::Linux | OperatingSystem::Windows
+        ) {
+            if let Ok(linker) = std::env::var("DX_HOST_LINKER") {
+                return Ok(PathBuf::from(linker));
+            }
+        }
+
+        if let Ok(linker) = std::env::var("DX_LINKER") {
+            return Ok(PathBuf::from(linker));
+        }
+
         let cc = match self.triple.operating_system {
             OperatingSystem::Unknown if self.platform == Platform::Web => self.workspace.wasm_ld(),
 

--- a/packages/cli/src/cli/link.rs
+++ b/packages/cli/src/cli/link.rs
@@ -122,7 +122,7 @@ impl LinkAction {
     /// The file will be given by the dx-magic-link-arg env var itself, so we use
     /// it both for determining if we should act as a linker and the for the file name itself.
     async fn run_link_inner(self) -> Result<()> {
-        let mut args: Vec<_> = std::env::args().skip(1).collect();
+        let mut args: Vec<_> = std::env::args().collect();
         if args.is_empty() {
             return Ok(());
         }
@@ -140,7 +140,7 @@ impl LinkAction {
                 let mut cmd = std::process::Command::new(linker);
                 match cfg!(target_os = "windows") {
                     true => cmd.arg(format!("@{}", &self.link_args_file.display())),
-                    false => cmd.args(args),
+                    false => cmd.args(args.iter().skip(1)),
                 };
                 let res = cmd.output().expect("Failed to run linker");
 


### PR DESCRIPTION
The response file handling is incorrect, so I'm removing it for now. Also, the finger print busting was bad, so on windows we use a more aggressive fingerprint busting strategy.

Also adds the ability to override the linker using some env vars since we don't have proper linker reading.