### PR TITLE
Fixed issue with the WebFileData file path function so it now returns the webkitRelativePath instead of the file name

### DIFF
--- a/packages/web/src/files.rs
+++ b/packages/web/src/files.rs
@@ -135,6 +135,16 @@ impl NativeFileData for WebFileData {
     }
 
     fn path(&self) -> std::path::PathBuf {
+        let key = JsValue::from_str("webkitRelativePath");
+
+        if let Ok(value) = js_sys::Reflect::get(&self.file, &key) {
+            if let Some(path_str) = value.as_string() {
+                if !path_str.is_empty() {
+                    return std::path::PathBuf::from(path_str);
+                }
+            }
+        }
+
         std::path::PathBuf::from(self.file.name())
     }
 


### PR DESCRIPTION
Modified the NativeFileData path function for WebFileData to return the webkitRelativePath property if it exists, or just the file name if it does not exist. This is to resolve issues #3136 and #3134 where using the folder upload form for web results in each file losing its relative path and only returning the file name.