### PR TITLE
Fix opening in new tab with internal links

### DIFF
--- a/packages/router/src/components/link.rs
+++ b/packages/router/src/components/link.rs
@@ -212,6 +212,11 @@ pub fn Link(props: LinkProps) -> Element {
             return;
         }
 
+        // If we need to open in a new tab, let the browser handle it
+        if new_tab {
+            return;
+        }
+
         // todo(jon): this is extra hacky for no reason - we should fix prevent default on Links
         if do_default && is_external {
             return;


### PR DESCRIPTION
When a link has the `new_tab` argument set to true, we need to fall back to the default link behavior instead of our client side routing to open the link in a new tab

Fixes #4657