### PR TITLE
fix(hotpatch): Gracefully handle missing '-flavor' flag during WASM link

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -2255,11 +2255,8 @@ impl BuildRequest {
 
         // We want to go through wasm-ld directly, so we need to remove the -flavor flag
         if let Some(flavor_idx) = args.iter().position(|arg| *arg == "-flavor") {
-            tracing::trace!("Removing redundant '-flavor' linker flag for direct wasm-ld run.");
             args.remove(flavor_idx + 1);
             args.remove(flavor_idx);
-        } else {
-            tracing::trace!("WASM/WASI target detected, but expected linker '-flavor' flag was not found. Continuing link directly.");
         }
 
         // Set the output file


### PR DESCRIPTION
Problem: The unwrap() panic that occurs for WASM targets when the "-flavor" flag is absent from the linker arguments. (It happened to me, error shown at the bottom 😢)

Solution: Graceful missing '-flavor' flag handling

The error:
[dev] Thread tokio-runtime-worker panicked at packages\cli\src\build\request.rs:2258:76:
called Option::unwrap() on a None value
[dev] Build failed: Build panicked! JoinError::Panic(Id(33), "called Option::unwrap() on a None value", ...)
