### PR TITLE
fix lints on rust 1.89

### DIFF
--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -1329,7 +1329,7 @@ fn name_is_bindgen_symbol(name: &str) -> bool {
 /// We need to do this for data symbols because walrus doesn't provide the right range and offset
 /// information for data segments. Fortunately, it provides it for code sections, so we only need to
 /// do a small amount extra of parsing here.
-fn parse_bytes_to_data_segment(bytes: &[u8]) -> Result<RawDataSection> {
+fn parse_bytes_to_data_segment(bytes: &[u8]) -> Result<RawDataSection<'_>> {
     let parser = wasmparser::Parser::new(0);
     let mut parser = parser.parse_all(bytes);
     let mut segments = vec![];
@@ -1441,7 +1441,7 @@ struct ParsedModule<'a> {
 
 /// Parse a module and return the mapping of index to FunctionID.
 /// We'll use this mapping to remap ModuleIDs
-fn parse_module_with_ids(bindgened: &[u8]) -> Result<ParsedModule> {
+fn parse_module_with_ids(bindgened: &[u8]) -> Result<ParsedModule<'_>> {
     let ids = Arc::new(RwLock::new(Vec::new()));
     let ids_ = ids.clone();
     let module = Module::from_buffer_with_config(

--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -401,7 +401,7 @@ struct DocField<'a> {
     input_arg_doc: String,
 }
 
-fn build_doc_fields(f: &FnArg) -> Option<DocField> {
+fn build_doc_fields(f: &FnArg) -> Option<DocField<'_>> {
     let FnArg::Typed(pt) = f else { unreachable!() };
 
     let arg_doc = pt

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -197,7 +197,7 @@ mod field_info {
             ordinal: usize,
             field: &syn::Field,
             field_defaults: FieldBuilderAttr,
-        ) -> Result<FieldInfo, Error> {
+        ) -> Result<FieldInfo<'_>, Error> {
             if let Some(ref name) = field.ident {
                 let mut builder_attr = field_defaults.with(&field.attrs)?;
 

--- a/packages/core/src/effect.rs
+++ b/packages/core/src/effect.rs
@@ -36,15 +36,15 @@ impl Effect {
     }
 }
 
-impl PartialOrd for Effect {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.order.cmp(&other.order))
-    }
-}
-
 impl Ord for Effect {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.order.cmp(&other.order)
+    }
+}
+
+impl PartialOrd for Effect {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/packages/core/src/error_boundary.rs
+++ b/packages/core/src/error_boundary.rs
@@ -250,7 +250,7 @@ impl ErrorContext {
     }
 
     /// Get all errors thrown from child components
-    pub fn errors(&self) -> Ref<[CapturedError]> {
+    pub fn errors(&self) -> Ref<'_, [CapturedError]> {
         Ref::map(self.errors.borrow(), |errors| errors.as_slice())
     }
 

--- a/packages/core/src/scheduler.rs
+++ b/packages/core/src/scheduler.rs
@@ -265,15 +265,14 @@ impl Borrow<ScopeOrder> for DirtyTasks {
     }
 }
 
-impl PartialOrd for DirtyTasks {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.order.cmp(&other.order))
-    }
-}
-
 impl Ord for DirtyTasks {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.order.cmp(&other.order)
+    }
+}
+impl PartialOrd for DirtyTasks {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/packages/core/src/scope_context.rs
+++ b/packages/core/src/scope_context.rs
@@ -294,7 +294,7 @@ impl Scope {
         for ctx in contexts.iter_mut() {
             // Swap the ptr directly
             if let Some(ctx) = ctx.downcast_mut::<T>() {
-                std::mem::swap(ctx, &mut value.clone());
+                *ctx = value.clone();
                 return value;
             }
         }

--- a/packages/core/src/suspense/mod.rs
+++ b/packages/core/src/suspense/mod.rs
@@ -170,7 +170,7 @@ impl SuspenseContext {
     }
 
     /// Get all suspended tasks
-    pub fn suspended_futures(&self) -> Ref<[SuspendedFuture]> {
+    pub fn suspended_futures(&self) -> Ref<'_, [SuspendedFuture]> {
         Ref::map(self.inner.suspended_tasks.borrow(), |tasks| {
             tasks.as_slice()
         })

--- a/packages/desktop/src/ipc.rs
+++ b/packages/desktop/src/ipc.rs
@@ -66,7 +66,7 @@ pub enum IpcMethod<'a> {
 }
 
 impl IpcMessage {
-    pub(crate) fn method(&self) -> IpcMethod {
+    pub(crate) fn method(&self) -> IpcMethod<'_> {
         match self.method.as_str() {
             "file_dialog" => IpcMethod::FileDialog,
             "user_event" => IpcMethod::UserEvent,

--- a/packages/manganis/manganis-core/src/asset.rs
+++ b/packages/manganis/manganis-core/src/asset.rs
@@ -94,6 +94,7 @@ impl BundledAsset {
 ///     img { src: ASSET }
 /// };
 /// ```
+#[allow(unpredictable_function_pointer_comparisons)]
 #[derive(PartialEq, Clone, Copy)]
 pub struct Asset {
     /// A function that returns a pointer to the bundled asset. This will be resolved after the linker has run and

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -694,6 +694,7 @@ impl RouteEnum {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum RouteEndpoint {
     Route(Route),
     Redirect(Redirect),
@@ -751,6 +752,7 @@ impl ToTokens for SiteMapSegment {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum SegmentType {
     Static(String),
     Dynamic(String),

--- a/packages/router-macro/src/query.rs
+++ b/packages/router-macro/src/query.rs
@@ -3,6 +3,7 @@ use syn::{Ident, Type};
 
 use proc_macro2::TokenStream as TokenStream2;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum QuerySegment {
     Single(FullQuerySegment),

--- a/packages/router-macro/src/route.rs
+++ b/packages/router-macro/src/route.rs
@@ -461,6 +461,7 @@ impl Route {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub(crate) enum RouteType {
     Child(Field),

--- a/packages/signals/src/read.rs
+++ b/packages/signals/src/read.rs
@@ -73,7 +73,7 @@ pub trait ReadableExt: Readable {
     /// If the value has been dropped, this will panic. Calling this on a Signal is the same as
     /// using the signal() syntax to read and subscribe to its value
     #[track_caller]
-    fn read(&self) -> ReadableRef<Self>
+    fn read(&self) -> ReadableRef<'_, Self>
     where
         Self::Target: 'static,
     {
@@ -82,7 +82,7 @@ pub trait ReadableExt: Readable {
 
     /// Try to get the current value of the state. If this is a signal, this will subscribe the current scope to the signal.
     #[track_caller]
-    fn try_read(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError>
+    fn try_read(&self) -> Result<ReadableRef<'_, Self>, generational_box::BorrowError>
     where
         Self::Target: 'static,
     {
@@ -136,7 +136,7 @@ pub trait ReadableExt: Readable {
     /// }
     /// ```
     #[track_caller]
-    fn peek(&self) -> ReadableRef<Self>
+    fn peek(&self) -> ReadableRef<'_, Self>
     where
         Self::Target: 'static,
     {
@@ -146,7 +146,7 @@ pub trait ReadableExt: Readable {
     /// Try to peek the current value of the signal without subscribing to updates. If the value has
     /// been dropped, this will return an error.
     #[track_caller]
-    fn try_peek(&self) -> Result<ReadableRef<Self>, generational_box::BorrowError>
+    fn try_peek(&self) -> Result<ReadableRef<'_, Self>, generational_box::BorrowError>
     where
         Self::Target: 'static,
     {
@@ -229,7 +229,10 @@ pub trait ReadableExt: Readable {
 
     /// Index into the inner value and return a reference to the result. If the value has been dropped or the index is invalid, this will panic.
     #[track_caller]
-    fn index<I>(&self, index: I) -> ReadableRef<Self, <Self::Target as std::ops::Index<I>>::Output>
+    fn index<I>(
+        &self,
+        index: I,
+    ) -> ReadableRef<'_, Self, <Self::Target as std::ops::Index<I>>::Output>
     where
         Self::Target: std::ops::Index<I> + 'static,
     {
@@ -313,7 +316,7 @@ pub trait ReadableVecExt<T>: Readable<Target = Vec<T>> {
 
     /// Get the first element of the inner vector.
     #[track_caller]
-    fn first(&self) -> Option<ReadableRef<Self, T>>
+    fn first(&self) -> Option<ReadableRef<'_, Self, T>>
     where
         T: 'static,
     {
@@ -322,7 +325,7 @@ pub trait ReadableVecExt<T>: Readable<Target = Vec<T>> {
 
     /// Get the last element of the inner vector.
     #[track_caller]
-    fn last(&self) -> Option<ReadableRef<Self, T>>
+    fn last(&self) -> Option<ReadableRef<'_, Self, T>>
     where
         T: 'static,
     {
@@ -331,7 +334,7 @@ pub trait ReadableVecExt<T>: Readable<Target = Vec<T>> {
 
     /// Get the element at the given index of the inner vector.
     #[track_caller]
-    fn get(&self, index: usize) -> Option<ReadableRef<Self, T>>
+    fn get(&self, index: usize) -> Option<ReadableRef<'_, Self, T>>
     where
         T: 'static,
     {
@@ -382,7 +385,7 @@ pub trait ReadableOptionExt<T>: Readable<Target = Option<T>> {
 
     /// Attempts to read the inner value of the Option.
     #[track_caller]
-    fn as_ref(&self) -> Option<ReadableRef<Self, T>>
+    fn as_ref(&self) -> Option<ReadableRef<'_, Self, T>>
     where
         T: 'static,
     {
@@ -408,7 +411,7 @@ pub trait ReadableResultExt<T, E>: Readable<Target = Result<T, E>> {
 
     /// Attempts to read the inner value of the Option.
     #[track_caller]
-    fn as_ref(&self) -> Result<ReadableRef<Self, T>, ReadableRef<Self, E>>
+    fn as_ref(&self) -> Result<ReadableRef<'_, Self, T>, ReadableRef<'_, Self, E>>
     where
         T: 'static,
         E: 'static,

--- a/packages/wasm-split/wasm-split-cli/src/lib.rs
+++ b/packages/wasm-split/wasm-split-cli/src/lib.rs
@@ -1466,7 +1466,7 @@ struct DataSymbol {
 /// We need to do this for data symbols because walrus doesn't provide the right range and offset
 /// information for data segments. Fortunately, it provides it for code sections, so we only need to
 /// do a small amount extra of parsing here.
-fn parse_bytes_to_data_segment(bytes: &[u8]) -> Result<RawDataSection> {
+fn parse_bytes_to_data_segment(bytes: &[u8]) -> Result<RawDataSection<'_>> {
     let parser = wasmparser::Parser::new(0);
     let mut parser = parser.parse_all(bytes);
     let mut segments = vec![];

--- a/packages/web/src/history.rs
+++ b/packages/web/src/history.rs
@@ -74,9 +74,11 @@ impl WebHistory {
     }
 
     fn scroll_pos(&self) -> ScrollPosition {
-        self.do_scroll_restoration
-            .then(|| ScrollPosition::of_window(&self.window))
-            .unwrap_or_default()
+        if self.do_scroll_restoration {
+            ScrollPosition::of_window(&self.window)
+        } else {
+            Default::default()
+        }
     }
 
     fn create_state(&self) -> [f64; 2] {
@@ -239,9 +241,11 @@ impl HashHistory {
     }
 
     fn scroll_pos(&self) -> ScrollPosition {
-        self.do_scroll_restoration
-            .then(|| ScrollPosition::of_window(&self.window))
-            .unwrap_or_default()
+        if self.do_scroll_restoration {
+            ScrollPosition::of_window(&self.window)
+        } else {
+            Default::default()
+        }
     }
 
     fn create_state(&self) -> [f64; 2] {


### PR DESCRIPTION
This fixes a number of clippy lints that were introduced in rust 1.89

We'll still keep the msrv in CI to be 1.85, but this at least makes us modern.

Fixes https://github.com/DioxusLabs/dioxus/issues/4562