### PR TITLE
signals: Rebuild stale global cache entries automatically

### DIFF
--- a/packages/signals/src/global/mod.rs
+++ b/packages/signals/src/global/mod.rs
@@ -190,16 +190,9 @@ where
                     return signal.clone();
                 }
                 evicted_stale_entry = true;
-                #[cfg(debug_assertions)]
-                tracing::warn!(
-                    ?key,
-                    stored_type = ?signal.type_id(),
-                    expected_type = std::any::type_name::<T>(),
-                    expected_type_id = ?std::any::TypeId::of::<T>(),
-                    "Global signal cache entry type mismatch; rebuilding entry"
-                );
             }
         }
+
         if evicted_stale_entry {
             context.map.borrow_mut().remove(&key);
         }


### PR DESCRIPTION
When rebuilding with `dx serve --hot-patch`, changing the type of the value held in a `GlobalSignal` currently results in a panic, due to a downcast failure.

This patch causes the runtime to evict the existing value with a warning when that happens, rather than panicking.

I considered making the type part of the key, but this feels gentler, since this is a rare occurrence.