### PR TITLE
Fixed API Docs link for rsx-rosetta README

### DIFF
--- a/packages/rsx-rosetta/README.md
+++ b/packages/rsx-rosetta/README.md
@@ -16,7 +16,7 @@
 
 [Website](https://dioxuslabs.com) |
 [Guides](https://dioxuslabs.com/learn/0.7/) |
-[API Docs](https://docs.rs/rsx-rosetta/latest/rsx-rosetta) |
+[API Docs](https://docs.rs/rsx-rosetta/latest/rsx_rosetta) |
 [Chat](https://discord.gg/XgGxMSkvUM)
 
 ## Overview


### PR DESCRIPTION
It was ```https://docs.rs/rsx-rosetta/latest/rsx-rosetta``` (with a dash)
It should be ```https://docs.rs/rsx-rosetta/latest/rsx_rosetta``` (with an underscore)