### PR TITLE
Fix integration of SSL libs into non-ARM64 Android builds.

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1250,7 +1250,10 @@ impl BuildRequest {
                     Architecture::Arm(_) => "armeabi-v7a",
                     Architecture::X86_32(_) => "x86",
                     Architecture::X86_64 => "x86_64",
-                    _ => panic!("Unsupported architecture for Android: {:?}", self.triple.architecture),
+                    _ => panic!(
+                        "Unsupported architecture for Android: {:?}",
+                        self.triple.architecture
+                    ),
                 };
 
                 self.root_dir()
@@ -1259,7 +1262,7 @@ impl BuildRequest {
                     .join("main")
                     .join("jniLibs")
                     .join(arch)
-            },
+            }
             OperatingSystem::Linux | OperatingSystem::Windows => self.root_dir(),
             _ => self.root_dir(),
         }


### PR DESCRIPTION
When building for Android target `libssl.so` and `libcrypto.so` were always put to `app/src/main/jniLibs/arm64-v8a` regardless the target architecture.

This PR fixes that and selects the proper destination directory (`arm64-v81`, `armeabi-v7a`, `x86` or `x86_64`).