### PR TITLE
chore(ssr): update `askama_escape` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "askama_escape"
-version = "0.10.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+checksum = "3df27b8d5ddb458c5fb1bbc1ce172d4a38c614a97d550b0ac89003897fb01de4"
 
 [[package]]
 name = "asn1-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ warnings = { version = "0.2.1" }
 prettier-please = { version = "0.3.0", features = ["verbatim"] }
 anyhow = "1.0.97"
 clap = { version = "4.5.31" }
-askama_escape = "0.10.3"
+askama_escape = "0.13.0"
 tracing = "0.1.41"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.19", default-features = false }

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -335,13 +335,13 @@ fn to_string_works() {
                     PreRendered("\"".to_string()),
                     PreRendered(">".to_string()),
                     InnerHtmlMarker,
-                    PreRendered("Hello world 1 --&gt;".to_string()),
+                    PreRendered("Hello world 1 --&#62;".to_string()),
                     Node {
                         index: 0,
                         escape_text: EscapeText::Escape
                     },
                     PreRendered(
-                        "&lt;-- Hello world 2<div>nest 1</div><div></div><div>nest 2</div>"
+                        "&#60;-- Hello world 2<div>nest 1</div><div></div><div>nest 2</div>"
                             .to_string()
                     ),
                     Node {
@@ -360,7 +360,7 @@ fn to_string_works() {
 
     use Segment::*;
 
-    assert_eq!(out, "<div class=\"asdasdasd asdasdasd\" id=\"id-123\">Hello world 1 --&gt;123&lt;-- Hello world 2<div>nest 1</div><div></div><div>nest 2</div>&lt;/diiiiiiiiv&gt;<div>finalize 0</div><div>finalize 1</div><div>finalize 2</div><div>finalize 3</div><div>finalize 4</div></div>");
+    assert_eq!(out, "<div class=\"asdasdasd asdasdasd\" id=\"id-123\">Hello world 1 --&#62;123&#60;-- Hello world 2<div>nest 1</div><div></div><div>nest 2</div>&#60;/diiiiiiiiv&#62;<div>finalize 0</div><div>finalize 1</div><div>finalize 2</div><div>finalize 3</div><div>finalize 4</div></div>");
 }
 
 #[test]

--- a/packages/ssr/tests/escape.rs
+++ b/packages/ssr/tests/escape.rs
@@ -11,7 +11,7 @@ fn escape_static_values() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<input disabled=\"&quot;&gt;&lt;div&gt;\" data-node-hydration=\"0\"/>"
+        "<input disabled=\"&#34;&#62;&#60;div&#62;\" data-node-hydration=\"0\"/>"
     );
 }
 
@@ -27,7 +27,7 @@ fn escape_dynamic_values() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<input disabled=\"&quot;&gt;&lt;div&gt;\" data-node-hydration=\"0\"/>"
+        "<input disabled=\"&#34;&#62;&#60;div&#62;\" data-node-hydration=\"0\"/>"
     );
 }
 
@@ -42,7 +42,7 @@ fn escape_static_style() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<div style=\"width:&quot;&gt;&lt;div&gt;;\" data-node-hydration=\"0\"></div>"
+        "<div style=\"width:&#34;&#62;&#60;div&#62;;\" data-node-hydration=\"0\"></div>"
     );
 }
 
@@ -58,7 +58,7 @@ fn escape_dynamic_style() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<div style=\"width:&quot;&gt;&lt;div&gt;;\" data-node-hydration=\"0\"></div>"
+        "<div style=\"width:&#34;&#62;&#60;div&#62;;\" data-node-hydration=\"0\"></div>"
     );
 }
 
@@ -77,7 +77,7 @@ fn escape_static_text() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<div data-node-hydration=\"0\">&quot;&gt;&lt;div&gt;</div>"
+        "<div data-node-hydration=\"0\">&#34;&#62;&#60;div&#62;</div>"
     );
 }
 
@@ -97,7 +97,7 @@ fn escape_dynamic_text() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<div data-node-hydration=\"0\"><!--node-id1-->&quot;&gt;&lt;div&gt;<!--#--></div>"
+        "<div data-node-hydration=\"0\"><!--node-id1-->&#34;&#62;&#60;div&#62;<!--#--></div>"
     );
 }
 
@@ -219,7 +219,7 @@ fn escape_static_component_fragment_div() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<div data-node-hydration=\"0\"><!--node-id1-->body { font-family: &quot;sans-serif&quot;; }<!--#--></div>"
+        "<div data-node-hydration=\"0\"><!--node-id1-->body { font-family: &#34;sans-serif&#34;; }<!--#--></div>"
     );
 }
 
@@ -244,6 +244,6 @@ fn escape_dynamic_component_fragment_div() {
 
     assert_eq!(
         dioxus_ssr::pre_render(&dom),
-        "<div data-node-hydration=\"0\"><!--node-id1-->body { font-family: &quot;sans-serif&quot;; }<!--#--></div>"
+        "<div data-node-hydration=\"0\"><!--node-id1-->body { font-family: &#34;sans-serif&#34;; }<!--#--></div>"
     );
 }

--- a/packages/ssr/tests/simple.rs
+++ b/packages/ssr/tests/simple.rs
@@ -42,7 +42,7 @@ fn dynamic() {
         dioxus_ssr::render_element(rsx! {
             div { "Hello world 1 -->" "{dynamic}" "<-- Hello world 2" }
         }),
-        "<div>Hello world 1 --&gt;123&lt;-- Hello world 2</div>"
+        "<div>Hello world 1 --&#62;123&#60;-- Hello world 2</div>"
     );
 }
 


### PR DESCRIPTION
[`askama_escape`] v0.13 uses codepoints instead of named entities for HTML escaping: `&lt;` → `&#60;`.

Only tests in `packages/ssr` were executed. Running `run_local_tests.sh` had errors unrelated to my changes; some docker images could not be downloaded. Could be that something is misconfigured on my system, though.

[`askama_escape`]: <https://crates.io/crates/askama_escape>