### PR TITLE
force the user to provide "." as path

### DIFF
--- a/packages/cli/src/cli/init.rs
+++ b/packages/cli/src/cli/init.rs
@@ -4,11 +4,13 @@ use cargo_generate::{GenerateArgs, TemplatePath, Vcs};
 #[derive(Clone, Debug, Default, Deserialize, Parser)]
 #[clap(name = "init")]
 pub struct Init {
-    /// Create a new Dioxus project at PATH
-    #[arg(default_value = ".")]
+    /// Create a new Dioxus project at PATH. Required.
+    /// The user should provide "." intentionally
+    /// if creating a project in current dir is requested.
+    #[clap(required(true), help("Please provide \".\" if you are sure you want to create the project inside the current directory"))]
     pub path: PathBuf,
 
-    /// Project name. Defaults to directory name
+    /// Project name. Defaults to directory name.
     #[arg(short, long)]
     pub name: Option<String>,
 
@@ -54,7 +56,10 @@ impl Init {
     pub async fn init(mut self) -> Result<StructuredOutput> {
         // Project name defaults to directory name.
         if self.name.is_none() {
-            self.name = Some(create::name_from_path(&self.path)?);
+            self.name = Some(
+                create::name_from_path(&self.path)
+                    .expect("Could not retrieve the current directory name"),
+            );
         }
 
         // Perform a connectivity check so we just don't it around doing nothing if there's a network error

--- a/packages/cli/src/cli/mod.rs
+++ b/packages/cli/src/cli/mod.rs
@@ -75,7 +75,7 @@ pub(crate) enum Commands {
     #[clap(name = "run")]
     Run(run::RunArgs),
 
-    /// Init a new project for Dioxus in the current directory (by default).
+    /// Init a new project for Dioxus in a given directory.
     /// Will attempt to keep your project in a good state.
     #[clap(name = "init")]
     Init(init::Init),


### PR DESCRIPTION
when creating a project in the current directory is requested.

The default behavior simply creates the project at "." no matter where i are. Maybe i am not even in a rust project or in my home directory. This most probably is not the wanted behavior the user requested.

When making the parameter required the user is forced to consciously confirm that he wants that behavior by providing a .

```
error: the following required arguments were not provided:
  <PATH>

Usage: dx init <PATH>
```

```
Init a new project for Dioxus in a given directory. Will attempt to keep your project in a good state

Usage: dx init [OPTIONS] <PATH>

Arguments:
  <PATH>  Please provide "." if you are sure you want to create the project inside the current directory
```