### PR TITLE
Remove must_use from Resource

### DIFF
--- a/packages/hooks/src/use_resource.rs
+++ b/packages/hooks/src/use_resource.rs
@@ -16,7 +16,6 @@ use std::{cell::Cell, future::Future, rc::Rc};
 #[doc = include_str!("../docs/moving_state_around.md")]
 #[doc(alias = "use_async_memo")]
 #[doc(alias = "use_memo_async")]
-#[must_use = "Consider using `cx.spawn` to run a future without reading its value"]
 #[track_caller]
 pub fn use_resource<T, F>(mut future: impl FnMut() -> F + 'static) -> Resource<T>
 where


### PR DESCRIPTION
`use_resource` does not need `must_use` since it can run reactive async effects