### PR TITLE
cli: Add a wait screen (HTML) instead of a plain text error when reverse proxy hits a non-started server

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -132,6 +132,7 @@ itertools = { workspace = true }
 throbber-widgets-tui = "0.8.0"
 unicode-segmentation = "1.12.0"
 handlebars = "6.3.2"
+html-escape = "0.2.13"
 strum = { version = "0.27.1", features = ["derive"] }
 memmap = "0.7.0"
 walrus = { workspace = true, features = ["parallel"] }


### PR DESCRIPTION
When waiting for the backend to load in fullstack builds, we currently see an error message that's a plaintext response from the reverse proxy, which... stalls out reload workflows, hard. If doing a full rebuild, you can end up hitting this screen, and then you have to go refresh all the windows that got stuck here.

This PR adds a simple HTML page that shows the error templated in, but tries to refresh periodically, trying to get to a working version of the page.

To save from it looking ugly as sin, I had an LLM generate inline styling here and it's... very aesthetic, but happy to adjust to match Dioxus's styling as appropriate!