### PR TITLE
Allows desktop apps to open mailto links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4002,7 +4002,6 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "tray-icon",
- "webbrowser",
  "wry",
 ]
 
@@ -16251,23 +16250,6 @@ dependencies = [
  "phf_codegen 0.11.3",
  "string_cache",
  "string_cache_codegen",
-]
-
-[[package]]
-name = "webbrowser"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5df295f8451142f1856b1bd86a606dfe9587d439bc036e319c827700dbd555e"
-dependencies = [
- "core-foundation 0.10.0",
- "home",
- "jni",
- "log",
- "ndk-context",
- "objc2 0.6.1",
- "objc2-foundation 0.3.1",
- "url",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3985,6 +3985,7 @@ dependencies = [
  "ndk-sys 0.6.0+11769913",
  "objc",
  "objc_id",
+ "open",
  "percent-encoding",
  "rand 0.8.5",
  "reqwest 0.12.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,7 +313,6 @@ memfd = "0.6.4"
 # desktop
 wry = { version = "0.45.0", default-features = false }
 tao = { version = "0.33.0", features = ["rwh_05"] }
-webbrowser = "1.0.3"
 infer = "0.19.0"
 dunce = "1.0.5"
 percent-encoding = "2.3.1"

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -4138,7 +4138,7 @@ r#" <script>
                     .trim()
                     .into();
                 let path_to_sim = path_to_xcode.join("Applications").join("Simulator.app");
-                open::that(path_to_sim)?;
+                open::that_detached(path_to_sim)?;
             }
 
             Platform::Android => {

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -37,7 +37,6 @@ tokio = { workspace = true, features = [
   "fs",
   "io-util",
 ], optional = true }
-webbrowser = { workspace = true }
 infer = { workspace = true }
 dunce = { workspace = true }
 slab = { workspace = true }

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -50,6 +50,7 @@ tao = { workspace = true, features = ["rwh_05"] }
 dioxus-history = { workspace = true }
 base64 = { workspace = true }
 libc = "0.2.170"
+open = "5.3.2"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.17"

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -48,8 +48,8 @@ async-trait = { workspace = true }
 tao = { workspace = true, features = ["rwh_05"] }
 dioxus-history = { workspace = true }
 base64 = { workspace = true }
+open = { workspace = true }
 libc = "0.2.170"
-open = "5.3.2"
 
 [target.'cfg(unix)'.dependencies]
 signal-hook = "0.3.17"

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -271,7 +271,7 @@ impl App {
         if let Some(temp) = msg.params().as_object() {
             if temp.contains_key("href") {
                 if let Some(href) = temp.get("href").and_then(|v| v.as_str()) {
-                    if let Err(e) = webbrowser::open(href) {
+                    if let Err(e) = open::that(href) {
                         tracing::error!("Open Browser error: {:?}", e);
                     }
                 }

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -271,7 +271,7 @@ impl App {
         if let Some(temp) = msg.params().as_object() {
             if temp.contains_key("href") {
                 if let Some(href) = temp.get("href").and_then(|v| v.as_str()) {
-                    if let Err(e) = open::that(href) {
+                    if let Err(e) = open::that_detached(href) {
                         tracing::error!("Open Browser error: {:?}", e);
                     }
                 }

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -350,7 +350,7 @@ impl WebviewInstance {
                         || var.starts_with("https://")
                         || var.starts_with("mailto:")
                     {
-                        _ = open::that(&var);
+                        _ = open::that_detached(&var);
                     }
                     false
                 }

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -346,9 +346,10 @@ impl WebviewInstance {
                 if var.starts_with("dioxus://") || var.starts_with("http://dioxus.") {
                     true
                 } else {
-                    if var.starts_with("http://") || var.starts_with("https://") {
-                        _ = webbrowser::open(&var);
-                    } else if var.starts_with("mailto:") {
+                    if var.starts_with("http://")
+                        || var.starts_with("https://")
+                        || var.starts_with("mailto:")
+                    {
                         _ = open::that(&var);
                     }
                     false

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -348,6 +348,8 @@ impl WebviewInstance {
                 } else {
                     if var.starts_with("http://") || var.starts_with("https://") {
                         _ = webbrowser::open(&var);
+                    } else if var.starts_with("mailto:") {
+                        _ = open::that(&var);
                     }
                     false
                 }


### PR DESCRIPTION
Added an option to the WebViewBuilder navigation handler to open links starting with "mailto:".

```rust
webview = webview
            .with_web_context(&mut web_context)
            .with_bounds(wry::Rect {
                position: wry::dpi::Position::Logical(wry::dpi::LogicalPosition::new(0.0, 0.0)),
                size: wry::dpi::Size::Physical(wry::dpi::PhysicalSize::new(
                    window.inner_size().width,
                    window.inner_size().height,
                )),
             })
            .with_transparent(cfg.window.window.transparent)
            .with_url("dioxus://index.html/")
            .with_ipc_handler(ipc_handler)
            .with_navigation_handler(|var| {
                // We don't want to allow any navigation
                // We only want to serve the index file and assets
                if var.starts_with("dioxus://") || var.starts_with("http://dioxus.") {
                    true
                 } else {
                    if var.starts_with("http://") || var.starts_with("https://") {
                        _ = webbrowser::open(&var);
                     } else if var.starts_with("mailto:") {
                        _ = open::that(&var);
                     }
                    false
                }
 })
 ```


This adds a dependency to the `open` crate.
We can also join the two `if` branches and use the `open` crate to open http, https, and mailto links. Is there a reason to keep them separated?

Fixes [https://github.com/DioxusLabs/dioxus/issues/2991](https://github.com/DioxusLabs/dioxus/issues/2991)