### PR TITLE
install.sh: Change shell interpreter from sh to bash

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eo pipefail
 
 # Reset


### PR DESCRIPTION
The `[[ ]]` syntax on line 16 and elsewhere, i.e. `if [[ -t 1 ]]; then` doesn't work in sh - it's a [bash feature](https://www.gnu.org/software/bash/manual/html_node/Conditional-Constructs.html#index-_005b_005b).

Tested on Ubuntu 25.10. The current install script errors with:

```
./install.sh: 16: [[: not found
./install.sh: 50: [[: not found
./install.sh: 69: [[: not found
#=O#-    #       #                                                                                                                                                                                                                    curl: (22) The requested URL returned error: 404
```

On this system, /bin/sh is symlinked to dash.

Changing to `#!/bin/bash` solves the problem, and the script works as expected.

It was probably working in many places because some systems symlink /bin/sh to /bin/bash.