### PR TITLE
Use rustc-demangle to detect wbindgen symbols even under v0 mangling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5513,6 +5513,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.12.24",
+ "rustc-demangle",
  "rustls 0.23.34",
  "self-replace",
  "self_update",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -150,6 +150,7 @@ memoize = "0.5.1"
 backtrace = "0.3.74"
 ar = "0.9.0"
 wasm-bindgen-externref-xform = "0.2.100"
+rustc-demangle = "0.1.26"
 pdb = "0.8.0"
 self_update = { version = "0.42.0", features = [
     "archive-tar",


### PR DESCRIPTION
cf. https://github.com/DioxusLabs/dioxus/issues/5005