### PR TITLE
Don't output escape codes for the cursor when the tui isn't active

### DIFF
--- a/packages/cli/src/logging.rs
+++ b/packages/cli/src/logging.rs
@@ -273,7 +273,7 @@ impl TraceController {
             tui_rx: Arc::new(tokio::sync::Mutex::new(tui_rx)),
             telemetry_rx: Arc::new(tokio::sync::Mutex::new(telemetry_rx)),
             http_client,
-            tui_active: tui_active.clone(),
+            tui_active,
         };
 
         // Spawn the telemetry uploader in the background


### PR DESCRIPTION
Fixes #4535