### PR TITLE
Removed wasm rel-preload link from bundle index.html to save bandwidth for Safari users

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -4826,10 +4826,10 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
             }
         }
 
-        // Manually inject the wasm file for preloading. WASM currently doesn't support preloading in the manganis asset system
-        head_resources.push_str(&format!(
-            "<link rel=\"preload\" as=\"fetch\" type=\"application/wasm\" href=\"/{{base_path}}/{wasm_path}\" crossorigin>"
-        ));
+        // Do not preload the wasm file, because in Safari, preload as=fetch requires additional fetch() options to exactly match the network request
+        // And if they do not match then Safari downloads the wasm file twice.
+        // See https://github.com/wasm-bindgen/wasm-bindgen/blob/ac51055a4c39fa0affe02f7b63fb1d4c9b3ddfaf/crates/cli-support/src/js/mod.rs#L967
+        
         Self::replace_or_insert_before("{style_include}", "</head", &head_resources, html);
 
         Ok(())


### PR DESCRIPTION
I noticed in Safari's Network tab, that my bundled wasm file (few hundred KB) was being downloaded twice.

I'm on macOS Tahoe with the latest updates.

After trying several combinations between link tag attributes and fetch() options, I found that the expected standard combinations that work in Chrome, did not in Safari. 

The most consistent solution is to remove the rel=preload entirely.

Research:
- mdn documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload#cors-enabled_fetches
- various solutions that work in Chrome and some in Safari as well, but require setting fetch() options: https://stackoverflow.com/a/63814972
 - the plain optionless fetch() call in wasm-bindgen:  https://github.com/wasm-bindgen/wasm-bindgen/blob/ac51055a4c39fa0affe02f7b63fb1d4c9b3ddfaf/crates/cli-support/src/js/mod.rs#L967