### PR TITLE
Always resolve icons relative to the crate, not the cwd of the CLI

### DIFF
--- a/packages/cli/src/cli/bundle.rs
+++ b/packages/cli/src/cli/bundle.rs
@@ -197,6 +197,18 @@ impl Bundle {
             }
         }
 
+        // resolve the icon relative to the crate, not the current working directory
+        if let Some(icons) = bundle_settings.icon.as_mut() {
+            for icon in icons {
+                let icon_path = build
+                    .crate_dir()
+                    .join(&icon)
+                    .canonicalize()
+                    .with_context(|| format!("Failed to canonicalize path to icon {icon:?}"))?;
+                *icon = icon_path.to_string_lossy().to_string();
+            }
+        }
+
         if bundle_settings.resources_map.is_none() {
             bundle_settings.resources_map = Some(HashMap::new());
         }


### PR DESCRIPTION
Fixes an issue @nicoburns ran into with the CLI bundling in workspaces with the [blitz browser pr](https://github.com/DioxusLabs/blitz/pull/292). If you run the bundler from the workspace, the CLI tries to resolve the icon path relative to the workspace instead of relative to the crate. This PR changes the behavior to always resolve icon paths relative to the crate