### PR TITLE
Support VSCode-Insiders in doctor command

### DIFF
--- a/packages/cli/src/cli/doctor.rs
+++ b/packages/cli/src/cli/doctor.rs
@@ -66,6 +66,11 @@ impl Doctor {
             Ok(path) => path.to_string_lossy().to_string(),
             Err(_) => "not found".to_string(),
         };
+        let vscode_insiders_ext = has_dioxus_ext(".vscode-insiders");
+        let vscode_insiders_ext_msg = match vscode_insiders_ext.as_ref() {
+            Ok(path) => path.to_string_lossy().to_string(),
+            Err(_) => "not found".to_string(),
+        };
         let cursor_ext = has_dioxus_ext(".cursor");
         let cursor_ext_msg = match cursor_ext.as_ref() {
             Ok(path) => path.to_string_lossy().to_string(),
@@ -216,6 +221,7 @@ impl Doctor {
 
 {LINK_STYLE}Devtools{LINK_STYLE:#}
  VSCode Extension: {HINT_STYLE}{vscode_ext_msg}{HINT_STYLE:#}
+ VSCode-Insiders Extension: {HINT_STYLE}{vscode_insiders_ext_msg}{HINT_STYLE:#}
  Cursor Extension: {HINT_STYLE}{cursor_ext_msg}{HINT_STYLE:#}
  TailwindCSS: {HINT_STYLE}{tailwindcss}{HINT_STYLE:#}
 


### PR DESCRIPTION
Add support for VSCode-Insiders to the dioxus-cli `doctor` command.

With this change, the Dev Tools section of the output looks like:

```
Devtools
 VSCode Extension: /home/craig/.vscode/extensions/dioxuslabs.dioxus-0.6.0
 VSCode-Insiders Extension: /home/craig/.vscode-insiders/extensions/dioxuslabs.dioxus-0.6.0
 Cursor Extension: not found
 TailwindCSS: /home/craig/snap/code-insiders/2152/.local/share/.dx/tailwind/tailwindcss-v4.1.5
```

I found this code while looking into how the debugger support works, and figured I might as well update it to better support my setup.