### PR TITLE
Rename unchecked methods to extended

### DIFF
--- a/examples/dog_app.rs
+++ b/examples/dog_app.rs
@@ -75,7 +75,7 @@ fn BreedPic(breed: WriteSignal<String>) -> Element {
             .await
     });
 
-    match fut.read_unchecked().as_ref() {
+    match fut.read_extended().as_ref() {
         Some(Ok(resp)) => rsx! {
             div {
                 button { onclick: move |_| fut.restart(), padding: "5px", background_color: "gray", color: "white", border_radius: "5px", "Click to fetch another doggo" }

--- a/examples/suspense.rs
+++ b/examples/suspense.rs
@@ -78,7 +78,7 @@ fn Doggo() -> Element {
         }
     })?;
 
-    match value.read_unchecked().as_ref() {
+    match value.read_extended().as_ref() {
         Ok(resp) => rsx! {
             button { onclick: move |_| resource.restart(), "Click to fetch another doggo" }
             div { img { max_width: "500px", max_height: "500px", src: "{resp.message}" } }

--- a/packages/autofmt/tests/samples/spaces.rsx
+++ b/packages/autofmt/tests/samples/spaces.rsx
@@ -1,5 +1,5 @@
 rsx! {
-    if let Some(Some(record)) = &*records.read_unchecked() {
+    if let Some(Some(record)) = &*records.read_extended() {
         {
             let (label, value): (Vec<String>, Vec<f64>) = record
                 .iter()

--- a/packages/core/tests/memory_leak.rs
+++ b/packages/core/tests/memory_leak.rs
@@ -13,7 +13,7 @@ async fn test_for_memory_leaks() {
             spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
-                    let val = *count.peek_unchecked();
+                    let val = *count.peek_extended();
                     if val == 70 {
                         count.set(0);
                     } else {

--- a/packages/hooks/docs/use_resource.md
+++ b/packages/hooks/docs/use_resource.md
@@ -25,7 +25,7 @@ fn app() -> Element {
         // conditionally render elements based off if it's future
         // finished (Some(Ok(_)), errored Some(Err(_)),
         // or is still running (None)
-        match &*current_weather.read_unchecked() {
+        match &*current_weather.read_extended() {
             Some(Ok(weather)) => rsx! { WeatherElement { weather } },
             Some(Err(e)) => rsx! { p { "Loading weather failed, {e}" } },
             None =>  rsx! { p { "Loading..." } }

--- a/packages/hooks/src/use_future.rs
+++ b/packages/hooks/src/use_future.rs
@@ -168,17 +168,17 @@ impl Readable for UseFuture {
     type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read_unchecked(
+    fn try_read_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
-        self.state.try_read_unchecked()
+        self.state.try_read_extended()
     }
 
     #[track_caller]
-    fn try_peek_unchecked(
+    fn try_peek_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
-        self.state.try_peek_unchecked()
+        self.state.try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers {

--- a/packages/hooks/src/use_resource.rs
+++ b/packages/hooks/src/use_resource.rs
@@ -104,8 +104,8 @@ where
 ///
 ///     // Since our resource may not be ready yet, the value is an Option. Our request may also fail, so the get function returns a Result
 ///     // The complete type we need to match is `Option<Result<String, reqwest::Error>>`
-///     // We can use `read_unchecked` to keep our matching code in one statement while avoiding a temporary variable error (this is still completely safe because dioxus checks the borrows at runtime)
-///     match &*resource.read_unchecked() {
+///     // We can use `read_extended` to keep our matching code in one statement while avoiding a temporary variable error (this is still completely safe because dioxus checks the borrows at runtime)
+///     match &*resource.read_extended() {
 ///         Some(Ok(value)) => rsx! { "{value:?}" },
 ///         Some(Err(err)) => rsx! { "Error: {err}" },
 ///         None => rsx! { "Loading..." },
@@ -402,8 +402,8 @@ impl<T> Resource<T> {
     ///
     ///     // Since our resource may not be ready yet, the value is an Option. Our request may also fail, so the get function returns a Result
     ///     // The complete type we need to match is `Option<Result<String, reqwest::Error>>`
-    ///     // We can use `read_unchecked` to keep our matching code in one statement while avoiding a temporary variable error (this is still completely safe because dioxus checks the borrows at runtime)
-    ///     match &*value.read_unchecked() {
+    ///     // We can use `read_extended` to keep our matching code in one statement while avoiding a temporary variable error (this is still completely safe because dioxus checks the borrows at runtime)
+    ///     match &*value.read_extended() {
     ///         Some(Ok(value)) => rsx! { "{value:?}" },
     ///         Some(Err(err)) => rsx! { "Error: {err}" },
     ///         None => rsx! { "Loading..." },
@@ -441,17 +441,17 @@ impl<T> Readable for Resource<T> {
     type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read_unchecked(
+    fn try_read_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
-        self.value.try_read_unchecked()
+        self.value.try_read_extended()
     }
 
     #[track_caller]
-    fn try_peek_unchecked(
+    fn try_peek_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
-        self.value.try_peek_unchecked()
+        self.value.try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers {

--- a/packages/router/src/contexts/router.rs
+++ b/packages/router/src/contexts/router.rs
@@ -201,7 +201,7 @@ impl RouterContext {
 
     pub(crate) fn push_any(&self, target: NavigationTarget) -> Option<ExternalNavigationFailure> {
         {
-            let mut write = self.inner.write_unchecked();
+            let mut write = self.inner.write_extended();
             match target {
                 NavigationTarget::Internal(p) => history().push(p),
                 NavigationTarget::External(e) => return write.external(e),
@@ -217,7 +217,7 @@ impl RouterContext {
     pub fn push(&self, target: impl Into<NavigationTarget>) -> Option<ExternalNavigationFailure> {
         let target = target.into();
         {
-            let mut write = self.inner.write_unchecked();
+            let mut write = self.inner.write_extended();
             match target {
                 NavigationTarget::Internal(p) => {
                     let history = history();
@@ -239,7 +239,7 @@ impl RouterContext {
     ) -> Option<ExternalNavigationFailure> {
         let target = target.into();
         {
-            let mut state = self.inner.write_unchecked();
+            let mut state = self.inner.write_extended();
             match target {
                 NavigationTarget::Internal(p) => {
                     let history = history();
@@ -291,7 +291,7 @@ impl RouterContext {
 
     /// Clear any unresolved errors
     pub fn clear_error(&self) {
-        let mut write_inner = self.inner.write_unchecked();
+        let mut write_inner = self.inner.write_extended();
         write_inner.unresolved_error = None;
 
         write_inner.update_subscribers();
@@ -303,7 +303,7 @@ impl RouterContext {
     }
 
     pub(crate) fn render_error(&self) -> Option<Element> {
-        let inner_write = self.inner.write_unchecked();
+        let inner_write = self.inner.write_extended();
         inner_write.subscribe_to_current_context();
         inner_write
             .unresolved_error
@@ -318,7 +318,7 @@ impl RouterContext {
             let callback = callback.clone();
             drop(self_read);
             if let Some(new) = callback(myself) {
-                let mut self_write = self.inner.write_unchecked();
+                let mut self_write = self.inner.write_extended();
                 match new {
                     NavigationTarget::Internal(p) => {
                         let history = history();

--- a/packages/signals/docs/signals.md
+++ b/packages/signals/docs/signals.md
@@ -58,7 +58,7 @@ Just like `RefCell<T>`, Signal checks borrows at runtime. If you read and write 
 # use dioxus::prelude::*;
 let mut signal = use_signal(|| 0);
 // If you create a read and hold it while you write to the signal, it will panic
-let read = signal.read_unchecked();
+let read = signal.read_extended();
 // This will panic
 signal += 1;
 println!("{}", read);

--- a/packages/signals/src/boxed.rs
+++ b/packages/signals/src/boxed.rs
@@ -105,34 +105,26 @@ impl<T: ?Sized> Readable for ReadSignal<T> {
     type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_read_unchecked()
+        self.value.try_peek_extended().unwrap().try_read_extended()
     }
 
     #[track_caller]
-    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>>
+    fn try_peek_extended(&self) -> BorrowResult<ReadableRef<'static, Self>>
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_peek_unchecked()
+        self.value.try_peek_extended().unwrap().try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers
     where
         T: 'static,
     {
-        self.value.try_peek_unchecked().unwrap().subscribers()
+        self.value.try_peek_extended().unwrap().subscribers()
     }
 }
 
@@ -223,22 +215,18 @@ impl<W: Readable> Readable for BoxWriteMetadata<W> {
 
     type Storage = W::Storage;
 
-    fn try_read_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
         W::Target: 'static,
     {
-        self.value.try_read_unchecked()
+        self.value.try_read_extended()
     }
 
-    fn try_peek_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
+    fn try_peek_extended(&self) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
         W::Target: 'static,
     {
-        self.value.try_peek_unchecked()
+        self.value.try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers
@@ -256,14 +244,14 @@ where
 {
     type WriteMetadata = Box<dyn Any>;
 
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<crate::WritableRef<'static, Self>, generational_box::BorrowMutError>
     where
         W::Target: 'static,
     {
         self.value
-            .try_write_unchecked()
+            .try_write_extended()
             .map(|w| w.map_metadata(|data| Box::new(data) as Box<dyn Any>))
     }
 }
@@ -316,50 +304,39 @@ impl<T: ?Sized> Readable for WriteSignal<T> {
     type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_read_unchecked()
+        self.value.try_peek_extended().unwrap().try_read_extended()
     }
 
     #[track_caller]
-    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>>
+    fn try_peek_extended(&self) -> BorrowResult<ReadableRef<'static, Self>>
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_peek_unchecked()
+        self.value.try_peek_extended().unwrap().try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers
     where
         T: 'static,
     {
-        self.value.try_peek_unchecked().unwrap().subscribers()
+        self.value.try_peek_extended().unwrap().subscribers()
     }
 }
 
 impl<T: ?Sized> Writable for WriteSignal<T> {
     type WriteMetadata = Box<dyn Any>;
 
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<crate::WritableRef<'static, Self>, generational_box::BorrowMutError>
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_write_unchecked()
+        self.value.try_peek_extended().unwrap().try_write_extended()
     }
 }
 

--- a/packages/signals/src/copy_value.rs
+++ b/packages/signals/src/copy_value.rs
@@ -153,7 +153,7 @@ impl<T, S: Storage<T>> Readable for CopyValue<T, S> {
     type Storage = S;
 
     #[track_caller]
-    fn try_read_unchecked(
+    fn try_read_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
         crate::warnings::copy_value_hoisted(self, std::panic::Location::caller());
@@ -161,7 +161,7 @@ impl<T, S: Storage<T>> Readable for CopyValue<T, S> {
     }
 
     #[track_caller]
-    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>> {
+    fn try_peek_extended(&self) -> BorrowResult<ReadableRef<'static, Self>> {
         crate::warnings::copy_value_hoisted(self, std::panic::Location::caller());
         self.value.try_read()
     }
@@ -175,7 +175,7 @@ impl<T, S: Storage<T>> Writable for CopyValue<T, S> {
     type WriteMetadata = ();
 
     #[track_caller]
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError> {
         crate::warnings::copy_value_hoisted(self, std::panic::Location::caller());

--- a/packages/signals/src/global/mod.rs
+++ b/packages/signals/src/global/mod.rs
@@ -52,21 +52,19 @@ where
     type Storage = T::Storage;
 
     #[track_caller]
-    fn try_read_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
         R: 'static,
     {
-        self.resolve().try_read_unchecked()
+        self.resolve().try_read_extended()
     }
 
     #[track_caller]
-    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>>
+    fn try_peek_extended(&self) -> BorrowResult<ReadableRef<'static, Self>>
     where
         R: 'static,
     {
-        self.resolve().try_peek_unchecked()
+        self.resolve().try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers
@@ -84,10 +82,10 @@ where
     type WriteMetadata = T::WriteMetadata;
 
     #[track_caller]
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError> {
-        self.resolve().try_write_unchecked()
+        self.resolve().try_write_extended()
     }
 }
 
@@ -97,7 +95,7 @@ where
 {
     /// Write this value
     pub fn write(&self) -> WritableRef<'static, T, R> {
-        self.resolve().try_write_unchecked().unwrap()
+        self.resolve().try_write_extended().unwrap()
     }
 
     /// Run a closure with a mutable reference to the signal's value.

--- a/packages/signals/src/impls.rs
+++ b/packages/signals/src/impls.rs
@@ -20,16 +20,16 @@
 ///     type Target = T;
 ///     type Storage = S;
 ///
-///     fn try_read_unchecked(
+///     fn try_read_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
-///     fn try_peek_unchecked(
+///     fn try_peek_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
 ///     fn subscribers(&self) -> Subscribers where T: 'static {
@@ -87,16 +87,16 @@ macro_rules! default_impl {
 ///     type Target = T;
 ///     type Storage = S;
 ///
-///     fn try_read_unchecked(
+///     fn try_read_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
-///     fn try_peek_unchecked(
+///     fn try_peek_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
 ///     fn subscribers(&self) -> Subscribers where T: 'static {
@@ -165,16 +165,16 @@ macro_rules! read_impls {
 ///     type Target = T;
 ///     type Storage = S;
 ///
-///     fn try_read_unchecked(
+///     fn try_read_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
-///     fn try_peek_unchecked(
+///     fn try_peek_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
 ///     fn subscribers(&self) -> Subscribers where T: 'static {
@@ -246,16 +246,16 @@ macro_rules! fmt_impls {
 ///     type Target = T;
 ///     type Storage = S;
 ///
-///     fn try_read_unchecked(
+///     fn try_read_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
-///     fn try_peek_unchecked(
+///     fn try_peek_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
 ///     fn subscribers(&self) -> Subscribers where T: 'static {
@@ -311,22 +311,22 @@ macro_rules! eq_impls {
 ///     type Target = T;
 ///     type Storage = S;
 ///
-///     fn try_read_unchecked(
+///     fn try_read_extended(
 ///         &self,
 ///     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> where T: 'static {
-///         self.value.try_read_unchecked()
+///         self.value.try_read_extended()
 ///     }
 ///
-///     fn peek_unchecked(&self) -> ReadableRef<'static, Self> where T: 'static {
-///         self.value.read_unchecked()
+///     fn peek_extended(&self) -> ReadableRef<'static, Self> where T: 'static {
+///         self.value.read_extended()
 ///     }
 /// }
 ///
 /// impl<T: 'static, S: Storage<T> + 'static> Writable for MyCopyValue<T, S> {
-///     fn try_write_unchecked(
+///     fn try_write_extended(
 ///         &self,
 ///     ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError> where T: 'static {
-///         self.value.try_write_unchecked()
+///         self.value.try_write_extended()
 ///     }
 ///
 ///     //...

--- a/packages/signals/src/map.rs
+++ b/packages/signals/src/map.rs
@@ -55,15 +55,15 @@ where
     type Target = O;
     type Storage = V::Storage;
 
-    fn try_read_unchecked(
+    fn try_read_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError> {
-        let value = self.value.try_read_unchecked()?;
+        let value = self.value.try_read_extended()?;
         Ok(V::Storage::map(value, |v| (self.map_fn)(v)))
     }
 
-    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>> {
-        let value = self.value.try_peek_unchecked()?;
+    fn try_peek_extended(&self) -> BorrowResult<ReadableRef<'static, Self>> {
+        let value = self.value.try_peek_extended()?;
         Ok(V::Storage::map(value, |v| (self.map_fn)(v)))
     }
 

--- a/packages/signals/src/map_mut.rs
+++ b/packages/signals/src/map_mut.rs
@@ -69,21 +69,19 @@ where
     type Target = O;
     type Storage = V::Storage;
 
-    fn try_read_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
         O: 'static,
     {
-        let value = self.value.try_read_unchecked()?;
+        let value = self.value.try_read_extended()?;
         Ok(V::Storage::map(value, |v| (self.map_fn)(v)))
     }
 
-    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>>
+    fn try_peek_extended(&self) -> BorrowResult<ReadableRef<'static, Self>>
     where
         O: 'static,
     {
-        let value = self.value.try_peek_unchecked()?;
+        let value = self.value.try_peek_extended()?;
         Ok(V::Storage::map(value, |v| (self.map_fn)(v)))
     }
 
@@ -105,10 +103,10 @@ where
 {
     type WriteMetadata = V::WriteMetadata;
 
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError> {
-        let value = self.value.try_write_unchecked()?;
+        let value = self.value.try_write_extended()?;
         Ok(WriteLock::map(value, |v| (self.map_fn_mut)(v)))
     }
 }

--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -164,14 +164,12 @@ where
     type Storage = UnsyncStorage;
 
     #[track_caller]
-    fn try_read_unchecked(
-        &self,
-    ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
         T: 'static,
     {
         // Read the inner generational box instead of the signal so we have more fine grained control over exactly when the subscription happens
-        let read = self.inner.inner.try_read_unchecked()?;
+        let read = self.inner.inner.try_read_extended()?;
 
         let needs_update = self
             .update
@@ -182,7 +180,7 @@ where
             drop(read);
             // We shouldn't be subscribed to the value here so we don't trigger the scope we are currently in to rerun even though that scope got the latest value because we synchronously update the value: https://github.com/DioxusLabs/dioxus/issues/2416
             self.recompute();
-            self.inner.inner.try_read_unchecked()
+            self.inner.inner.try_read_extended()
         } else {
             Ok(read)
         };
@@ -200,11 +198,11 @@ where
     ///
     /// If the signal has been dropped, this will panic.
     #[track_caller]
-    fn try_peek_unchecked(&self) -> BorrowResult<ReadableRef<'static, Self>>
+    fn try_peek_extended(&self) -> BorrowResult<ReadableRef<'static, Self>>
     where
         T: 'static,
     {
-        self.inner.try_peek_unchecked()
+        self.inner.try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers

--- a/packages/signals/src/read.rs
+++ b/packages/signals/src/read.rs
@@ -42,10 +42,10 @@ pub trait Readable {
     /// The type of the storage this readable uses.
     type Storage: AnyStorage;
 
-    /// Try to get a reference to the value without checking the lifetime. This will subscribe the current scope to the signal.
+    /// Try to get a reference to the value without checking the lifetime - extending the lifetime to 'static. This will subscribe the current scope to the signal.
     ///
     /// NOTE: This method is completely safe because borrow checking is done at runtime.
-    fn try_read_unchecked(
+    fn try_read_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
@@ -55,7 +55,7 @@ pub trait Readable {
     /// been dropped, this will return an error.
     ///
     /// NOTE: This method is completely safe because borrow checking is done at runtime.
-    fn try_peek_unchecked(
+    fn try_peek_extended(
         &self,
     ) -> Result<ReadableRef<'static, Self>, generational_box::BorrowError>
     where
@@ -86,19 +86,19 @@ pub trait ReadableExt: Readable {
     where
         Self::Target: 'static,
     {
-        self.try_read_unchecked()
+        self.try_read_extended()
             .map(Self::Storage::downcast_lifetime_ref)
     }
 
-    /// Get a reference to the value without checking the lifetime. This will subscribe the current scope to the signal.
+    /// Get a reference to the value without checking the lifetime - extending the lifetime to 'static. This will subscribe the current scope to the signal.
     ///
     /// NOTE: This method is completely safe because borrow checking is done at runtime.
     #[track_caller]
-    fn read_unchecked(&self) -> ReadableRef<'static, Self>
+    fn read_extended(&self) -> ReadableRef<'static, Self>
     where
         Self::Target: 'static,
     {
-        self.try_read_unchecked().unwrap()
+        self.try_read_extended().unwrap()
     }
 
     /// Get the current value of the state without subscribing to updates. If the value has been dropped, this will panic.
@@ -140,7 +140,7 @@ pub trait ReadableExt: Readable {
     where
         Self::Target: 'static,
     {
-        Self::Storage::downcast_lifetime_ref(self.peek_unchecked())
+        Self::Storage::downcast_lifetime_ref(self.peek_extended())
     }
 
     /// Try to peek the current value of the signal without subscribing to updates. If the value has
@@ -150,19 +150,19 @@ pub trait ReadableExt: Readable {
     where
         Self::Target: 'static,
     {
-        self.try_peek_unchecked()
+        self.try_peek_extended()
             .map(Self::Storage::downcast_lifetime_ref)
     }
 
-    /// Get the current value of the signal without checking the lifetime. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
+    /// Get the current value of the signal without checking the lifetime - extending the lifetime to 'static. **Unlike read, this will not subscribe the current scope to the signal which can cause parts of your UI to not update.**
     ///
     /// If the signal has been dropped, this will panic.
     #[track_caller]
-    fn peek_unchecked(&self) -> ReadableRef<'static, Self>
+    fn peek_extended(&self) -> ReadableRef<'static, Self>
     where
         Self::Target: 'static,
     {
-        self.try_peek_unchecked().unwrap()
+        self.try_peek_extended().unwrap()
     }
 
     /// Map the references of the readable value to a new type. This lets you provide a view

--- a/packages/signals/src/write.rs
+++ b/packages/signals/src/write.rs
@@ -38,10 +38,10 @@ pub trait Writable: Readable {
     /// Additional data associated with the write reference.
     type WriteMetadata;
 
-    /// Try to get a mutable reference to the value without checking the lifetime. This will update any subscribers.
+    /// Try to get a mutable reference to the value without checking the lifetime - extending the lifetime to 'static. This will update any subscribers.
     ///
     /// NOTE: This method is completely safe because borrow checking is done at runtime.
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<WritableRef<'static, Self>, generational_box::BorrowMutError>
     where
@@ -274,18 +274,18 @@ pub trait WritableExt: Writable {
     where
         Self::Target: 'static,
     {
-        self.try_write_unchecked().map(WriteLock::downcast_lifetime)
+        self.try_write_extended().map(WriteLock::downcast_lifetime)
     }
 
-    /// Get a mutable reference to the value without checking the lifetime. This will update any subscribers.
+    /// Get a mutable reference to the value without checking the lifetime - extending the lifetime to 'static. This will update any subscribers.
     ///
     /// NOTE: This method is completely safe because borrow checking is done at runtime.
     #[track_caller]
-    fn write_unchecked(&self) -> WritableRef<'static, Self>
+    fn write_extended(&self) -> WritableRef<'static, Self>
     where
         Self::Target: 'static,
     {
-        self.try_write_unchecked().unwrap()
+        self.try_write_extended().unwrap()
     }
 
     /// Map the references and mutable references of the writable value to a new type. This lets you provide a view
@@ -571,7 +571,7 @@ impl<'a, T: 'static, R: Writable<Target = Vec<T>>> Iterator for WritableValueIte
         let index = self.index;
         self.index += 1;
         WriteLock::filter_map(
-            self.value.try_write_unchecked().unwrap(),
+            self.value.try_write_extended().unwrap(),
             |v: &mut Vec<T>| v.get_mut(index),
         )
         .map(WriteLock::downcast_lifetime)

--- a/packages/stores/src/impls/btreemap.rs
+++ b/packages/stores/src/impls/btreemap.rs
@@ -73,7 +73,7 @@ impl<Lens: Readable<Target = BTreeMap<K, V>> + 'static, K: 'static, V: 'static>
         Lens: Clone,
     {
         self.selector().track_shallow();
-        let keys: Vec<_> = self.selector().peek_unchecked().keys().cloned().collect();
+        let keys: Vec<_> = self.selector().peek_extended().keys().cloned().collect();
         keys.into_iter().map(move |key| {
             let value = self.clone().get(key.clone()).unwrap();
             (key, value)
@@ -275,11 +275,11 @@ where
 
     type Storage = Write::Storage;
 
-    fn try_read_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    fn try_read_extended(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
     where
         Self::Target: 'static,
     {
-        self.write.try_read_unchecked().map(|value| {
+        self.write.try_read_extended().map(|value| {
             Self::Storage::map(value, |value: &Write::Target| {
                 value
                     .get(&self.index)
@@ -288,11 +288,11 @@ where
         })
     }
 
-    fn try_peek_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    fn try_peek_extended(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
     where
         Self::Target: 'static,
     {
-        self.write.try_peek_unchecked().map(|value| {
+        self.write.try_peek_extended().map(|value| {
             Self::Storage::map(value, |value: &Write::Target| {
                 value
                     .get(&self.index)
@@ -317,13 +317,13 @@ where
 {
     type WriteMetadata = Write::WriteMetadata;
 
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<dioxus_signals::WritableRef<'static, Self>, BorrowMutError>
     where
         Self::Target: 'static,
     {
-        self.write.try_write_unchecked().map(|value| {
+        self.write.try_write_extended().map(|value| {
             WriteLock::map(value, |value: &mut Write::Target| {
                 value
                     .get_mut(&self.index)

--- a/packages/stores/src/impls/hashmap.rs
+++ b/packages/stores/src/impls/hashmap.rs
@@ -79,7 +79,7 @@ impl<Lens: Readable<Target = HashMap<K, V, St>> + 'static, K: 'static, V: 'stati
         Lens: Clone,
     {
         self.selector().track_shallow();
-        let keys: Vec<_> = self.selector().peek_unchecked().keys().cloned().collect();
+        let keys: Vec<_> = self.selector().peek_extended().keys().cloned().collect();
         keys.into_iter().map(move |key| {
             let value = self.clone().get(key.clone()).unwrap();
             (key, value)
@@ -286,11 +286,11 @@ where
 
     type Storage = Write::Storage;
 
-    fn try_read_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    fn try_read_extended(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
     where
         Self::Target: 'static,
     {
-        self.write.try_read_unchecked().map(|value| {
+        self.write.try_read_extended().map(|value| {
             Self::Storage::map(value, |value: &Write::Target| {
                 value
                     .get(&self.index)
@@ -299,11 +299,11 @@ where
         })
     }
 
-    fn try_peek_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    fn try_peek_extended(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
     where
         Self::Target: 'static,
     {
-        self.write.try_peek_unchecked().map(|value| {
+        self.write.try_peek_extended().map(|value| {
             Self::Storage::map(value, |value: &Write::Target| {
                 value
                     .get(&self.index)
@@ -329,13 +329,13 @@ where
 {
     type WriteMetadata = Write::WriteMetadata;
 
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<dioxus_signals::WritableRef<'static, Self>, BorrowMutError>
     where
         Self::Target: 'static,
     {
-        self.write.try_write_unchecked().map(|value| {
+        self.write.try_write_extended().map(|value| {
             WriteLock::map(value, |value: &mut Write::Target| {
                 value
                     .get_mut(&self.index)

--- a/packages/stores/src/impls/index.rs
+++ b/packages/stores/src/impls/index.rs
@@ -51,22 +51,22 @@ where
 
     type Storage = Write::Storage;
 
-    fn try_read_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    fn try_read_extended(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
     where
         Self::Target: 'static,
     {
-        self.write.try_read_unchecked().map(|value| {
+        self.write.try_read_extended().map(|value| {
             Self::Storage::map(value, |value: &Write::Target| {
                 value.index(self.index.clone())
             })
         })
     }
 
-    fn try_peek_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    fn try_peek_extended(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
     where
         Self::Target: 'static,
     {
-        self.write.try_peek_unchecked().map(|value| {
+        self.write.try_peek_extended().map(|value| {
             Self::Storage::map(value, |value: &Write::Target| {
                 value.index(self.index.clone())
             })
@@ -89,13 +89,13 @@ where
 {
     type WriteMetadata = Write::WriteMetadata;
 
-    fn try_write_unchecked(
+    fn try_write_extended(
         &self,
     ) -> Result<dioxus_signals::WritableRef<'static, Self>, BorrowMutError>
     where
         Self::Target: 'static,
     {
-        self.write.try_write_unchecked().map(|value| {
+        self.write.try_write_extended().map(|value| {
             WriteLock::map(value, |value: &mut Write::Target| {
                 value.index_mut(self.index.clone())
             })

--- a/packages/stores/src/scope.rs
+++ b/packages/stores/src/scope.rs
@@ -183,7 +183,7 @@ impl<Lens> SelectorScope<Lens> {
     where
         Lens: Writable,
     {
-        self.write.write_unchecked()
+        self.write.write_extended()
     }
 }
 
@@ -191,13 +191,13 @@ impl<Lens: Readable> Readable for SelectorScope<Lens> {
     type Target = Lens::Target;
     type Storage = Lens::Storage;
 
-    fn try_read_unchecked(&self) -> Result<ReadableRef<'static, Lens>, BorrowError> {
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Lens>, BorrowError> {
         self.track();
-        self.write.try_read_unchecked()
+        self.write.try_read_extended()
     }
 
-    fn try_peek_unchecked(&self) -> Result<ReadableRef<'static, Lens>, BorrowError> {
-        self.write.try_peek_unchecked()
+    fn try_peek_extended(&self) -> Result<ReadableRef<'static, Lens>, BorrowError> {
+        self.write.try_peek_extended()
     }
 
     fn subscribers(&self) -> Subscribers {
@@ -208,8 +208,8 @@ impl<Lens: Readable> Readable for SelectorScope<Lens> {
 impl<Lens: Writable> Writable for SelectorScope<Lens> {
     type WriteMetadata = Lens::WriteMetadata;
 
-    fn try_write_unchecked(&self) -> Result<WritableRef<'static, Lens>, BorrowMutError> {
+    fn try_write_extended(&self) -> Result<WritableRef<'static, Lens>, BorrowMutError> {
         self.mark_dirty();
-        self.write.try_write_unchecked()
+        self.write.try_write_extended()
     }
 }

--- a/packages/stores/src/store.rs
+++ b/packages/stores/src/store.rs
@@ -254,11 +254,11 @@ where
 {
     type Storage = Lens::Storage;
     type Target = T;
-    fn try_read_unchecked(&self) -> Result<ReadableRef<'static, Self>, BorrowError> {
-        self.selector.try_read_unchecked()
+    fn try_read_extended(&self) -> Result<ReadableRef<'static, Self>, BorrowError> {
+        self.selector.try_read_extended()
     }
-    fn try_peek_unchecked(&self) -> Result<ReadableRef<'static, Self>, BorrowError> {
-        self.selector.try_peek_unchecked()
+    fn try_peek_extended(&self) -> Result<ReadableRef<'static, Self>, BorrowError> {
+        self.selector.try_peek_extended()
     }
     fn subscribers(&self) -> Subscribers {
         self.selector.subscribers()
@@ -270,8 +270,8 @@ where
     T: 'static,
 {
     type WriteMetadata = Lens::WriteMetadata;
-    fn try_write_unchecked(&self) -> Result<WritableRef<'static, Self>, BorrowMutError> {
-        self.selector.try_write_unchecked()
+    fn try_write_extended(&self) -> Result<WritableRef<'static, Self>, BorrowMutError> {
+        self.selector.try_write_extended()
     }
 }
 impl<T, Lens> IntoAttributeValue for Store<T, Lens>


### PR DESCRIPTION
This renames all "unchecked" methods to better define their behavior. "unchecked" methods in Rust are traditionally used to signify methods that can have undefined behavior if used incorrectly. These methods do not have undefined behavior. These methods are completely safe and what is really happening is the lifetime is extended to `'static` and runtime checks are used to enforce safety instead. Thus `unchecked` is renamed to `extended`.

closes https://github.com/DioxusLabs/dioxus/issues/4517