### PR TITLE
Add server dirty flag

### DIFF
--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -204,6 +204,12 @@ pub(crate) async fn serve_all(args: ServeArgs, tracer: &TraceController) -> Resu
                         screen.push_stdio(bundle_format, msg, tracing::Level::ERROR);
                     }
                     BuilderUpdate::ProcessExited { status } => {
+                        if matches!(id, BuildId::SECONDARY) && builder.server.is_some() {
+                            builder.mark_server_dirty();
+                            tracing::debug!(
+                                "Server process exited with status {status}; will restart on next open"
+                            );
+                        }
                         if status.success() {
                             tracing::info!(
                                 r#"Application [{bundle_format}] exited gracefully.


### PR DESCRIPTION
This fixed an issue for me where modifying rust code in a dependency of only /web was causing everything including /server to reload unnecessarily. Then the page would reload out of sync with the server function registration and give the following error, requiring a manual reload to resolve:

```
Backend connection failed. The backend is likely still starting up. Please try again in a few seconds. Error: Error {
    context: "Failed to send proxy request",
    source: hyper_util::client::legacy::Error(
        Connect,
        ConnectError(
            "tcp connect error",
            0.0.0.0:64443,
            Os {
                code: 61,
                kind: ConnectionRefused,
                message: "Connection refused",
            },
        ),
    ),
}
```

Note that AI wrote all this, so I don't know if it's good or even necessary but it fixed my issue and might be helpful to others so I figured I'd post it.