### PR TITLE
Use tokio 1.48 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ tracing = "0.1.41"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.19", default-features = false }
 toml = "0.8"
-tokio = "1.46"
+tokio = "1.48"
 tokio-util = { version = "0.7.15" }
 tokio-stream = { version = "0.1.17" }
 slab = "0.4.10"
@@ -489,7 +489,7 @@ pollster = "0.4.0"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
-tokio = { version = "1.46", default-features = false, features = [
+tokio = { version = "1.48", default-features = false, features = [
     "sync",
     "macros",
     "io-util",
@@ -499,7 +499,7 @@ tokio = { version = "1.46", default-features = false, features = [
 uuid = { workspace = true, features = ["v4", "serde", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1.46", features = ["full"] }
+tokio = { version = "1.48", features = ["full"] }
 
 # To make most examples faster to compile, we split out assets and http-related stuff
 # This trims off like 270 dependencies, leading to a significant speedup in compilation time


### PR DESCRIPTION
## WHAT

Updates the version of `tokio` in Cargo.toml to match Cargo.lock

Lockfile updated here: https://github.com/DioxusLabs/dioxus/pull/4715
tokio release: [1.48.0](https://github.com/tokio-rs/tokio/releases/tag/tokio-1.48.0)

## WHY

The use of `try_get` [added here](https://github.com/DioxusLabs/dioxus/pull/4849/files#diff-7b2be6fb4aff488393009623170b236c834b97fbb6867145d53ed3577251a92bR136) depends upon `1.48`.

Leading to this error:
```
14:26:12 [cargo] error[E0599]: no method named `try_get` found for struct `tokio::task::LocalKey<T>` in the current scope
   --> /home/n/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/dioxus-fullstack-core-0.7.1/src/streaming.rs:158:48
    |
158 |         if let Ok(context) = FULLSTACK_CONTEXT.try_get() {
    |                                                ^^^^^^^ method not found in `tokio::task::LocalKey<FullstackContext>`
```

An outdated patch version of `reqwest` in my deps was pulling down the version to an incompatible `1.47`. If the version here matched, this would have instead been a more clear error. Here it is after applying this change:

```
error: failed to select a version for `tokio`.
    ... required by package `dioxus-asset-resolver v0.7.1 (/home/n/dev/github.com/nessex/dioxus/packages/asset-resolver)`
    ... which satisfies path dependency `dioxus-asset-resolver` of package `dioxus v0.7.1 (/home/n/dev/github.com/nessex/dioxus/packages/dioxus)`
    ... which satisfies path dependency `dioxus` of package `thing v0.1.0 (/home/n/dev/github.com/nessex/thing)`
versions that meet the requirements `^1.48` are: 1.48.0

all possible versions conflict with previously selected packages.

  previously selected package `tokio v1.47.1`
    ... which satisfies dependency `tokio = "^1.0"` (locked to 1.47.1) of package `reqwest v0.12.23`
    ... which satisfies dependency `reqwest = "^0.12"` (locked to 0.12.23) of package `thing v0.1.0 (/home/n/dev/github.com/nessex/thing)`

```