### PR TITLE
fix: don't eat comments in more situations

### DIFF
--- a/packages/autofmt/src/lib.rs
+++ b/packages/autofmt/src/lib.rs
@@ -97,7 +97,7 @@ pub fn try_fmt_file(
 
         // TESTME
         // Writing *should* not fail but it's possible that it does
-        if writer.write_rsx_call(&body.body).is_err() {
+        if writer.write_rsx_call(&body).is_err() {
             let span = writer.invalid_exprs.pop().unwrap_or_else(Span::call_site);
             return Err(syn::Error::new(span, "Failed emit valid rsx - likely due to partially complete expressions in the rsx! macro"));
         }
@@ -149,7 +149,7 @@ pub fn try_fmt_file(
 /// that passed partial expansion but failed to parse.
 pub fn write_block_out(body: &CallBody) -> Option<String> {
     let mut buf = Writer::new("", IndentOptions::default());
-    buf.write_rsx_call(&body.body).ok()?;
+    buf.write_rsx_call(&body).ok()?;
     buf.consume()
 }
 
@@ -158,7 +158,7 @@ pub fn fmt_block(block: &str, indent_level: usize, indent: IndentOptions) -> Opt
 
     let mut buf = Writer::new(block, indent);
     buf.out.indent_level = indent_level;
-    buf.write_rsx_call(&body.body).ok()?;
+    buf.write_rsx_call(&body).ok()?;
 
     // writing idents leaves the final line ended at the end of the last ident
     if buf.out.buf.contains('\n') {

--- a/packages/autofmt/src/lib.rs
+++ b/packages/autofmt/src/lib.rs
@@ -149,7 +149,7 @@ pub fn try_fmt_file(
 /// that passed partial expansion but failed to parse.
 pub fn write_block_out(body: &CallBody) -> Option<String> {
     let mut buf = Writer::new("", IndentOptions::default());
-    buf.write_rsx_call(&body).ok()?;
+    buf.write_rsx_call(body).ok()?;
     buf.consume()
 }
 

--- a/packages/autofmt/tests/samples/comments.rsx
+++ b/packages/autofmt/tests/samples/comments.rsx
@@ -59,4 +59,69 @@ rsx! {
         // please dont eat me 3
         abc: 123,
     }
+
+    div {
+        // I am just a comment
+    }
+
+    div {
+        "text"
+        // I am just a comment
+    }
+
+    div {
+        div {}
+        // I am just a comment
+    }
+
+    div {
+        {some_expr()}
+        // I am just a comment
+    }
+
+    div {
+        "text" // I am just a comment
+    }
+
+    div {
+        div {} // I am just a comment
+    }
+
+    div {
+        {some_expr()} // I am just a comment
+    }
+
+    div {
+        // Please dont eat me 1
+        div {
+            // Please dont eat me 2
+        }
+        // Please dont eat me 3
+    }
+
+    div {
+        "hi"
+        // Please dont eat me 1
+    }
+    div {
+        "hi" // Please dont eat me 1
+        // Please dont eat me 2
+    }
+
+    // Please dont eat me 2
+    Component {}
+
+    // Please dont eat me 1
+    Component {
+        // Please dont eat me 2
+    }
+
+    // Please dont eat me 1
+    Component {
+        // Please dont eat me 2
+    }
+
+    // Please dont eat me 1
+    //
+    // Please dont eat me 2
 }


### PR DESCRIPTION
Fixes rsx autofmt eating comments in even more situations.

The comment test is quite comprehensive now, so you should see wayyyy less issues with rsx autofmt. 

Also tries to roll in the fixes from https://github.com/DioxusLabs/dioxus/pull/4410