### PR TITLE
Fix updating components and local components

### DIFF
--- a/packages/cli/src/cli/component.rs
+++ b/packages/cli/src/cli/component.rs
@@ -790,7 +790,7 @@ async fn copy_global_assets(
     assets_root: &Path,
     component: &ResolvedComponent,
 ) -> Result<()> {
-    let cononical_registry_root = dunce::canonicalize(registry_root)?;
+    let canonical_registry_root = dunce::canonicalize(registry_root)?;
     for path in &component.global_assets {
         let src = component.path.join(path);
         let absolute_source = dunce::canonicalize(&src).with_context(|| {
@@ -802,12 +802,12 @@ async fn copy_global_assets(
         })?;
 
         // Make sure the source is inside the component registry somewhere
-        if !absolute_source.starts_with(&cononical_registry_root) {
+        if !absolute_source.starts_with(&canonical_registry_root) {
             bail!(
                 "Cannot copy global asset '{}' for component '{}' because it is outside of the component registry '{}'",
                 absolute_source.display(),
                 component.name,
-                cononical_registry_root.display()
+                canonical_registry_root.display()
             );
         }
 


### PR DESCRIPTION
Fixes two issues with the registry in the new component command:
1) The path checking was too strict for local registries. After this PR, they work correctly while testing with the dx components registry locally
2) The update command only fetched the latest commit without checking it out which made it impossible to pull in the latest version of the component registry