### PR TITLE
Resolves #5045:  Trim slashes to prevent base path resolution issues in web

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -521,14 +521,11 @@ impl AppBuilder {
             envs.push(("RUST_BACKTRACE".into(), "1".to_string()));
         }
 
-        if let Some(base_path) = krate.base_path() {
-            let trimmed = base_path.trim_matches('/');
-            if !trimmed.is_empty() {
-                envs.push((
-                    dioxus_cli_config::ASSET_ROOT_ENV.into(),
-                    trimmed.to_string(),
-                ));
-            }
+        if let Some(base_path) = krate.trimmed_base_path() {
+            envs.push((
+                dioxus_cli_config::ASSET_ROOT_ENV.into(),
+                base_path.to_string(),
+            ));
         }
 
         if let Some(env_filter) = env::var_os("RUST_LOG").and_then(|e| e.into_string().ok()) {


### PR DESCRIPTION
Normalize the base path when set to `/` to prevent routing and asset resolution errors in web. This resolves #5045.