### PR TITLE
fix: Handle undefined modifier keys in browser autofill events

### DIFF
--- a/packages/html/src/events/keyboard.rs
+++ b/packages/html/src/events/keyboard.rs
@@ -105,9 +105,13 @@ pub struct SerializedKeyboardData {
     key_code: KeyCode,
     #[serde(deserialize_with = "resilient_deserialize_code")]
     code: Code,
+    #[serde(default)]
     alt_key: bool,
+    #[serde(default)]
     ctrl_key: bool,
+    #[serde(default)]
     meta_key: bool,
+    #[serde(default)]
     shift_key: bool,
     location: usize,
     repeat: bool,


### PR DESCRIPTION
Browser autofill can dispatch synthetic keyboard events where modifier keys (`altKey`, `ctrlKey`, etc.) have undefined values instead of `booleans`. This causes WASM binding errors and crashes the application with `BorrowMutError`.

Added `serde(default)` attributes to all modifier key fields in `SerializedKeyboardData` to gracefully handle undefined values by defaulting them to false.

Fixes #4486