### PR TITLE
👩‍🏫 Add support for `default-members`

### DIFF
--- a/packages/cli/src/workspace.rs
+++ b/packages/cli/src/workspace.rs
@@ -302,6 +302,29 @@ impl Workspace {
             return Ok(self.krates.nid_for_kid(kid).unwrap());
         };
 
+        // if we have default members specified, try them first
+        if let Some(ws) = &self.cargo_toml.workspace {
+            for default in &ws.default_members {
+                let mut workspace_members = self.krates.workspace_members();
+                let default_member_path = std::fs::canonicalize(default).unwrap();
+
+                let found = workspace_members.find_map(|node| {
+                    if let krates::Node::Krate { id, krate, .. } = node {
+                        let member_path =
+                            std::fs::canonicalize(krate.manifest_path.parent().unwrap()).unwrap();
+                        if member_path == default_member_path {
+                            return Some(id);
+                        }
+                    }
+                    None
+                });
+
+                if let Some(kid) = found {
+                    return Ok(self.krates.nid_for_kid(kid).unwrap());
+                }
+            }
+        }
+
         // Otherwise find the package that is the closest parent of the current directory
         let current_dir = std::env::current_dir()?;
         let current_dir = current_dir.as_path();


### PR DESCRIPTION
This add pretty basic support for the `default-members` field in `Cargo.toml`, it's not perfect but it make things quite a bit better for larger projects using a bigger virtual workspace. 

For us it means that now we can just use `dx serve` instead of `dx serve -p the-project` which is a nice little productivity and onboarding win.