### PR TITLE
properly respect rustflags, fix x86-sim issue

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -630,7 +630,7 @@ impl BuildRequest {
                         Architecture::Aarch64(_) if device => "aarch64-apple-ios".parse().unwrap(),
                         Architecture::Aarch64(_) => "aarch64-apple-ios-sim".parse().unwrap(),
                         _ if device => "x86_64-apple-ios".parse().unwrap(),
-                        _ => "x86_64-apple-ios-sim".parse().unwrap(),
+                        _ => "x86_64-apple-ios".parse().unwrap(),
                     }
                 }
 

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -647,7 +647,7 @@ impl BuildRequest {
         // Somethings we override are also present in the user's config.
         // If we can't get them by introspecting cargo, then we need to get them from the config
         //
-        // This involves specificaly two fields:
+        // This involves specifically two fields:
         // - The linker since we override it for Android and hotpatching
         // - RUSTFLAGS since we also override it for Android and hotpatching
         let cargo_config = cargo_config2::Config::load().unwrap();


### PR DESCRIPTION
Fixes: https://github.com/DioxusLabs/dioxus/issues/4238
Fixes: https://github.com/DioxusLabs/dioxus/issues/4296

Tested:
- merging of rustflags
- using .cargo/config
- using RUSTFLAGS env var
- hotpatching enabled and hotpatching disabled


```rust
// main.rs
use dioxus::prelude::*;

fn main() {
    dioxus::launch(app);
}

fn app() -> Element {
    let mut buf = [0u8; 120];
    getrandom::fill(&mut buf).unwrap();

    rsx! {
        div {
            h1 { "Hello, Dioxus!" }
            p { "This is a simple Dioxus application." }
            pre { "Random bytes: {buf:?}" }
        }
    }
}
```

```toml
# .cargo/config.toml
[target.wasm32-unknown-unknown]
rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
```