### PR TITLE
Skip default members when canonicalize fails

### DIFF
--- a/packages/cli/src/workspace.rs
+++ b/packages/cli/src/workspace.rs
@@ -318,7 +318,7 @@ impl Workspace {
                                 return None;
                             }
                             if std::fs::canonicalize(krate.manifest_path.parent().unwrap())
-                                .is_ok_and(|memeber_path| memeber_path == default_member_path)
+                                .is_ok_and(|member_path| member_path == default_member_path)
                             {
                                 return Some(id);
                             }


### PR DESCRIPTION
**Summary:**
Avoid panicking when searching default members in a current directory different from the main workspace folder.
Unfortunately #4895 was not targeting the actual issue of #4873.

**Details:**
Basically it avoid panicking on line 309. 
Unwrapping on 322 should be fine but for code style consistency I've also edited it.

Fix #4873 