### PR TITLE
feat: add --raw-json-diagnostics flag to dx build

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -399,6 +399,7 @@ pub(crate) struct BuildRequest {
     pub(crate) apple_entitlements: Option<PathBuf>,
     pub(crate) apple_team_id: Option<String>,
     pub(crate) session_cache_dir: PathBuf,
+    pub(crate) raw_json_diagnostics: bool,
 }
 
 /// dx can produce different "modes" of a build. A "regular" build is a "base" build. The Fat and Thin
@@ -1033,6 +1034,7 @@ impl BuildRequest {
             inject_loading_scripts: args.inject_loading_scripts,
             apple_entitlements: args.apple_entitlements.clone(),
             apple_team_id: args.apple_team_id.clone(),
+            raw_json_diagnostics: args.raw_json_diagnostics,
         })
     }
 
@@ -1189,6 +1191,11 @@ impl BuildRequest {
                 Ok(Some(line)) = stderr.next_line() => line,
                 else => break,
             };
+
+            // If raw JSON diagnostics are requested, relay the line directly
+            if self.raw_json_diagnostics {
+                println!("{}", line);
+            }
 
             let Some(Ok(message)) = Message::parse_stream(std::io::Cursor::new(line)).next() else {
                 continue;

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -161,6 +161,14 @@ pub(crate) struct TargetArgs {
     /// See <https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170> for more information.
     #[clap(long, help_heading = HELP_HEADING)]
     pub(crate) windows_subsystem: Option<String>,
+
+    /// Output raw JSON diagnostics from cargo instead of processing them [default: false]
+    ///
+    /// When enabled, cargo's JSON output will be relayed directly to stdout without any processing or formatting by DX.
+    /// This is useful for integration with other tools that expect cargo's raw JSON format.
+    #[clap(long, help_heading = HELP_HEADING)]
+    #[serde(default)]
+    pub(crate) raw_json_diagnostics: bool,
 }
 
 impl Anonymized for TargetArgs {
@@ -186,6 +194,7 @@ impl Anonymized for TargetArgs {
             "base_path": self.base_path.is_some(),
             "cargo_args": self.cargo_args.is_some(),
             "rustc_args": self.rustc_args.is_some(),
+            "raw_json_diagnostics": self.raw_json_diagnostics,
         }}
     }
 }


### PR DESCRIPTION
This flag allows users to get the raw JSON output from cargo instead of having it processed by Dioxus. This is useful for integration with other tools that expect cargo's native JSON diagnostic format.

When enabled, cargo's JSON messages are relayed directly to stdout while still allowing DX to track essential build information internally.

Usage: dx build --raw-json-diagnostics

---

Example Zed/rust-analyzer config:

```json
{
  "lsp": {
    "rust-analyzer": {
      "initialization_options": {
        "check": {
          "overrideCommand": ["dx", "build", "--web", "--raw-json-diagnostics"]
        }
      }
    }
  }
}
```