### PR TITLE
feat: copy frameworks to Frameworks folder, detect linkers, custom target dirs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,6 +2956,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cross-tls-crate"
+version = "0.1.0"
+
+[[package]]
+name = "cross-tls-crate-dylib"
+version = "0.1.0"
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13479,6 +13487,15 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "subsecond-tls-harness"
+version = "0.1.0"
+dependencies = [
+ "cross-tls-crate",
+ "cross-tls-crate-dylib",
+ "dioxus-devtools",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2023,6 +2023,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-config2"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc3749a36e0423c991f1e7a3e4ab0c36a1f489658313db4b187d401d79cc461"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml_edit 0.22.26",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "cargo-generate"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3662,6 +3674,7 @@ dependencies = [
  "backtrace",
  "brotli 7.0.0",
  "built",
+ "cargo-config2",
  "cargo-generate",
  "cargo_metadata",
  "cargo_toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,9 @@ members = [
     # subsecond
     "packages/subsecond/subsecond",
     "packages/subsecond/subsecond-types",
+    "packages/subsecond/subsecond-tests/cross-tls-crate",
+    "packages/subsecond/subsecond-tests/cross-tls-crate-dylib",
+    "packages/subsecond/subsecond-tests/cross-tls-test",
 
     # Full project examples
     "example-projects/fullstack-hackernews",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -138,6 +138,7 @@ wasm-bindgen-externref-xform = "0.2.100"
 pdb = "0.8.0"
 self_update = { version = "0.42.0", features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"] }
 self-replace = "1.5.0"
+cargo-config2.workspace = true
 
 [build-dependencies]
 built = { version = "0.7.5", features = ["git2"] }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -138,7 +138,7 @@ wasm-bindgen-externref-xform = "0.2.100"
 pdb = "0.8.0"
 self_update = { version = "0.42.0", features = ["archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate"] }
 self-replace = "1.5.0"
-cargo-config2.workspace = true
+cargo-config2 = { workspace = true }
 
 [build-dependencies]
 built = { version = "0.7.5", features = ["git2"] }

--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -208,12 +208,12 @@ impl AppBuilder {
                             self.bundling_progress = 0.0;
                         }
                         BuildStage::Starting { crate_count, .. } => {
-                            self.expected_crates = *crate_count;
+                            self.expected_crates = *crate_count.max(&1);
                         }
                         BuildStage::InstallingTooling => {}
                         BuildStage::Compiling { current, total, .. } => {
                             self.compiled_crates = *current;
-                            self.expected_crates = *total;
+                            self.expected_crates = *total.max(&1);
 
                             if self.compile_start.is_none() {
                                 self.compile_start = Some(Instant::now());

--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -836,6 +836,7 @@ pub fn create_undefined_symbol_stub(
     // Get the offset from the main module and adjust the addresses by the slide
     let aslr_ref_address = symbol_table
         .get("_main")
+        .or_else(|| symbol_table.get("main"))
         .map(|s| s.address)
         .context("Failed to find _main symbol")?;
 

--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -1034,7 +1034,7 @@ pub fn create_undefined_symbol_stub(
                     kind: SymbolKind::Text,
                     weak: false,
                     section: SymbolSection::Section(text_section),
-                    flags: SymbolFlags::None,
+                    flags: SymbolFlags::None, // ignore for these stubs
                 });
             }
 
@@ -1103,7 +1103,7 @@ pub fn create_undefined_symbol_stub(
                     kind: SymbolKind::Tls,
                     weak: false,
                     section: SymbolSection::Section(tls_section),
-                    flags: SymbolFlags::None,
+                    flags: SymbolFlags::None, // ignore for these stubs
                 });
             }
 
@@ -1123,7 +1123,7 @@ pub fn create_undefined_symbol_stub(
                     kind,
                     weak: sym.is_weak,
                     section: SymbolSection::Absolute,
-                    flags: sym.flags,
+                    flags: sym.flags, // important on elf where these matter
                 });
             }
         }

