### PR TITLE
Enable serve_dioxus_application for WASM targets

### DIFF
--- a/packages/server/src/server.rs
+++ b/packages/server/src/server.rs
@@ -116,11 +116,6 @@ where
         self
     }
 
-    #[cfg(target_arch = "wasm32")]
-    fn serve_static_assets(mut self) -> Self {
-        self
-    }
-
     fn serve_dioxus_application(self, cfg: ServeConfig, app: fn() -> Element) -> Self {
         // Add server functions and render index.html
         let server = self

--- a/packages/server/src/server.rs
+++ b/packages/server/src/server.rs
@@ -182,6 +182,27 @@ pub trait DioxusRouterFnExt<S> {
     /// }
     /// ```
     fn register_server_functions_with_context(self, context_providers: ContextProviders) -> Self;
+
+    /// Serves a Dioxus application without static assets.
+    /// Sets up server function routes and rendering endpoints only.
+    ///
+    /// Useful for WebAssembly environments or when static assets
+    /// are served by another system.
+    ///
+    /// # Example
+    /// ```rust, no_run
+    /// # use dioxus_lib::prelude::*;
+    /// # use dioxus_fullstack::prelude::*;
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let router = axum::Router::new()
+    ///         .serve_api_application(ServeConfig::new().unwrap(), app)
+    ///         .into_make_service();
+    ///     // ...
+    /// }
+    fn serve_api_application(self, cfg: ServeConfig, app: fn() -> Element) -> Self
+    where
+        Self: Sized;
 }
 
 impl<S> DioxusRouterFnExt<S> for Router<S>
@@ -196,6 +217,20 @@ where
             self = register_server_fn_on_router(f, self, context_providers.clone());
         }
         self
+    }
+
+    fn serve_api_application(self, cfg: ServeConfig, app: fn() -> Element) -> Self
+    where
+        Self: Sized,
+    {
+        let server = self.register_server_functions_with_context(cfg.context_providers.clone());
+
+        let ssr_state = SSRState::new(&cfg);
+
+        server.fallback(
+            get(render_handler)
+                .with_state(RenderHandleState::new(cfg, app).with_ssr_state(ssr_state)),
+        )
     }
 }
 

--- a/packages/server/src/server.rs
+++ b/packages/server/src/server.rs
@@ -67,11 +67,11 @@ pub trait DioxusRouterExt<S>: DioxusRouterFnExt<S> {
         Self: Sized;
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl<S> DioxusRouterExt<S> for Router<S>
 where
     S: Send + Sync + Clone + 'static,
 {
+    #[cfg(not(target_arch = "wasm32"))]
     fn serve_static_assets(mut self) -> Self {
         use tower_http::services::{ServeDir, ServeFile};
 
@@ -115,6 +115,9 @@ where
 
         self
     }
+
+    #[cfg(target_arch = "wasm32")]
+    fn serve_static_assets(mut self) -> Self {}
 
     fn serve_dioxus_application(self, cfg: ServeConfig, app: fn() -> Element) -> Self {
         // Add server functions and render index.html

--- a/packages/server/src/server.rs
+++ b/packages/server/src/server.rs
@@ -117,7 +117,9 @@ where
     }
 
     #[cfg(target_arch = "wasm32")]
-    fn serve_static_assets(mut self) -> Self {}
+    fn serve_static_assets(mut self) -> Self {
+        self
+    }
 
     fn serve_dioxus_application(self, cfg: ServeConfig, app: fn() -> Element) -> Self {
         // Add server functions and render index.html

--- a/packages/server/src/server.rs
+++ b/packages/server/src/server.rs
@@ -67,11 +67,11 @@ pub trait DioxusRouterExt<S>: DioxusRouterFnExt<S> {
         Self: Sized;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<S> DioxusRouterExt<S> for Router<S>
 where
     S: Send + Sync + Clone + 'static,
 {
-    #[cfg(not(target_arch = "wasm32"))]
     fn serve_static_assets(mut self) -> Self {
         use tower_http::services::{ServeDir, ServeFile};
 


### PR DESCRIPTION
Motivation
Currently, WASM servers cannot use `serve_dioxus_application` because it's trait extension only has an implementation for non-WASM targets. If users try to manually implement this functionality, they encounter difficulty accessing the private `context_providers` field in the `ServeConfig`, and have to rewrite a lot of the core logic for SSR which has a maintenance burden.

### Solution
This PR adds conditional compilation for the `serve_static_assets` method:
- For non-WASM targets: maintains the existing implementation that serves static assets from the public directory
- For WASM targets: provides a simple implementation that just returns `self` (no-op)

This allows WASM servers to use the same `serve_dioxus_application` API as non-WASM servers, simplifying code that needs to work across both environments. Since this trait is never used on wasm currently, it should not introduce a breaking change.
