### PR TITLE
Native: Accept `winit::WindowAttributes` as a config value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16633,6 +16633,7 @@ dependencies = [
  "dioxus-native",
  "tracing-subscriber",
  "wgpu 24.0.5",
+ "winit",
 ]
 
 [[package]]

--- a/examples/wgpu-texture/Cargo.toml
+++ b/examples/wgpu-texture/Cargo.toml
@@ -18,6 +18,7 @@ tracing = ["dep:tracing-subscriber", "dioxus-native/tracing"]
 dioxus-native = { path = "../../packages/native" }
 dioxus = { workspace = true }
 wgpu = "24"
+winit = "0.30"
 bytemuck = "1"
 color = "0.3"
 tracing-subscriber = { workspace = true, optional = true }

--- a/examples/wgpu-texture/src/main.rs
+++ b/examples/wgpu-texture/src/main.rs
@@ -5,6 +5,8 @@ use dioxus::prelude::*;
 use dioxus_native::use_wgpu;
 use std::any::Any;
 use wgpu::{Features, Limits};
+use winit::dpi::LogicalSize;
+use winit::window::WindowAttributes;
 
 mod demo_renderer;
 
@@ -19,6 +21,13 @@ fn limits() -> Limits {
         ..Limits::default()
     }
 }
+fn window_attributes() -> WindowAttributes {
+    // You can also use a `<title>` element to set the window title
+    // but this demonstrates the use of `WindowAttributes`
+    WindowAttributes::default()
+        .with_title("WGPU Example")
+        .with_inner_size(LogicalSize::new(800, 600))
+}
 
 type Color = OpaqueColor<Srgb>;
 
@@ -26,7 +35,11 @@ fn main() {
     #[cfg(feature = "tracing")]
     tracing_subscriber::fmt::init();
 
-    let config: Vec<Box<dyn Any>> = vec![Box::new(FEATURES), Box::new(limits())];
+    let config: Vec<Box<dyn Any>> = vec![
+        Box::new(FEATURES),
+        Box::new(limits()),
+        Box::new(window_attributes()),
+    ];
     dioxus_native::launch_cfg(app, Vec::new(), config);
 }
 

--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -27,6 +27,7 @@ pub use dioxus_renderer::{use_wgpu, DioxusNativeWindowRenderer, Features, Limits
 use blitz_shell::{create_default_event_loop, BlitzShellEvent, Config, WindowConfig};
 use dioxus_core::{ComponentFunction, Element, VirtualDom};
 use std::any::Any;
+use winit::window::WindowAttributes;
 
 type NodeId = usize;
 
@@ -70,10 +71,12 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
     // Read config values
     let mut features = None;
     let mut limits = None;
+    let mut window_attributes = None;
     let mut _config = None;
     for mut cfg in configs {
         cfg = try_read_config!(cfg, features, Features);
         cfg = try_read_config!(cfg, limits, Limits);
+        cfg = try_read_config!(cfg, window_attributes, WindowAttributes);
         cfg = try_read_config!(cfg, _config, Config);
         let _ = cfg;
     }
@@ -125,7 +128,11 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
     // Create document + window from the baked virtualdom
     let doc = DioxusDocument::new(vdom, net_provider);
     let renderer = DioxusNativeWindowRenderer::with_features_and_limits(features, limits);
-    let config = WindowConfig::new(Box::new(doc) as _, renderer.clone());
+    let config = WindowConfig::with_attributes(
+        Box::new(doc) as _,
+        renderer.clone(),
+        window_attributes.unwrap_or_default(),
+    );
 
     // Create application
     let mut application = DioxusNativeApplication::new(event_loop.create_proxy(), config);


### PR DESCRIPTION
Allows for things like setting the initial window size.