### PR TITLE
Fix chained attribute if statements with static strings

### DIFF
--- a/packages/core/tests/conditional_formatted_attributes.rs
+++ b/packages/core/tests/conditional_formatted_attributes.rs
@@ -28,5 +28,20 @@ fn partially_formatted_conditional_attribute() {
         input {
             type: if true { opt.to_string() } else if true { "" } else { "text with {width}" },
         }
+        input {
+            type: if true { "one" } else if true { "two" } else { "three" },
+        }
+        input {
+            type: if true { "one" } else if true { "two" } else if true { "three" } else { opt },
+        }
+        input {
+            type: if true { "one" } else if true { if false { "true" } else { "false" } } else { "three" },
+        }
+        input {
+            type: if true { "one".to_string() },
+        }
+        input {
+            type: if true { "one" },
+        }
     };
 }


### PR DESCRIPTION
The logic for finding expressions in if statement branches was wrong causing type inference to fail with this snippet:
```rust
input {
    type: if true { "one" } else if true { "two" } else { "three" },
}
```

This PR fixes that issue.

Fixes https://github.com/DioxusLabs/dioxus/issues/4720