### PR TITLE
Fix hydration with empty spread attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5767,6 +5767,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-playwright-fullstack-spread-test"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+]
+
+[[package]]
 name = "dioxus-playwright-fullstack-test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ members = [
     "packages/playwright-tests/barebones-template",
     "packages/playwright-tests/fullstack",
     "packages/playwright-tests/fullstack-mounted",
+    "packages/playwright-tests/fullstack-spread",
     "packages/playwright-tests/fullstack-routing",
     "packages/playwright-tests/suspense-carousel",
     "packages/playwright-tests/nested-suspense",

--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -819,10 +819,14 @@ impl VNode {
                 }
             };
 
+            // Write the value for each attribute in the group
             for attr in &**attribute {
                 self.write_attribute(attribute_path, attr, id, mount, dom, to);
-                dom.set_mounted_dyn_attr(mount, attribute_idx, id);
             }
+            // Set the mounted dynamic attribute once. This must be set even if no actual
+            // attributes are present so it is present for renderers like fullstack to look
+            // up the position where attributes may be inserted in the future
+            dom.set_mounted_dyn_attr(mount, attribute_idx, id);
         }
     }
 

--- a/packages/fullstack-protocol/src/lib.rs
+++ b/packages/fullstack-protocol/src/lib.rs
@@ -69,12 +69,7 @@ impl HydrationContext {
 
     /// Extend this data with the data from another [`HydrationContext`]
     pub fn extend(&self, other: &Self) {
-<<<<<<< Updated upstream
         self.data.borrow_mut().extend(&other.data.borrow());
-=======
-        let other = other.data.borrow();
-        self.data.borrow_mut().extend(&other);
->>>>>>> Stashed changes
     }
 
     #[cfg(feature = "web")]

--- a/packages/fullstack-protocol/src/lib.rs
+++ b/packages/fullstack-protocol/src/lib.rs
@@ -69,7 +69,12 @@ impl HydrationContext {
 
     /// Extend this data with the data from another [`HydrationContext`]
     pub fn extend(&self, other: &Self) {
+<<<<<<< Updated upstream
         self.data.borrow_mut().extend(&other.data.borrow());
+=======
+        let other = other.data.borrow();
+        self.data.borrow_mut().extend(&other);
+>>>>>>> Stashed changes
     }
 
     #[cfg(feature = "web")]

--- a/packages/playwright-tests/fullstack-spread.spec.js
+++ b/packages/playwright-tests/fullstack-spread.spec.js
@@ -1,0 +1,13 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+test("spread attributes hydrate", async ({ page }) => {
+  await page.goto("http://localhost:7979");
+
+  // Expect the page to contain the button
+  const counter = page.locator("#counter");
+  await expect(counter).toHaveText("Count: 0");
+  // Clicking on the button should increment the count
+  await counter.click();
+  await expect(counter).toHaveText("Count: 1");
+});

--- a/packages/playwright-tests/fullstack-spread/Cargo.toml
+++ b/packages/playwright-tests/fullstack-spread/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "dioxus-playwright-fullstack-spread-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dioxus = { workspace = true, features = ["fullstack"] }
+
+[features]
+default = []
+server = ["dioxus/server"]
+web = ["dioxus/web"]

--- a/packages/playwright-tests/fullstack-spread/src/main.rs
+++ b/packages/playwright-tests/fullstack-spread/src/main.rs
@@ -1,0 +1,40 @@
+//! Regression test for https://github.com/DioxusLabs/dioxus/issues/4646
+
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::launch(|| {
+        rsx! {
+            Comp {}
+            Comp {}
+            Button {}
+        }
+    });
+}
+
+#[component]
+fn Button() -> Element {
+    let mut count = use_signal(|| 0);
+
+    rsx! {
+        button {
+            id: "counter",
+            onclick: move |_| {
+                count += 1;
+            },
+            "Count: {count}"
+        }
+    }
+}
+
+#[component]
+fn Comp(#[props(extends = GlobalAttributes)] attributes: Vec<Attribute>) -> Element {
+    rsx! {
+        div {
+            width: 100,
+            div {
+                ..attributes,
+            }
+        }
+    }
+}

--- a/packages/playwright-tests/fullstack-spread/src/main.rs
+++ b/packages/playwright-tests/fullstack-spread/src/main.rs
@@ -1,4 +1,4 @@
-//! Regression test for https://github.com/DioxusLabs/dioxus/issues/4646
+//! Regression test for <https://github.com/DioxusLabs/dioxus/issues/4646>
 
 use dioxus::prelude::*;
 

--- a/packages/playwright-tests/playwright.config.js
+++ b/packages/playwright-tests/playwright.config.js
@@ -130,6 +130,15 @@ module.exports = defineConfig({
       stdout: "pipe",
     },
     {
+      cwd: path.join(process.cwd(), "fullstack-spread"),
+      command:
+        'cargo run --package dioxus-cli --release -- run --verbose --force-sequential --web --addr "127.0.0.1" --port 7979',
+      port: 7979,
+      timeout: 50 * 60 * 1000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+    },
+    {
       cwd: path.join(process.cwd(), "fullstack-routing"),
       command:
         'cargo run --package dioxus-cli --release -- run --verbose --force-sequential --web --addr "127.0.0.1" --port 8888',

--- a/packages/web/src/hydration/hydrate.rs
+++ b/packages/web/src/hydration/hydrate.rs
@@ -301,9 +301,12 @@ impl WebsysDom {
                         let id = vnode
                             .mounted_dynamic_attribute(*id, dom)
                             .ok_or(VNodeNotInitialized)?;
+                        // We always need to hydrate the node even if the attributes are empty so we have
+                        // a mount for the node later. This could be spread attributes that are currently empty,
+                        // but will be filled later
+                        mounted_id = Some(id);
                         for attribute in attributes {
                             let value = &attribute.value;
-                            mounted_id = Some(id);
                             if let AttributeValue::Listener(_) = value {
                                 if attribute.name == "onmounted" {
                                     to_mount.push(id);


### PR DESCRIPTION
When we switched from having a single attribute per mount slot to many per mount slot, the hydration logic wasn't changed. We currently only hydrate nodes that have any real attributes attached to them which causes issues with empty spread attributes. They have a slot we need to keep track of where attributes could be inserted in the future, but don't have any attributes today. This PR fixes that issue and adds a regression test

After this, #4640, and #4600 the component library works out of the box with hydration

Fixes #4646