### PR TITLE
Fix ReadOnlySignal alias without storage

### DIFF
--- a/packages/signals/src/boxed.rs
+++ b/packages/signals/src/boxed.rs
@@ -14,7 +14,7 @@ use crate::{
     since = "0.7.0",
     note = "Use `ReadSignal` instead. Will be removed in 0.8"
 )]
-pub type ReadOnlySignal<T, S> = ReadSignal<T, S>;
+pub type ReadOnlySignal<T, S = UnsyncStorage> = ReadSignal<T, S>;
 
 /// A boxed version of [Readable] that can be used to store any readable type.
 pub struct ReadSignal<T: ?Sized, S: BoxedSignalStorage<T> = UnsyncStorage> {


### PR DESCRIPTION
When updating dioxus, I noticed ReadOnlySignal failed to compile. We have the alias, but the storage default wasn't set which makes it more difficult to migrate to the new version