### PR TITLE
fix hot-reload watcher for client/server

### DIFF
--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -97,11 +97,11 @@ pub(crate) struct TargetArgs {
 #[command(subcommand_precedence_over_arg = true)]
 pub(crate) enum TargetCmd {
     /// Specify the arguments for the client build
-    #[clap(name = "client")]
+    #[clap(name = "@client")]
     Client(ChainedCommand<TargetArgs, TargetCmd>),
 
     /// Specify the arguments for the server build
-    #[clap(name = "server")]
+    #[clap(name = "@server")]
     Server(ChainedCommand<TargetArgs, TargetCmd>),
 }
 

--- a/packages/dioxus/src/launch.rs
+++ b/packages/dioxus/src/launch.rs
@@ -342,7 +342,7 @@ impl LaunchBuilder {
 
         #[cfg(feature = "server")]
         if matches!(platform, KnownPlatform::Server) {
-            return dioxus_server::launch(app, contexts, configs);
+            return dioxus_server::launch_cfg(app, contexts, configs);
         }
 
         #[cfg(feature = "web")]

--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -74,6 +74,48 @@ pub use dioxus_logger as logger;
 #[cfg_attr(docsrs, doc(cfg(feature = "cli-config")))]
 pub use dioxus_cli_config as cli_config;
 
+#[cfg(feature = "server")]
+#[cfg_attr(docsrs, doc(cfg(feature = "server")))]
+pub use dioxus_server as server;
+
+#[cfg(feature = "devtools")]
+#[cfg_attr(docsrs, doc(cfg(feature = "devtools")))]
+pub use dioxus_devtools as devtools;
+
+#[cfg(feature = "web")]
+#[cfg_attr(docsrs, doc(cfg(feature = "web")))]
+pub use dioxus_web as web;
+
+#[cfg(feature = "router")]
+#[cfg_attr(docsrs, doc(cfg(feature = "router")))]
+pub use dioxus_router as router;
+
+#[cfg(feature = "fullstack")]
+#[cfg_attr(docsrs, doc(cfg(feature = "fullstack")))]
+pub use dioxus_fullstack as fullstack;
+
+#[cfg(feature = "desktop")]
+#[cfg_attr(docsrs, doc(cfg(feature = "desktop")))]
+pub use dioxus_desktop as desktop;
+
+#[cfg(feature = "mobile")]
+#[cfg_attr(docsrs, doc(cfg(feature = "mobile")))]
+pub use dioxus_mobile as mobile;
+
+#[cfg(feature = "liveview")]
+#[cfg_attr(docsrs, doc(cfg(feature = "liveview")))]
+pub use dioxus_liveview as liveview;
+
+#[cfg(feature = "ssr")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ssr")))]
+pub use dioxus_ssr as ssr;
+
+#[cfg(feature = "warnings")]
+#[cfg_attr(docsrs, doc(cfg(feature = "warnings")))]
+pub use warnings;
+
+pub use dioxus_config_macros as config_macros;
+
 #[cfg(feature = "wasm-split")]
 #[cfg_attr(docsrs, doc(cfg(feature = "wasm-split")))]
 pub use wasm_splitter as wasm_split;
@@ -146,37 +188,3 @@ pub mod prelude {
     #[cfg_attr(docsrs, doc(cfg(feature = "wasm-split")))]
     pub use wasm_splitter as wasm_split;
 }
-
-#[cfg(feature = "web")]
-#[cfg_attr(docsrs, doc(cfg(feature = "web")))]
-pub use dioxus_web as web;
-
-#[cfg(feature = "router")]
-#[cfg_attr(docsrs, doc(cfg(feature = "router")))]
-pub use dioxus_router as router;
-
-#[cfg(feature = "fullstack")]
-#[cfg_attr(docsrs, doc(cfg(feature = "fullstack")))]
-pub use dioxus_fullstack as fullstack;
-
-#[cfg(feature = "desktop")]
-#[cfg_attr(docsrs, doc(cfg(feature = "desktop")))]
-pub use dioxus_desktop as desktop;
-
-#[cfg(feature = "mobile")]
-#[cfg_attr(docsrs, doc(cfg(feature = "mobile")))]
-pub use dioxus_mobile as mobile;
-
-#[cfg(feature = "liveview")]
-#[cfg_attr(docsrs, doc(cfg(feature = "liveview")))]
-pub use dioxus_liveview as liveview;
-
-#[cfg(feature = "ssr")]
-#[cfg_attr(docsrs, doc(cfg(feature = "ssr")))]
-pub use dioxus_ssr as ssr;
-
-#[cfg(feature = "warnings")]
-#[cfg_attr(docsrs, doc(cfg(feature = "warnings")))]
-pub use warnings;
-
-pub use dioxus_config_macros as config_macros;

--- a/packages/server/src/launch.rs
+++ b/packages/server/src/launch.rs
@@ -30,9 +30,14 @@ type ContextList = Vec<Box<dyn Fn() -> Box<dyn Any> + Send + Sync>>;
 
 type BaseComp = fn() -> Element;
 
+/// Launch a fullstack app with the given root component.
+pub fn launch(root: BaseComp) -> ! {
+    launch_cfg(root, vec![], vec![])
+}
+
 /// Launch a fullstack app with the given root component, contexts, and config.
 #[allow(unused)]
-pub fn launch(root: BaseComp, contexts: ContextList, platform_config: Vec<Box<dyn Any>>) -> ! {
+pub fn launch_cfg(root: BaseComp, contexts: ContextList, platform_config: Vec<Box<dyn Any>>) -> ! {
     #[cfg(not(target_arch = "wasm32"))]
     tokio::runtime::Runtime::new()
         .unwrap()

--- a/packages/server/src/lib.rs
+++ b/packages/server/src/lib.rs
@@ -80,7 +80,7 @@ pub use document::ServerDocument;
 mod launch;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use launch::launch;
+pub use launch::{launch_cfg, launch};
 
 /// Re-export commonly used items
 pub mod prelude {


### PR DESCRIPTION
Dioxus 0.7 now allows separate frontend and backend crates. This PR fixes the file watcher such that you can hotpatch both simultaneously.


https://github.com/user-attachments/assets/26b9be47-affe-4bb2-b650-1570d965af2d

