### PR TITLE
Fix FileStream.file_name()

### DIFF
--- a/packages/fullstack/src/payloads/files.rs
+++ b/packages/fullstack/src/payloads/files.rs
@@ -212,12 +212,9 @@ impl<S> FromRequest<S> for FileStream {
             let filename = match disposition.map(|s| s.to_str()) {
                 Some(Ok(dis)) => {
                     let content = content_disposition::parse_content_disposition(dis);
-                    let names = content.filename();
-                    match names {
-                        Some((_name, Some(filename))) => filename.to_string(),
-                        Some((name, None)) => name.to_string(),
-                        None => "file".to_string(),
-                    }
+                    content
+                        .filename_full()
+                        .unwrap_or_else(|| "file".to_string())
                 }
                 _ => "file".to_string(),
             };


### PR DESCRIPTION
Use `ParsedContentDisposition.filename_full()` to get the file name with the extension in a single string.

On the other hand, `ParsedContentDisposition.file_name()` returns a tuple with just the name as the first value, and the file extension as the last value.