### PR TITLE
Fix empty borrow location warnings

### DIFF
--- a/packages/generational-box/src/sync.rs
+++ b/packages/generational-box/src/sync.rs
@@ -59,13 +59,19 @@ pub struct SyncStorage {
 impl SyncStorage {
     pub(crate) fn read(
         pointer: GenerationalPointer<Self>,
-    ) -> BorrowResult<MappedRwLockReadGuard<'static, Box<dyn Any + Send + Sync + 'static>>> {
-        Self::get_split_ref(pointer).map(|(_, guard)| {
-            RwLockReadGuard::map(guard, |data| match &data.data {
-                RwLockStorageEntryData::Data(data) => data,
-                RwLockStorageEntryData::Rc(data) => &data.data,
-                _ => unreachable!(),
-            })
+    ) -> BorrowResult<(
+        MappedRwLockReadGuard<'static, Box<dyn Any + Send + Sync + 'static>>,
+        GenerationalPointer<Self>,
+    )> {
+        Self::get_split_ref(pointer).map(|(resolved, guard)| {
+            (
+                RwLockReadGuard::map(guard, |data| match &data.data {
+                    RwLockStorageEntryData::Data(data) => data,
+                    RwLockStorageEntryData::Rc(data) => &data.data,
+                    _ => unreachable!(),
+                }),
+                resolved,
+            )
         })
     }
 
@@ -99,14 +105,19 @@ impl SyncStorage {
 
     pub(crate) fn write(
         pointer: GenerationalPointer<Self>,
-    ) -> BorrowMutResult<MappedRwLockWriteGuard<'static, Box<dyn Any + Send + Sync + 'static>>>
-    {
-        Self::get_split_mut(pointer).map(|(_, guard)| {
-            RwLockWriteGuard::map(guard, |data| match &mut data.data {
-                RwLockStorageEntryData::Data(data) => data,
-                RwLockStorageEntryData::Rc(data) => &mut data.data,
-                _ => unreachable!(),
-            })
+    ) -> BorrowMutResult<(
+        MappedRwLockWriteGuard<'static, Box<dyn Any + Send + Sync + 'static>>,
+        GenerationalPointer<Self>,
+    )> {
+        Self::get_split_mut(pointer).map(|(resolved, guard)| {
+            (
+                RwLockWriteGuard::map(guard, |data| match &mut data.data {
+                    RwLockStorageEntryData::Data(data) => data,
+                    RwLockStorageEntryData::Rc(data) => &mut data.data,
+                    _ => unreachable!(),
+                }),
+                resolved,
+            )
         })
     }
 
@@ -277,7 +288,7 @@ impl<T: Sync + Send + 'static> Storage<T> for SyncStorage {
     fn try_read(
         pointer: GenerationalPointer<Self>,
     ) -> Result<Self::Ref<'static, T>, error::BorrowError> {
-        let read = Self::read(pointer)?;
+        let (read, pointer) = Self::read(pointer)?;
 
         let read = MappedRwLockReadGuard::try_map(read, |any| {
             // Then try to downcast
@@ -298,7 +309,7 @@ impl<T: Sync + Send + 'static> Storage<T> for SyncStorage {
     fn try_write(
         pointer: GenerationalPointer<Self>,
     ) -> Result<Self::Mut<'static, T>, error::BorrowMutError> {
-        let write = Self::write(pointer)?;
+        let (write, pointer) = Self::write(pointer)?;
 
         let write = MappedRwLockWriteGuard::try_map(write, |any| {
             // Then try to downcast


### PR DESCRIPTION
Rc generational boxes were using the box borrow info instead of the resolved borrow info which causes the borrow list to be empty.

This PR fixes that issue by resolving the pointer first then getting the borrow guard. It fixes the error message for this example:
```rust
use dioxus::prelude::*;

fn main() {
    dioxus::launch(app);
}

fn app() -> Element {
    let mut count = use_signal(|| 0);
    let foo = count.write_unchecked();
    let bar = count.read_unchecked();

    rsx! {
        h1 { "High-Five counter: {count}" }
        button { onclick: move |_| count += 1, "Up high!" }
        button { onclick: move |_| count -= 1, "Down low!" }
    }
}
```