### PR TITLE
Fix wasm hotpatching for zero-sized data symbols

### DIFF
--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -1388,10 +1388,6 @@ fn parse_bytes_to_data_segment(bytes: &[u8]) -> Result<RawDataSection<'_>> {
 
         data_symbol_map.insert(*name, index);
 
-        if symbol.size == 0 {
-            continue;
-        }
-
         let data_segment = segments
             .get(symbol.index as usize)
             .context("Failed to find data segment")?;


### PR DESCRIPTION
## Summary
- always record data symbols even when their size is zero in the parsed wasm linking table
- ensure GOT.mem fixups succeed during wasm hot-patching of WASM targets

## Motivation
- the hot-patch pipeline resolves GOT.mem imports via the `data_symbols` map; when crates like `tracing`, `tracing_subscriber`, or `sharded_slab` emit zero-sized statics (e.g. `sharded_slab::tid::REGISTRY`, `tracing_subscriber::layer::NONE_LAYER_MARKER`, `tracing_core::dispatcher::NO_SUBSCRIBER`), wasm-ld writes them to the symbol table with `size = 0`
- the parser previously skipped those entries, so `create_wasm_jump_table` looked them up by index, failed with `Failed to find data symbol by its index`, and aborted hot-patching back to a full rebuild

## Rationale
- keeping the zero-sized entries matches the wasm symbol table, and the subsequent logic only relies on the segment index and offset, so empty ranges are safe
- this avoids having to special-case call-sites later while unblocking WASM hot-patching in projects that depend on tracing

## Testing
- `dx new wasm-tracing` (or reuse any Dioxus web app), add `tracing = "0.1"` and `tracing-subscriber = "0.3"`, and initialize a subscriber in `main`
- run `dx serve --hot-patch --web`, edit `src/main.rs` to trigger a hot patch, and verify the build stays incremental without `Failed to find data symbol by its index`
