### PR TITLE
Fix multiple headers set in server functions

### DIFF
--- a/packages/server/src/context.rs
+++ b/packages/server/src/context.rs
@@ -402,7 +402,7 @@ mod server_fn_impl {
             {
                 let mut_headers = response.headers_mut();
                 for (key, value) in parts.headers.iter() {
-                    mut_headers.insert(key, value.clone());
+                    mut_headers.append(key, value.clone());
                 }
             }
             if self


### PR DESCRIPTION
If multiple values were set for a single header, the server function would only copy over the first header value. This PR fixes that issue by switching from inserting to appending the headers we copy