### PR TITLE
Rebuild router on every hot reload message

### DIFF
--- a/packages/server/src/launch.rs
+++ b/packages/server/src/launch.rs
@@ -144,59 +144,58 @@ async fn serve_server(
                         if hot_reload_msg.for_build_id == Some(dioxus_cli_config::build_id()) {
                             if let Some(table) = hot_reload_msg.jump_table {
                                 unsafe { dioxus_devtools::subsecond::apply_patch(table).unwrap() };
-
-                                let mut new_router = axum::Router::new().serve_static_assets();
-                                let new_cfg = ServeConfig::new().unwrap();
-
-                                let server_fn_iter = collect_raw_server_fns();
-
-                                // de-duplicate iteratively by preferring the most recent (first, since it's linked)
-                                let mut server_fn_map: HashMap<_, _> = HashMap::new();
-                                for f in server_fn_iter.into_iter().rev() {
-                                    server_fn_map.insert(f.path(), f);
-                                }
-
-                                for (_, fn_) in server_fn_map {
-                                    tracing::trace!(
-                                        "Registering server function: {:?} {:?}",
-                                        fn_.path(),
-                                        fn_.method()
-                                    );
-                                    new_router = crate::register_server_fn_on_router(
-                                        fn_,
-                                        new_router,
-                                        new_cfg.context_providers.clone(),
-                                    );
-                                }
-
-                                let hot_root = subsecond::HotFn::current(original_root);
-                                let new_root_addr = hot_root.ptr_address().0 as usize as *const ();
-                                let new_root = unsafe {
-                                    std::mem::transmute::<*const (), fn() -> Element>(new_root_addr)
-                                };
-
-                                crate::document::reset_renderer();
-
-                                let state = RenderHandleState::new(new_cfg.clone(), new_root)
-                                    .with_ssr_state(SSRState::new(&new_cfg));
-
-                                let fallback_handler =
-                                    axum::routing::get(render_handler).with_state(state);
-
-                                make_service = apply_base_path(
-                                    new_router.fallback(fallback_handler),
-                                    new_root,
-                                    new_cfg.clone(),
-                                    base_path().map(|s| s.to_string()),
-                                )
-                                .into_make_service();
-
-                                shutdown_tx.send_modify(|i| {
-                                    *i += 1;
-                                    hr_idx += 1;
-                                });
                             }
                         }
+
+                        let mut new_router = axum::Router::new().serve_static_assets();
+                        let new_cfg = ServeConfig::new().unwrap();
+
+                        let server_fn_iter = collect_raw_server_fns();
+
+                        // de-duplicate iteratively by preferring the most recent (first, since it's linked)
+                        let mut server_fn_map: HashMap<_, _> = HashMap::new();
+                        for f in server_fn_iter.into_iter().rev() {
+                            server_fn_map.insert(f.path(), f);
+                        }
+
+                        for (_, fn_) in server_fn_map {
+                            tracing::trace!(
+                                "Registering server function: {:?} {:?}",
+                                fn_.path(),
+                                fn_.method()
+                            );
+                            new_router = crate::register_server_fn_on_router(
+                                fn_,
+                                new_router,
+                                new_cfg.context_providers.clone(),
+                            );
+                        }
+
+                        let hot_root = subsecond::HotFn::current(original_root);
+                        let new_root_addr = hot_root.ptr_address().0 as usize as *const ();
+                        let new_root = unsafe {
+                            std::mem::transmute::<*const (), fn() -> Element>(new_root_addr)
+                        };
+
+                        crate::document::reset_renderer();
+
+                        let state = RenderHandleState::new(new_cfg.clone(), new_root)
+                            .with_ssr_state(SSRState::new(&new_cfg));
+
+                        let fallback_handler = axum::routing::get(render_handler).with_state(state);
+
+                        make_service = apply_base_path(
+                            new_router.fallback(fallback_handler),
+                            new_root,
+                            new_cfg.clone(),
+                            base_path().map(|s| s.to_string()),
+                        )
+                        .into_make_service();
+
+                        shutdown_tx.send_modify(|i| {
+                            *i += 1;
+                            hr_idx += 1;
+                        });
                     }
                     DevserverMsg::FullReloadStart => {}
                     DevserverMsg::FullReloadFailed => {}


### PR DESCRIPTION
This is an attempt to fix magic number/word error when in fullstack mode and hot patching is active:
```
13:39:49 [web] panicked at /home/sebba/.cargo/git/checkouts/dioxus-d8abd2ecf6e8b5b4/a519fba/packages/subsecond/subsecond/src/lib.rs:647:10:
called `Result::unwrap()` on an `Err` value: JsValue(CompileError: wasm validation error: at offset 4: failed to match magic number)
```

**Why this happens?**
This bug is present only in fullstack mode, the cause is axum router that serves static assets needs to be rebuilt to serve newly added file, and rebuild was only triggered if incoming hot-reload message included a server patch jumptable. 

This meant if client didn't generate wasm patch file before server patch was ready, router would respond with a 404 even if the file was present in the filesystem, and magic number error would apear

**The fix:**
I'm not sure if this is the right way to fix this, but it does work in web and desktop targets without issues.
Currently change is very simple, router rebuild logic was moved outside conditional that required message to be a server patch, so router now gets rebuilt on every patch

**Limitations of the current fix:**
There is one "downside" to this patch, if developers setup axum server manually dev tools are never connected, see [launch.rs](https://github.com/DioxusLabs/dioxus/blob/871998e19e51880988de18eeadf320b39848844c/packages/server/src/launch.rs#L61) for more info

The manual approach looks something like this, taken from https://dioxuslabs.com/learn/0.6/guides/fullstack/axum
```rust
#[cfg(feature = "server")]
async fn launch_server(component: fn() -> Element) {
    use std::net::{IpAddr, Ipv4Addr, SocketAddr};

    // Get the address the server should run on. If the CLI is running, the CLI proxies fullstack into the main address
    // and we use the generated address the CLI gives us
    let ip =
        dioxus::cli_config::server_ip().unwrap_or_else(|| IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
    let port = dioxus::cli_config::server_port().unwrap_or(8080);
    let address = SocketAddr::new(ip, port);
    let listener = tokio::net::TcpListener::bind(address).await.unwrap();
    let router = axum::Router::new()
        // serve_dioxus_application adds routes to server side render the application, serve static assets, and register server functions
        .serve_dioxus_application(ServeConfigBuilder::default(), App)
        .into_make_service();
    axum::serve(listener, router).await.unwrap();
}
```