### PR TITLE
Fix hot patching hook types

### DIFF
--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -64,6 +64,11 @@ pub struct Runtime {
     // We need to store this information on the virtual dom so that we know what nodes are mounted where when we bubble events
     // Each mount is associated with a whole rsx block. [`VirtualDom::elements`] link to a specific node in the block
     pub(crate) mounts: RefCell<Slab<VNodeMount>>,
+
+    /// Keeps track if this app has been hot patched. We relax the rules of hooks during hot patching to allow
+    /// more apps to be hot patched
+    #[cfg(debug_assertions)]
+    pub(crate) after_hot_patch: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Runtime {
@@ -85,6 +90,8 @@ impl Runtime {
             dirty_tasks: Default::default(),
             elements: RefCell::new(elements),
             mounts: Default::default(),
+            #[cfg(debug_assertions)]
+            after_hot_patch: Default::default(),
         })
     }
 

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -758,9 +758,12 @@ impl VirtualDom {
 
     #[cfg(debug_assertions)]
     fn register_subsecond_handler(&self) {
-        let sender = self.runtime().sender.clone();
+        let runtime = self.runtime();
+        let sender = runtime.sender.clone();
+        let after_hot_patch = runtime.after_hot_patch.clone();
         subsecond::register_handler(std::sync::Arc::new(move || {
             _ = sender.unbounded_send(SchedulerMsg::AllDirty);
+            after_hot_patch.store(true, std::sync::atomic::Ordering::SeqCst);
         }));
     }
 }


### PR DESCRIPTION
We don't allow the type of hooks to change after they are first set because that is usually caused by breaking the rules of hooks. However, during hot patching it can be a valid change. This PR allows changing the type of hooks by run the new initialization closure after the first hot patch

Fixes #4346 