### PR TITLE
feat: add subsecond serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5398,6 +5398,8 @@ dependencies = [
  "dioxus-core",
  "dioxus-devtools-types",
  "dioxus-signals",
+ "futures-channel",
+ "futures-util",
  "serde",
  "serde_json",
  "subsecond",
@@ -7236,9 +7238,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",

--- a/packages/devtools/Cargo.toml
+++ b/packages/devtools/Cargo.toml
@@ -19,6 +19,9 @@ serde_json = { workspace = true }
 subsecond = { workspace = true }
 thiserror = { workspace = true }
 
+futures-util = { workspace = true, features = ["sink", "async-await-macro"], optional = true }
+futures-channel = { workspace = true, optional = true }
+
 # hot reloading serve
 tracing = { workspace = true }
 warnings = { workspace = true }
@@ -32,3 +35,7 @@ serde_json = { workspace = true }
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
+[features]
+default = []
+serve = ["dep:futures-util", "dep:futures-channel"]

--- a/packages/devtools/src/lib.rs
+++ b/packages/devtools/src/lib.rs
@@ -114,7 +114,7 @@ pub fn connect_at(endpoint: String, mut callback: impl FnMut(DevserverMsg) + Sen
 ///
 /// Whenever your code changes, the future is dropped and a new one is created using the new function.
 ///
-/// This is useful for using subsecond outside of dioxus, like with axum. To pass args to the underyling
+/// This is useful for using subsecond outside of dioxus, like with axum. To pass args to the underlying
 /// function, you can use the `serve_subsecond_with_args` function.
 ///
 /// ```rust, ignore


### PR DESCRIPTION
This PR adds a `dioxus_devtools::subsecond_serve` which makes it easier to run the subsecond hot-reload engine outside of dioxus.


This should handle cases like TUIs, Axum, Burn, and other hot-reload systems that want a "hot" async integration.

For example, an axum app that gets hot-reload looks like so:
```rust
#[tokio::main]
async fn main() {
    dioxus_devtools::serve_subsecond(router_main).await;
}

async fn router_main() {
    use axum::{Router, routing::get};

    let app = Router::new().route("/", get(test_route));

    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
    println!("Server running on http://localhost:3000");

    axum::serve(listener, app.clone()).await.unwrap()
}

async fn test_route() -> axum::response::Html<&'static str> {
    "axum works!!!!!".into()
}
```
