### PR TITLE
better logs, don't run codesign if no assets are found

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -1086,7 +1086,7 @@ We checked the folders:
             .args(["find-identity", "-v", "-p", "codesigning"])
             .output()
             .await
-            .context("Failed to run `security find-identity -v -p codesigning`")
+            .context("Failed to run `security find-identity -v -p codesigning` - is `security` in your path?")
             .map(|e| {
                 String::from_utf8(e.stdout)
                     .context("Failed to parse `security find-identity -v -p codesigning`")
@@ -1191,7 +1191,7 @@ We checked the folders:
             .arg(self.build.root_dir())
             .output()
             .await
-            .context("Failed to codesign the app")?;
+            .context("Failed to codesign the app - is `codesign` in your path?")?;
 
         if !output.status.success() {
             bail!(

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1874,7 +1874,7 @@ impl BuildRequest {
             // but is necessary for some linkers to work properly.
             // We ignore its error in case it doesn't recognize the architecture
             if self.linker_flavor() == LinkerFlavor::Darwin {
-                if let Some(ranlib) = self.select_ranlib() {
+                if let Some(ranlib) = Workspace::select_ranlib() {
                     _ = Command::new(ranlib).arg(&out_ar_path).output().await;
                 }
             }
@@ -4605,13 +4605,6 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
         };
 
         Ok(())
-    }
-
-    fn select_ranlib(&self) -> Option<PathBuf> {
-        // prefer the modern llvm-ranlib if they have it
-        which::which("llvm-ranlib")
-            .or_else(|_| which::which("ranlib"))
-            .ok()
     }
 
     /// Assemble a series of `--config key=value` arguments for the build command.


### PR DESCRIPTION
In the Bevy discord, nix users were running into issues because we call out to a variety of tools from PATH, but they purposefully unset their PATH and thus the tools were failing.

This PR adds better logging in a few critical places, pointing people to add the tools to their path.

It also updates our `dx doctor` command to provide `which` locations for these tools and lets users run `dx doctor` from anywhere on their machine, not just from within projects.

The original issue where this occurred:
https://github.com/DioxusLabs/dioxus/issues/4372