### PR TITLE
fix(cli): correct Android toolchain target for 32-bit arm architectures

### DIFF
--- a/packages/cli/src/build/tools.rs
+++ b/packages/cli/src/build/tools.rs
@@ -252,7 +252,9 @@ impl AndroidTools {
 
         match output {
             Ok(Ok(out)) => match out.trim() {
-                "armv7l" | "armv8l" => triple.architecture = Architecture::Arm(ArmArchitecture::Arm),
+                "armv7l" | "armv8l" => {
+                    triple.architecture = Architecture::Arm(ArmArchitecture::Arm)
+                }
                 "aarch64" => {
                     triple.architecture = Architecture::Aarch64(Aarch64Architecture::Aarch64)
                 }


### PR DESCRIPTION
## Problem

When I run `dx serve --android --device 192.168.0.2:5555 --target armv7-linux-androideabi` on a physical Android 12 device with a 32-bit ARM architecture, I get a build error.

```
[dev] Build failed: Android linker not found at "/Users/me/Library/Android/sdk/ndk/29.0.14206865/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7-linux-androideabi28-clang".
Please set the \`ANDROID_NDK_HOME` environment variable to the root of your NDK installation.
```

## Fix

Update the CLI so that, consistent with the other parts of the CLI, the NDK architecture for 32-bit ARM is treated as `armv7a`.

* The toolchain path logic in `AndroidTools::clang_path` now uses `"armv7a-linux-androideabi"` for all 32-bit ARM architectures.
* The architecture detection logic now treats both `"armv7l"` and `"armv8l"` as `Architecture::Arm(ArmArchitecture::Arm)`, ensuring that both variants are recognized as ARM and handled correctly. (My physical device was `armv8l`)

## `dx doctor`

```
❯ dx doctor
Setup
 Web: wasm-bindgen, wasm-opt, and TailwindCSS are downloaded automatically
 iOS: Install iOS SDK and developer tools and through XCode
 Android: Install Android Studio, NDK, and then set ANDROID_HOME and ANDROID_NDK_HOME
 macOS: all tools should be installed by default
 Windows: install the webview2 binary
 Linux: Install libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libayatana-appindicator3-dev libxdo-dev libglib2.0-dev
 nix: Make sure all tools are in your path (codesign, ld, etc.)

Rust
 Rustc version: rustc 1.90.0 (1159e78c4 2025-09-14)
                                                                                                                                                                                                                     
 Rustc sysroot: /Users/a13400/.rustup/toolchains/1.90.0-aarch64-apple-darwin
 Rustc path: /Users/a13400/.cargo/bin/rustc
 Cargo path: /Users/a13400/.cargo/bin/cargo
 cc path: /usr/bin/cc

Devtools
 VSCode Extension: not found
 Cursor Extension: not found
 TailwindCSS: /Users/a13400/.dx/tailwind/tailwindcss-v4.1.5

Web
 wasm-opt: not installed
 wasm-bindgen: /Users/a13400/.dx/wasm-bindgen/wasm-bindgen-0.2.104
 wasm-bindgen version: 0.2.104

iOS/macOS
 XCode: /Library/Developer/CommandLineTools
 Simulator: not found
 Security CLI: /usr/bin/security
 Codesign CII: /usr/bin/codesign
 xcode-select: /usr/bin/xcode-select
 xcrun: /usr/bin/xcrun
 ranlib: /usr/bin/ranlib

Android
 sdk: /Users/a13400/Library/Android/sdk
 ndk: /Users/a13400/Library/Android/sdk/ndk/29.0.14206865
 adb: /Users/a13400/Library/Android/sdk/platform-tools/adb
 emulator: /Users/a13400/Library/Android/sdk/emulator/emulator
 java_home: /Users/a13400/.local/share/mise/installs/java/corretto-21.0.9.10.1

Toolchains
 ❌ wasm32-unknown-unknown (web)
 ✅ aarch64-android-linux (android)
 ✅ i686-linux-android (android)
 ✅ armv7-linux-androideabi (android)
 ✅ x86_64-android-linux (android)
 ❌ x86_64-apple-ios (iOS)
 ❌ aarch64-apple-ios (iOS)
 ❌ aarch64-apple-ios-sim (iOS)
 ✅ aarch64-apple-darwin (iOS)

Get help: https://discord.gg/XgGxMSkvUM
More info: https://dioxuslabs.com/learn/0.6/
```