### PR TITLE
show panics in the toast in wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5686,7 +5686,6 @@ dependencies = [
 name = "dioxus-logger"
 version = "0.7.0-rc.0"
 dependencies = [
- "console_error_panic_hook",
  "dioxus",
  "dioxus-cli-config",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,7 +307,6 @@ criterion = { version = "0.6" }
 cargo_metadata = "0.19.2"
 parking_lot = "0.12.4"
 tracing-wasm = "0.2.1"
-console_error_panic_hook = "0.1.7"
 base16 = "0.2.1"
 digest = "0.10.7"
 sha2 = "0.10.9"

--- a/packages/logger/Cargo.toml
+++ b/packages/logger/Cargo.toml
@@ -22,7 +22,6 @@ default = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tracing-wasm = { workspace = true }
-console_error_panic_hook = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tracing-subscriber = { workspace = true, features = ["fmt"] }

--- a/packages/logger/src/lib.rs
+++ b/packages/logger/src/lib.rs
@@ -91,7 +91,6 @@ pub fn init(level: Level) -> Result<(), SetGlobalDefaultError> {
         let layer = tracing_wasm::WASMLayer::new(layer_config);
         let reg = Registry::default().with(layer);
 
-        console_error_panic_hook::set_once();
         set_global_default(reg)
     }
 

--- a/packages/web/src/cfg.rs
+++ b/packages/web/src/cfg.rs
@@ -14,6 +14,7 @@ use wasm_bindgen::JsCast as _;
 /// ```
 pub struct Config {
     pub(crate) hydrate: bool,
+    pub(crate) panic_hook: bool,
     pub(crate) root: ConfigRoot,
     #[cfg(feature = "document")]
     pub(crate) history: Option<Rc<dyn dioxus_history::History>>,
@@ -96,6 +97,7 @@ impl Default for Config {
             root: ConfigRoot::RootName("main".to_string()),
             #[cfg(feature = "document")]
             history: None,
+            panic_hook: true,
         }
     }
 }

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -51,6 +51,9 @@ pub use hydration::*;
 /// wasm_bindgen_futures::spawn_local(app_fut);
 /// ```
 pub async fn run(mut virtual_dom: VirtualDom, web_config: Config) -> ! {
+    #[cfg(all(feature = "devtools", debug_assertions))]
+    let mut hotreload_rx = devtools::init(&web_config);
+
     #[cfg(feature = "document")]
     if let Some(history) = web_config.history.clone() {
         virtual_dom.in_runtime(|| dioxus_core::ScopeId::ROOT.provide_context(history));
@@ -60,9 +63,6 @@ pub async fn run(mut virtual_dom: VirtualDom, web_config: Config) -> ! {
     virtual_dom.in_runtime(document::init_document);
 
     let runtime = virtual_dom.runtime();
-
-    #[cfg(all(feature = "devtools", debug_assertions))]
-    let mut hotreload_rx = devtools::init();
 
     // If the hydrate feature is enabled, launch the client with hydration enabled
     let should_hydrate = web_config.hydrate || cfg!(feature = "hydrate");


### PR DESCRIPTION
When apps panic in the browser, we now show a toast with the stack trace and the panic info.

This should help people diagnose crashing WASM apps better.

<img width="620" height="773" alt="Screenshot 2025-08-19 at 5 05 18 PM" src="https://github.com/user-attachments/assets/b5e70b67-c8b4-4f03-a81e-b41ebe6091f5" />
