### PR TITLE
Trigger rebuilds on both [web.watcher].watch_path (in the config but not wired up) and cargo's depinfo

### DIFF
--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -997,6 +997,18 @@ impl AppServer {
             }
         }
 
+        // Watch additional paths from [web.watcher].watch_path config
+        let crate_dir = self.client.build.crate_dir();
+        for watch_path in &self.client.build.config.web.watcher.watch_path {
+            let path = crate_dir.join(watch_path);
+            if path.exists() {
+                tracing::trace!("Watching configured path {path:?}");
+                if let Err(err) = self.watcher.watch(&path, RecursiveMode::Recursive) {
+                    handle_notify_error(err);
+                }
+            }
+        }
+
         if let Some(server) = self.server.as_ref() {
             // Watch the server's crate directory as well
             for path in self.watch_paths(server.build.crate_dir(), server.build.crate_package) {


### PR DESCRIPTION
Hullo hullo – as described. In using build.rs with Dioxus, I found that there wasn't a way (any more) to get the watcher to rebuild on custom input paths.

I'm using `rerun-if-changed` – I first tried using `watch_path`, but it looks like that got un-wired in #3797. I also wired up support for directories in rerun-if-changed as well.