### PR TITLE
Native: Add vello feature flag

### DIFF
--- a/packages/native/Cargo.toml
+++ b/packages/native/Cargo.toml
@@ -10,7 +10,17 @@ homepage = "https://dioxuslabs.com/learn/0.6/getting_started"
 keywords = ["dom", "ui", "gui", "react"]
 
 [features]
-default = ["accessibility", "hot-reload", "net", "html", "svg", "system-fonts", "clipboard", "file_dialog"]
+default = [
+  "accessibility",
+  "hot-reload",
+  "net",
+  "html",
+  "svg",
+  "system-fonts",
+  "clipboard",
+  "file_dialog",
+  "vello",
+]
 clipboard = ["blitz-shell/clipboard"]
 file_dialog = ["blitz-shell/file_dialog"]
 svg = ["blitz-dom/svg", "blitz-paint/svg"]
@@ -22,10 +32,12 @@ hot-reload = ["dep:dioxus-cli-config", "dep:dioxus-devtools"]
 system-fonts = ["blitz-dom/system_fonts"]
 autofocus = []
 
+# Renderers
+vello = ["dep:anyrender_vello"]
 [dependencies]
 # Blitz dependencies
 anyrender = { workspace = true }
-anyrender_vello = { workspace = true }
+anyrender_vello = { workspace = true, optional = true }
 blitz-dom = { workspace = true }
 blitz-html = { workspace = true, optional = true }
 blitz-net = { workspace = true, optional = true }

--- a/packages/native/src/assets.rs
+++ b/packages/native/src/assets.rs
@@ -33,6 +33,7 @@ impl NetProvider<Resource> for DioxusNativeNetProvider {
         handler: blitz_traits::net::BoxedHandler<Resource>,
     ) {
         if request.url.scheme() == "dioxus" {
+            #[allow(clippy::single_match)]
             match dioxus_asset_resolver::native::serve_asset(request.url.path()) {
                 Ok(res) => {
                     #[cfg(feature = "tracing")]

--- a/packages/native/src/dioxus_renderer.rs
+++ b/packages/native/src/dioxus_renderer.rs
@@ -4,14 +4,18 @@ use std::sync::Arc;
 
 use anyrender::WindowRenderer;
 
+#[cfg(not(feature = "vello"))]
+compile_error!("At least one of the renderer features must be enabled");
+
+#[cfg(feature = "vello")]
 pub use anyrender_vello::{
     wgpu::{Features, Limits},
     CustomPaintSource, VelloRendererOptions, VelloWindowRenderer as InnerRenderer,
 };
 
+#[cfg(feature = "vello")]
 pub fn use_wgpu<T: CustomPaintSource>(create_source: impl FnOnce() -> T) -> u64 {
     use dioxus_core::{consume_context, use_hook_with_cleanup};
-
     let (_renderer, id) = use_hook_with_cleanup(
         || {
             let renderer = consume_context::<DioxusNativeWindowRenderer>();
@@ -44,6 +48,7 @@ impl DioxusNativeWindowRenderer {
         Self::with_inner_renderer(vello_renderer)
     }
 
+    #[cfg(feature = "vello")]
     pub fn with_features_and_limits(features: Option<Features>, limits: Option<Limits>) -> Self {
         let vello_renderer = InnerRenderer::with_options(VelloRendererOptions {
             features,
@@ -60,6 +65,7 @@ impl DioxusNativeWindowRenderer {
     }
 }
 
+#[cfg(feature = "vello")]
 impl DioxusNativeWindowRenderer {
     pub fn register_custom_paint_source(&self, source: Box<dyn CustomPaintSource>) -> u64 {
         self.inner.borrow_mut().register_custom_paint_source(source)

--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -18,16 +18,19 @@ mod link_handler;
 #[doc(inline)]
 pub use dioxus_native_dom::*;
 
+#[cfg(feature = "vello")]
 pub use anyrender_vello::{CustomPaintCtx, CustomPaintSource, DeviceHandle, TextureHandle};
+#[cfg(feature = "vello")]
+pub use dioxus_renderer::{use_wgpu, Features, Limits};
+
 use assets::DioxusNativeNetProvider;
 pub use dioxus_application::{DioxusNativeApplication, DioxusNativeEvent};
-pub use dioxus_renderer::{use_wgpu, DioxusNativeWindowRenderer, Features, Limits};
+pub use dioxus_renderer::DioxusNativeWindowRenderer;
 
 use blitz_shell::{create_default_event_loop, BlitzShellEvent, Config, WindowConfig};
 use dioxus_core::{ComponentFunction, Element, VirtualDom};
 use link_handler::DioxusNativeNavigationProvider;
 use std::any::Any;
-#[cfg(feature = "html")]
 use std::sync::Arc;
 use winit::window::WindowAttributes;
 
@@ -69,13 +72,18 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
     }
 
     // Read config values
+    #[cfg(feature = "vello")]
     let mut features = None;
+    #[cfg(feature = "vello")]
     let mut limits = None;
     let mut window_attributes = None;
     let mut _config = None;
     for mut cfg in configs {
-        cfg = try_read_config!(cfg, features, Features);
-        cfg = try_read_config!(cfg, limits, Limits);
+        #[cfg(feature = "vello")]
+        {
+            cfg = try_read_config!(cfg, features, Features);
+            cfg = try_read_config!(cfg, limits, Limits);
+        }
         cfg = try_read_config!(cfg, window_attributes, WindowAttributes);
         cfg = try_read_config!(cfg, _config, Config);
         let _ = cfg;
@@ -143,7 +151,10 @@ pub fn launch_cfg_with_props<P: Clone + 'static, M: 'static>(
             ..Default::default()
         },
     );
+    #[cfg(feature = "vello")]
     let renderer = DioxusNativeWindowRenderer::with_features_and_limits(features, limits);
+    #[cfg(not(feature = "vello"))]
+    let renderer = DioxusNativeWindowRenderer::new();
     let config = WindowConfig::with_attributes(
         Box::new(doc) as _,
         renderer.clone(),


### PR DESCRIPTION
This is a super-minimal PR that just feature flags the existing `vello` backend for Dioxus Native (without adding any additional rendering backends). Disabling the feature causes a compile error, which is what we want because it means that adding additional backends can be done as a non-breaking change.