### PR TITLE
Enable logs for tauri-bundler

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -114,8 +114,7 @@ crossterm = { workspace = true, features = ["event-stream"] }
 ratatui = { workspace = true, features = ["crossterm", "unstable"] }
 shell-words = { workspace = true }
 
-# disable `log` entirely since `walrus` uses it and is *much* slower with it enableda
-log = { version = "0.4", features = ["max_level_off", "release_max_level_off"] }
+log = { version = "0.4" }
 
 # link intercept
 tempfile = "3.19.1"


### PR DESCRIPTION
This hides logs from tauri-bundler which may be critical to find out what the issue is. I'm unsure about the performance impact but I think it's important to not hide the logs.