### PR TITLE
Fix unresponsive linux menu

### DIFF
--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -241,13 +241,17 @@ impl App {
             .unmounted_dom
             .take()
             .expect("Virtualdom should be set before initialization");
+        #[allow(unused_mut)]
         let mut cfg = self
             .cfg
             .take()
             .expect("Config should be set before initialization");
 
         self.is_visible_before_start = cfg.window.window.visible;
-        cfg.window = cfg.window.with_visible(false);
+        #[cfg(not(target_os = "linux"))]
+        {
+            cfg.window = cfg.window.with_visible(false);
+        }
         let explicit_window_size = cfg.window.window.inner_size;
         let explicit_window_position = cfg.window.window.position;
 
@@ -284,9 +288,12 @@ impl App {
 
         view.edits.wry_queue.send_edits();
 
-        view.desktop_context
-            .window
-            .set_visible(self.is_visible_before_start);
+        #[cfg(not(target_os = "linux"))]
+        {
+            view.desktop_context
+                .window
+                .set_visible(self.is_visible_before_start);
+        }
 
         _ = self.shared.proxy.send_event(UserWindowEvent::Poll(id));
     }


### PR DESCRIPTION
It looks like there is a bug with wry or tao that causes window decorations to become unresponsive if you ever make the window invisible on linux: https://github.com/tauri-apps/tauri/issues/11856

This PR just works around that issue by not waiting for the first render to make the window visible. That means there will be a flash before the content is rendered

We should also fix this upstream or move to a different library for windowing. We have talked about unifying the windowing code for blitz and desktop with winit. I'm unsure if they have the same bug

Fixes #3667 