### PR TITLE
fix: tokio rt is not set when calling handlers

### DIFF
--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -261,7 +261,14 @@ impl WebviewInstance {
                 asset_handlers,
                 edits
             ];
+
+            #[cfg(feature = "tokio_runtime")]
+            let tokio_rt = tokio::runtime::Handle::current();
+
             move |_id: WebViewId, request, responder: RequestAsyncResponder| {
+                #[cfg(feature = "tokio_runtime")]
+                let _guard = tokio_rt.enter();
+
                 protocol::desktop_handler(
                     request,
                     asset_handlers.clone(),
@@ -382,11 +389,25 @@ impl WebviewInstance {
         }
 
         for (name, handler) in cfg.protocols.drain(..) {
-            webview = webview.with_custom_protocol(name, handler);
+            #[cfg(feature = "tokio_runtime")]
+            let tokio_rt = tokio::runtime::Handle::current();
+
+            webview = webview.with_custom_protocol(name, move |a, b| {
+                #[cfg(feature = "tokio_runtime")]
+                let _guard = tokio_rt.enter();
+                handler(a, b)
+            });
         }
 
         for (name, handler) in cfg.asynchronous_protocols.drain(..) {
-            webview = webview.with_asynchronous_custom_protocol(name, handler);
+            #[cfg(feature = "tokio_runtime")]
+            let tokio_rt = tokio::runtime::Handle::current();
+
+            webview = webview.with_asynchronous_custom_protocol(name, move |a, b, c| {
+                #[cfg(feature = "tokio_runtime")]
+                let _guard = tokio_rt.enter();
+                handler(a, b, c)
+            });
         }
 
         const INITIALIZATION_SCRIPT: &str = r#"


### PR DESCRIPTION
This fixes  https://github.com/DioxusLabs/dioxus/issues/4847

I think something changed in wry/tao since using tokio RT *used* to work without needing to manually enter the runtime.

Tao on android has weird problems with thread safety and locking. Looking at the stack trace, it seems that `handleRequest` is called from wry in a thread that tokio was never used on. That doesn't make much sense to me, but I imagine it might be a java thread that existed *before* our `main` thread.

This PR just drags the runtime along into the async protocols, fixing the bug. I imagine there might be other similar issues with global runtimes we might need to look at later, but can't quite tell.