### PR TITLE
Implement copy for eval

### DIFF
--- a/packages/document/src/eval.rs
+++ b/packages/document/src/eval.rs
@@ -57,6 +57,14 @@ impl IntoFuture for Eval {
     }
 }
 
+impl Clone for Eval {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl Copy for Eval {}
+
 /// The platform's evaluator.
 pub trait Evaluator {
     /// Sends a message to the evaluated JavaScript.


### PR DESCRIPTION
Eval is backed by a generational box so it can trivially implement copy