### PR TITLE
white-list .rcgu.o files in the linking phase, otherwise dump them into the normal linking pile

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1726,7 +1726,6 @@ impl BuildRequest {
 
                 // Some rlibs contain weird artifacts that we don't want to include in the fat archive.
                 // However, we still want them around in the linker in case the regular linker can handle them.
-                // For example, dylibs,
                 if keep_linker_rlib {
                     compiler_rlibs.push(rlib.clone());
                 }


### PR DESCRIPTION
Attempts to fix https://github.com/DioxusLabs/dioxus/issues/4237 by white-listing just rust's incremental object files and instead lets the linker deal with "funny" rlibs. Note that for rlibs that contain "funny" artifacts and rust artifacts, we still submit the rust ones.