### PR TITLE
fix: Make `Writable::toggle` use peek to avoid subscribing as `Readable::Cloned` uses `Readable::read`

### DIFF
--- a/packages/signals/src/write.rs
+++ b/packages/signals/src/write.rs
@@ -102,7 +102,8 @@ pub trait Writable: Readable {
     where
         Self::Target: std::ops::Not<Output = Self::Target> + Clone,
     {
-        self.set(!self.cloned());
+        let inverted = !(*self.peek()).clone();
+        self.set(inverted);
     }
 
     /// Index into the inner value and return a reference to the result.


### PR DESCRIPTION
I found this while debugging https://github.com/marc2332/freya/issues/1173