### PR TITLE
Fix macro path sanitization to use absolute paths

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -204,7 +204,7 @@ mod field_info {
                 // children field is automatically defaulted to None
                 if name == "children" {
                     builder_attr.default =
-                        Some(syn::parse(quote!(dioxus_core::VNode::empty()).into()).unwrap());
+                        Some(syn::parse(quote!(::dioxus_core::VNode::empty()).into()).unwrap());
                 }
 
                 // String fields automatically use impl Display
@@ -1023,7 +1023,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                 );
                 quote! {
                     #[allow(dead_code, non_camel_case_types, missing_docs)]
-                    impl #impl_generics dioxus_elements::extensions::#marker_name for #builder_name < #( #ty_generics ),* > #where_clause {}
+                    impl #impl_generics ::dioxus_html::extensions::#marker_name for #builder_name < #( #ty_generics ),* > #where_clause {}
                 }
             });
 
@@ -1152,9 +1152,9 @@ Finally, call `.build()` to create the instance of `{name}`.
                 let marker_ident = syn::Ident::new("__Marker", proc_macro2::Span::call_site());
                 marker = Some(marker_ident.clone());
                 (
-                    quote!(impl dioxus_core::SuperInto<#arg_type, #marker_ident>),
+                    quote!(impl ::dioxus_core::SuperInto<#arg_type, #marker_ident>),
                     // If this looks like a signal type, we automatically convert it with SuperInto and use the props struct as the owner
-                    quote!(dioxus_core::with_owner(self.owner.clone(), move || dioxus_core::SuperInto::super_into(#field_name))),
+                    quote!(::dioxus_core::with_owner(self.owner.clone(), move || ::dioxus_core::SuperInto::super_into(#field_name))),
                 )
             } else if field.builder_attr.auto_into || field.builder_attr.strip_option {
                 let marker_ident = syn::Ident::new("__Marker", proc_macro2::Span::call_site());

--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -682,7 +682,7 @@ impl RouteEnum {
                     #(#site_map,)*
                 ];
 
-                fn render(&self, level: usize) -> dioxus_core::Element {
+                fn render(&self, level: usize) -> ::dioxus_core::Element {
                     let myself = self.clone();
                     match (level, myself) {
                         #(#matches)*

--- a/packages/rsx/src/attribute.rs
+++ b/packages/rsx/src/attribute.rs
@@ -183,21 +183,21 @@ impl Attribute {
 
         let ns = |name: &AttributeName| match (el_name, name) {
             (ElementName::Ident(i), AttributeName::BuiltIn(_)) => {
-                quote! { dioxus_elements::#i::#name.1 }
+                quote! { ::dioxus_html::#i::#name.1 }
             }
             _ => quote! { None },
         };
 
         let volatile = |name: &AttributeName| match (el_name, name) {
             (ElementName::Ident(i), AttributeName::BuiltIn(_)) => {
-                quote! { dioxus_elements::#i::#name.2 }
+                quote! { ::dioxus_html::#i::#name.2 }
             }
             _ => quote! { false },
         };
 
         let attribute = |name: &AttributeName| match name {
             AttributeName::BuiltIn(name) => match el_name {
-                ElementName::Ident(_) => quote! { dioxus_elements::#el_name::#name.0 },
+                ElementName::Ident(_) => quote! { ::dioxus_html::#el_name::#name.0 },
                 ElementName::Custom(_) => {
                     let as_string = name.to_string();
                     quote!(#as_string)
@@ -226,7 +226,7 @@ impl Attribute {
                     let value = quote! { #value };
 
                     quote! {
-                        dioxus_core::Attribute::new(
+                        ::dioxus_core::Attribute::new(
                             #attribute,
                             #value,
                             #ns,
@@ -268,7 +268,7 @@ impl Attribute {
                         AttributeName::BuiltIn(name) => {
                             let event_tokens_is_closure = check_tokens_is_closure(&tokens);
                             let function_name =
-                                quote_spanned! { span => dioxus_elements::events::#name };
+                                quote_spanned! { span => ::dioxus_html::events::#name };
                             let function = if event_tokens_is_closure {
                                 // If we see an explicit closure, we can call the `call_with_explicit_closure` version of the event for better type inference
                                 quote_spanned! { span => #function_name::call_with_explicit_closure }
@@ -284,7 +284,7 @@ impl Attribute {
                     }
                 }
                 _ => {
-                    quote_spanned! { value.span() => dioxus_elements::events::#name(#value) }
+                    quote_spanned! { value.span() => ::dioxus_html::events::#name(#value) }
                 }
             }
         };
@@ -360,9 +360,9 @@ impl Attribute {
                 #[doc(hidden)]
                 mod __completions {
                     // Autocomplete as an attribute
-                    pub use super::dioxus_elements::#el::*;
+                    pub use ::dioxus_html::#el::*;
                     // Autocomplete as an element
-                    pub use super::dioxus_elements::elements::completions::CompleteWithBraces::*;
+                    pub use ::dioxus_html::elements::completions::CompleteWithBraces::*;
                     fn ignore() {
                         #name;
                     }

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -96,11 +96,11 @@ impl ToTokens for Component {
         let diagnostics = &self.diagnostics;
 
         tokens.append_all(quote! {
-            dioxus_core::DynamicNode::Component({
+            ::dioxus_core::DynamicNode::Component({
 
                 // todo: ensure going through the trait actually works
                 // we want to avoid importing traits
-                use dioxus_core::Properties;
+                use ::dioxus_core::Properties;
                 let __comp = ({
                     #props
                 }).into_vcomponent(
@@ -222,7 +222,7 @@ impl Component {
             // we only want to span the name and generics, not the `fc_to_builder` call so jump-to-def
             // only finds the single entry (#name)
             let spanned = quote_spanned! { self.name.span() => #name #generics };
-            quote! { dioxus_core::fc_to_builder(#spanned) }
+            quote! { ::dioxus_core::fc_to_builder(#spanned) }
         };
 
         tokens.append_all(self.add_fields_to_builder(
@@ -306,7 +306,7 @@ impl Component {
                         ).emit_as_expr_tokens());
                     } else {
                         // tokens = quote! {
-                        //     dioxus_core::HasAttributes::push_attribute(
+                        //     ::dioxus_core::HasAttributes::push_attribute(
                         //         #tokens,
                         //         #name,
                         //         None,

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -112,7 +112,7 @@ impl ToTokens for Element {
         let el_name = &el.name;
 
         let ns = |name| match el_name {
-            ElementName::Ident(i) => quote! { dioxus_elements::#i::#name },
+            ElementName::Ident(i) => quote! { ::dioxus_html::#i::#name },
             ElementName::Custom(_) => quote! { None },
         };
 
@@ -124,7 +124,7 @@ impl ToTokens for Element {
                 // Early return for dynamic attributes
                 let Some((name, value)) = attr.as_static_str_literal() else {
                     let id = attr.dyn_idx.get();
-                    return quote! { dioxus_core::TemplateAttribute::Dynamic { id: #id  } };
+                    return quote! { ::dioxus_core::TemplateAttribute::Dynamic { id: #id  } };
                 };
 
                 let ns = match name {
@@ -137,7 +137,7 @@ impl ToTokens for Element {
 
                 let name = match (el_name, name) {
                     (ElementName::Ident(_), AttributeName::BuiltIn(_)) => {
-                        quote! { dioxus_elements::#el_name::#name.0 }
+                        quote! { ::dioxus_html::#el_name::#name.0 }
                     }
                     //hmmmm I think we could just totokens this, but the to_string might be inserting quotes
                     _ => {
@@ -149,7 +149,7 @@ impl ToTokens for Element {
                 let value = value.to_static().unwrap();
 
                 quote! {
-                    dioxus_core::TemplateAttribute::Static {
+                    ::dioxus_core::TemplateAttribute::Static {
                         name: #name,
                         namespace: #ns,
                         value: #value,
@@ -163,27 +163,27 @@ impl ToTokens for Element {
             BodyNode::Element(el) => quote! { #el },
             BodyNode::Text(text) if text.is_static() => {
                 let text = text.input.to_static().unwrap();
-                quote! { dioxus_core::TemplateNode::Text { text: #text } }
+                quote! { ::dioxus_core::TemplateNode::Text { text: #text } }
             }
             BodyNode::Text(text) => {
                 let id = text.dyn_idx.get();
-                quote! { dioxus_core::TemplateNode::Dynamic { id: #id } }
+                quote! { ::dioxus_core::TemplateNode::Dynamic { id: #id } }
             }
             BodyNode::ForLoop(floop) => {
                 let id = floop.dyn_idx.get();
-                quote! { dioxus_core::TemplateNode::Dynamic { id: #id } }
+                quote! { ::dioxus_core::TemplateNode::Dynamic { id: #id } }
             }
             BodyNode::RawExpr(exp) => {
                 let id = exp.dyn_idx.get();
-                quote! { dioxus_core::TemplateNode::Dynamic { id: #id } }
+                quote! { ::dioxus_core::TemplateNode::Dynamic { id: #id } }
             }
             BodyNode::Component(exp) => {
                 let id = exp.dyn_idx.get();
-                quote! { dioxus_core::TemplateNode::Dynamic { id: #id } }
+                quote! { ::dioxus_core::TemplateNode::Dynamic { id: #id } }
             }
             BodyNode::IfChain(exp) => {
                 let id = exp.dyn_idx.get();
-                quote! { dioxus_core::TemplateNode::Dynamic { id: #id } }
+                quote! { ::dioxus_core::TemplateNode::Dynamic { id: #id } }
             }
         });
 
@@ -199,7 +199,7 @@ impl ToTokens for Element {
 
                 #diagnostics
 
-                dioxus_core::TemplateNode::Element {
+                ::dioxus_core::TemplateNode::Element {
                     tag: #el_name,
                     namespace: #ns,
                     attrs: &[ #(#static_attrs),* ],
@@ -323,7 +323,7 @@ impl Element {
                 #[doc(hidden)]
                 mod __completions {
                     fn ignore() {
-                        super::dioxus_elements::elements::completions::CompleteWithBraces::#name
+                        ::dioxus_html::elements::completions::CompleteWithBraces::#name
                     }
                 }
             }
@@ -368,7 +368,7 @@ impl Parse for ElementName {
 impl ElementName {
     pub(crate) fn tag_name(&self) -> TokenStream2 {
         match self {
-            ElementName::Ident(i) => quote! { dioxus_elements::elements::#i::TAG_NAME },
+            ElementName::Ident(i) => quote! { ::dioxus_html::elements::#i::TAG_NAME },
             ElementName::Custom(s) => quote! { #s },
         }
     }

--- a/packages/rsx/src/expr_node.rs
+++ b/packages/rsx/src/expr_node.rs
@@ -29,7 +29,7 @@ impl ToTokens for ExprNode {
         tokens.append_all(quote! {
             {
                 #[allow(unused_braces)]
-                let ___nodes = dioxus_core::IntoDynNode::into_dyn_node(#expr);
+                let ___nodes = ::dioxus_core::IntoDynNode::into_dyn_node(#expr);
                 ___nodes
             }
         })

--- a/packages/rsx/src/forloop.rs
+++ b/packages/rsx/src/forloop.rs
@@ -49,7 +49,7 @@ impl ToTokens for ForLoop {
         // the temporary is important so we create a lifetime binding
         tokens.append_all(quote! {
             {
-                let ___nodes = dioxus_core::IntoDynNode::into_dyn_node((#expr).into_iter().map(|#pat| { #body }));
+                let ___nodes = ::dioxus_core::IntoDynNode::into_dyn_node((#expr).into_iter().map(|#pat| { #body }));
                 ___nodes
             }
         });

--- a/packages/rsx/src/ifchain.rs
+++ b/packages/rsx/src/ifchain.rs
@@ -121,13 +121,13 @@ impl ToTokens for IfChain {
 
         if !terminated {
             body.append_all(quote! {
-                else { dioxus_core::VNode::empty() }
+                else { ::dioxus_core::VNode::empty() }
             });
         }
 
         tokens.append_all(quote! {
             {
-                let ___nodes = dioxus_core::IntoDynNode::into_dyn_node(#body);
+                let ___nodes = ::dioxus_core::IntoDynNode::into_dyn_node(#body);
                 ___nodes
             }
         })

--- a/packages/rsx/src/literal.rs
+++ b/packages/rsx/src/literal.rs
@@ -47,12 +47,14 @@ pub enum HotLiteral {
 impl HotLiteral {
     pub fn quote_as_hot_reload_literal(&self) -> TokenStream2 {
         match &self {
-            HotLiteral::Fmted(f) => quote! { dioxus_core::internal::HotReloadLiteral::Fmted(#f) },
+            HotLiteral::Fmted(f) => quote! { ::dioxus_core::internal::HotReloadLiteral::Fmted(#f) },
             HotLiteral::Float(f) => {
-                quote! { dioxus_core::internal::HotReloadLiteral::Float(#f as _) }
+                quote! { ::dioxus_core::internal::HotReloadLiteral::Float(#f as _) }
             }
-            HotLiteral::Int(f) => quote! { dioxus_core::internal::HotReloadLiteral::Int(#f as _) },
-            HotLiteral::Bool(f) => quote! { dioxus_core::internal::HotReloadLiteral::Bool(#f) },
+            HotLiteral::Int(f) => {
+                quote! { ::dioxus_core::internal::HotReloadLiteral::Int(#f as _) }
+            }
+            HotLiteral::Bool(f) => quote! { ::dioxus_core::internal::HotReloadLiteral::Bool(#f) },
         }
     }
 }
@@ -194,21 +196,21 @@ impl ToTokens for HotReloadFormattedSegment {
         let mut idx = 0_usize;
         let segments = self.segments.iter().map(|s| match s {
             Segment::Literal(lit) => quote! {
-                dioxus_core::internal::FmtSegment::Literal { value: #lit }
+                ::dioxus_core::internal::FmtSegment::Literal { value: #lit }
             },
             Segment::Formatted(_fmt) => {
                 // increment idx for the dynamic segment so we maintain the mapping
                 let _idx = self.dynamic_node_indexes[idx].get();
                 idx += 1;
                 quote! {
-                   dioxus_core::internal::FmtSegment::Dynamic { id: #_idx }
+                   ::dioxus_core::internal::FmtSegment::Dynamic { id: #_idx }
                 }
             }
         });
 
         // The static segments with idxs for locations
         tokens.extend(quote! {
-            dioxus_core::internal::FmtedSegments::new( vec![ #(#segments),* ], )
+            ::dioxus_core::internal::FmtedSegments::new( vec![ #(#segments),* ], )
         });
     }
 }

--- a/packages/rsx/src/text_node.rs
+++ b/packages/rsx/src/text_node.rs
@@ -29,7 +29,7 @@ impl ToTokens for TextNode {
 
         if txt.is_static() {
             tokens.append_all(quote! {
-                dioxus_core::DynamicNode::Text(dioxus_core::VText::new(#txt.to_string()))
+                ::dioxus_core::DynamicNode::Text(::dioxus_core::VText::new(#txt.to_string()))
             })
         } else {
             // todo:
@@ -38,7 +38,7 @@ impl ToTokens for TextNode {
             let as_lit = HotLiteral::Fmted(txt.clone());
 
             tokens.append_all(quote! {
-                dioxus_core::DynamicNode::Text(dioxus_core::VText::new( #as_lit ))
+                ::dioxus_core::DynamicNode::Text(::dioxus_core::VText::new( #as_lit ))
             })
         }
     }


### PR DESCRIPTION
Fixes #4781 by using absolute paths (::dioxus_core::, ::dioxus_html::, etc.) in all macro-generated code to prevent compilation errors when the prelude isn't imported.