### PR TITLE
fix ios codesign on device

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -514,14 +514,6 @@ impl AppBuilder {
             }
 
             Platform::Ios => {
-                tracing::info!(
-                    "Opening iOS app on {}",
-                    if self.build.device {
-                        "device"
-                    } else {
-                        "simulator"
-                    }
-                );
                 if self.build.device {
                     self.codesign_ios().await?;
                     self.open_ios_device().await?
@@ -868,49 +860,23 @@ impl AppBuilder {
     ///
     /// Converting these commands shouldn't be too hard, but device support would imply we need
     /// better support for codesigning and entitlements.
-    #[allow(unused)]
     async fn open_ios_device(&self) -> Result<()> {
         use serde_json::Value;
-        let app_path = self.build.root_dir();
 
-        // 2. Determine which device the app was installed to
+        // 1. Find an active device
         let device_uuid = get_device_uuid().await?;
 
-        // install_app(&app_path, &device_uuid).await?;
+        // 2. Get the installation URL of the app
+        let installation_url = get_installation_url(&device_uuid, &self.build.root_dir()).await?;
 
-        // 3. Get the installation URL of the app
-        let installation_url = get_installation_url(&device_uuid, &app_path).await?;
-
-        // 4. Launch the app into the background, paused
+        // 3. Launch the app into the background, paused
         launch_app_paused(&device_uuid, &installation_url).await?;
-
-        // 5. Pick up the paused app and resume it
-        resume_app(&device_uuid).await?;
-
-        async fn install_app(app_path: &PathBuf, device_uuid: &str) -> Result<()> {
-            // xcrun devicectl device install app --device "${DEVICE_UUID}" "${APP_PATH}" --json-output target/xcrun.json
-
-            let output = Command::new("xcrun")
-                .args(["devicectl", "install", "app"])
-                .arg("--device")
-                .arg(device_uuid)
-                .arg("--path")
-                .arg(app_path)
-                .output()
-                .await?;
-
-            if !output.status.success() {
-                return Err(format!("Failed to install app: {:?}", output).into());
-            }
-
-            Ok(())
-        }
 
         async fn get_device_uuid() -> Result<String> {
             let tmpfile = tempfile::NamedTempFile::new()
                 .context("Failed to create temporary file for device list")?;
 
-            let output = Command::new("xcrun")
+            Command::new("xcrun")
                 .args([
                     "devicectl".to_string(),
                     "list".to_string(),
@@ -932,6 +898,9 @@ impl AppBuilder {
         }
 
         async fn get_installation_url(device_uuid: &str, app_path: &Path) -> Result<String> {
+            let tmpfile = tempfile::NamedTempFile::new()
+                .context("Failed to create temporary file for device list")?;
+
             // xcrun devicectl device install app --device <uuid> --path <path> --json-output
             let output = Command::new("xcrun")
                 .args([
@@ -943,8 +912,8 @@ impl AppBuilder {
                     device_uuid,
                     &app_path.display().to_string(),
                     "--json-output",
-                    "target/xcrun.json",
                 ])
+                .arg(tmpfile.path())
                 .output()
                 .await?;
 
@@ -952,7 +921,7 @@ impl AppBuilder {
                 return Err(format!("Failed to install app: {:?}", output).into());
             }
 
-            let json: Value = serde_json::from_str(&std::fs::read_to_string("target/xcrun.json")?)
+            let json: Value = serde_json::from_str(&std::fs::read_to_string(tmpfile.path())?)
                 .context("Failed to parse xcrun output")?;
             let installation_url = json["result"]["installedApplications"][0]["installationURL"]
                 .as_str()
@@ -963,6 +932,9 @@ impl AppBuilder {
         }
 
         async fn launch_app_paused(device_uuid: &str, installation_url: &str) -> Result<()> {
+            let tmpfile = tempfile::NamedTempFile::new()
+                .context("Failed to create temporary file for device list")?;
+
             let output = Command::new("xcrun")
                 .args([
                     "devicectl",
@@ -975,8 +947,8 @@ impl AppBuilder {
                     device_uuid,
                     installation_url,
                     "--json-output",
-                    "target/launch.json",
                 ])
+                .arg(tmpfile.path())
                 .output()
                 .await?;
 
@@ -984,11 +956,7 @@ impl AppBuilder {
                 return Err(format!("Failed to launch app: {:?}", output).into());
             }
 
-            Ok(())
-        }
-
-        async fn resume_app(device_uuid: &str) -> Result<()> {
-            let json: Value = serde_json::from_str(&std::fs::read_to_string("target/launch.json")?)
+            let json: Value = serde_json::from_str(&std::fs::read_to_string(tmpfile.path())?)
                 .context("Failed to parse xcrun output")?;
 
             let status_pid = json["result"]["process"]["processIdentifier"]
@@ -1101,10 +1069,11 @@ We checked the folder: {}
         struct ProvisioningProfile {
             #[serde(rename = "TeamIdentifier")]
             team_identifier: Vec<String>,
-            #[serde(rename = "ApplicationIdentifierPrefix")]
-            application_identifier_prefix: Vec<String>,
             #[serde(rename = "Entitlements")]
             entitlements: Entitlements,
+            #[allow(dead_code)]
+            #[serde(rename = "ApplicationIdentifierPrefix")]
+            application_identifier_prefix: Vec<String>,
         }
 
         #[derive(serde::Deserialize, Debug)]


### PR DESCRIPTION
Apparently the mobile codesign folder changed in xcode 16, breaking the old version of this. Didn't realize it.

Fixed it and some other bugs related to `--device` and now `dx serve --platform ios --device` works!

Fixes https://github.com/DioxusLabs/dioxus/issues/3858

https://github.com/dotnet/macios/issues/20771

![IMG_7673](https://github.com/user-attachments/assets/3085ac54-7256-4297-9744-bdb5042080da)
