### PR TITLE
FIX: web.https configuration - error: no process-level CryptoProvider available

### DIFF
--- a/packages/cli/src/serve/server.rs
+++ b/packages/cli/src/serve/server.rs
@@ -26,6 +26,7 @@ use futures_util::{
     StreamExt,
 };
 use hyper::HeaderMap;
+use rustls::crypto::{aws_lc_rs::default_provider, CryptoProvider};
 use serde::{Deserialize, Serialize};
 use std::{
     convert::Infallible,
@@ -416,7 +417,10 @@ async fn devserver_mainloop(
         return Ok(());
     }
 
-    // If we're using rustls, we need to get the cert/key paths and then set up rustls
+    // If we're using rustls, we need to install the provider, get the cert/key paths, and then set up rustls
+    if let Err(provider) = CryptoProvider::install_default(default_provider()) {
+        bail!("Failed to install default CryptoProvider: {provider:?}");
+    }
     let (cert_path, key_path) = get_rustls(&https_cfg).await?;
     let rustls = axum_server::tls_rustls::RustlsConfig::from_pem_file(cert_path, key_path).await?;
 


### PR DESCRIPTION
This PR fixes #3815 because `rustls` requires installation of a `CryptoProvider` before `axum` (or any server) can use it.

Said installation is accomplished by calling:
```rust
rustls::crypto::CryptoProvider::install_default(
    rustls::crypto::aws_lc_rs::default_provider()
)
```

before calling `axum_server::from_tcp_rustls().serve()`.

`install_default` can fail, but I think it is safe to call `bail!` on failure here because:
- it should only fail if a `CryptoProvider` is not already installed;
- `start` and `devserver_mainloop` are not public API.

By submitting this PR, I agree that my contributions become part of the `dioxus` project as per the MIT and Apache licenses.
