### PR TITLE
prevent_default must be called synchronously or it will have no effect

### DIFF
--- a/examples/file_upload.rs
+++ b/examples/file_upload.rs
@@ -79,11 +79,13 @@ fn app() -> Element {
                 hovered.set(true)
             },
             ondragleave: move |_| hovered.set(false),
-            ondrop: move |evt| async move {
+            ondrop: move |evt| {
                 evt.prevent_default();
                 hovered.set(false);
                 if let Some(file_engine) = evt.files() {
-                    read_files(file_engine).await;
+                    spawn(async move {
+                        read_files(file_engine).await;
+                    });
                 }
             },
             "Drop files here"


### PR DESCRIPTION
When dropping js or txt files, the browser would still do its default behavior of showing the contents of the file (either in a new tab or navigating away from the current Dioxus app page, depending on the browser/user preferences). The docs for prevent_default say, "Note: This must be called synchronously when handling the event. Calling it after the event has been handled will have no effect."

This makes the `ondrop` handler synchronous and uses `spawn` to handle the file reading.

I'm not an expert on Dioxus or Rust so there might be something wrong/bad with this solution.