### PR TITLE
Capture the rustc environment and project it into `run`

### DIFF
--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -70,7 +70,7 @@ impl CommandWithPlatformOverrides<BuildArgs> {
         let ssg = self.shared.ssg;
         let targets = self.into_targets().await?;
 
-        AppBuilder::started(&targets.client, BuildMode::Base)?
+        AppBuilder::started(&targets.client, BuildMode::Base { run: false })?
             .finish_build()
             .await?;
 
@@ -78,7 +78,7 @@ impl CommandWithPlatformOverrides<BuildArgs> {
 
         if let Some(server) = targets.server.as_ref() {
             // If the server is present, we need to build it as well
-            let mut server_build = AppBuilder::started(server, BuildMode::Base)?;
+            let mut server_build = AppBuilder::started(server, BuildMode::Base { run: false })?;
             server_build.finish_build().await?;
 
             // Run SSG and cache static routes

--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -39,7 +39,7 @@ impl Bundle {
 
         let BuildTargets { client, server } = self.args.into_targets().await?;
 
-        AppBuilder::started(&client, BuildMode::Base)?
+        AppBuilder::started(&client, BuildMode::Base { run: false })?
             .finish_build()
             .await?;
 
@@ -47,7 +47,7 @@ impl Bundle {
 
         if let Some(server) = server.as_ref() {
             // If the server is present, we need to build it as well
-            AppBuilder::started(server, BuildMode::Base)?
+            AppBuilder::started(server, BuildMode::Base { run: false })?
                 .finish_build()
                 .await?;
 

--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -198,7 +198,7 @@ pub(crate) async fn serve_all(args: ServeArgs, tracer: &mut TraceController) -> 
                                 }
                             }
                         }
-                        BuildMode::Base | BuildMode::Fat => {
+                        BuildMode::Base { .. } | BuildMode::Fat => {
                             _ = builder
                                 .open(&bundle, &mut devserver)
                                 .await

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -227,7 +227,7 @@ impl AppServer {
     pub(crate) fn initialize(&mut self) {
         let build_mode = match self.use_hotpatch_engine {
             true => BuildMode::Fat,
-            false => BuildMode::Base,
+            false => BuildMode::Base { run: true },
         };
 
         self.client.start(build_mode.clone());
@@ -495,9 +495,9 @@ impl AppServer {
                 self.clear_cached_rsx();
                 server.send_patch_start().await;
             } else {
-                self.client.start_rebuild(BuildMode::Base);
+                self.client.start_rebuild(BuildMode::Base { run: true });
                 if let Some(server) = self.server.as_mut() {
-                    server.start_rebuild(BuildMode::Base);
+                    server.start_rebuild(BuildMode::Base { run: true });
                 }
                 self.clear_hot_reload_changes();
                 self.clear_cached_rsx();
@@ -680,7 +680,7 @@ impl AppServer {
     pub(crate) async fn full_rebuild(&mut self) {
         let build_mode = match self.use_hotpatch_engine {
             true => BuildMode::Fat,
-            false => BuildMode::Base,
+            false => BuildMode::Base { run: true },
         };
 
         self.client.start_rebuild(build_mode.clone());


### PR DESCRIPTION
This PR properly sets the environment variables that cargo sets when it `cargo run`s your app.

This fixes the bevy use case where they rely on CARGO_MANIFEST_DIR being set to locate the asset folder.

To capture the environment, we simply extract the env vars prefixed with `CARGO_` from the `RUSTCWRAPPER`. Previously, we weren't wrapping cargo, so implementing this would've been super annoying, but now that we do, it was a quite easy fix.

~~Note that dioxus itself relies on CARGO_MANIFEST_DIR *not* being set in some cases and I haven't tested those yet.~~

The only case we rely on it is as a fallback when DIOXUS_CLI_ENABLED=false