### PR TITLE
Add sorting of Tailwind CSS class names in RSX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,6 +3647,8 @@ name = "dioxus-autofmt"
 version = "0.7.0-alpha.0"
 dependencies = [
  "dioxus-rsx",
+ "itertools 0.14.0",
+ "lightningcss",
  "pretty_assertions",
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,7 @@ libloading = "0.8.6"
 libc = "0.2.170"
 memmap2 = "0.9.5"
 memfd = "0.6.4"
+lightningcss = { version = "1.0.0-alpha.66", default-features = false }
 
 # desktop
 wry = { version = "0.45.0", default-features = false }

--- a/packages/autofmt/Cargo.toml
+++ b/packages/autofmt/Cargo.toml
@@ -21,6 +21,8 @@ syn = { workspace = true, features = [
 ] }
 serde = { workspace = true, features = ["derive"] }
 prettyplease = { workspace = true }
+itertools = { workspace = true }
+lightningcss = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/packages/autofmt/src/class_names.rs
+++ b/packages/autofmt/src/class_names.rs
@@ -1,0 +1,380 @@
+//! Implements autosorting of Tailwind classes according to their opinionated class name sorting:
+//! https://tailwindcss.com/blog/automatic-class-sorting-with-prettier#how-classes-are-sorted
+//!
+//! This methodology should match the sorting of their Prettier plugin.
+
+use std::cmp::Ordering;
+
+use dioxus_rsx::{AttributeValue, BodyNode, CallBody, HotReloadFormattedSegment};
+use itertools::Itertools;
+use lightningcss::{
+    printer::PrinterOptions,
+    rules::CssRule,
+    stylesheet::{ParserOptions, StyleSheet},
+    traits::ToCss,
+};
+use syn::LitStr;
+
+#[derive(Debug, Clone)]
+pub struct TailwindSorter {
+    class_order: Vec<String>,
+}
+
+impl TailwindSorter {
+    /// Create a new instance of the sorter class.
+    /// Needs to receive an instance of compiled Tailwind CSS,
+    /// so it can parse the available classes.
+    pub fn new(tailwind_css: &str) -> Option<Self> {
+        let css_rules = StyleSheet::parse(tailwind_css, ParserOptions::default())
+            .ok()?
+            .rules
+            .0;
+
+        // Get each layer's class names and sort each of them according to Tailwind's priorities.
+        let base_classes = find_layer(&css_rules, "base")
+            .map(|layer| get_class_names(layer))
+            .unwrap_or_default();
+        let components_classes = find_layer(&css_rules, "components")
+            .map(|layer| get_class_names(layer))
+            .unwrap_or_default();
+        let utilities_classes = find_layer(&css_rules, "utilities")
+            .map(|layer| get_class_names(layer))
+            .unwrap_or_default();
+
+        // Now we merge all the layers together, along with non-Tailwind CSS classes at the front.
+        let mut class_order = Vec::with_capacity(
+            base_classes.len() + components_classes.len() + utilities_classes.len(),
+        );
+        class_order.extend(base_classes);
+        class_order.extend(components_classes);
+        class_order.extend(utilities_classes);
+        sort_tailwind_classes(&mut class_order);
+
+        Some(Self { class_order })
+    }
+
+    /// Returns a sorted list of class names given an input class string.
+    pub fn sort_class_names(&self, classes: &str) -> String {
+        // First sort alphabetically, for any classes that are not part of Tailwind.
+        // We will give them all an equivalent priority of -1 and stable-sort in phase 2
+        // so that they remain alphabetized as the front of the list.
+        let mut class_list = classes.split_ascii_whitespace().collect::<Vec<_>>();
+        class_list.sort_unstable();
+
+        // Assign a priority value to each class that is found, and use this to sort them.
+        class_list.sort_by_key(|class| {
+            self.class_order
+                .iter()
+                .position(|tailwind_class| tailwind_class == class)
+                .map(|idx| idx as i32)
+                .unwrap_or(-1)
+        });
+        class_list.join(" ")
+    }
+}
+
+fn find_layer<'a, 'b>(ruleset: &'a [CssRule<'b>], layer_name: &str) -> Option<&'a [CssRule<'b>]> {
+    ruleset.iter().find_map(|rule| match rule {
+        lightningcss::rules::CssRule::LayerBlock(layer_block_rule)
+            if layer_block_rule
+                .name
+                .as_ref()
+                .and_then(|name| name.0.first())
+                .map(|name| name.as_ref())
+                == Some(layer_name) =>
+        {
+            Some(layer_block_rule.rules.0.as_slice())
+        }
+        _ => None,
+    })
+}
+
+fn get_class_names(ruleset: &[CssRule]) -> Vec<String> {
+    let mut raw_items = Vec::new();
+    for rule in ruleset.iter() {
+        match rule {
+            CssRule::Style(style_rule) => {
+                if let Some(selector) = style_rule.selectors.0.first() {
+                    raw_items.push(
+                        selector
+                            .to_css_string(PrinterOptions::default())
+                            .unwrap_or_default(),
+                    );
+                }
+            }
+            CssRule::Media(media_rule) => {
+                for rule in &media_rule.rules.0 {
+                    if let CssRule::Style(style_rule) = rule {
+                        if let Some(selector) = style_rule.selectors.0.first() {
+                            let selector = selector
+                                .to_css_string(PrinterOptions::default())
+                                .unwrap_or_default();
+                            if selector
+                                .split(':')
+                                .filter(|part| !part.starts_with("."))
+                                .count()
+                                > 1
+                            {
+                                raw_items.push(selector.rsplit_once(':').unwrap().0.to_string());
+                            } else {
+                                raw_items.push(selector);
+                            }
+                        }
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+
+    raw_items
+        .into_iter()
+        .filter_map(|selector| {
+            if selector.starts_with('.') && selector.len() > 1 {
+                Some(selector[1..].replace("\\:", ":"))
+            } else {
+                None
+            }
+        })
+        .unique()
+        .collect::<Vec<_>>()
+}
+
+fn sort_tailwind_classes(classes: &mut [String]) {
+    // We want classes with modifiers to come last, and alphabetized by their prefixes.
+    // Must be a stable sort, to keep the suffixes in the correct order.
+    classes.sort_by(|class_a, class_b| {
+        match (class_a.rsplit_once(':'), class_b.rsplit_once(':')) {
+            (None, None) => Ordering::Equal,
+            (Some((prefix_a, _)), Some((prefix_b, _))) => prefix_a.cmp(prefix_b),
+            (Some((_prefix_a, _)), None) => Ordering::Greater,
+            (None, Some((_prefix_b, _))) => Ordering::Less,
+        }
+    });
+
+    // However, we want responsive classes sorted by size, and grouped together.
+    // This also must be a stable sort.
+    classes.sort_by(|class_a, class_b| {
+        const RESPONSIVE_SIZES: &[&str] = &["sm", "md", "lg", "xl", "2xl"];
+
+        match (class_a.split_once(':'), class_b.split_once(':')) {
+            (Some((prefix_a, _)), Some((prefix_b, _))) => {
+                let prefix_a_idx = RESPONSIVE_SIZES.iter().position(|size| size == &prefix_a);
+                let prefix_b_idx = RESPONSIVE_SIZES.iter().position(|size| size == &prefix_b);
+
+                if let Some(prefix_a_idx) = prefix_a_idx {
+                    if let Some(prefix_b_idx) = prefix_b_idx {
+                        // Both have a responsive sizing, so sort them
+                        prefix_a_idx.cmp(&prefix_b_idx)
+                    } else {
+                        // Only prefix_a has a responsive sizing, so put it last
+                        Ordering::Greater
+                    }
+                } else if prefix_b_idx.is_some() {
+                    // Only prefix_b has a responsive sizing, so put it last
+                    Ordering::Less
+                } else {
+                    // Neither has a responsive sizing, so maintain current sorting
+                    Ordering::Equal
+                }
+            }
+            _ => Ordering::Equal,
+        }
+    });
+
+    // For the rest of the sorting, it seems safe to assume that the
+    // sorting of classes in the input tailwind.css file is correct.
+}
+
+pub(crate) fn format_class_attrs(body: &mut CallBody, sorter: &TailwindSorter) {
+    for item in &mut body.body.roots {
+        format_elem_class_attrs(item, sorter);
+    }
+}
+
+fn format_elem_class_attrs(item: &mut BodyNode, sorter: &TailwindSorter) {
+    match item {
+        BodyNode::Element(element) => {
+            let class_attr = element
+                .raw_attributes
+                .iter_mut()
+                .find(|attr| match &attr.name {
+                    dioxus_rsx::AttributeName::BuiltIn(ident) => *ident == "class",
+                    _ => false,
+                });
+            if let Some(class_attr) = class_attr {
+                format_class_attr_value(&mut class_attr.value, sorter);
+            }
+
+            for child in &mut element.children {
+                format_elem_class_attrs(child, sorter);
+            }
+        }
+        BodyNode::Component(component) => {
+            let class_attr = component.fields.iter_mut().find(|attr| match &attr.name {
+                dioxus_rsx::AttributeName::BuiltIn(ident) => *ident == "class",
+                _ => false,
+            });
+            if let Some(class_attr) = class_attr {
+                format_class_attr_value(&mut class_attr.value, sorter);
+            }
+
+            for child in &mut component.children.roots.iter_mut() {
+                format_elem_class_attrs(child, sorter);
+            }
+        }
+        BodyNode::ForLoop(for_loop) => {
+            for child in &mut for_loop.body.roots.iter_mut() {
+                format_elem_class_attrs(child, sorter);
+            }
+        }
+        BodyNode::IfChain(if_chain) => {
+            for child in &mut if_chain.then_branch.roots.iter_mut() {
+                format_elem_class_attrs(child, sorter);
+            }
+            if let Some(else_branch) = if_chain.else_branch.as_mut() {
+                for child in else_branch.roots.iter_mut() {
+                    format_elem_class_attrs(child, sorter);
+                }
+            }
+        }
+        _ => (),
+    }
+}
+
+fn format_class_attr_value(value: &mut AttributeValue, sorter: &TailwindSorter) {
+    match value {
+        dioxus_rsx::AttributeValue::AttrLiteral(dioxus_rsx::HotLiteral::Fmted(lit)) => {
+            format_class_hot_literal(lit, sorter);
+        }
+        dioxus_rsx::AttributeValue::IfExpr(if_attribute_value) => {
+            // We can format string literals inside if exprs as well
+            format_class_attr_value(&mut if_attribute_value.then_value, sorter);
+            if let Some(else_value) = if_attribute_value.else_value.as_mut() {
+                format_class_attr_value(else_value, sorter);
+            }
+        }
+        _ => (),
+    }
+}
+
+fn format_class_hot_literal(lit: &mut HotReloadFormattedSegment, sorter: &TailwindSorter) {
+    // We can really only consider this safe to format if it's a string literal,
+    // which will have a singular "Literal" segment.
+    if lit.formatted_input.segments.len() != 1 {
+        return;
+    }
+
+    if let dioxus_rsx::Segment::Literal(class_str) = &mut lit.formatted_input.segments[0] {
+        *class_str = sorter.sort_class_names(class_str);
+        lit.formatted_input.source = LitStr::new(class_str, lit.formatted_input.source.span());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_CSS: &str = include_str!("../tests/test_css.css");
+
+    #[test]
+    fn sorts_classes_correctly() {
+        // This list of examples is pulled from Tailwind's documentation
+        let before = "text-white px-4 sm:px-8 py-2 sm:py-3 bg-sky-700 hover:bg-sky-800";
+        let after = "bg-sky-700 px-4 py-2 text-white hover:bg-sky-800 sm:px-8 sm:py-3";
+        assert_eq!(
+            &TailwindSorter::new(TEST_CSS)
+                .unwrap()
+                .sort_class_names(before),
+            after
+        );
+    }
+
+    #[test]
+    fn sorts_classes_by_layer() {
+        // Any classes in the base layer will be sorted first,
+        // followed by classes in the components layer,
+        // and then finally classes in the utilities layer.
+        let before = "container mx-auto px-6";
+        let after = "container mx-auto px-6";
+        assert_eq!(
+            &TailwindSorter::new(TEST_CSS)
+                .unwrap()
+                .sort_class_names(before),
+            after
+        );
+    }
+
+    #[test]
+    fn sorts_classes_by_priority() {
+        // Utilities themselves are sorted in the same order we sort them in the CSS as well,
+        // which means that any classes that override other classes
+        // always appear later in the class list:
+        let before = "pt-2 p-4";
+        let after = "p-4 pt-2";
+        assert_eq!(
+            &TailwindSorter::new(TEST_CSS)
+                .unwrap()
+                .sort_class_names(before),
+            after
+        );
+    }
+
+    #[test]
+    fn sorts_classes_by_impact() {
+        // The actual order of the different utilities is loosely based on the box model,
+        // and tries to put high impact classes that affect the layout at the beginning
+        // and decorative classes at the end, while also trying to keep related utilities together:
+        let before = "text-gray-700 shadow-md p-3 border-gray-300 ml-4 h-24 flex border-2";
+        let after = "ml-4 flex h-24 border-2 border-gray-300 p-3 text-gray-700 shadow-md";
+        assert_eq!(
+            &TailwindSorter::new(TEST_CSS)
+                .unwrap()
+                .sort_class_names(before),
+            after
+        );
+    }
+
+    #[test]
+    fn sorts_classes_by_modifiers() {
+        // Modifiers like hover: and focus: are grouped together and sorted after any plain utilities:
+        let before = "hover:opacity-75 opacity-50 hover:scale-150 scale-125";
+        let after = "scale-125 opacity-50 hover:scale-150 hover:opacity-75";
+        assert_eq!(
+            &TailwindSorter::new(TEST_CSS)
+                .unwrap()
+                .sort_class_names(before),
+            after
+        );
+    }
+
+    #[test]
+    fn sorts_classes_by_responsive_size() {
+        // Responsive modifiers like md: and lg: are grouped together at the end
+        // in the same order they're configured in your theme
+        // — which is smallest to largest by default:
+        let before = "lg:grid-cols-4 grid sm:grid-cols-3 grid-cols-2";
+        let after = "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4";
+        assert_eq!(
+            &TailwindSorter::new(TEST_CSS)
+                .unwrap()
+                .sort_class_names(before),
+            after
+        );
+    }
+
+    #[test]
+    fn sorts_custom_classes_first() {
+        // Any custom classes that don't come from Tailwind plugins
+        // (like classes for targeting a third-party library) are always sorted to the front,
+        // so it's easy to see when an element is using them:
+        let before = "p-3 shadow-xl select2-dropdown";
+        let after = "select2-dropdown p-3 shadow-xl";
+        assert_eq!(
+            &TailwindSorter::new(TEST_CSS)
+                .unwrap()
+                .sort_class_names(before),
+            after
+        );
+    }
+}

--- a/packages/autofmt/tests/error_handling.rs
+++ b/packages/autofmt/tests/error_handling.rs
@@ -8,7 +8,7 @@ fn no_parse() {
 fn parses_but_fmt_fails() {
     let src = include_str!("./partials/wrong.rsx");
     let file = syn::parse_file(src).unwrap();
-    let formatted = dioxus_autofmt::try_fmt_file(src, &file, Default::default());
+    let formatted = dioxus_autofmt::try_fmt_file(src, &file, Default::default(), None);
     assert!(&formatted.is_err());
 }
 
@@ -16,6 +16,6 @@ fn parses_but_fmt_fails() {
 fn parses_and_is_okay() {
     let src = include_str!("./partials/okay.rsx");
     let file = syn::parse_file(src).unwrap();
-    let formatted = dioxus_autofmt::try_fmt_file(src, &file, Default::default()).unwrap();
+    let formatted = dioxus_autofmt::try_fmt_file(src, &file, Default::default(), None).unwrap();
     assert_ne!(formatted.len(), 0);
 }

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -14,7 +14,7 @@ macro_rules! twoway {
             #[test]
             fn $name() {
                 let src = include_str!(concat!("./samples/", stringify!($name), ".rsx"));
-                let formatted = dioxus_autofmt::fmt_file(src, Default::default());
+                let formatted = dioxus_autofmt::fmt_file(src, Default::default(), None);
                 let out = dioxus_autofmt::apply_formats(src, formatted);
                 // normalize line endings
                 let out = out.replace("\r", "");

--- a/packages/autofmt/tests/test_css.css
+++ b/packages/autofmt/tests/test_css.css
@@ -1,0 +1,556 @@
+/*! tailwindcss v4.1.7 | MIT License | https://tailwindcss.com */
+@layer properties;
+@layer theme, base, components, utilities;
+@layer theme {
+  :root,
+  :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+      "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      "Liberation Mono", "Courier New", monospace;
+    --color-teal-950: oklch(27.7% 0.046 192.524);
+    --color-sky-700: oklch(50% 0.134 242.749);
+    --color-sky-800: oklch(44.3% 0.11 240.79);
+    --color-sky-900: oklch(39.1% 0.09 240.876);
+    --color-blue-950: oklch(28.2% 0.091 267.935);
+    --color-gray-300: oklch(87.2% 0.01 258.338);
+    --color-gray-700: oklch(37.3% 0.034 259.733);
+    --color-white: #fff;
+    --spacing: 0.25rem;
+    --container-lg: 32rem;
+    --text-3xl: 1.875rem;
+    --text-3xl--line-height: calc(2.25 / 1.875);
+    --text-5xl: 3rem;
+    --text-5xl--line-height: 1;
+    --radius-md: 0.375rem;
+    --default-font-family: var(--font-sans);
+    --default-mono-font-family: var(--font-mono);
+  }
+}
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: 0 solid;
+  }
+  html,
+  :host {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    font-family: var(
+      --default-font-family,
+      ui-sans-serif,
+      system-ui,
+      sans-serif,
+      "Apple Color Emoji",
+      "Segoe UI Emoji",
+      "Segoe UI Symbol",
+      "Noto Color Emoji"
+    );
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+  b,
+  strong {
+    font-weight: bolder;
+  }
+  code,
+  kbd,
+  samp,
+  pre {
+    font-family: var(
+      --default-mono-font-family,
+      ui-monospace,
+      SFMono-Regular,
+      Menlo,
+      Monaco,
+      Consolas,
+      "Liberation Mono",
+      "Courier New",
+      monospace
+    );
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(
+      --default-mono-font-variation-settings,
+      normal
+    );
+    font-size: 1em;
+  }
+  small {
+    font-size: 80%;
+  }
+  sub,
+  sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+  sub {
+    bottom: -0.25em;
+  }
+  sup {
+    top: -0.5em;
+  }
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+  :-moz-focusring {
+    outline: auto;
+  }
+  progress {
+    vertical-align: baseline;
+  }
+  summary {
+    display: list-item;
+  }
+  ol,
+  ul,
+  menu {
+    list-style: none;
+  }
+  img,
+  svg,
+  video,
+  canvas,
+  audio,
+  iframe,
+  embed,
+  object {
+    display: block;
+    vertical-align: middle;
+  }
+  img,
+  video {
+    max-width: 100%;
+    height: auto;
+  }
+  button,
+  input,
+  select,
+  optgroup,
+  textarea,
+  ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    border-radius: 0;
+    background-color: transparent;
+    opacity: 1;
+  }
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+  ::placeholder {
+    opacity: 1;
+  }
+  @supports (not (-webkit-appearance: -apple-pay-button)) or
+    (contain-intrinsic-size: 1px) {
+    ::placeholder {
+      color: currentcolor;
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, currentcolor 50%, transparent);
+      }
+    }
+  }
+  textarea {
+    resize: vertical;
+  }
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+  ::-webkit-datetime-edit,
+  ::-webkit-datetime-edit-year-field,
+  ::-webkit-datetime-edit-month-field,
+  ::-webkit-datetime-edit-day-field,
+  ::-webkit-datetime-edit-hour-field,
+  ::-webkit-datetime-edit-minute-field,
+  ::-webkit-datetime-edit-second-field,
+  ::-webkit-datetime-edit-millisecond-field,
+  ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+  button,
+  input:where([type="button"], [type="reset"], [type="submit"]),
+  ::file-selector-button {
+    appearance: button;
+  }
+  ::-webkit-inner-spin-button,
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+}
+@layer utilities {
+  .container {
+    width: 100%;
+    @media (width >= 40rem) {
+      max-width: 40rem;
+    }
+    @media (width >= 48rem) {
+      max-width: 48rem;
+    }
+    @media (width >= 64rem) {
+      max-width: 64rem;
+    }
+    @media (width >= 80rem) {
+      max-width: 80rem;
+    }
+    @media (width >= 96rem) {
+      max-width: 96rem;
+    }
+  }
+  .m-8 {
+    margin: calc(var(--spacing) * 8);
+  }
+  .mx-4 {
+    margin-inline: calc(var(--spacing) * 4);
+  }
+  .mx-auto {
+    margin-inline: auto;
+  }
+  .my-8 {
+    margin-block: calc(var(--spacing) * 8);
+  }
+  .mb-4 {
+    margin-bottom: calc(var(--spacing) * 4);
+  }
+  .ml-4 {
+    margin-left: calc(var(--spacing) * 4);
+  }
+  .flex {
+    display: flex;
+  }
+  .grid {
+    display: grid;
+  }
+  .h-24 {
+    height: calc(var(--spacing) * 24);
+  }
+  .h-screen {
+    height: 100vh;
+  }
+  .w-lg {
+    width: var(--container-lg);
+  }
+  .w-screen {
+    width: 100vw;
+  }
+  .scale-125 {
+    --tw-scale-x: 125%;
+    --tw-scale-y: 125%;
+    --tw-scale-z: 125%;
+    scale: var(--tw-scale-x) var(--tw-scale-y);
+  }
+  .grid-cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .flex-col {
+    flex-direction: column;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .rounded-md {
+    border-radius: var(--radius-md);
+  }
+  .border-2 {
+    border-style: var(--tw-border-style);
+    border-width: 2px;
+  }
+  .border-gray-300 {
+    border-color: var(--color-gray-300);
+  }
+  .bg-blue-950 {
+    background-color: var(--color-blue-950);
+  }
+  .bg-sky-700 {
+    background-color: var(--color-sky-700);
+  }
+  .bg-teal-950 {
+    background-color: var(--color-teal-950);
+  }
+  .p-3 {
+    padding: calc(var(--spacing) * 3);
+  }
+  .p-4 {
+    padding: calc(var(--spacing) * 4);
+  }
+  .px-4 {
+    padding-inline: calc(var(--spacing) * 4);
+  }
+  .px-6 {
+    padding-inline: calc(var(--spacing) * 6);
+  }
+  .py-2 {
+    padding-block: calc(var(--spacing) * 2);
+  }
+  .py-4 {
+    padding-block: calc(var(--spacing) * 4);
+  }
+  .pt-2 {
+    padding-top: calc(var(--spacing) * 2);
+  }
+  .text-center {
+    text-align: center;
+  }
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
+  .text-5xl {
+    font-size: var(--text-5xl);
+    line-height: var(--tw-leading, var(--text-5xl--line-height));
+  }
+  .whitespace-nowrap {
+    white-space: nowrap;
+  }
+  .text-gray-700 {
+    color: var(--color-gray-700);
+  }
+  .text-white {
+    color: var(--color-white);
+  }
+  .subpixel-antialiased {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+  }
+  .opacity-50 {
+    opacity: 50%;
+  }
+  .shadow-md {
+    --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1)),
+      0 2px 4px -2px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow),
+      var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-xl {
+    --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)),
+      0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow),
+      var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .hover\:scale-150 {
+    &:hover {
+      @media (hover: hover) {
+        --tw-scale-x: 150%;
+        --tw-scale-y: 150%;
+        --tw-scale-z: 150%;
+        scale: var(--tw-scale-x) var(--tw-scale-y);
+      }
+    }
+  }
+  .hover\:bg-sky-900 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-sky-900);
+      }
+    }
+  }
+  .hover\:opacity-75 {
+    &:hover {
+      @media (hover: hover) {
+        opacity: 75%;
+      }
+    }
+  }
+  .sm\:grid-cols-3 {
+    @media (width >= 40rem) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .sm\:px-8 {
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 8);
+    }
+  }
+  .sm\:py-3 {
+    @media (width >= 40rem) {
+      padding-block: calc(var(--spacing) * 3);
+    }
+  }
+  .lg\:grid-cols-4 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+  /* Unoptimized tailwind builds generate blocks like the ones above
+  but optimized builds generate ones that look like the one below.
+  We need to handle both properly. */
+  @media (hover: hover) {
+    .hover\:bg-sky-800:hover {
+      background-color: var(--color-sky-800);
+    }
+  }
+}
+@property --tw-scale-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-scale-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-scale-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 1;
+}
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+@layer properties {
+  @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or
+    ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+    *,
+    ::before,
+    ::after,
+    ::backdrop {
+      --tw-scale-x: 1;
+      --tw-scale-y: 1;
+      --tw-scale-z: 1;
+      --tw-border-style: solid;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+    }
+  }
+}
+.select2-dropdown {
+  background-color: #fff;
+}

