### PR TITLE
Fix Sse keepalive build error

### DIFF
--- a/packages/fullstack/src/payloads/sse.rs
+++ b/packages/fullstack/src/payloads/sse.rs
@@ -350,15 +350,15 @@ mod server_impl {
 
     impl<T> IntoResponse for ServerEvents<T> {
         fn into_response(self) -> axum_core::response::Response {
-            let mut sse = self
+            let sse = self
                 .sse
                 .expect("SSE should be initialized before using it as a response");
 
             if let Some(keep_alive) = self.keep_alive {
-                sse = sse.keep_alive(keep_alive)
+                sse.keep_alive(keep_alive).into_response()
+            } else {
+                sse.into_response()
             }
-
-            sse.into_response()
         }
     }
 


### PR DESCRIPTION
Not sure since when, but axum's Sse::keep_alive now returns a different type so we can't re-assign `let mut sse` to its result.

(Also not sure how CI didn't catch this?)