### PR TITLE
Handle wasm-bindgen wbg_cast helper in wasm hotpatching

### DIFF
--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -1326,6 +1326,7 @@ fn name_is_bindgen_symbol(name: &str) -> bool {
         || name.contains("wasm_bindgen..describe..WasmDescribe")
         || name.contains("wasm_bindgen..closure..WasmClosure$GT$8describe")
         || name.contains("wasm_bindgen7closure16Closure$LT$T$GT$4wrap8describe")
+        || name.contains("wasm_bindgen4__rt8wbg_")
 }
 
 /// Manually parse the data section from a wasm module


### PR DESCRIPTION
## Summary
- teach `name_is_bindgen_symbol` to recognize the `wasm_bindgen::__rt::wbg_*` cast helpers emitted by wasm-bindgen
- lets the wasm hot-patcher rewrite those imports into indirect calls alongside the existing `__wbindgen_*` shims

## Motivation
- the hot-patching path hits the import `_ZN12wasm_bindgen4__rt8wbg_cast17breaks_if_inlined17ha430ab957428946fE`
- wasm-bindgen emits that helper whenever web devtools are enabled; because the current heuristic doesn’t match its name, the patch leaves the `env` import unresolved and the browser aborts with `LinkError: function import requires a callable`

## Rationale
- these `__rt::wbg_*` helpers are the same wasm-bindgen glue as the descriptors we already rewrite, so they should follow the identical indirect-call path
- matching the `wasm_bindgen4__rt8wbg_` prefix keeps the logic simple and aligned with wasm-bindgen’s naming convention, ensuring the patched module contains no stray imports

## Testing
- `dx new wasm-devtools` (or reuse a Dioxus web app) and enable web devtools in `Dioxus.toml`
- run `dx serve --hot-patch --web`, edit a component to trigger a patch, and confirm the browser no longer throws `LinkError: function import requires a callable`
