### PR TITLE
Fixing regression due to route preservation

### DIFF
--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -7,8 +7,7 @@ use crate::{
     shortcut::ShortcutRegistry,
     webview::{PendingWebview, WebviewInstance},
 };
-use dioxus_core::{consume_context, ScopeId, VirtualDom};
-use dioxus_history::History;
+use dioxus_core::VirtualDom;
 use std::{
     cell::{Cell, RefCell},
     collections::HashMap,
@@ -480,9 +479,6 @@ impl App {
 
     #[cfg(debug_assertions)]
     fn persist_window_state(&self) {
-        use dioxus_core::ScopeId;
-        use dioxus_history::History;
-
         if let Some(webview) = self.webviews.values().next() {
             let window = &webview.desktop_context.window;
 
@@ -518,17 +514,12 @@ impl App {
                 return;
             };
 
-            let url = webview.dom.in_scope(ScopeId::ROOT, || {
-                consume_context::<Rc<dyn History>>().current_route()
-            });
-
             let state = PreservedWindowState {
                 x,
                 y,
                 width: width.max(200),
                 height: height.max(200),
                 monitor: monitor_name.to_string(),
-                url: Some(url),
             };
 
             // Yes... I know... we're loading a file that might not be ours... but it's a debug feature
@@ -582,13 +573,6 @@ impl App {
                         window.set_inner_size(tao::dpi::PhysicalSize::new(size.0, size.1));
                     }
                 }
-
-                // Set the url if it exists
-                webview.dom.in_scope(ScopeId::ROOT, || {
-                    if let Some(url) = state.url {
-                        consume_context::<Rc<dyn History>>().replace(url);
-                    }
-                })
             }
         }
     }
@@ -627,7 +611,6 @@ struct PreservedWindowState {
     width: u32,
     height: u32,
     monitor: String,
-    url: Option<String>,
 }
 
 /// Return the location of a tempfile with our window state in it such that we can restore it later


### PR DESCRIPTION
When closing the application, the URL was saved for subsequent restoration the next time it was opened.
**This is completely incorrect behavior (which breaks my development).**

This change was made in the very first release of 0.7.x by @jkelleyrtp 
Perhaps you would like to explain yourself?

Fixes #4934