### PR TITLE
bump android min-sdk up to 28

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -742,7 +742,7 @@ impl BuildRequest {
 
         // If no custom linker is set, then android falls back to us as the linker
         if custom_linker.is_none() && bundle == BundleFormat::Android {
-            let min_sdk_version = config.application.android_min_sdk_version.unwrap_or(24);
+            let min_sdk_version = config.application.android_min_sdk_version.unwrap_or(28);
             custom_linker = Some(
                 workspace
                     .android_tools()?


### PR DESCRIPTION
This PR bumps the android_min_sdk fallback up to 28.

This unlocks crates like cpal to compile normally, fixing https://github.com/DioxusLabs/dioxus/issues/4443

Note that sdk 28 was released in 2018 while 24 was released in 2016.