### PR TITLE
fix: dx self-update on windows failing

### DIFF
--- a/packages/cli/src/cli/update.rs
+++ b/packages/cli/src/cli/update.rs
@@ -159,7 +159,12 @@ impl SelfUpdate {
                 .extract_into(&install_dir)
                 .context("Failed to extract update")?;
 
-            let executable = install_dir.join("dx");
+            let exe = if cfg!(target_os = "windows") {
+                "dx.exe"
+            } else {
+                "dx"
+            };
+            let executable = install_dir.join(exe);
             if !executable.exists() {
                 bail!("Executable not found in {}", install_dir.display());
             }


### PR DESCRIPTION
Fixes #4938, which happens since windows exes have the file extension so when it looks up `dx` it finds nothing and fails with the message `Executable not found`.
Adds config for windows to lookup the file with the extension