--- a/packages/autofmt/tests/wrong.rs
+++ b/packages/autofmt/tests/wrong.rs
@@ -13,7 +13,7 @@ macro_rules! twoway {
                 .expect("fmt_file should only be called on valid syn::File files");
 
             let formatted =
-                dioxus_autofmt::try_fmt_file(src_wrong, &parsed, $indent).unwrap_or_default();
+                dioxus_autofmt::try_fmt_file(src_wrong, &parsed, $indent, None).unwrap_or_default();
             let out = dioxus_autofmt::apply_formats(src_wrong, formatted);
 
             // normalize line endings

--- a/packages/extension/src/lib.rs
+++ b/packages/extension/src/lib.rs
@@ -3,6 +3,9 @@
 use dioxus_autofmt::{FormattedBlock, IndentOptions, IndentType};
 use wasm_bindgen::prelude::*;
 
+// TODO: Can we add Tailwind class sorting to these functions?
+// We would need access to the project's Dioxus.toml.
+
 #[wasm_bindgen]
 pub fn format_rsx(raw: String, use_tabs: bool, indent_size: usize) -> String {
     let block = dioxus_autofmt::fmt_block(
@@ -17,6 +20,7 @@ pub fn format_rsx(raw: String, use_tabs: bool, indent_size: usize) -> String {
             indent_size,
             false,
         ),
+        None,
     );
     block.unwrap()
 }
@@ -40,6 +44,7 @@ pub fn format_selection(
             indent_size,
             false,
         ),
+        None,
     );
     block.unwrap()
 }
@@ -77,7 +82,7 @@ pub fn format_file(contents: String, use_tabs: bool, indent_size: usize) -> Form
     );
 
     let Ok(Ok(_edits)) = syn::parse_file(&contents)
-        .map(|file| dioxus_autofmt::try_fmt_file(&contents, &file, options))
+        .map(|file| dioxus_autofmt::try_fmt_file(&contents, &file, options, None))
     else {
         return FormatBlockInstance {
             new: contents,


### PR DESCRIPTION
Addresses #3478.

This takes the same approach as the prettier plugin, which is to load the Tailwind CSS file to parse the list of available Tailwind CSS classes, and use that along with a bit of additional sorting to determine the correct order for classes.

This implementation is somewhat limited at the moment. For example, it can only handle string literals, and it cannot handle class strings that are defined as consts outside of an `rsx!` block. It is hoped that this can be improved in the future. However, this implementation should cover the majority of cases.