### PR TITLE
Support custom asset mount paths

### DIFF
--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -375,7 +375,7 @@ impl AppServer {
             // todo(jon): don't hardcode this here
             if let Some(bundled_names) = self.client.hotreload_bundled_assets(path).await {
                 for bundled_name in bundled_names {
-                    assets.push(PathBuf::from("/assets/").join(bundled_name));
+                    assets.push(bundled_name);
                 }
             }
 

--- a/packages/manganis/manganis-core/src/css.rs
+++ b/packages/manganis/manganis-core/src/css.rs
@@ -1,5 +1,5 @@
 use crate::{AssetOptions, AssetOptionsBuilder, AssetVariant};
-use const_serialize::SerializeConst;
+use const_serialize::{ConstStr, SerializeConst};
 
 /// Options for a css asset
 #[derive(
@@ -91,9 +91,16 @@ impl AssetOptionsBuilder<CssAssetOptions> {
 
     /// Convert the options into options for a generic asset
     pub const fn into_asset_options(self) -> AssetOptions {
+        let (mount_path, has_mount_path) = match self.mount_path {
+            Some(path) => (ConstStr::new(path), true),
+            None => (ConstStr::new(""), false),
+        };
+
         AssetOptions {
-            add_hash: true,
+            add_hash: self.add_hash,
             variant: AssetVariant::Css(self.variant),
+            mount_path,
+            has_mount_path,
         }
     }
 }

--- a/packages/manganis/manganis-core/src/css_module.rs
+++ b/packages/manganis/manganis-core/src/css_module.rs
@@ -1,5 +1,5 @@
 use crate::{AssetOptions, AssetOptionsBuilder, AssetVariant};
-use const_serialize::SerializeConst;
+use const_serialize::{ConstStr, SerializeConst};
 use std::collections::HashSet;
 
 /// Options for a css module asset
@@ -84,9 +84,16 @@ impl AssetOptionsBuilder<CssModuleAssetOptions> {
 
     /// Convert the options into options for a generic asset
     pub const fn into_asset_options(self) -> AssetOptions {
+        let (mount_path, has_mount_path) = match self.mount_path {
+            Some(path) => (ConstStr::new(path), true),
+            None => (ConstStr::new(""), false),
+        };
+
         AssetOptions {
             add_hash: self.add_hash,
             variant: AssetVariant::CssModule(self.variant),
+            mount_path,
+            has_mount_path,
         }
     }
 }

--- a/packages/manganis/manganis-core/src/folder.rs
+++ b/packages/manganis/manganis-core/src/folder.rs
@@ -1,6 +1,5 @@
-use const_serialize::SerializeConst;
-
 use crate::{AssetOptions, AssetOptionsBuilder};
+use const_serialize::{ConstStr, SerializeConst};
 
 /// The builder for a folder asset.
 #[derive(
@@ -50,9 +49,16 @@ impl AssetOptions {
 impl AssetOptionsBuilder<FolderAssetOptions> {
     /// Convert the options into options for a generic asset
     pub const fn into_asset_options(self) -> AssetOptions {
+        let (mount_path, has_mount_path) = match self.mount_path {
+            Some(path) => (ConstStr::new(path), true),
+            None => (ConstStr::new(""), false),
+        };
+
         AssetOptions {
             add_hash: false,
             variant: crate::AssetVariant::Folder(self.variant),
+            mount_path,
+            has_mount_path,
         }
     }
 }

--- a/packages/manganis/manganis-core/src/images.rs
+++ b/packages/manganis/manganis-core/src/images.rs
@@ -1,6 +1,5 @@
-use const_serialize::SerializeConst;
-
 use crate::{AssetOptions, AssetOptionsBuilder, AssetVariant};
+use const_serialize::{ConstStr, SerializeConst};
 
 /// The type of an image. You can read more about the tradeoffs between image formats [here](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types)
 #[derive(
@@ -227,9 +226,16 @@ impl AssetOptionsBuilder<ImageAssetOptions> {
 
     /// Convert the options into options for a generic asset
     pub const fn into_asset_options(self) -> AssetOptions {
+        let (mount_path, has_mount_path) = match self.mount_path {
+            Some(path) => (ConstStr::new(path), true),
+            None => (ConstStr::new(""), false),
+        };
+
         AssetOptions {
             add_hash: self.add_hash,
             variant: AssetVariant::Image(self.variant),
+            mount_path,
+            has_mount_path,
         }
     }
 }

--- a/packages/manganis/manganis-core/src/js.rs
+++ b/packages/manganis/manganis-core/src/js.rs
@@ -1,6 +1,5 @@
-use const_serialize::SerializeConst;
-
 use crate::{AssetOptions, AssetOptionsBuilder, AssetVariant};
+use const_serialize::{ConstStr, SerializeConst};
 
 /// Options for a javascript asset
 #[derive(
@@ -94,9 +93,16 @@ impl AssetOptionsBuilder<JsAssetOptions> {
 
     /// Convert the builder into asset options with the given variant
     pub const fn into_asset_options(self) -> AssetOptions {
+        let (mount_path, has_mount_path) = match self.mount_path {
+            Some(path) => (ConstStr::new(path), true),
+            None => (ConstStr::new(""), false),
+        };
+
         AssetOptions {
             add_hash: self.add_hash,
             variant: AssetVariant::Js(self.variant),
+            mount_path,
+            has_mount_path,
         }
     }
 }

--- a/packages/manganis/manganis/README.md
+++ b/packages/manganis/manganis/README.md
@@ -26,6 +26,23 @@ pub const RESIZED_PNG_ASSET: Asset =
 pub const AVIF_ASSET: Asset = asset!("/assets/image.png", AssetOptions::image().with_format(ImageFormat::Avif));
 ```
 
+## Custom mount paths
+
+By default, bundled assets are emitted under `/assets/…`. You can override the served location with `with_mount_path`, which is especially useful for well-known files:
+
+```rust
+use manganis::{asset, Asset, AssetOptions};
+
+const SECURITY_TXT: Asset = asset!(
+    "/assets/security.txt",
+    AssetOptions::builder()
+        .with_hash_suffix(false)
+        .with_mount_path("/.well-known")
+);
+```
+
+When paired with the updated CLI, the file above will be written to `/.well-known/security.txt` in web builds, and requests to that URL will resolve correctly at runtime.
+
 ## Adding Support to Your CLI
 
 To add support for your CLI, you need to integrate with the [manganis_cli_support](https://github.com/DioxusLabs/manganis/tree/main/cli-support) crate. This crate provides utilities to collect assets that integrate with the Manganis macro. It makes it easy to integrate an asset collection and optimization system into a build tool.


### PR DESCRIPTION
See issue #4778 for more details and motivation!

- add optional mount_path to manganis AssetOptions + builders
- have CLI honor mount paths when copying assets and generating URLs
- update HTML preload injection, docs, and hotreload notifications
- honor AssetOptions mount_path across every bundle type
- serve native assets from mount directories via resolver fallback
- ensure Android hotreload pushes files into mount-aware locations

Tests: cargo test -p manganis-core; cargo check -p dioxus-cli