### PR TITLE
Fix asset location for linux bundles

### DIFF
--- a/packages/asset-resolver/src/lib.rs
+++ b/packages/asset-resolver/src/lib.rs
@@ -99,6 +99,11 @@ fn get_asset_root() -> PathBuf {
     #[cfg(target_os = "linux")]
     {
         // In linux bundles, the assets are placed in the lib/$product_name directory
+        // bin/
+        //   main
+        // lib/
+        //   $product_name/
+        //     assets/
         if let Some(product_name) = dioxus_cli_config::product_name() {
             let asset_dir = cur_exe
                 .parent()

--- a/packages/asset-resolver/src/lib.rs
+++ b/packages/asset-resolver/src/lib.rs
@@ -100,7 +100,13 @@ fn get_asset_root() -> PathBuf {
     {
         // In linux bundles, the assets are placed in the lib/$product_name directory
         if let Some(product_name) = dioxus_cli_config::product_name() {
-            return cur_exe.parent().unwrap().join("lib").join(product_name);
+            return cur_exe
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("lib")
+                .join(product_name);
         }
     }
 

--- a/packages/asset-resolver/src/lib.rs
+++ b/packages/asset-resolver/src/lib.rs
@@ -105,14 +105,11 @@ fn get_asset_root() -> PathBuf {
         //   $product_name/
         //     assets/
         if let Some(product_name) = dioxus_cli_config::product_name() {
-            let asset_dir = cur_exe
-                .parent()
-                .unwrap()
-                .parent()
-                .unwrap()
-                .join("lib")
-                .join(product_name);
-            if asset_dir.exists() {
+            let lib_asset_path = || {
+                let path = cur_exe.parent()?.parent()?.join("lib").join(product_name);
+                path.exists().then_some(path)
+            };
+            if let Some(asset_dir) = lib_asset_path() {
                 return asset_dir;
             }
         }

--- a/packages/asset-resolver/src/lib.rs
+++ b/packages/asset-resolver/src/lib.rs
@@ -80,7 +80,7 @@ pub fn serve_asset(path: &str) -> Result<Response<Vec<u8>>, AssetServeError> {
 /// - [x] Windows
 /// - [x] Linux (appimage)
 /// - [ ] Linux (rpm)
-/// - [ ] Linux (deb)
+/// - [x] Linux (deb)
 /// - [ ] Android
 #[allow(unreachable_code)]
 fn get_asset_root() -> PathBuf {
@@ -100,13 +100,16 @@ fn get_asset_root() -> PathBuf {
     {
         // In linux bundles, the assets are placed in the lib/$product_name directory
         if let Some(product_name) = dioxus_cli_config::product_name() {
-            return cur_exe
+            let asset_dir = cur_exe
                 .parent()
                 .unwrap()
                 .parent()
                 .unwrap()
                 .join("lib")
                 .join(product_name);
+            if asset_dir.exists() {
+                return asset_dir;
+            }
         }
     }
 

--- a/packages/asset-resolver/src/lib.rs
+++ b/packages/asset-resolver/src/lib.rs
@@ -96,6 +96,14 @@ fn get_asset_root() -> PathBuf {
             .join("Resources");
     }
 
+    #[cfg(target_os = "linux")]
+    {
+        // In linux bundles, the assets are placed in the lib/$product_name directory
+        if let Some(product_name) = dioxus_cli_config::product_name() {
+            return cur_exe.parent().unwrap().join("lib").join(product_name);
+        }
+    }
+
     // For all others, the structure looks like this:
     // app.(exe/appimage)
     //   main.exe

--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -331,5 +331,5 @@ pub fn build_id() -> u64 {
 
 /// The product name of the bundled application.
 pub fn product_name() -> Option<String> {
-    read_env_config!(PRODUCT_NAME_ENV)
+    read_env_config!("DIOXUS_PRODUCT_NAME")
 }

--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -64,6 +64,7 @@ pub const DEVSERVER_PORT_ENV: &str = "DIOXUS_DEVSERVER_PORT";
 pub const ALWAYS_ON_TOP_ENV: &str = "DIOXUS_ALWAYS_ON_TOP";
 pub const ASSET_ROOT_ENV: &str = "DIOXUS_ASSET_ROOT";
 pub const APP_TITLE_ENV: &str = "DIOXUS_APP_TITLE";
+pub const PRODUCT_NAME_ENV: &str = "DIOXUS_PRODUCT_NAME";
 
 #[deprecated(since = "0.6.0", note = "The CLI currently does not set this.")]
 #[doc(hidden)]
@@ -326,4 +327,9 @@ pub fn build_id() -> u64 {
             .and_then(|s| s.parse().ok())
             .unwrap_or(0)
     }
+}
+
+/// The product name of the bundled application.
+pub fn product_name() -> Option<String> {
+    read_env_config!(PRODUCT_NAME_ENV)
 }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -323,7 +323,7 @@ use crate::{
 use anyhow::{bail, Context};
 use cargo_metadata::diagnostic::Diagnostic;
 use depinfo::RustcDepInfo;
-use dioxus_cli_config::format_base_path_meta_element;
+use dioxus_cli_config::{format_base_path_meta_element, PRODUCT_NAME_ENV};
 use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV};
 use dioxus_cli_opt::{process_file_to, AssetManifest};
 use itertools::Itertools;
@@ -2423,6 +2423,7 @@ impl BuildRequest {
                 env_vars.push((ASSET_ROOT_ENV.into(), base_path.to_string()));
             }
             env_vars.push((APP_TITLE_ENV.into(), self.config.web.app.title.clone()));
+            env_vars.push((PRODUCT_NAME_ENV.into(), self.bundled_app_name()));
         }
 
         // Assemble the rustflags by peering into the `.cargo/config.toml` file


### PR DESCRIPTION
Linux appimage and dep bundles store the binary in `/bin/binary` and the assets in `/lib/$product_name` directory. This PR changes the resolver to use the correct path.

I have tested this branch with normal release builds and release bundles with appimage and dep on `Ubuntu 22.04.5 LTS` with this project: https://github.com/ealmloff/linux-bundle-dioxus

Addresses (but doesn't totally fix) https://github.com/DioxusLabs/dioxus/issues/4161