### PR TITLE
Add GlobalStore to the prelude

### DIFF
--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -161,7 +161,7 @@ pub mod prelude {
     pub use dioxus_signals::*;
 
     #[cfg(feature = "signals")]
-    pub use dioxus_stores::{self, store, use_store, ReadStore, Store, WriteStore};
+    pub use dioxus_stores::{self, store, use_store, GlobalStore, ReadStore, Store, WriteStore};
 
     #[cfg(feature = "macro")]
     #[cfg_attr(docsrs, doc(cfg(feature = "macro")))]


### PR DESCRIPTION
GlobalSignal is in the prelude, but GlobalStore is missing. This PR re-exports the global store in the prelude