### PR TITLE
Vendor OpenSSL on android with google prebuilt libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5321,7 +5321,6 @@ dependencies = [
  "ndk-sys 0.6.0+11769913",
  "objc",
  "objc_id",
- "openssl",
  "percent-encoding",
  "rand 0.9.1",
  "reqwest 0.12.22",
@@ -5411,7 +5410,6 @@ dependencies = [
  "futures-util",
  "getrandom 0.3.3",
  "http-range",
- "openssl",
  "ouroboros",
  "rand 0.9.1",
  "reqwest 0.12.22",
@@ -5668,7 +5666,6 @@ dependencies = [
  "dioxus-native-dom",
  "futures-util",
  "keyboard-types",
- "openssl",
  "rustc-hash 2.1.1",
  "tokio",
  "tracing",
@@ -11615,15 +11612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.1+3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11631,7 +11619,6 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -366,7 +366,7 @@ winit = { version = "0.30.11", features = ["rwh_06"] }
 incremental = true
 
 # crank up the opt level for wasm-split-cli in dev mode
-# important here that lto is on and the debug symbols are present (since they're used by wasm-opt)a
+# important here that lto is on and the debug symbols are present (since they're used by wasm-opt)
 [profile.wasm-split-release]
 inherits = "release"
 opt-level = 'z'
@@ -448,10 +448,6 @@ tokio = { version = "1.46", default-features = false, features = ["sync", "macro
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.46", features = ["full"] }
-
-# force vendored openssl on android
-[target.'cfg(target_os = "android")'.dev-dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
 
 # To make most examples faster to compile, we split out assets and http-related stuff
 # This trims off like 270 dependencies, leading to a significant speedup in compilation time

--- a/packages/cli/assets/android/prebuilt/README.md
+++ b/packages/cli/assets/android/prebuilt/README.md
@@ -1,0 +1,13 @@
+This folder contains prebuilt versions of android crates to make cross-compiling easier.
+
+We use the official prebuilds distributed by google.
+
+You can find the full set of prebuilt libraries that google distributes here:
+
+https://maven.google.com/web/index.html?q=com.android.ndk.thirdparty#com.android.ndk.thirdparty
+
+The version included in `dx` is downloaded from here:
+
+https://maven.google.com/web/index.html?q=com.android.ndk.thirdparty#com.android.ndk.thirdparty:openssl:1.1.1q-beta-1
+
+The SHA of the `.aar` file from google and `dx` are different. The Rust openssl-sys crate expects libcrypto and libssl to be in the same folder, but the `.aar` that google distributes splits the two libraries into two different folders. I (jon) have simply merged the folders together and then re-packed the folder as a `.tar.gz`.

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1147,6 +1147,10 @@ impl BuildRequest {
     async fn write_frameworks(&self, _ctx: &BuildContext, direct_rustc: &RustcArgs) -> Result<()> {
         let framework_dir = self.frameworks_folder();
 
+        // We have some prebuilt stuff that needs to be copied into the framework dir
+        let openssl_dir = AndroidTools::openssl_lib_dir(&self.triple);
+        let openssl_dir_disp = openssl_dir.display().to_string();
+
         for arg in &direct_rustc.link_args {
             // todo - how do we handle windows dlls? we don't want to bundle the system dlls
             // for now, we don't do anything with dlls, and only use .dylibs and .so files
@@ -1186,6 +1190,18 @@ impl BuildRequest {
                     framework_dir.join("libc++_shared.so"),
                 )
                 .with_context(|| "Failed to copy libc++_shared.so into bundle")?;
+            }
+
+            // Copy over libssl and libcrypto if they are present in the link args
+            if arg.contains(openssl_dir_disp.as_str()) && self.bundle == BundleFormat::Android {
+                let libssl = openssl_dir.join("libssl.so");
+                let libcrypto = openssl_dir.join("libcrypto.so");
+                std::fs::copy(&libssl, framework_dir.join("libssl.so")).with_context(|| {
+                    format!("Failed to copy libssl.so into bundle from {libssl:?}")
+                })?;
+                std::fs::copy(&libcrypto, framework_dir.join("libcrypto.so")).with_context(
+                    || format!("Failed to copy libcrypto.so into bundle from {libcrypto:?}"),
+                )?;
             }
         }
 
@@ -2590,17 +2606,21 @@ impl BuildRequest {
 
         // choose the clang target with the highest version
         // Should we filter for only numbers?
-        let clang_builtins_target = std::fs::read_dir(clang_folder)
-            .expect("Unable to get clang target directory")
-            .filter_map(|a| a.ok())
-            .max_by(|a, b| a.file_name().cmp(&b.file_name()))
-            .expect("Unable to get clang target")
-            .path();
-        let clang_rt = format!(
-            "-L{} -lstatic=clang_rt.builtins-{}-android",
-            clang_builtins_target.join("lib").join("linux").display(),
-            rt_builtins(&triple)
-        );
+        let clang_rt = std::fs::read_dir(&clang_folder)
+            .map(|dir| {
+                let clang_builtins_target = dir
+                    .filter_map(|a| a.ok())
+                    .max_by(|a, b| a.file_name().cmp(&b.file_name()))
+                    .map(|s| s.path())
+                    .unwrap_or_else(|| clang_folder.join("clang"));
+
+                format!(
+                    "-L{} -lstatic=clang_rt.builtins-{}-android",
+                    clang_builtins_target.join("lib").join("linux").display(),
+                    rt_builtins(&triple)
+                )
+            })
+            .unwrap_or_default();
 
         let extra_include: String = format!(
             "{}/usr/include/{}",
@@ -2613,6 +2633,9 @@ impl BuildRequest {
             &cargo_ndk_sysroot_path.display(),
             extra_include
         );
+
+        let openssl_lib_dir = AndroidTools::openssl_lib_dir(&self.triple);
+        let openssl_include_dir = AndroidTools::openssl_include_dir();
 
         for env in [
             (cc_key, target_cc.clone().into_os_string()),
@@ -2651,6 +2674,15 @@ impl BuildRequest {
                 linker.into_os_string(),
             ),
             ("ANDROID_NDK_ROOT".to_string(), ndk_home.into_os_string()),
+            (
+                "OPENSSL_LIB_DIR".to_string(),
+                openssl_lib_dir.into_os_string(),
+            ),
+            (
+                "OPENSSL_INCLUDE_DIR".to_string(),
+                openssl_include_dir.into_os_string(),
+            ),
+            ("OPENSSL_LIBS".to_string(), "ssl:crypto".to_string().into()),
             // Set the wry env vars - this is where wry will dump its kotlin files.
             // Their setup is really annyoing and requires us to hardcode `dx` to specific versions of tao/wry.
             (
@@ -4683,6 +4715,11 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
             self.config.application.tailwind_output.clone(),
         )
         .await?;
+
+        // We want to copy over the prebuilt OpenSSL binaries to ~/.dx/prebuilt/openssl-<version>
+        if self.bundle == BundleFormat::Android {
+            AndroidTools::unpack_prebuilt_openssl()?;
+        }
 
         Ok(())
     }

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -78,11 +78,6 @@ ndk = { version = "0.9.0" }
 ndk-sys = { version = "0.6.0" }
 ndk-context = { version = "0.1.1" }
 
-# The `openssl` dependency generally does not know how to cross-compile for Android. To make the lives
-# of our users easier, we automatically enable the `openssl` feature when building for Android.
-# Feature are additive, so users will need to "subtract" this feature if they do not want it.
-openssl = { version = "0.10", features = ["vendored"], optional = true }
-
 # use native tls on other platforms
 [target.'cfg(not(target_os = "android"))'.dependencies]
 tungstenite = { workspace = true, features = ["native-tls"] }
@@ -96,12 +91,11 @@ objc = "0.2.7"
 lazy-js-bundle = { workspace = true }
 
 [features]
-default = ["tokio_runtime", "transparent", "devtools", "openssl-vendored-android"]
+default = ["tokio_runtime", "transparent", "devtools"]
 tokio_runtime = ["dep:tokio"]
 fullscreen = ["wry/fullscreen"]
 devtools = ["wry/devtools", "dep:dioxus-devtools", "dioxus-signals"]
 transparent = ["wry/transparent"]
-openssl-vendored-android = ["openssl"]
 gnu = []
 
 [package.metadata.docs.rs]

--- a/packages/native/Cargo.toml
+++ b/packages/native/Cargo.toml
@@ -10,14 +10,13 @@ homepage = "https://dioxuslabs.com/learn/0.6/getting_started"
 keywords = ["dom", "ui", "gui", "react"]
 
 [features]
-default = ["accessibility", "hot-reload", "tracing", "net", "svg", "system-fonts", "openssl-vendored-android"]
+default = ["accessibility", "hot-reload", "tracing", "net", "svg", "system-fonts"]
 svg = ["blitz-dom/svg", "blitz-paint/svg"]
 net = ["dep:tokio", "dep:blitz-net"]
 accessibility = ["blitz-shell/accessibility", "blitz-dom/accessibility"]
 tracing = ["dep:tracing", "blitz-shell/tracing", "blitz-dom/tracing"]
 hot-reload = ["dep:dioxus-cli-config", "dep:dioxus-devtools"]
 system-fonts = ["blitz-dom/system_fonts"]
-openssl-vendored-android = ["openssl"]
 autofocus = []
 
 [dependencies]
@@ -51,9 +50,6 @@ tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
 tracing = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 futures-util = { workspace = true }
-
-[target.'cfg(target_os = "android")'.dependencies]
-openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This PR attempts to fix all openssl and crypto related issues by vendoring prebuilt OpenSSL binaries downloaded from google's maven repository.

https://android-developers.googleblog.com/2020/02/native-dependencies-in-android-studio-40.html

The binaries were downloaded here:

https://maven.google.com/web/index.html?q=com.android.ndk.thirdparty#com.android.ndk.thirdparty:openssl:1.1.1q-beta-1

I unpacked and repacked the `.aar` files because google's format is not compatible with openssl-sys.