--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -852,7 +852,7 @@ pub fn create_undefined_symbol_stub(
             .symbol_table
             .get(name.as_str().trim_start_matches("__imp_"))
         else {
-            tracing::error!("Symbol not found: {}", name);
+            tracing::debug!("Symbol not found: {}", name);
             continue;
         };
 

--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -852,7 +852,6 @@ pub fn create_undefined_symbol_stub(
     // for each symbol we either write the address directly (as a symbol) or create a PLT/GOT entry
     let text_section = obj.section_id(StandardSection::Text);
     for name in undefined_symbols {
-        tracing::debug!("Processing symbol: {}", name);
         let Some(sym) = symbol_table.get(name.as_str().trim_start_matches("__imp_")) else {
             tracing::error!("Symbol not found: {}", name);
             continue;

--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -326,9 +326,9 @@ fn create_windows_jump_table(patch: &Path, cache: &HotpatchModuleCache) -> Resul
         .context("failed to find 'main' symbol in patch")?;
 
     let aslr_reference = old_name_to_addr
-        .get("__aslr_reference")
+        .get("main")
         .map(|s| s.address)
-        .context("failed to find '_aslr_reference' symbol in original module")?;
+        .context("failed to find '_main' symbol in original module")?;
 
     Ok(JumpTable {
         lib: patch.to_path_buf(),
@@ -392,10 +392,10 @@ fn create_native_jump_table(
     };
 
     let aslr_reference = old_name_to_addr
-        .get("___aslr_reference")
-        .or_else(|| old_name_to_addr.get("__aslr_reference"))
+        .get("_main")
+        .or_else(|| old_name_to_addr.get("main"))
         .map(|s| s.address)
-        .context("failed to find '___aslr_reference' symbol in original module")?;
+        .context("failed to find '_main' symbol in original module")?;
 
     Ok(JumpTable {
         lib: patch.to_path_buf(),
@@ -835,16 +835,24 @@ pub fn create_undefined_symbol_stub(
 
     // Get the offset from the main module and adjust the addresses by the slide
     let aslr_ref_address = symbol_table
-        .get("___aslr_reference")
-        .or_else(|| symbol_table.get("__aslr_reference"))
+        .get("_main")
         .map(|s| s.address)
-        .context("Failed to find ___aslr_reference symbol")?;
+        .context("Failed to find _main symbol")?;
+
+    if aslr_reference < aslr_ref_address {
+        return Err(PatchError::InvalidModule(
+            "ASLR reference is less than the main module's address - is there a `main`?"
+                .to_string(),
+        ));
+    }
+
     let aslr_offset = aslr_reference - aslr_ref_address;
 
     // we need to assemble a PLT/GOT so direct calls to the patch symbols work
     // for each symbol we either write the address directly (as a symbol) or create a PLT/GOT entry
     let text_section = obj.section_id(StandardSection::Text);
     for name in undefined_symbols {
+        tracing::debug!("Processing symbol: {}", name);
         let Some(sym) = symbol_table.get(name.as_str().trim_start_matches("__imp_")) else {
             tracing::error!("Symbol not found: {}", name);
             continue;

--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -1115,6 +1115,14 @@ pub fn create_undefined_symbol_stub(
                     k => k,
                 };
 
+                // plain linux *wants* these flags, but android doesn't.
+                // unsure what's going on here, but this is special cased for now.
+                // I think the more advanced linkers don't want these flags, but the default linux linker (ld) does.
+                let flags = match triple.environment {
+                    target_lexicon::Environment::Android => SymbolFlags::None,
+                    _ => sym.flags,
+                };
+
                 obj.add_symbol(Symbol {
                     name: name.as_bytes()[name_offset..].to_vec(),
                     value: abs_addr,
@@ -1123,7 +1131,7 @@ pub fn create_undefined_symbol_stub(
                     kind,
                     weak: sym.is_weak,
                     section: SymbolSection::Absolute,
-                    flags: sym.flags, // important on elf where these matter
+                    flags,
                 });
             }
         }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -911,7 +911,11 @@ impl BuildRequest {
         let mode = ctx.mode.clone();
         let platform = self.platform;
 
-        tracing::debug!("Build completed successfully: {:?}", exe);
+        tracing::debug!(
+            "Build completed successfully in {}us: {:?}",
+            time_end.duration_since(time_start).unwrap().as_micros(),
+            exe
+        );
 
         Ok(BuildArtifacts {
             time_end,

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1646,7 +1646,7 @@ impl BuildRequest {
         // Check if we already have a cached object file
         let out_ar_path = exe.with_file_name(format!("libdeps-{hash_id}.a",));
         let out_rlibs_list = exe.with_file_name(format!("rlibs-{hash_id}.txt"));
-        let mut archive_has_contents = false;
+        let mut archive_has_contents = out_ar_path.exists();
 
         // Use the rlibs list if it exists
         let mut compiler_rlibs = std::fs::read_to_string(&out_rlibs_list)
@@ -1662,7 +1662,7 @@ impl BuildRequest {
         //
         // Since we're using the git hash for the CLI entropy, debug builds should always regenerate
         // the archive since their hash might not change, but the logic might.
-        if !out_ar_path.exists() || cfg!(debug_assertions) {
+        if !archive_has_contents || cfg!(debug_assertions) {
             compiler_rlibs.clear();
 
             let mut bytes = vec![];

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1744,6 +1744,7 @@ impl BuildRequest {
                     }
 
                     args.insert(first_rlib, "/HIGHENTROPYVA:NO".to_string());
+                    args.insert(first_rlib, "/EXPORT:main".to_string());
                 }
                 LinkerFlavor::Unsupported => {
                     tracing::error!("Unsupported platform for fat linking");

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -927,7 +927,15 @@ impl BuildRequest {
 
         // Fat builds need to be linked with the fat linker. Would also like to link here for thin builds
         if matches!(ctx.mode, BuildMode::Fat) {
+            let link_start = SystemTime::now();
             self.run_fat_link(ctx, &exe, &direct_rustc).await?;
+            tracing::debug!(
+                "Fat linking completed in {}us",
+                SystemTime::now()
+                    .duration_since(link_start)
+                    .unwrap()
+                    .as_micros()
+            );
         }
 
         let assets = self.collect_assets(&exe, ctx)?;

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1497,9 +1497,9 @@ impl BuildRequest {
                 }
 
                 // use ld.lld if it exists. todo: use rust-lld
-                if self.workspace.lld.is_some() {
-                    out_args.push("-Wl,-fuse-ld=lld".to_string());
-                }
+                // if self.workspace.lld.is_some() {
+                //     out_args.push("-Wl,-fuse-ld=lld".to_string());
+                // }
             }
 
             LinkerFlavor::Msvc => {
@@ -1663,7 +1663,10 @@ impl BuildRequest {
         //
         // The nature of this process involves making extremely fat archives, so we should try and
         // speed up the future linking process by caching the archive.
-        if !out_ar_path.exists() {
+        //
+        // Since we're using the git hash for the CLI entropy, debug builds should always regenerate
+        // the archive since their hash might not change, but the logic might.
+        if !out_ar_path.exists() || cfg!(debug_assertions) {
             let mut bytes = vec![];
             let mut out_ar = ar::Builder::new(&mut bytes);
             for rlib in &rlibs {
@@ -1758,16 +1761,16 @@ impl BuildRequest {
                         args.insert(first_rlib + 3, rlib.display().to_string());
                     }
 
-                    // Export `main` so subsecond can use it for a reference point
-                    args.insert(first_rlib, "-Wl,--export-dynamic-symbol,main".to_string());
+                    // // Export `main` so subsecond can use it for a reference point
+                    // args.insert(first_rlib, "-Wl,--export-dynamic-symbol,main".to_string());
 
-                    // use ld.lld if it exists, and don't override their linker.
-                    // todo: use rust-lld
-                    if self.workspace.lld.is_some()
-                        && !args.iter().any(|arg| arg.starts_with("-Wl,-fuse-ld"))
-                    {
-                        args.insert(first_rlib, "-Wl,-fuse-ld=lld".to_string());
-                    }
+                    // // use ld.lld if it exists, and don't override their linker.
+                    // // todo: use rust-lld
+                    // if self.workspace.lld.is_some()
+                    //     && !args.iter().any(|arg| arg.starts_with("-Wl,-fuse-ld"))
+                    // {
+                    //     args.insert(first_rlib, "-Wl,-fuse-ld=lld".to_string());
+                    // }
                 }
                 LinkerFlavor::Darwin => {
                     args[first_rlib] = "-Wl,-force_load".to_string();
@@ -2021,7 +2024,7 @@ impl BuildRequest {
 
                 cmd.envs(rustc_args.envs.iter().cloned());
 
-                tracing::trace!("Setting env vars: {:#?}", rustc_args.envs);
+                // tracing::trace!("Setting env vars: {:#?}", rustc_args.envs);
 
                 Ok(cmd)
             }
@@ -2138,8 +2141,8 @@ impl BuildRequest {
                 cargo_args.push("-Clink-arg=-Wl,-rpath,@executable_path".to_string());
             }
             OperatingSystem::Linux => {
-                cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN/../lib".to_string());
-                cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN".to_string());
+                // cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN/../lib".to_string());
+                // cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN".to_string());
             }
             _ => {}
         }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1848,6 +1848,8 @@ impl BuildRequest {
             target_lexicon::Environment::Macabi => LinkerFlavor::Darwin,
             _ => match self.triple.operating_system {
                 OperatingSystem::Darwin(_) => LinkerFlavor::Darwin,
+                OperatingSystem::IOS(_) => LinkerFlavor::Darwin,
+                OperatingSystem::MacOSX(_) => LinkerFlavor::Darwin,
                 OperatingSystem::Linux => LinkerFlavor::Gnu,
                 OperatingSystem::Windows => LinkerFlavor::Msvc,
                 _ => match self.triple.architecture {

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1485,6 +1485,7 @@ impl BuildRequest {
                     if arg.starts_with("-l")
                         || arg.starts_with("-m")
                         || arg.starts_with("-Wl,--target=")
+                        || arg.starts_with("-Wl,-fuse-ld")
                     {
                         out_args.push(arg.to_string());
                     }
@@ -2129,8 +2130,8 @@ impl BuildRequest {
                 cargo_args.push("-Clink-arg=-Wl,-rpath,@executable_path".to_string());
             }
             OperatingSystem::Linux => {
-                // cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN/../lib".to_string());
-                // cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN".to_string());
+                cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN/../lib".to_string());
+                cargo_args.push("-Clink-arg=-Wl,-rpath,$ORIGIN".to_string());
             }
             _ => {}
         }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1815,6 +1815,10 @@ impl BuildRequest {
         Ok(())
     }
 
+    /// Automatically detect the linker flavor based on the target triple and any custom linkers.
+    ///
+    /// This tries to replicate what rustc does when selecting the linker flavor based on the linker
+    /// and triple.
     fn linker_flavor(&self) -> LinkerFlavor {
         if let Some(custom) = self.custom_linker.as_ref() {
             let name = custom.file_name().unwrap().to_ascii_lowercase();
@@ -1826,6 +1830,8 @@ impl BuildRequest {
                 Some("ld.lld") => return LinkerFlavor::Gnu,
                 Some("ld.gold") => return LinkerFlavor::Gnu,
                 Some("mold") => return LinkerFlavor::Gnu,
+                Some("sold") => return LinkerFlavor::Gnu,
+                Some("wild") => return LinkerFlavor::Gnu,
                 _ => {}
             }
         }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1487,6 +1487,11 @@ impl BuildRequest {
                         out_args.push(arg.to_string());
                     }
                 }
+
+                // use ld.lld if it exists. todo: use rust-lld
+                if self.workspace.lld.is_some() {
+                    out_args.push("-Wl,-fuse-ld=lld".to_string());
+                }
             }
 
             LinkerFlavor::Msvc => {
@@ -1747,6 +1752,14 @@ impl BuildRequest {
 
                     // Export `main` so subsecond can use it for a reference point
                     args.insert(first_rlib, "-Wl,--export-dynamic-symbol,main".to_string());
+
+                    // use ld.lld if it exists, and don't override their linker.
+                    // todo: use rust-lld
+                    if self.workspace.lld.is_some()
+                        && !args.iter().any(|arg| arg.starts_with("-Wl,-fuse-ld"))
+                    {
+                        args.insert(first_rlib, "-Wl,-fuse-ld=lld".to_string());
+                    }
                 }
                 LinkerFlavor::Darwin => {
                     args[first_rlib] = "-Wl,-force_load".to_string();

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1615,7 +1615,8 @@ impl BuildRequest {
 
         // Acquire a hash from the rlib names, sizes, modified times, and dx's git commit hash
         // This ensures that any changes in dx or the rlibs will cause a new hash to be generated
-        // The hash relies on both dx and rustc hashes, so it should be thoroughly unique
+        // The hash relies on both dx and rustc hashes, so it should be thoroughly unique. Keep it
+        // short to avoid long file names.
         let hash_id = Uuid::new_v5(
             &Uuid::NAMESPACE_OID,
             rlibs
@@ -1635,10 +1636,14 @@ impl BuildRequest {
                 })
                 .collect::<String>()
                 .as_bytes(),
-        );
+        )
+        .to_string()
+        .chars()
+        .take(8)
+        .collect::<String>();
 
         // Check if we already have a cached object file
-        let out_ar_path = exe.with_file_name(format!("libfatdependencies-{hash_id}.a"));
+        let out_ar_path = exe.with_file_name(format!("libdeps-{hash_id}.a",));
         let out_rlibs_list = exe.with_file_name(format!("rlibs-{hash_id}.txt"));
 
         // Use the rlibs list if it exists

--- a/packages/cli/src/cli/link.rs
+++ b/packages/cli/src/cli/link.rs
@@ -44,8 +44,8 @@ pub enum LinkerFlavor {
     Gnu,
     Darwin,
     WasmLld,
-    Unix,
     Msvc,
+    Unsupported, // a catch-all for unsupported linkers, usually the stripped-down unix ones
 }
 
 impl LinkAction {

--- a/packages/cli/src/devcfg.rs
+++ b/packages/cli/src/devcfg.rs
@@ -1,15 +1,5 @@
 //! Configuration of the CLI at runtime to enable certain experimental features.
 
-use std::path::Path;
-
-/// Should we cache the dependency library?
-///
-/// When the `DIOXUS_CACHE_DEP_LIB` environment variable is set, we will cache the dependency library
-/// built from the target's dependencies.
-pub(crate) fn should_cache_dep_lib(lib: &Path) -> bool {
-    std::env::var("DIOXUS_CACHE_DEP_LIB").is_ok() && lib.exists()
-}
-
 /// Should we force the entropy to be used on the main exe?
 ///
 /// This is used to verify that binaries are copied with different names such that they don't collide

--- a/packages/cli/src/rustcwrapper.rs
+++ b/packages/cli/src/rustcwrapper.rs
@@ -25,6 +25,7 @@ pub fn is_wrapping_rustc() -> bool {
 pub struct RustcArgs {
     pub args: Vec<String>,
     pub envs: Vec<(String, String)>,
+    pub link_args: Vec<String>,
 }
 
 /// Run rustc directly, but output the result to a file.
@@ -50,6 +51,7 @@ pub async fn run_rustc() {
     let rustc_args = RustcArgs {
         args: args().skip(1).collect::<Vec<_>>(),
         envs: vars().collect::<_>(),
+        link_args: Default::default(),
     };
 
     std::fs::create_dir_all(var_file.parent().expect("Failed to get parent dir"))

--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -721,7 +721,13 @@ impl Output {
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 "Hotreload: ".gray(),
-                "rsx and assets".yellow(),
+                if !state.runner.automatic_rebuilds {
+                    "disabled".dark_gray()
+                } else if state.runner.use_hotpatch_engine {
+                    "hot-patching".yellow()
+                } else {
+                    "rsx and assets".yellow()
+                },
             ])),
             meta_list[3],
         );

--- a/packages/cli/src/serve/proxy.rs
+++ b/packages/cli/src/serve/proxy.rs
@@ -138,9 +138,10 @@ pub(crate) fn proxy_to(
         match res {
             Ok(res) => {
                 // log assets at a different log level
-                if uri.path().starts_with("/assets")
-                    || uri.path().starts_with("/_dioxus")
-                    || uri.path().starts_with("/public")
+                if uri.path().starts_with("/assets/")
+                    || uri.path().starts_with("/_dioxus/")
+                    || uri.path().starts_with("/public/")
+                    || uri.path().starts_with("/wasm/")
                 {
                     tracing::trace!(dx_src = ?TraceSrc::Dev, "[{}] {}", res.status().as_u16(), uri);
                 } else {

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -341,14 +341,14 @@ impl AppServer {
                     continue;
                 };
 
+                // Update the most recent version of the file, so when we force a rebuild, we keep operating on the most recent version
+                cached_file.most_recent = Some(new_contents);
+
                 // This assumes the two files are structured similarly. If they're not, we can't diff them
                 let Some(changed_rsx) = dioxus_rsx_hotreload::diff_rsx(&new_file, &old_file) else {
                     needs_full_rebuild = true;
                     break;
                 };
-
-                // Update the most recent version of the file, so when we force a rebuild, we keep operating on the most recent version
-                cached_file.most_recent = Some(new_contents);
 
                 for ChangedRsx { old, new } in changed_rsx {
                     let old_start = old.span().start();

--- a/packages/cli/src/workspace.rs
+++ b/packages/cli/src/workspace.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::{collections::HashSet, path::Path};
 use target_lexicon::Triple;
 use tokio::process::Command;
+use which::which;
 
 pub struct Workspace {
     pub(crate) krates: Krates,
@@ -20,6 +21,7 @@ pub struct Workspace {
     pub(crate) ignore: Gitignore,
     pub(crate) cargo_toml: cargo_toml::Manifest,
     pub(crate) android_tools: Option<Arc<AndroidTools>>,
+    pub(crate) lld: Option<PathBuf>,
 }
 
 impl Workspace {
@@ -66,6 +68,8 @@ impl Workspace {
 
         let android_tools = crate::build::get_android_tools();
 
+        let lld = which::which("lld").or_else(|_| which("ld.lld")).ok();
+
         let workspace = Arc::new(Self {
             krates,
             settings,
@@ -75,6 +79,7 @@ impl Workspace {
             ignore,
             cargo_toml,
             android_tools,
+            lld,
         });
 
         tracing::debug!(

--- a/packages/cli/src/workspace.rs
+++ b/packages/cli/src/workspace.rs
@@ -20,7 +20,6 @@ pub struct Workspace {
     pub(crate) ignore: Gitignore,
     pub(crate) cargo_toml: cargo_toml::Manifest,
     pub(crate) android_tools: Option<Arc<AndroidTools>>,
-    pub(crate) lld: Option<PathBuf>,
 }
 
 impl Workspace {
@@ -67,8 +66,6 @@ impl Workspace {
 
         let android_tools = crate::build::get_android_tools();
 
-        let lld = which::which("lld").or_else(|_| which::which("ld.lld")).ok();
-
         let workspace = Arc::new(Self {
             krates,
             settings,
@@ -78,7 +75,6 @@ impl Workspace {
             ignore,
             cargo_toml,
             android_tools,
-            lld,
         });
 
         tracing::debug!(

--- a/packages/cli/src/workspace.rs
+++ b/packages/cli/src/workspace.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use std::{collections::HashSet, path::Path};
 use target_lexicon::Triple;
 use tokio::process::Command;
-use which::which;
 
 pub struct Workspace {
     pub(crate) krates: Krates,
@@ -68,7 +67,7 @@ impl Workspace {
 
         let android_tools = crate::build::get_android_tools();
 
-        let lld = which::which("lld").or_else(|_| which("ld.lld")).ok();
+        let lld = which::which("lld").or_else(|_| which::which("ld.lld")).ok();
 
         let workspace = Arc::new(Self {
             krates,

--- a/packages/desktop/src/launch.rs
+++ b/packages/desktop/src/launch.rs
@@ -1,3 +1,228 @@
+// use crate::Config;
+// use crate::{
+//     app::App,
+//     ipc::{IpcMethod, UserWindowEvent},
+// };
+// use dioxus_core::*;
+// use dioxus_document::eval;
+// use std::any::Any;
+// use tao::event::{Event, StartCause, WindowEvent};
+
+// /// Launches the WebView and runs the event loop
+// pub fn launch(root: fn() -> Element) {
+//     launch_cfg(root, vec![], vec![]);
+// }
+
+// /// Launches the WebView and runs the event loop, with configuration and root props.
+// pub fn launch_cfg(
+//     root: fn() -> Element,
+//     contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
+//     platform_config: Vec<Box<dyn Any>>,
+// ) {
+//     let mut virtual_dom = VirtualDom::new(root);
+
+//     for context in contexts {
+//         virtual_dom.insert_any_root_context(context());
+//     }
+
+//     let platform_config = *platform_config
+//         .into_iter()
+//         .find_map(|cfg| cfg.downcast::<Config>().ok())
+//         .unwrap_or_default();
+
+//     launch_virtual_dom(virtual_dom, platform_config)
+// }
+
+// /// Launches the WebView and runs the event loop, with configuration and root props.
+// pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) -> ! {
+//     #[cfg(feature = "tokio_runtime")]
+//     {
+//         tokio::runtime::Builder::new_multi_thread()
+//             .enable_all()
+//             .build()
+//             .unwrap()
+//             .block_on(tokio::task::unconstrained(async move {
+//                 launch_virtual_dom_blocking(virtual_dom, desktop_config)
+//             }));
+
+//         unreachable!("The desktop launch function will never exit")
+//     }
+
+//     #[cfg(not(feature = "tokio_runtime"))]
+//     {
+//         launch_virtual_dom_blocking(virtual_dom, desktop_config);
+//     }
+// }
+
+// /// Launch the WebView and run the event loop, with configuration and root props.
+// ///
+// /// This will block the main thread, and *must* be spawned on the main thread. This function does not assume any runtime
+// /// and is equivalent to calling launch_with_props with the tokio feature disabled.
+// pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, mut desktop_config: Config) -> ! {
+//     let mut custom_event_handler = desktop_config.custom_event_handler.take();
+//     let (event_loop, mut app) = App::new(desktop_config, virtual_dom);
+
+//     event_loop.run(move |window_event, event_loop, control_flow| {
+//         // Set the control flow and check if any events need to be handled in the app itself
+//         app.tick(&window_event);
+
+//         if let Some(ref mut f) = custom_event_handler {
+//             f(&window_event, event_loop)
+//         }
+
+//         match window_event {
+//             Event::NewEvents(StartCause::Init) => app.handle_start_cause_init(),
+//             Event::LoopDestroyed => app.handle_loop_destroyed(),
+//             Event::WindowEvent {
+//                 event, window_id, ..
+//             } => match event {
+//                 WindowEvent::CloseRequested => app.handle_close_requested(window_id),
+//                 WindowEvent::Destroyed { .. } => app.window_destroyed(window_id),
+//                 WindowEvent::Resized(new_size) => app.resize_window(window_id, new_size),
+//                 _ => {}
+//             },
+
+//             Event::UserEvent(event) => match event {
+//                 UserWindowEvent::Poll(id) => app.poll_vdom(id),
+//                 UserWindowEvent::NewWindow => app.handle_new_window(),
+//                 UserWindowEvent::CloseWindow(id) => app.handle_close_msg(id),
+//                 UserWindowEvent::Shutdown => app.control_flow = tao::event_loop::ControlFlow::Exit,
+
+//                 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+//                 UserWindowEvent::GlobalHotKeyEvent(evnt) => app.handle_global_hotkey(evnt),
+
+//                 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+//                 UserWindowEvent::MudaMenuEvent(evnt) => app.handle_menu_event(evnt),
+
+//                 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+//                 UserWindowEvent::TrayMenuEvent(evnt) => app.handle_tray_menu_event(evnt),
+
+//                 #[cfg(any(target_os = "windows", target_os = "linux", target_os = "macos"))]
+//                 UserWindowEvent::TrayIconEvent(evnt) => app.handle_tray_icon_event(evnt),
+
+//                 #[cfg(all(feature = "devtools", debug_assertions))]
+//                 UserWindowEvent::HotReloadEvent(msg) => app.handle_hot_reload_msg(msg),
+
+//                 // Windows-only drag-n-drop fix events. We need to call the interpreter drag-n-drop code.
+//                 UserWindowEvent::WindowsDragDrop(id) => {
+//                     if let Some(webview) = app.webviews.get(&id) {
+//                         webview.dom.in_runtime(|| {
+//                             ScopeId::ROOT.in_runtime(|| {
+//                                 eval("window.interpreter.handleWindowsDragDrop();");
+//                             });
+//                         });
+//                     }
+//                 }
+//                 UserWindowEvent::WindowsDragLeave(id) => {
+//                     if let Some(webview) = app.webviews.get(&id) {
+//                         webview.dom.in_runtime(|| {
+//                             ScopeId::ROOT.in_runtime(|| {
+//                                 eval("window.interpreter.handleWindowsDragLeave();");
+//                             });
+//                         });
+//                     }
+//                 }
+//                 UserWindowEvent::WindowsDragOver(id, x_pos, y_pos) => {
+//                     if let Some(webview) = app.webviews.get(&id) {
+//                         webview.dom.in_runtime(|| {
+//                             ScopeId::ROOT.in_runtime(|| {
+//                                 let e = eval(
+//                                     r#"
+//                                     const xPos = await dioxus.recv();
+//                                     const yPos = await dioxus.recv();
+//                                     window.interpreter.handleWindowsDragOver(xPos, yPos)
+//                                     "#,
+//                                 );
+
+//                                 _ = e.send(x_pos);
+//                                 _ = e.send(y_pos);
+//                             });
+//                         });
+//                     }
+//                 }
+
+//                 UserWindowEvent::Ipc { id, msg } => match msg.method() {
+//                     IpcMethod::Initialize => app.handle_initialize_msg(id),
+//                     IpcMethod::FileDialog => app.handle_file_dialog_msg(msg, id),
+//                     IpcMethod::UserEvent => {}
+//                     IpcMethod::Query => app.handle_query_msg(msg, id),
+//                     IpcMethod::BrowserOpen => app.handle_browser_open(msg),
+//                     IpcMethod::Other(_) => {}
+//                 },
+//             },
+//             _ => {}
+//         }
+
+//         *control_flow = app.control_flow;
+//     })
+// }
+
+// /// Expose the `Java_dev_dioxus_main_WryActivity_create` function to the JNI layer.
+// /// We hardcode these to have a single trampoline for host Java code to call into.
+// ///
+// /// This saves us from having to plumb the top-level package name all the way down into
+// /// this file. This is better for modularity (ie just call dioxus' main to run the app) as
+// /// well as cache thrashing since this crate doesn't rely on external env vars.
+// ///
+// /// The CLI is expecting to find `dev.dioxus.main` in the final library. If you find a need to
+// /// change this, you'll need to change the CLI as well.
+// #[cfg(target_os = "android")]
+// #[no_mangle]
+// #[inline(never)]
+// pub extern "C" fn start_app() {
+//     wry::android_binding!(dev_dioxus, main, wry);
+//     tao::android_binding!(
+//         dev_dioxus,
+//         main,
+//         WryActivity,
+//         wry::android_setup,
+//         dioxus_main_root_fn,
+//         tao
+//     );
+// }
+
+// #[cfg(target_os = "android")]
+// #[doc(hidden)]
+// pub fn dioxus_main_root_fn() {
+//     // we're going to find the `main` symbol using dlsym directly and call it
+//     unsafe {
+//         let mut main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"main\0".as_ptr() as _);
+
+//         if main_fn_ptr.is_null() {
+//             main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"_main\0".as_ptr() as _);
+//         }
+
+//         if main_fn_ptr.is_null() {
+//             panic!("Failed to find main symbol");
+//         }
+
+//         // Set the env vars that rust code might expect, passed off to us by the android app
+//         // Doing this before main emulates the behavior of a regular executable
+//         if cfg!(target_os = "android") && cfg!(debug_assertions) {
+//             load_env_file_from_session_cache();
+//         }
+
+//         let main_fn: extern "C" fn() = std::mem::transmute(main_fn_ptr);
+//         main_fn();
+//     };
+// }
+
+// /// Load the env file from the session cache if we're in debug mode and on android
+// ///
+// /// This is a slightly hacky way of being able to use std::env::var code in android apps without
+// /// going through their custom java-based system.
+// #[cfg(target_os = "android")]
+// fn load_env_file_from_session_cache() {
+//     let env_file = dioxus_cli_config::android_session_cache_dir().join(".env");
+//     if let Some(env_file) = std::fs::read_to_string(&env_file).ok() {
+//         for line in env_file.lines() {
+//             if let Some((key, value)) = line.trim().split_once('=') {
+//                 std::env::set_var(key, value);
+//             }
+//         }
+//     }
+// }
+
 use crate::Config;
 use crate::{
     app::App,
@@ -7,52 +232,6 @@ use dioxus_core::*;
 use dioxus_document::eval;
 use std::any::Any;
 use tao::event::{Event, StartCause, WindowEvent};
-
-/// Launches the WebView and runs the event loop
-pub fn launch(root: fn() -> Element) {
-    launch_cfg(root, vec![], vec![]);
-}
-
-/// Launches the WebView and runs the event loop, with configuration and root props.
-pub fn launch_cfg(
-    root: fn() -> Element,
-    contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
-    platform_config: Vec<Box<dyn Any>>,
-) {
-    let mut virtual_dom = VirtualDom::new(root);
-
-    for context in contexts {
-        virtual_dom.insert_any_root_context(context());
-    }
-
-    let platform_config = *platform_config
-        .into_iter()
-        .find_map(|cfg| cfg.downcast::<Config>().ok())
-        .unwrap_or_default();
-
-    launch_virtual_dom(virtual_dom, platform_config)
-}
-
-/// Launches the WebView and runs the event loop, with configuration and root props.
-pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) -> ! {
-    #[cfg(feature = "tokio_runtime")]
-    {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .build()
-            .unwrap()
-            .block_on(tokio::task::unconstrained(async move {
-                launch_virtual_dom_blocking(virtual_dom, desktop_config)
-            }));
-
-        unreachable!("The desktop launch function will never exit")
-    }
-
-    #[cfg(not(feature = "tokio_runtime"))]
-    {
-        launch_virtual_dom_blocking(virtual_dom, desktop_config);
-    }
-}
 
 /// Launch the WebView and run the event loop, with configuration and root props.
 ///
@@ -157,68 +336,43 @@ pub fn launch_virtual_dom_blocking(virtual_dom: VirtualDom, mut desktop_config: 
     })
 }
 
-/// Expose the `Java_dev_dioxus_main_WryActivity_create` function to the JNI layer.
-/// We hardcode these to have a single trampoline for host Java code to call into.
-///
-/// This saves us from having to plumb the top-level package name all the way down into
-/// this file. This is better for modularity (ie just call dioxus' main to run the app) as
-/// well as cache thrashing since this crate doesn't rely on external env vars.
-///
-/// The CLI is expecting to find `dev.dioxus.main` in the final library. If you find a need to
-/// change this, you'll need to change the CLI as well.
-#[cfg(target_os = "android")]
-#[no_mangle]
-#[inline(never)]
-pub extern "C" fn start_app() {
-    wry::android_binding!(dev_dioxus, main, wry);
-    tao::android_binding!(
-        dev_dioxus,
-        main,
-        WryActivity,
-        wry::android_setup,
-        dioxus_main_root_fn,
-        tao
-    );
-}
+/// Launches the WebView and runs the event loop, with configuration and root props.
+pub fn launch_virtual_dom(virtual_dom: VirtualDom, desktop_config: Config) -> ! {
+    #[cfg(feature = "tokio_runtime")]
+    {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(tokio::task::unconstrained(async move {
+                launch_virtual_dom_blocking(virtual_dom, desktop_config)
+            }));
 
-#[cfg(target_os = "android")]
-#[doc(hidden)]
-pub fn dioxus_main_root_fn() {
-    // we're going to find the `main` symbol using dlsym directly and call it
-    unsafe {
-        let mut main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"main\0".as_ptr() as _);
-
-        if main_fn_ptr.is_null() {
-            main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"_main\0".as_ptr() as _);
-        }
-
-        if main_fn_ptr.is_null() {
-            panic!("Failed to find main symbol");
-        }
-
-        // Set the env vars that rust code might expect, passed off to us by the android app
-        // Doing this before main emulates the behavior of a regular executable
-        if cfg!(target_os = "android") && cfg!(debug_assertions) {
-            load_env_file_from_session_cache();
-        }
-
-        let main_fn: extern "C" fn() = std::mem::transmute(main_fn_ptr);
-        main_fn();
-    };
-}
-
-/// Load the env file from the session cache if we're in debug mode and on android
-///
-/// This is a slightly hacky way of being able to use std::env::var code in android apps without
-/// going through their custom java-based system.
-#[cfg(target_os = "android")]
-fn load_env_file_from_session_cache() {
-    let env_file = dioxus_cli_config::android_session_cache_dir().join(".env");
-    if let Some(env_file) = std::fs::read_to_string(&env_file).ok() {
-        for line in env_file.lines() {
-            if let Some((key, value)) = line.trim().split_once('=') {
-                std::env::set_var(key, value);
-            }
-        }
+        unreachable!("The desktop launch function will never exit")
     }
+
+    #[cfg(not(feature = "tokio_runtime"))]
+    {
+        launch_virtual_dom_blocking(virtual_dom, desktop_config);
+    }
+}
+
+/// Launches the WebView and runs the event loop, with configuration and root props.
+pub fn launch(
+    root: fn() -> Element,
+    contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
+    platform_config: Vec<Box<dyn Any>>,
+) -> ! {
+    let mut virtual_dom = VirtualDom::new(root);
+
+    for context in contexts {
+        virtual_dom.insert_any_root_context(context());
+    }
+
+    let platform_config = *platform_config
+        .into_iter()
+        .find_map(|cfg| cfg.downcast::<Config>().ok())
+        .unwrap_or_default();
+
+    launch_virtual_dom(virtual_dom, platform_config)
 }

--- a/packages/devtools/src/lib.rs
+++ b/packages/devtools/src/lib.rs
@@ -80,7 +80,7 @@ pub fn connect_at(endpoint: String, mut callback: impl FnMut(DevserverMsg) + Sen
     std::thread::spawn(move || {
         let uri = format!(
             "{endpoint}?aslr_reference={}&build_id={}",
-            subsecond::__aslr_reference(),
+            subsecond::aslr_reference(),
             dioxus_cli_config::build_id()
         );
 

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -332,12 +332,12 @@ impl LaunchBuilder {
 
         #[cfg(feature = "mobile")]
         if matches!(platform, KnownPlatform::Mobile) {
-            return dioxus_desktop::launch::launch_cfg(app, contexts, configs);
+            return dioxus_mobile::launch_bindings::launch(app, contexts, configs);
         }
 
         #[cfg(feature = "desktop")]
         if matches!(platform, KnownPlatform::Desktop) {
-            return dioxus_desktop::launch::launch_cfg(app, contexts, configs);
+            return dioxus_desktop::launch::launch(app, contexts, configs);
         }
 
         #[cfg(feature = "server")]

--- a/packages/mobile/src/lib.rs
+++ b/packages/mobile/src/lib.rs
@@ -5,6 +5,23 @@
 pub use dioxus_desktop::*;
 use dioxus_lib::prelude::*;
 use std::any::Any;
+use std::sync::Mutex;
+
+pub mod launch_bindings {
+
+    use super::*;
+    pub fn launch(
+        root: fn() -> Element,
+        contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
+        platform_config: Vec<Box<dyn Any>>,
+    ) {
+        super::launch_cfg(root, contexts, platform_config);
+    }
+
+    pub fn launch_virtual_dom(_virtual_dom: VirtualDom, _desktop_config: Config) -> ! {
+        todo!()
+    }
+}
 
 /// Launch via the binding API
 pub fn launch(root: fn() -> Element) {
@@ -16,5 +33,147 @@ pub fn launch_cfg(
     contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
     platform_config: Vec<Box<dyn Any>>,
 ) {
-    dioxus_desktop::launch::launch_cfg(root, contexts, platform_config);
+    #[cfg(target_os = "android")]
+    {
+        *APP_OBJECTS.lock().unwrap() = Some(BoundLaunchObjects {
+            root,
+            contexts,
+            platform_config,
+        });
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        dioxus_desktop::launch::launch(root, contexts, platform_config);
+    }
 }
+
+/// We need to store the root function and contexts in a static so that when the tao bindings call
+/// "start_app", that the original function arguments are still around.
+///
+/// If you look closely, you'll notice that we impl Send for this struct. This would normally be
+/// unsound. However, we know that the thread that created these objects ("main()" - see JNI_OnLoad)
+/// is finished once `start_app` is called. This is similar to how an Rc<T> is technically safe
+/// to move between threads if you can prove that no other thread is using the Rc<T> at the same time.
+/// Crates like https://crates.io/crates/sendable exist that build on this idea but with runtimk,
+/// validation that the current thread is the one that created the object.
+///
+/// Since `main()` completes, the only reader of this data will be `start_app`, so it's okay to
+/// impl this as Send/Sync.
+///
+/// Todo(jon): the visibility of functions in this module is too public. Make sure to hide them before
+/// releasing 0.7.
+struct BoundLaunchObjects {
+    root: fn() -> Element,
+    contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
+    platform_config: Vec<Box<dyn Any>>,
+}
+
+unsafe impl Send for BoundLaunchObjects {}
+unsafe impl Sync for BoundLaunchObjects {}
+
+static APP_OBJECTS: Mutex<Option<BoundLaunchObjects>> = Mutex::new(None);
+
+#[doc(hidden)]
+pub fn root() {
+    let app = APP_OBJECTS
+        .lock()
+        .expect("APP_FN_PTR lock failed")
+        .take()
+        .expect("Android to have set the app trampoline");
+
+    let BoundLaunchObjects {
+        root,
+        contexts,
+        platform_config,
+    } = app;
+
+    dioxus_desktop::launch::launch(root, contexts, platform_config);
+}
+
+/// Expose the `Java_dev_dioxus_main_WryActivity_create` function to the JNI layer.
+/// We hardcode these to have a single trampoline for host Java code to call into.
+///
+/// This saves us from having to plumb the top-level package name all the way down into
+/// this file. This is better for modularity (ie just call dioxus' main to run the app) as
+/// well as cache thrashing since this crate doesn't rely on external env vars.
+///
+/// The CLI is expecting to find `dev.dioxus.main` in the final library. If you find a need to
+/// change this, you'll need to change the CLI as well.
+#[cfg(target_os = "android")]
+#[no_mangle]
+#[inline(never)]
+pub extern "C" fn start_app() {
+    tao::android_binding!(dev_dioxus, main, WryActivity, wry::android_setup, root, tao);
+    wry::android_binding!(dev_dioxus, main, wry);
+}
+
+/// Call our `main` function to initialize the rust runtime and set the launch binding trampoline
+#[cfg(target_os = "android")]
+#[no_mangle]
+#[inline(never)]
+pub extern "C" fn JNI_OnLoad(
+    _vm: *mut libc::c_void,
+    _reserved: *mut libc::c_void,
+) -> jni::sys::jint {
+    // we're going to find the `main` symbol using dlsym directly and call it
+    unsafe {
+        let mut main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"main\0".as_ptr() as _);
+
+        if main_fn_ptr.is_null() {
+            main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"_main\0".as_ptr() as _);
+        }
+
+        if main_fn_ptr.is_null() {
+            panic!("Failed to find main symbol");
+        }
+
+        // Set the env vars that rust code might expect, passed off to us by the android app
+        // Doing this before main emulates the behavior of a regular executable
+        if cfg!(target_os = "android") && cfg!(debug_assertions) {
+            load_env_file_from_session_cache();
+        }
+
+        let main_fn: extern "C" fn() = std::mem::transmute(main_fn_ptr);
+        main_fn();
+    };
+
+    jni::sys::JNI_VERSION_1_6
+}
+
+/// Load the env file from the session cache if we're in debug mode and on android
+///
+/// This is a slightly hacky way of being able to use std::env::var code in android apps without
+/// going through their custom java-based system.
+#[cfg(target_os = "android")]
+fn load_env_file_from_session_cache() {
+    let env_file = dioxus_cli_config::android_session_cache_dir().join(".env");
+    if let Some(env_file) = std::fs::read_to_string(&env_file).ok() {
+        for line in env_file.lines() {
+            if let Some((key, value)) = line.trim().split_once('=') {
+                std::env::set_var(key, value);
+            }
+        }
+    }
+}
+
+// #![doc = include_str!("../README.md")]
+// #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/79236386")]
+// #![doc(html_favicon_url = "https://avatars.githubusercontent.com/u/79236386")]
+
+// pub use dioxus_desktop::*;
+// use dioxus_lib::prelude::*;
+// use std::any::Any;
+
+// /// Launch via the binding API
+// pub fn launch(root: fn() -> Element) {
+//     launch_cfg(root, vec![], vec![]);
+// }
+
+// pub fn launch_cfg(
+//     root: fn() -> Element,
+//     contexts: Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>,
+//     platform_config: Vec<Box<dyn Any>>,
+// ) {
+//     dioxus_desktop::launch::launch_cfg(root, contexts, platform_config);
+// }

--- a/packages/server/src/config.rs
+++ b/packages/server/src/config.rs
@@ -354,19 +354,18 @@ impl ServeConfigBuilder {
                 let index_path = self
                     .index_path
                     .unwrap_or_else(|| public_path.join("index.html"));
-                load_index_path(index_path)?
-                // load_index_path(index_path).unwrap_or_else(|_| {
-                //     r#"
-                //     <!DOCTYPE html>
-                //     <html>
-                //         <head> </head>
-                //         <body>
-                //             <div id="main"></div>
-                //         </body>
-                //     </html>
-                //     "#
-                //     .to_string()
-                // })
+                load_index_path(index_path).unwrap_or_else(|_| {
+                    r#"
+                    <!DOCTYPE html>
+                    <html>
+                        <head> </head>
+                        <body>
+                            <div id="main"></div>
+                        </body>
+                    </html>
+                    "#
+                    .to_string()
+                })
             }
         };
 

--- a/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/Cargo.toml
+++ b/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cross-tls-crate-dylib"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[lib]
+crate-type = ["dylib"]
+
+[dependencies]

--- a/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/Cargo.toml
+++ b/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 publish = false
 
 [lib]
-crate-type = ["dylib"]
+# when testing, use a dylib
+# crate-type = ["dylib"]
 
 [dependencies]

--- a/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/Cargo.toml
+++ b/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cross-tls-crate-dylib"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [lib]

--- a/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/src/lib.rs
+++ b/packages/subsecond/subsecond-tests/cross-tls-crate-dylib/src/lib.rs
@@ -1,0 +1,25 @@
+pub use std::cell::Cell;
+use std::{cell::RefCell, thread::LocalKey};
+
+#[derive(Debug)]
+pub struct StoredItem {
+    pub name: String,
+    pub value: f32,
+    pub items: Vec<String>,
+}
+
+thread_local! {
+    pub static BAZ: RefCell<Option<StoredItem>> = const { RefCell::new(None) };
+}
+
+pub fn get_baz() -> &'static LocalKey<RefCell<Option<StoredItem>>> {
+    if BAZ.with(|f| f.borrow().is_none()) {
+        BAZ.set(Some(StoredItem {
+            name: "BAR".to_string(),
+            value: 0.0,
+            items: vec!["item1".to_string(), "item2".to_string()],
+        }));
+    }
+
+    &BAZ
+}

--- a/packages/subsecond/subsecond-tests/cross-tls-crate/Cargo.toml
+++ b/packages/subsecond/subsecond-tests/cross-tls-crate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cross-tls-crate"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/packages/subsecond/subsecond-tests/cross-tls-crate/Cargo.toml
+++ b/packages/subsecond/subsecond-tests/cross-tls-crate/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cross-tls-crate"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]

--- a/packages/subsecond/subsecond-tests/cross-tls-crate/src/lib.rs
+++ b/packages/subsecond/subsecond-tests/cross-tls-crate/src/lib.rs
@@ -1,0 +1,25 @@
+pub use std::cell::Cell;
+use std::{cell::RefCell, thread::LocalKey};
+
+#[derive(Debug)]
+pub struct StoredItem {
+    pub name: String,
+    pub value: f32,
+    pub items: Vec<String>,
+}
+
+thread_local! {
+    pub static BAR: RefCell<Option<StoredItem>> = const { RefCell::new(None) };
+}
+
+pub fn get_bar() -> &'static LocalKey<RefCell<Option<StoredItem>>> {
+    if BAR.with(|f| f.borrow().is_none()) {
+        BAR.set(Some(StoredItem {
+            name: "BAR".to_string(),
+            value: 0.0,
+            items: vec!["item1".to_string(), "item2".to_string()],
+        }));
+    }
+
+    &BAR
+}

--- a/packages/subsecond/subsecond-tests/cross-tls-test/Cargo.toml
+++ b/packages/subsecond/subsecond-tests/cross-tls-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "subsecond-tls-harness"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/packages/subsecond/subsecond-tests/cross-tls-test/Cargo.toml
+++ b/packages/subsecond/subsecond-tests/cross-tls-test/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "subsecond-tls-harness"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+dioxus-devtools = { workspace = true }
+cross-tls-crate = { path = "../cross-tls-crate" }
+cross-tls-crate-dylib = { path = "../cross-tls-crate-dylib" }

--- a/packages/subsecond/subsecond-tests/cross-tls-test/README.md
+++ b/packages/subsecond/subsecond-tests/cross-tls-test/README.md
@@ -1,0 +1,13 @@
+harness for testing cross-crate TLS imports.
+
+TLS is the hardest to get right with binary patchinig since we need to rewrite initializers.
+
+this crate relies on two crates - one as a dylib and the other as an rlib
+
+the dylib should make it into our bundle and the rlib should just be linked.
+
+both shouldn't cause access errors or segfaults during hotpatch.
+
+```sh
+cargo run --package dioxus-cli -- serve --hotpatch
+```

--- a/packages/subsecond/subsecond-tests/cross-tls-test/src/main.rs
+++ b/packages/subsecond/subsecond-tests/cross-tls-test/src/main.rs
@@ -1,0 +1,33 @@
+use std::{cell::Cell, thread, time::Duration};
+
+use cross_tls_crate::get_bar;
+use cross_tls_crate_dylib::get_baz;
+
+fn main() {
+    dioxus_devtools::connect_subsecond();
+    loop {
+        dioxus_devtools::subsecond::call(|| {
+            use cross_tls_crate::BAR;
+            use cross_tls_crate_dylib::BAZ;
+
+            thread_local! {
+                pub static FOO: Cell<f32> = const { Cell::new(2.0) };
+            }
+
+            println!("Hello  123s123123s: {}", FOO.get());
+            get_bar().with(|f| println!("Bar: {:?}", f.borrow()));
+            thread::sleep(Duration::from_secs(1));
+
+            FOO.set(2.0);
+            get_bar().with(|f| f.borrow_mut().as_mut().unwrap().value = 3.0);
+            get_baz().with(|f| f.borrow_mut().as_mut().unwrap().value = 4.0);
+
+            BAR.with_borrow(|f| {
+                println!("Bar: {:?}", f);
+            });
+            BAZ.with_borrow(|f| {
+                println!("Baz: {:?}", f);
+            });
+        });
+    }
+}

--- a/packages/subsecond/subsecond/src/lib.rs
+++ b/packages/subsecond/subsecond/src/lib.rs
@@ -235,7 +235,7 @@ use std::{
     backtrace,
     mem::transmute,
     panic::AssertUnwindSafe,
-    sync::{Arc, Mutex, atomic::AtomicPtr},
+    sync::{atomic::AtomicPtr, Arc, Mutex},
 };
 
 /// Call a given function with hot-reloading enabled. If the function's code changes, `call` will use
@@ -537,9 +537,9 @@ pub unsafe fn apply_patch(mut table: JumpTable) -> Result<(), PatchError> {
             ArrayBuffer, Object, Reflect,
             WebAssembly::{self, Memory, Table},
         };
+        use wasm_bindgen::prelude::*;
         use wasm_bindgen::JsValue;
         use wasm_bindgen::UnwrapThrowExt;
-        use wasm_bindgen::prelude::*;
         use wasm_bindgen_futures::JsFuture;
 
         let funcs: Table = wasm_bindgen::function_table().unchecked_into();
@@ -730,7 +730,7 @@ pub fn aslr_reference() -> usize {
 /// - https://developer.android.com/ndk/reference/structandroid/dlextinfo
 #[cfg(target_os = "android")]
 unsafe fn android_memmap_dlopen(file: &std::path::Path) -> Result<libloading::Library, PatchError> {
-    use std::ffi::{CStr, CString, c_void};
+    use std::ffi::{c_void, CStr, CString};
     use std::os::fd::{AsRawFd, BorrowedFd};
     use std::ptr;
 

--- a/packages/subsecond/subsecond/src/lib.rs
+++ b/packages/subsecond/subsecond/src/lib.rs
@@ -694,7 +694,7 @@ pub fn aslr_reference() -> usize {
         GetProcAddress(GetModuleHandleA(std::ptr::null()), c"main".as_ptr() as _) as _
     };
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(any(target_family = "wasm", windows)))]
     unsafe {
         libc::dlsym(libc::RTLD_DEFAULT, c"main".as_ptr() as _) as _
     }


### PR DESCRIPTION
Fixes https://github.com/DioxusLabs/dioxus/issues/4154 by implementing framework linking in our bundle setup.
Fixes https://github.com/DioxusLabs/dioxus/issues/4146
Fixes https://github.com/DioxusLabs/dioxus/issues/4149
Fixes https://github.com/DioxusLabs/dioxus/issues/4159
Fixes https://github.com/DioxusLabs/dioxus/issues/4165
Fixes long paths?
Fixes aarch64-unknown-linux subsecond

Previously we assumed all apps were statically linked into the bundle, but projects like bevy rely on dynamic linking of code, which breaks that assumption. This fix is not just for subsecond, but rather any rust crate that compiles as a dylib, since we weren't distributing those dylibs at all.

This kicks in for both `.so` files and `.dylibs`, but I'm unsure how we should handle windows, so I simply left it as a todo. We can't just blindly copy `.dll` files since system frameworks also end in `.dll`.

Anyways, this fixes subsecond + bevy dynamic linking which makes the rebuilds much faster.
