### PR TITLE
Honor subdir for hashless assets

### DIFF
--- a/packages/cli-opt/src/hash.rs
+++ b/packages/cli-opt/src/hash.rs
@@ -148,7 +148,7 @@ pub fn add_hash_to_asset(asset: &mut BundledAsset) {
             let mut bundled_path = if asset.options().hash_suffix() {
                 PathBuf::from(format!("{}-dxh{hash}", file_stem.to_string_lossy()))
             } else {
-                PathBuf::from(file_stem)
+                PathBuf::from(asset.relative_source_path().trim_start_matches("/assets/")).with_extension("")
             };
 
             if let Some(ext) = ext {
@@ -160,7 +160,7 @@ pub fn add_hash_to_asset(asset: &mut BundledAsset) {
 
             let bundled_path = bundled_path.to_string_lossy().to_string();
 
-            *asset = BundledAsset::new(source, &bundled_path, options);
+            *asset = BundledAsset::new(asset.relative_source_path(), source, &bundled_path, options);
         }
         Err(err) => {
             tracing::error!("Failed to hash asset: {err}");

--- a/packages/cli-opt/src/lib.rs
+++ b/packages/cli-opt/src/lib.rs
@@ -32,6 +32,7 @@ impl AssetManifest {
     /// Manually add an asset to the manifest
     pub fn register_asset(
         &mut self,
+        relative_source_path: &Path,
         asset_path: &Path,
         options: manganis::AssetOptions,
     ) -> anyhow::Result<BundledAsset> {
@@ -40,7 +41,7 @@ impl AssetManifest {
         ))?;
 
         let mut bundled_asset =
-            manganis::macro_helpers::create_bundled_asset(output_path_str, options);
+            manganis::macro_helpers::create_bundled_asset(relative_source_path.to_str().unwrap(), output_path_str, options);
         add_hash_to_asset(&mut bundled_asset);
 
         self.assets

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -3760,7 +3760,7 @@ impl BuildRequest {
                 writeln!(
                     glue, "export const __wasm_split_load_chunk_{idx} = makeLoad(\"/assets/{url}\", [], fusedImports);",
                     url = assets
-                        .register_asset(&path, AssetOptions::builder().into_asset_options())?.bundled_path(),
+                        .register_asset(&path, &path, AssetOptions::builder().into_asset_options())?.bundled_path(),
                 )?;
             }
 
@@ -3788,7 +3788,7 @@ impl BuildRequest {
 
                     // Again, register this wasm with the asset system
                     url = assets
-                        .register_asset(&path, AssetOptions::builder().into_asset_options())?
+                        .register_asset(&path, &path, AssetOptions::builder().into_asset_options())?
                         .bundled_path(),
 
                     // This time, make sure to write the dependencies of this chunk
@@ -3839,6 +3839,7 @@ impl BuildRequest {
             // Make sure to register the main wasm file with the asset system
             assets.register_asset(
                 &post_bindgen_wasm,
+                &post_bindgen_wasm,
                 AssetOptions::builder().into_asset_options(),
             )?;
         }
@@ -3849,6 +3850,7 @@ impl BuildRequest {
         if self.should_bundle_to_asset() {
             // Register the main.js with the asset system so it bundles in the snippets and optimizes
             assets.register_asset(
+                &self.wasm_bindgen_js_output_file(),
                 &self.wasm_bindgen_js_output_file(),
                 AssetOptions::js()
                     .with_minify(true)

--- a/packages/manganis/manganis-core/src/asset.rs
+++ b/packages/manganis/manganis-core/src/asset.rs
@@ -9,6 +9,7 @@ use std::{fmt::Debug, hash::Hash, path::PathBuf};
 /// to use.
 #[derive(Debug, Eq, Clone, Copy, SerializeConst, serde::Serialize, serde::Deserialize)]
 pub struct BundledAsset {
+    relative_source_path: ConstStr,
     /// The absolute path of the asset
     absolute_source_path: ConstStr,
     /// The bundled path of the asset
@@ -55,11 +56,13 @@ impl BundledAsset {
     /// This should only be called from the macro
     /// Create a new asset
     pub const fn new(
+        relative_source_path: &str,
         absolute_source_path: &str,
         bundled_path: &str,
         options: AssetOptions,
     ) -> Self {
         Self {
+            relative_source_path: ConstStr::new(relative_source_path),
             absolute_source_path: ConstStr::new(absolute_source_path),
             bundled_path: ConstStr::new(bundled_path),
             options,
@@ -79,6 +82,10 @@ impl BundledAsset {
     /// Get the options for the asset
     pub const fn options(&self) -> &AssetOptions {
         &self.options
+    }
+
+    pub fn relative_source_path(&self) -> &str {
+        self.relative_source_path.as_str()
     }
 }
 

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -13,6 +13,7 @@ use syn::{
 };
 
 pub struct AssetParser {
+    pub(crate) src: String,
     /// The token(s) of the source string, for error reporting
     pub(crate) path_expr: proc_macro2::TokenStream,
 
@@ -50,6 +51,7 @@ impl Parse for AssetParser {
         let options = input.parse()?;
 
         Ok(Self {
+            src,
             path_expr,
             asset,
             options,
@@ -102,8 +104,11 @@ impl ToTokens for AssetParser {
             self.options.clone()
         };
 
+        let src = &self.src;
+
         tokens.extend(quote! {
             {
+                const __ASSET_RELATIVE_SOURCE_PATH: &'static str = #src;
                 // The source is used by the CLI to copy the asset
                 const __ASSET_SOURCE_PATH: &'static str = #asset_str;
                 // The options give the CLI info about how to process the asset
@@ -114,7 +119,7 @@ impl ToTokens for AssetParser {
                 const __ASSET_HASH: &'static str = #asset_hash;
                 // Create the asset that the crate will use. This is used both in the return value and
                 // added to the linker for the bundler to copy later
-                const __ASSET: manganis::BundledAsset = manganis::macro_helpers::#constructor(__ASSET_SOURCE_PATH, __ASSET_OPTIONS);
+                const __ASSET: manganis::BundledAsset = manganis::macro_helpers::#constructor(__ASSET_RELATIVE_SOURCE_PATH, __ASSET_SOURCE_PATH, __ASSET_OPTIONS);
 
                 #link_section
 

--- a/packages/manganis/manganis-macro/src/css_module.rs
+++ b/packages/manganis/manganis-macro/src/css_module.rs
@@ -39,6 +39,7 @@ impl Parse for CssModuleParser {
         }
 
         let asset_parser = AssetParser {
+            src,
             path_expr,
             asset,
             options,

--- a/packages/manganis/manganis/src/macro_helpers.rs
+++ b/packages/manganis/manganis/src/macro_helpers.rs
@@ -5,8 +5,8 @@ use manganis_core::{AssetOptions, BundledAsset};
 const PLACEHOLDER_HASH: &str = "This should be replaced by dx as part of the build process. If you see this error, make sure you are using a matching version of dx and dioxus and you are not stripping symbols from your binary.";
 
 /// Create a bundled asset from the input path, the content hash, and the asset options
-pub const fn create_bundled_asset(input_path: &str, asset_config: AssetOptions) -> BundledAsset {
-    BundledAsset::new(input_path, PLACEHOLDER_HASH, asset_config)
+pub const fn create_bundled_asset(relative_source_path: &str, input_path: &str, asset_config: AssetOptions) -> BundledAsset {
+    BundledAsset::new(relative_source_path, input_path, PLACEHOLDER_HASH, asset_config)
 }
 
 /// Create a bundled asset from the input path, the content hash, and the asset options with a relative asset deprecation warning
@@ -19,7 +19,7 @@ pub const fn create_bundled_asset_relative(
     input_path: &str,
     asset_config: AssetOptions,
 ) -> BundledAsset {
-    create_bundled_asset(input_path, asset_config)
+    create_bundled_asset(input_path, input_path, asset_config)
 }
 
 /// Serialize an asset to a const buffer


### PR DESCRIPTION
When combining multiple dioxus runs (for example web worker output with web application) it is helpful when the subdirectories are also honored for hashless assets so that the wasm imports from the `wasm/` folder of the web worker is correctly found.

I don't know if this is the best solution but maybe you have a better idea. Also at some places the correct relative path is not calculated. 