### PR TITLE
subsecond/cli:  fix linker and passing through -fuse-ld properly

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1488,6 +1488,7 @@ impl BuildRequest {
                         || arg.starts_with("-m")
                         || arg.starts_with("-Wl,--target=")
                         || arg.starts_with("-Wl,-fuse-ld")
+                        || arg.starts_with("-fuse-ld")
                     {
                         out_args.push(arg.to_string());
                     }

--- a/packages/cli/src/cli/link.rs
+++ b/packages/cli/src/cli/link.rs
@@ -98,7 +98,10 @@ impl LinkAction {
         if let Some(linker) = &self.linker {
             env_vars.push((
                 Self::DX_LINK_CUSTOM_LINKER,
-                dunce::canonicalize(linker)?.to_string_lossy().to_string(),
+                dunce::canonicalize(linker)
+                    .unwrap_or(linker.clone())
+                    .to_string_lossy()
+                    .to_string(),
             ));
         }
 


### PR DESCRIPTION
in LinkAction, dunce::canonicalize(linker) was being called, which resulted in a "file not found" IoError as it tried to find the linker relative to the workdir, even though `linker="command_on_PATH"` is accepted by Cargo. This falls back to using the linker command directly in those cases.

This used to only pass through `-Wl,-fuse-ld=mold` when thin linking, but Rustflags uses `-C link-arg=-fuse-ld=mold` which causes `-fuse-ld=mold` to be passed. This PR adds that case.

These changes present a big annoyance with setting up subsecond to use a linker besides the default, like Mold. With this PR the following .cargo/config.toml works as expected:

```toml
[target.x86_64-unknown-linux-gnu]
linker = "clang"
rustflags = [
    "-C",
    "link-arg=-fuse-ld=mold",
]
```

Fixes:
- #4193