### PR TITLE
Fix assets with odd extensions and race condition with the same asset at different paths

### DIFF
--- a/packages/cli-opt/src/file.rs
+++ b/packages/cli-opt/src/file.rs
@@ -97,7 +97,8 @@ pub(crate) fn process_file_to_with_options(
     }
 
     // If everything was successful, rename the temp file to the final output path
-    std::fs::rename(temp_path, output_path).context("Failed to rename output file")?;
+    std::fs::rename(temp_path, output_path)
+        .with_context(|| format!("Failed to rename output file to: {}", output_path.display()))?;
 
     Ok(())
 }

--- a/packages/cli-opt/src/hash.rs
+++ b/packages/cli-opt/src/hash.rs
@@ -152,7 +152,10 @@ pub fn add_hash_to_asset(asset: &mut BundledAsset) {
             };
 
             if let Some(ext) = ext {
-                bundled_path.set_extension(ext);
+                // Push the extension to the bundled path. There may be multiple extensions (e.g. .js.map)
+                // with one left after the file_stem is extracted above so we need to push the extension
+                // instead of setting it
+                bundled_path.as_mut_os_string().push(format!(".{ext}"));
             }
 
             let bundled_path = bundled_path.to_string_lossy().to_string();

--- a/packages/cli-opt/src/lib.rs
+++ b/packages/cli-opt/src/lib.rs
@@ -79,9 +79,14 @@ impl AssetManifest {
             .is_some_and(|assets| assets.contains(asset))
     }
 
-    /// Iterate over all the assets in the manifest
-    pub fn assets(&self) -> impl Iterator<Item = &BundledAsset> {
-        self.assets.values().flat_map(|assets| assets.iter())
+    /// Iterate over all the assets with unique output paths in the manifest. This will not include
+    /// assets that have different source paths, but the same file contents.
+    pub fn unique_assets(&self) -> impl Iterator<Item = &BundledAsset> {
+        let mut seen = HashSet::new();
+        self.assets
+            .values()
+            .flat_map(|assets| assets.iter())
+            .filter(move |asset| seen.insert(asset.bundled_path()))
     }
 
     pub fn load_from_file(path: &Path) -> anyhow::Result<Self> {

--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -637,7 +637,7 @@ impl AppBuilder {
         let asset_dir = self.build.asset_dir();
 
         // Hotpatch asset!() calls
-        for bundled in res.assets.assets() {
+        for bundled in res.assets.unique_assets() {
             let original_artifacts = self
                 .artifacts
                 .as_mut()

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1189,7 +1189,7 @@ impl BuildRequest {
 
         // Create a set of all the paths that new files will be bundled to
         let mut keep_bundled_output_paths: HashSet<_> = assets
-            .assets()
+            .unique_assets()
             .map(|a| asset_dir.join(a.bundled_path()))
             .collect();
 
@@ -1228,7 +1228,7 @@ impl BuildRequest {
         let mut assets_to_transfer = vec![];
 
         // Queue the bundled assets
-        for bundled in assets.assets() {
+        for bundled in assets.unique_assets() {
             let from = PathBuf::from(bundled.absolute_source_path());
             let to = asset_dir.join(bundled.bundled_path());
 
@@ -4310,7 +4310,7 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
         }
 
         // Inject any resources from manganis into the head
-        for asset in assets.assets() {
+        for asset in assets.unique_assets() {
             let asset_path = asset.bundled_path();
             match asset.options().variant() {
                 AssetVariant::Css(css_options) => {

--- a/packages/cli/src/cli/build_assets.rs
+++ b/packages/cli/src/cli/build_assets.rs
@@ -19,7 +19,7 @@ impl BuildAssets {
         let manifest = extract_assets_from_file(&self.executable)?;
 
         create_dir_all(&self.destination)?;
-        for asset in manifest.assets() {
+        for asset in manifest.unique_assets() {
             let source_path = PathBuf::from(asset.absolute_source_path());
             let destination_path = self.destination.join(asset.bundled_path());
             debug!(


### PR DESCRIPTION
This fixes two bugs with the asset system:
1) Assets with multiple extensions like `foo.tar.gz` lost the hash because the second extension  with the hash (`tar-hash`) was replaced instead of pushing a the final extension
2) If the asset system includes two files with an identical content hash, but different source paths they were not deduplicated and one of the threads will fail to write the duplicate asset to the output path

Fixes #4432 