### PR TITLE
Add '.zed' folder for Zed-related development

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,3 @@
+{
+  "format_on_save": "off"
+}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,3 +1,13 @@
 {
-  "format_on_save": "off"
+  "languages": {
+    "TOML": {
+      "format_on_save": "off"
+    },
+    "HTML": {
+      "format_on_save": "off"
+    },
+    "JavaScript": {
+      "format_on_save": "off"
+    }
+  }
 }


### PR DESCRIPTION
Added the `.zed` configuration folder to enable Zed development. `.zed/settings.json` is a mirror of the `.vscode/settings.json`.