### PR TITLE
Allow changing the base path from a cli arg

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -758,10 +758,10 @@ impl AppBuilder {
     /// Check if we need to use https or not, and if so, add the protocol.
     /// Go to the basepath if that's set too.
     fn open_web(&self, address: SocketAddr) {
-        let base_path = self.build.config.web.app.base_path.clone();
+        let base_path = self.build.base_path();
         let https = self.build.config.web.https.enabled.unwrap_or_default();
         let protocol = if https { "https" } else { "http" };
-        let base_path = match base_path.as_deref() {
+        let base_path = match base_path {
             Some(base_path) => format!("/{}", base_path.trim_matches('/')),
             None => "".to_owned(),
         };
@@ -1380,10 +1380,10 @@ We checked the folder: {}
                 // code --open-url "vscode://DioxusLabs.dioxus/debugger?uri=http://127.0.0.1:8080"
                 // todo - debugger could open to the *current* page afaik we don't have a way to have that info
                 let address = server.devserver_address();
-                let base_path = self.build.config.web.app.base_path.clone();
+                let base_path = self.build.base_path();
                 let https = self.build.config.web.https.enabled.unwrap_or_default();
                 let protocol = if https { "https" } else { "http" };
-                let base_path = match base_path.as_deref() {
+                let base_path = match base_path {
                     Some(base_path) => format!("/{}", base_path.trim_matches('/')),
                     None => "".to_owned(),
                 };

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -388,6 +388,7 @@ pub(crate) struct BuildRequest {
     pub(crate) link_args_file: Arc<NamedTempFile>,
     pub(crate) link_err_file: Arc<NamedTempFile>,
     pub(crate) rustc_wrapper_args_file: Arc<NamedTempFile>,
+    pub(crate) base_path: Option<String>,
 }
 
 /// dx can produce different "modes" of a build. A "regular" build is a "base" build. The Fat and Thin
@@ -727,6 +728,7 @@ impl BuildRequest {
             release,
             package,
             skip_assets: args.skip_assets,
+            base_path: args.base_path.clone(),
             wasm_split: args.wasm_split,
             debug_symbols: args.debug_symbols,
             inject_loading_scripts: args.inject_loading_scripts,
@@ -4045,11 +4047,9 @@ r#" <script>
 
     /// Get the base path from the config or None if this is not a web or server build
     pub(crate) fn base_path(&self) -> Option<&str> {
-        self.config
-            .web
-            .app
-            .base_path
+        self.base_path
             .as_deref()
+            .or(self.config.web.app.base_path.as_deref())
             .filter(|_| matches!(self.platform, Platform::Web | Platform::Server))
     }
 

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -90,6 +90,11 @@ pub(crate) struct TargetArgs {
     /// If device is false, then we'll build for the simulator
     #[clap(long)]
     pub(crate) device: Option<bool>,
+
+    /// The base path the build will fetch assets relative to. This will override the
+    /// base path set in the `dioxus` config. [default: "."]
+    #[clap(long)]
+    pub(crate) base_path: Option<String>,
 }
 
 /// Chain together multiple target commands

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -92,7 +92,7 @@ pub(crate) struct TargetArgs {
     pub(crate) device: Option<bool>,
 
     /// The base path the build will fetch assets relative to. This will override the
-    /// base path set in the `dioxus` config. [default: "."]
+    /// base path set in the `dioxus` config.
     #[clap(long)]
     pub(crate) base_path: Option<String>,
 }

--- a/packages/cli/src/serve/server.rs
+++ b/packages/cli/src/serve/server.rs
@@ -475,11 +475,7 @@ fn build_devserver_router(
             runner
                 .client()
                 .build
-                .config
-                .web
-                .app
-                .base_path
-                .as_deref()
+                .base_path()
                 .unwrap_or_default()
                 .trim_matches('/')
         );


### PR DESCRIPTION
Adds a new CLI argument that overrides the base path. This makes the preview deploy action a lot nicer