### PR TITLE
Implement asset root path generation for Linux .appimage and .deb

### DIFF
--- a/packages/asset-resolver/src/lib.rs
+++ b/packages/asset-resolver/src/lib.rs
@@ -79,8 +79,8 @@ pub fn serve_asset(path: &str) -> Result<Response<Vec<u8>>, AssetServeError> {
 /// - [x] iOS
 /// - [x] Windows
 /// - [x] Linux (appimage)
+/// - [x] Linux (deb)
 /// - [ ] Linux (rpm)
-/// - [ ] Linux (deb)
 /// - [ ] Android
 #[allow(unreachable_code)]
 fn get_asset_root() -> PathBuf {
@@ -94,6 +94,19 @@ fn get_asset_root() -> PathBuf {
             .parent()
             .unwrap()
             .join("Resources");
+    }
+
+    #[cfg(all(target_os = "linux", not(debug_assertions)))]
+    {
+        // For both Linux .AppImage and .deb packages, the assets are on the path
+        // `../lib/<app_name>` relative to the executable.
+        return cur_exe
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("lib")
+            .join(dioxus_cli_config::bundled_app_name().unwrap());
     }
 
     // For all others, the structure looks like this:

--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -64,6 +64,7 @@ pub const DEVSERVER_PORT_ENV: &str = "DIOXUS_DEVSERVER_PORT";
 pub const ALWAYS_ON_TOP_ENV: &str = "DIOXUS_ALWAYS_ON_TOP";
 pub const ASSET_ROOT_ENV: &str = "DIOXUS_ASSET_ROOT";
 pub const APP_TITLE_ENV: &str = "DIOXUS_APP_TITLE";
+pub const BUNDLED_APP_NAME_ENV: &str = "DIOXUS_BUNDLED_APP_NAME";
 
 #[deprecated(since = "0.6.0", note = "The CLI currently does not set this.")]
 #[doc(hidden)]
@@ -191,6 +192,13 @@ pub fn fullstack_address_or_localhost() -> SocketAddr {
 /// This is used to set the title of the desktop window if the app itself doesn't set it.
 pub fn app_title() -> Option<String> {
     read_env_config!("DIOXUS_APP_TITLE")
+}
+
+/// Get the product name of the application, as generated at build time during bundling.
+///
+/// This is used to generate the asset root path on Linux desktop builds.
+pub fn bundled_app_name() -> Option<String> {
+    read_env_config!("DIOXUS_BUNDLED_APP_NAME")
 }
 
 /// Check if the application should forced to "float" on top of other windows.


### PR DESCRIPTION
This PR addresses #232 to make it possible to bundle Linux .appimage and .deb packages with correct asset root generation.