### PR TITLE
fix: allow to name module `std` in project

### DIFF
--- a/packages/const-serialize-macro/src/lib.rs
+++ b/packages/const-serialize-macro/src/lib.rs
@@ -175,7 +175,7 @@ pub fn derive_parse(input: TokenStream) -> TokenStream {
                                     const_serialize::Layout::Struct(layout) => layout,
                                     _ => panic!("VariantStruct::MEMORY_LAYOUT must be a struct"),
                                 },
-                                std::mem::align_of::<VariantStruct>(),
+                                ::std::mem::align_of::<VariantStruct>(),
                             )
                         }
                     }
@@ -183,7 +183,7 @@ pub fn derive_parse(input: TokenStream) -> TokenStream {
                 quote! {
                     unsafe impl #impl_generics const_serialize::SerializeConst for #ty #ty_generics #where_clause {
                         const MEMORY_LAYOUT: const_serialize::Layout = const_serialize::Layout::Enum(const_serialize::EnumLayout::new(
-                            std::mem::size_of::<Self>(),
+                            ::std::mem::size_of::<Self>(),
                             const_serialize::PrimitiveLayout::new(
                                 #discriminant_size as usize,
                             ),

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -491,7 +491,7 @@ impl RouteEnum {
 
         quote! {
             impl std::fmt::Display for #name {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                     #[allow(unused)]
                     match self {
                         #(#display_match)*
@@ -514,14 +514,14 @@ impl RouteEnum {
 
         quote! {
             impl<'a> ::core::convert::TryFrom<&'a str> for #name {
-                type Error = <Self as std::str::FromStr>::Err;
+                type Error = <Self as ::std::str::FromStr>::Err;
 
                 fn try_from(s: &'a str) -> ::std::result::Result<Self, Self::Error> {
                     s.parse()
                 }
             }
 
-            impl std::str::FromStr for #name {
+            impl ::std::str::FromStr for #name {
                 type Err = dioxus_router::routable::RouteParseError<#error_name>;
 
                 fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
@@ -646,14 +646,14 @@ impl RouteEnum {
                 #(#error_variants),*
             }
 
-            impl std::fmt::Debug for #match_error_name {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            impl ::std::fmt::Debug for #match_error_name {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                     write!(f, "{}({})", stringify!(#match_error_name), self)
                 }
             }
 
-            impl std::fmt::Display for #match_error_name {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            impl ::std::fmt::Display for #match_error_name {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                     match self {
                         #(#display_match),*
                     }

--- a/packages/router-macro/src/route.rs
+++ b/packages/router-macro/src/route.rs
@@ -180,8 +180,8 @@ impl Route {
                 let child = field.ident.as_ref().unwrap();
                 quote! {
                     Self::#name { #(#dynamic_segments,)* #child } => {
-                        use std::fmt::Display;
-                        use std::fmt::Write;
+                        use ::std::fmt::Display;
+                        use ::std::fmt::Write;
                         let mut route = String::new();
                         {
                             let f = &mut route;
@@ -334,8 +334,8 @@ impl Route {
                                         }
                                     }
 
-                                    impl<T: std::fmt::Display> std::fmt::Display for NoPartialEq<T> {
-                                        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                                    impl<T: ::std::fmt::Display> ::std::fmt::Display for NoPartialEq<T> {
+                                        fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                                             self.0.fmt(f)
                                         }
                                     }

--- a/packages/router-macro/src/segment.rs
+++ b/packages/router-macro/src/segment.rs
@@ -314,14 +314,14 @@ pub(crate) fn create_error_type(
             #(#error_variants,)*
         }
 
-        impl std::fmt::Debug for #error_name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl ::std::fmt::Debug for #error_name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 write!(f, "{}({})", stringify!(#error_name), self)
             }
         }
 
-        impl std::fmt::Display for #error_name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        impl ::std::fmt::Display for #error_name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 match self {
                     Self::ExtraSegments(segments) => {
                         write!(f, "Found additional trailing segments: {}", segments)?

--- a/packages/wasm-split/wasm-split-macro/src/lib.rs
+++ b/packages/wasm-split/wasm-split-macro/src/lib.rs
@@ -25,10 +25,10 @@ pub fn wasm_split(args: TokenStream, input: TokenStream) -> TokenStream {
     desugard_async_sig.asyncness = None;
     desugard_async_sig.output = match &desugard_async_sig.output {
         ReturnType::Default => {
-            parse_quote! { -> std::pin::Pin<Box<dyn std::future::Future<Output = ()>>> }
+            parse_quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = ()>>> }
         }
         ReturnType::Type(_, ty) => {
-            parse_quote! { -> std::pin::Pin<Box<dyn std::future::Future<Output = #ty>>> }
+            parse_quote! { -> ::std::pin::Pin<Box<dyn ::std::future::Future<Output = #ty>>> }
         }
     };
 


### PR DESCRIPTION
Extends the fix for `core` (see #4331) add some missing prefix '::' for use of 'std' as module name.

Thanks to @zhiyanzhaiji for the PR #4350 .
