### PR TITLE
Add secure context on android

### DIFF
--- a/packages/cli/assets/android/gen/app/src/main/AndroidManifest.xml.hbs
+++ b/packages/cli/assets/android/gen/app/src/main/AndroidManifest.xml.hbs
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <application android:hasCode="true" android:supportsRtl="true" android:icon="@mipmap/ic_launcher"
         android:extractNativeLibs="true"
         android:allowNativeHeapPointerTagging="false"

--- a/packages/desktop/src/protocol.rs
+++ b/packages/desktop/src/protocol.rs
@@ -7,7 +7,10 @@ use wry::{
     RequestAsyncResponder,
 };
 
-#[cfg(any(target_os = "android", target_os = "windows"))]
+#[cfg(target_os = "android")]
+const EVENTS_PATH: &str = "https://dioxus.index.html/__events";
+
+#[cfg(target_os = "windows")]
 const EVENTS_PATH: &str = "http://dioxus.index.html/__events";
 
 #[cfg(not(any(target_os = "android", target_os = "windows")))]

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -317,7 +317,10 @@ impl WebviewInstance {
             .with_navigation_handler(move |var| {
                 // We don't want to allow any navigation
                 // We only want to serve the index file and assets
-                if var.starts_with("dioxus://") || var.starts_with("http://dioxus.") {
+                if var.starts_with("dioxus://")
+                    || var.starts_with("http://dioxus.")
+                    || var.starts_with("https://dioxus.")
+                {
                     // After the page has loaded once, don't allow any more navigation
                     let page_loaded = page_loaded.swap(true, std::sync::atomic::Ordering::SeqCst);
                     !page_loaded
@@ -332,6 +335,14 @@ impl WebviewInstance {
                 }
             }) // prevent all navigations
             .with_asynchronous_custom_protocol(String::from("dioxus"), request_handler);
+
+        // Enable https scheme on android, needed for secure context API, like the geolocation API
+        #[cfg(target_os = "android")]
+        {
+            use wry::WebViewBuilderExtAndroid as _;
+
+            webview = webview.with_https_scheme(true);
+        };
 
         // Disable the webview default shortcuts to disable the reload shortcut
         #[cfg(target_os = "windows")]


### PR DESCRIPTION
Hi ! This PR adds the secure context on android.

I needed to access the GPS for an android app, and the best way I found was using the geolocation API on js. However, the webview blocked the location request because the webview interpreted the internal url as `http://dioxus.index.html/`. With a lot of digging, I found this bit of doc : https://docs.rs/wry/latest/wry/struct.WebViewBuilder.html#method.with_custom_protocol.

In the future with dioxus-sdk, I have no doubt that a better solution (without JS) will exist, but for the time being, I think it works well enough. And I don't see any downside to use this function.

I have also added 2 rules in the AndroidManifest. I see that it is a handlebars template, so maybe in the future, this should be a cli option ?