### PR TITLE
Remove write on memo and create a new derived signal hook

### DIFF
--- a/packages/hooks/docs/derived_signal.md
+++ b/packages/hooks/docs/derived_signal.md
@@ -1,0 +1,37 @@
+Creates a new Signal that is derived from other state. The derived signal will automatically update whenever any of the reactive values it reads on are written to. Note the signal is not memorized and the update is not immediate, the signal will be set to the value after the next async tick. Derived signals are useful for initializing values from props.
+
+```rust
+# use dioxus::prelude::*;
+#
+# fn App() -> Element {
+#     rsx! {
+#         Router::<Route> {}
+#     }
+# }
+#[derive(Routable, Clone)]
+enum Route {
+    // When you first navigate to this route, initial_count will be used to set the value of
+    // the count signal
+    #[route("/:initial_count")]
+    Counter { initial_count: u32 },
+}
+
+#[component]
+fn Counter(initial_count: ReadSignal<u32>) -> Element {
+    // The count will reset to the value of the prop whenever the prop changes
+    let mut count = use_derived_signal(move || initial_count());
+
+    rsx! {
+        button {
+            onclick: move |_| count += 1,
+            "{count}"
+        }
+        Link {
+            // Navigating to this link will change the initial_count prop to 10. Note, this
+            // only updates the props, the component is not remounted
+            to: Route::Counter { initial_count: 10 },
+            "Go to initial count 10"
+        }
+    }
+}
+```

--- a/packages/hooks/src/lib.rs
+++ b/packages/hooks/src/lib.rs
@@ -104,3 +104,6 @@ pub use use_action::*;
 
 mod use_waker;
 pub use use_waker::*;
+
+mod use_derived_signal;
+pub use use_derived_signal::*;

--- a/packages/hooks/src/use_derived_signal.rs
+++ b/packages/hooks/src/use_derived_signal.rs
@@ -1,0 +1,14 @@
+use crate::use_callback;
+use dioxus_core::use_hook;
+use dioxus_signals::Signal;
+
+#[doc = include_str!("../docs/derived_signal.md")]
+#[doc = include_str!("../docs/rules_of_hooks.md")]
+#[doc = include_str!("../docs/moving_state_around.md")]
+#[track_caller]
+pub fn use_derived_signal<R: 'static>(mut f: impl FnMut() -> R + 'static) -> Signal<R> {
+    let callback = use_callback(move |_| f());
+    let caller = std::panic::Location::caller();
+    #[allow(clippy::redundant_closure)]
+    use_hook(|| Signal::derived_signal_with_location(move || callback(()), caller))
+}

--- a/packages/signals/src/derived_signal.rs
+++ b/packages/signals/src/derived_signal.rs
@@ -1,0 +1,32 @@
+use dioxus_core::{current_scope_id, spawn_isomorphic, ReactiveContext};
+use futures_util::StreamExt;
+
+use crate::{Signal, WritableExt};
+
+pub(crate) fn derived_signal<T: 'static>(
+    mut init: impl FnMut() -> T + 'static,
+    location: &'static std::panic::Location<'static>,
+) -> Signal<T> {
+    let (tx, mut rx) = futures_channel::mpsc::unbounded();
+
+    let rc = ReactiveContext::new_with_callback(
+        move || _ = tx.unbounded_send(()),
+        current_scope_id(),
+        location,
+    );
+
+    // Create a new signal in that context, wiring up its dependencies and subscribers
+    let mut recompute = move || rc.reset_and_run_in(&mut init);
+    let value = recompute();
+    let mut state: Signal<T> = Signal::new_with_caller(value, location);
+
+    spawn_isomorphic(async move {
+        while rx.next().await.is_some() {
+            // Remove any pending updates
+            while rx.try_next().is_ok() {}
+            state.set(recompute());
+        }
+    });
+
+    state
+}

--- a/packages/signals/src/lib.rs
+++ b/packages/signals/src/lib.rs
@@ -44,3 +44,5 @@ pub mod warnings;
 
 mod boxed;
 pub use boxed::*;
+
+mod derived_signal;

--- a/packages/signals/src/memo.rs
+++ b/packages/signals/src/memo.rs
@@ -1,6 +1,6 @@
-use crate::{read::Readable, write_impls, ReadableRef, Signal};
+use crate::CopyValue;
+use crate::{read::Readable, ReadableRef, Signal};
 use crate::{read_impls, GlobalMemo, ReadableExt, WritableExt};
-use crate::{CopyValue, Writable};
 use std::{
     cell::RefCell,
     ops::Deref,
@@ -214,19 +214,6 @@ where
     }
 }
 
-impl<T: 'static + PartialEq> Writable for Memo<T> {
-    type WriteMetadata = <Signal<T> as Writable>::WriteMetadata;
-
-    fn try_write_unchecked(
-        &self,
-    ) -> Result<crate::WritableRef<'static, Self>, generational_box::BorrowMutError>
-    where
-        Self::Target: 'static,
-    {
-        self.inner.try_write_unchecked()
-    }
-}
-
 impl<T> IntoAttributeValue for Memo<T>
 where
     T: Clone + IntoAttributeValue + PartialEq + 'static,
@@ -263,7 +250,6 @@ where
 }
 
 read_impls!(Memo<T> where T: PartialEq);
-write_impls!(Memo<T> where T: PartialEq);
 
 impl<T> Clone for Memo<T> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
Removes writable from use_memo and replaces it with a derived signal hook. Note the new hook does not memoize the value or rerun immediately which makes it possible to return a normal signal while still filling the signal derived from reactive props use case
```rust
#[derive(Routable, Clone)]
enum Route {
    // When you first navigate to this route, initial_count will be used to set the value of
    // the count signal
    #[route("/:initial_count")]
    Counter { initial_count: u32 },
}

#[component]
fn Counter(initial_count: ReadSignal<u32>) -> Element {
    // The count will reset to the value of the prop whenever the prop changes
    let mut count = use_derived_signal(move || initial_count());

    rsx! {
        button {
            onclick: move |_| count += 1,
            "{count}"
        }
        Link {
            // Navigating to this link will change the initial_count prop to 10. Note, this
            // only updates the props, the component is not remounted
            to: Route::Counter { initial_count: 10 },
            "Go to initial count 10"
        }
    }
}
```

Closes https://github.com/DioxusLabs/dioxus/issues/4800