### PR TITLE
Allow user to specify =false for default true flags

### DIFF
--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -94,7 +94,7 @@ pub(crate) struct TargetArgs {
     pub(crate) skip_assets: bool,
 
     /// Inject scripts to load the wasm and js files for your dioxus app if they are not already present [default: true]
-    #[clap(long, default_value_t = true, help_heading = HELP_HEADING)]
+    #[clap(long, default_value_t = true, help_heading = HELP_HEADING, num_args = 0..=1)]
     pub(crate) inject_loading_scripts: bool,
 
     /// Experimental: Bundle split the wasm binary into multiple chunks based on `#[wasm_split]` annotations [default: false]
@@ -105,7 +105,7 @@ pub(crate) struct TargetArgs {
     ///
     /// This will make the binary larger and take longer to compile, but will allow you to debug the
     /// wasm binary
-    #[clap(long, default_value_t = true, help_heading = HELP_HEADING)]
+    #[clap(long, default_value_t = true, help_heading = HELP_HEADING, num_args = 0..=1)]
     pub(crate) debug_symbols: bool,
 
     /// Are we building for a device or just the simulator.

--- a/packages/cli/src/cli/update.rs
+++ b/packages/cli/src/cli/update.rs
@@ -18,7 +18,7 @@ pub(crate) struct SelfUpdate {
     pub version: Option<String>,
 
     /// Install the update.
-    #[clap(long, default_value = "true")]
+    #[clap(long, default_value = "true", num_args = 0..=1)]
     pub install: bool,
 
     /// List available versions.


### PR DESCRIPTION
Currently, some CLI flags that default to true cannot be disabled. This change allows users to opt-out with `--install=false` or `--install false`.