### PR TITLE
fix issue: Routable doesn't work with component in a core module. #4331

### DIFF
--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -513,7 +513,7 @@ impl RouteEnum {
         });
 
         quote! {
-            impl<'a> core::convert::TryFrom<&'a str> for #name {
+            impl<'a> ::core::convert::TryFrom<&'a str> for #name {
                 type Error = <Self as std::str::FromStr>::Err;
 
                 fn try_from(s: &'a str) -> ::std::result::Result<Self, Self::Error> {


### PR DESCRIPTION
link to issue: https://github.com/DioxusLabs/dioxus/issues/4331

what happens:
  in route_macro/lib.rs, there is a core::convert method call, in user's case, he/she has a self `core` module

fix:
  clarify `core::convert` to `::core::convert`