### PR TITLE
Clarify telemetry paragraph about rollups

### DIFF
--- a/packages/cli-telemetry/src/lib.rs
+++ b/packages/cli-telemetry/src/lib.rs
@@ -18,7 +18,8 @@
 //! - Heartbeat: helps us track version distribution of the CLI and critical "failures on launch" useful during new version rollouts.
 //! - Rollups: helps us track performance and issues over time, as well as usage of various commands.
 //!
-//! If you don't run the CLI, then we won't send any data. Rollups are not done in background processes.
+//! Rollups are not done in background processes, but rather directly by the `dx` CLI.
+//! If you don't run the CLI, then we won't send any data.
 //!
 //! We don't collect any PII, but we do collect three "controversial" pieces of data:
 //! - the target triple of your system (OS, arch, etc)


### PR DESCRIPTION
[Context](https://discord.com/channels/899851952891002890/929946920628138036/1404776484798726195)

The current phrasing is confusing. The "Rollups are not done in background processes." sounds like an unrelated sentence that implies "Rollups are done in foreground processes."

Simply by switching the order of sentences it makes more sense. Further explaining ambiguous sentence hopefully removes any confusion that one might have.
