### PR TITLE
Simple but critical fix for fullstack server fn handling

### DIFF
--- a/packages/fullstack/src/magic.rs
+++ b/packages/fullstack/src/magic.rs
@@ -550,8 +550,7 @@ pub mod req_from {
 
                 let out = serde_json::from_slice::<In>(bytes)
                     .map(map)
-                    .map_err(|e| ServerFnError::from(e).into_response())
-                    .unwrap();
+                    .map_err(|e| ServerFnError::from(e).into_response())?;
 
                 Ok((out, headers))
             }


### PR DESCRIPTION
Getting full panics here in prod: 
thread '<unnamed>' (23) panicked at /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dioxus-fullstack-0.7.0/src/magic.rs:554:22: called `Result::unwrap()` on an `Err` value: Response { status: 500, version: HTTP/1.1, headers: {"content-type": "application/json"}, body: Body(UnsyncBoxBody) }

Could be triggered by something as simple as a client choosing to send formdata-style body instead of JSON. (I discovered this because exactly that was happening; not maliciously, but because of the upgrade from 0.6.3 to 0.7). 

As far as I can tell, this was just meant to be an early return with a failure case of the Response, mapped from the ServerFnError. The .unwrap() left there was probably just an erroneous artifact from the various waves of the development process. 

If this is incorrect or I've missed something, please let me know! But I believe this is a very simple fix for an otherwise critical problem