### PR TITLE
fix(bundle): add serde defaults to prevent deserialization errors

### DIFF
--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -35,6 +35,7 @@ pub(crate) struct DebianSettings {
     pub replaces: Option<Vec<String>>,
     /// List of custom files to add to the deb package.
     /// Maps the path on the debian package to the path of the file to include (relative to the current working directory).
+    #[serde(default)]
     pub files: HashMap<PathBuf, PathBuf>,
     /// Path to a custom desktop file Handlebars template.
     ///
@@ -112,11 +113,17 @@ pub(crate) struct MacOsSettings {
     pub(crate) bundle_name: Option<String>,
     /// List of custom files to add to the application bundle.
     /// Maps the path in the Contents directory in the app to the path of the file to include (relative to the current working directory).
+    #[serde(default)]
     pub files: HashMap<PathBuf, PathBuf>,
     /// Preserve the hardened runtime version flag, see <https://developer.apple.com/documentation/security/hardened_runtime>
     ///
     /// Settings this to `false` is useful when using an ad-hoc signature, making it less strict.
+    #[serde(default = "default_hardened_runtime")]
     pub hardened_runtime: bool,
+}
+
+fn default_hardened_runtime() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -124,11 +131,13 @@ pub(crate) struct WindowsSettings {
     pub(crate) digest_algorithm: Option<String>,
     pub(crate) certificate_thumbprint: Option<String>,
     pub(crate) timestamp_url: Option<String>,
+    #[serde(default)]
     pub(crate) tsp: bool,
     pub(crate) wix: Option<WixSettings>,
     pub(crate) icon_path: Option<PathBuf>,
     pub(crate) webview_install_mode: WebviewInstallMode,
     pub(crate) webview_fixed_runtime_path: Option<PathBuf>,
+    #[serde(default)]
     pub(crate) allow_downgrades: bool,
     pub(crate) nsis: Option<NsisSettings>,
     /// Specify a custom command to sign the binaries.
@@ -156,6 +165,7 @@ pub(crate) struct NsisSettings {
     pub(crate) install_mode: NSISInstallerMode,
     pub(crate) languages: Option<Vec<String>>,
     pub(crate) custom_language_files: Option<HashMap<String, PathBuf>>,
+    #[serde(default)]
     pub(crate) display_language_selector: bool,
     pub(crate) start_menu_folder: Option<String>,
     pub(crate) installer_hooks: Option<PathBuf>,


### PR DESCRIPTION
This PR adds `#[serde(default)]` to various fields in bundle config structs to prevent deserialization errors when those fields are omitted from Dioxus.toml.

- MacOsSettings: `files`, `hardened_runtime`
- DebianSettings: `files`
- WindowsSettings: `tsp`, `allow_downgrades`
- NsisSettings: `display_language_selector`

Default values for more [bundle] settings #3785

