### PR TITLE
Adds `spawn_in_scope`

### DIFF
--- a/packages/core/src/global_context.rs
+++ b/packages/core/src/global_context.rs
@@ -204,7 +204,14 @@ pub fn queue_effect(f: impl FnOnce() + 'static) {
 ///
 #[doc = include_str!("../docs/common_spawn_errors.md")]
 pub fn spawn_forever(fut: impl Future<Output = ()> + 'static) -> Option<Task> {
-    Runtime::with_scope(ScopeId::ROOT, |cx| cx.spawn(fut)).ok()
+    spawn_in_scope(ScopeId::ROOT, fut)
+}
+
+/// Spawns a future in the provided scope. This task will automatically be canceled when the component's scope is dropped.
+///
+#[doc = include_str!("../docs/common_spawn_errors.md")]
+pub fn spawn_in_scope(scope: ScopeId, fut: impl Future<Output = ()> + 'static) -> Option<Task> {
+    Runtime::with_scope(scope, |cx| cx.spawn(fut)).ok()
 }
 
 /// Informs the scheduler that this task is no longer needed and should be removed.

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -95,7 +95,7 @@ pub mod prelude {
         consume_context, consume_context_from_scope, current_owner, current_scope_id,
         fc_to_builder, generation, has_context, needs_update, needs_update_any, parent_scope,
         provide_context, provide_error_boundary, provide_root_context, queue_effect, remove_future,
-        schedule_update, schedule_update_any, spawn, spawn_forever, spawn_isomorphic, suspend,
+        schedule_update, schedule_update_any, spawn, spawn_forever, spawn_in_scope, spawn_isomorphic, suspend,
         throw_error, try_consume_context, use_after_render, use_before_render, use_drop, use_hook,
         use_hook_with_cleanup, with_owner, AnyValue, Attribute, Callback, Component,
         ComponentFunction, Context, Element, ErrorBoundary, ErrorContext, Event, EventHandler,


### PR DESCRIPTION
This adds the function `spawn_in_scope` which spawns a future with the scope provided by the user. I needed this since I have a `Signal` at a given scope (created with `Signal::new_maybe_sync_in_scope_with_caller`) that is periodically updated by an associated future. `spawn_forever` did not work since the root scope in the future would attempt to update the subscope's Signal. 

Note: This PR is on the `v0.6` branch so you might want to upstream it to `main` too. 