### PR TITLE
unset CARGO_MANIFEST_DIR, don't set it to empty string

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -455,7 +455,11 @@ impl AppBuilder {
             ),
         ];
 
-        if crate::VERBOSITY.get().unwrap().verbose {
+        if crate::VERBOSITY
+            .get()
+            .map(|f| f.verbose)
+            .unwrap_or_default()
+        {
             envs.push(("RUST_BACKTRACE", "1".to_string()));
         }
 

--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -453,11 +453,11 @@ impl AppBuilder {
                 dioxus_cli_config::ALWAYS_ON_TOP_ENV,
                 always_on_top.to_string(),
             ),
-            // unset the cargo dirs in the event we're running `dx` locally
-            // since the child process will inherit the env vars, we don't want to confuse the downstream process
-            ("CARGO_MANIFEST_DIR", "".to_string()),
-            ("RUST_BACKTRACE", "1".to_string()),
         ];
+
+        if crate::VERBOSITY.get().unwrap().verbose {
+            envs.push(("RUST_BACKTRACE", "1".to_string()));
+        }
 
         if let Some(base_path) = krate.base_path() {
             envs.push((dioxus_cli_config::ASSET_ROOT_ENV, base_path.to_string()));
@@ -734,6 +734,7 @@ impl AppBuilder {
 
         let mut child = Command::new(main_exe)
             .envs(envs)
+            .env_remove("CARGO_MANIFEST_DIR") // running under `dx` shouldn't expose cargo-only :
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())
             .kill_on_drop(true)
@@ -796,6 +797,7 @@ impl AppBuilder {
             .arg("booted")
             .arg(self.build.bundle_identifier())
             .envs(ios_envs)
+            .env_remove("CARGO_MANIFEST_DIR")
             .stderr(Stdio::piped())
             .stdout(Stdio::piped())
             .kill_on_drop(true)


### PR DESCRIPTION
I think the cause of https://github.com/DioxusLabs/dioxus/issues/4223 is because we set CARGO_MANIFEST_DIR to `Ok("")` when we're really just trying to unset it altogether. This leads to the executable thinking that its CARGO_MANIFEST_DIR is "" which can cause issues.

Note that we can't and won't set CARGO_MANIFEST_DIR to anything that cargo might set since 
1) we're not cargo
2) tracking all these envs that cargo uses is not stable long term 
3) crossplatform apps should not be relying on this to be set since it won't when running in production.

