### PR TITLE
Improve placeholder hash error message

### DIFF
--- a/packages/manganis/manganis/src/macro_helpers.rs
+++ b/packages/manganis/manganis/src/macro_helpers.rs
@@ -2,7 +2,7 @@ pub use const_serialize;
 use const_serialize::{serialize_const, ConstVec, SerializeConst};
 use manganis_core::{AssetOptions, BundledAsset};
 
-const PLACEHOLDER_HASH: &str = "this is a placeholder hash which will be replaced by the linker";
+const PLACEHOLDER_HASH: &str = "This should be replaced by dx as part of the build process. If you see this error, make sure you are using a matching version of dx and dioxus and you are not stripping symbols from your binary.";
 
 /// Create a bundled asset from the input path, the content hash, and the asset options
 pub const fn create_bundled_asset(input_path: &str, asset_config: AssetOptions) -> BundledAsset {


### PR DESCRIPTION
You will run into this message if you try to build dioxus with a mismatched version of dx. The current error message mentions something about the linker, but doesn't provide any debugging steps. This PR adds some help information to resolve the issue