### PR TITLE
fix: #4931 Add `use_drop` to prelude

### DIFF
--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -236,7 +236,7 @@ pub mod prelude {
 
     #[doc(inline)]
     pub use dioxus_core::{
-        consume_context, provide_context, spawn, suspend, try_consume_context, use_hook,
+        consume_context, provide_context, spawn, suspend, try_consume_context, use_drop, use_hook,
         AnyhowContext, Attribute, Callback, Component, Element, ErrorBoundary, ErrorContext, Event,
         EventHandler, Fragment, HasAttributes, IntoDynNode, RenderError, Result, ScopeId,
         SuspenseBoundary, SuspenseContext, VNode, VirtualDom,


### PR DESCRIPTION
Encountered this enhancement myself and saw that an issue for it existed.