### PR TITLE
Add generic `create_waker` function to `dioxus-core`

### DIFF
--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -77,12 +77,13 @@ pub(crate) mod innerlude {
 }
 
 pub use crate::innerlude::{
-    fc_to_builder, generation, schedule_update, schedule_update_any, use_hook, vdom_is_rendering,
-    AnyValue, Attribute, AttributeValue, CapturedError, Component, ComponentFunction, DynamicNode,
-    Element, ElementId, Event, Fragment, HasAttributes, IntoDynNode, LaunchConfig,
-    ListenerCallback, MarkerWrapper, Mutation, Mutations, NoOpMutations, Ok, Properties, Result,
-    Runtime, ScopeId, ScopeState, SpawnIfAsync, Task, Template, TemplateAttribute, TemplateNode,
-    VComponent, VNode, VNodeInner, VPlaceholder, VText, VirtualDom, WriteMutations,
+    create_waker, fc_to_builder, generation, schedule_update, schedule_update_any, use_hook,
+    vdom_is_rendering, AnyValue, Attribute, AttributeValue, CapturedError, Component,
+    ComponentFunction, DynamicNode, Element, ElementId, Event, Fragment, HasAttributes,
+    IntoDynNode, LaunchConfig, ListenerCallback, MarkerWrapper, Mutation, Mutations, NoOpMutations,
+    Ok, Properties, Result, Runtime, ScopeId, ScopeState, SpawnIfAsync, Task, Template,
+    TemplateAttribute, TemplateNode, VComponent, VNode, VNodeInner, VPlaceholder, VText,
+    VirtualDom, WriteMutations,
 };
 
 /// The purpose of this module is to alleviate imports of many common types

--- a/packages/core/src/tasks.rs
+++ b/packages/core/src/tasks.rs
@@ -405,3 +405,18 @@ impl ArcWake for LocalTaskHandle {
             .unbounded_send(SchedulerMsg::TaskNotified(arc_self.id));
     }
 }
+
+/// Create a waker that will call a  callback
+pub fn create_waker(callback: Box<dyn Fn() + 'static + Send + Sync>) -> std::task::Waker {
+    struct CallbackHandle {
+        callback: Box<dyn Fn() + 'static + Send + Sync>,
+    }
+
+    impl futures_util::task::ArcWake for CallbackHandle {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            (arc_self.callback)()
+        }
+    }
+
+    futures_util::task::waker(Arc::new(CallbackHandle { callback }))
+}


### PR DESCRIPTION
`dioxus-core`'s `VirtualDom` expects you to pass it a `Context` which you create from a `Waker`. But it does not provide an easy way to create a `Waker`. This function will create a waker that will call `Box<dyn Fn()>` callback that you can do anything in (e.g. close over a Winit/Tao proxy and send an event).