### PR TITLE
Downgrade chrono to 0.4.39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,7 @@ fluent-uri = { version = "0.3.2", features = ["serde"] }
 internment = { version = "0.8.6" }
 proc-macro2-diagnostics = { version = "0.10", default-features = false }
 env_logger = "0.11.8"
-chrono = { version = "0.4.41" }
+chrono = { version = "0.4.39" }
 gloo = { version = "0.11.0" }
 gloo-utils = { version = "0.2.0" }
 rustversion = "1.0.21"


### PR DESCRIPTION
Certain packages do not yet support chrono 0.4.40
Examples:
arrow-arith which is used by influxdb3

Arrow-rs will have to update chrono, but as this is deep in dependency chain it will take time to do so. So as we do not require features from chrono >0.4.39, I propose to keep it at 0.4.39.