### PR TITLE
Fix paths under stores

### DIFF
--- a/packages/stores/src/subscriptions.rs
+++ b/packages/stores/src/subscriptions.rs
@@ -54,8 +54,10 @@ impl SelectorNode {
     /// This is used to mark nodes dirty recursively when a Store is written to.
     fn paths_under(&self, current_path: &[PathKey], paths: &mut Vec<Box<[PathKey]>>) {
         paths.push(current_path.into());
-        for child in self.root.values() {
-            child.paths_under(current_path, paths);
+        for (key, child) in self.root.iter() {
+            let mut current_path = current_path.to_vec();
+            current_path.push(*key);
+            child.paths_under(&current_path, paths);
         }
     }
 


### PR DESCRIPTION
When a parent store node is marked as dirty, it also needs to mark all child nodes as dirty. This logic is currently broken because the child path is not added to the parent path. This breaks setting stores directly making only fine grained updates reactive. This PR fixes that issue which fixes the following example reported on discord:
```rust
use dioxus::{prelude::*, stores::index::IndexWrite};

fn main() {
    launch(App);
}

#[component]
fn App() -> Element {
    rsx! {
        FirstSetup {}
    }
}

#[derive(Store, Default)]
struct SomeStore {
    pub items: Vec<Item>,
}

#[derive(Store)]
struct Item {
    pub name: String,
    pub id: String,
}

#[component]
pub fn FirstSetup() -> Element {
    let mut some_store = use_store(|| SomeStore::default());
    rsx!(
        button {
            onclick: move |_| {
                some_store.set(SomeStore{items: vec![Item{name: "first".into(), id: "1".into()}, Item{name: "second".into(), id: "2".into()}]});
            },
            "Change store"
        }
        div{
            for item in some_store.items().iter() {
                Items {
                   item
                }
            }
        }
    )
}

#[component]
fn Items(item: Store<Item>) -> Element {
    rsx!(
        "Name: {item.name()}"
        "Id: {item.id()}"
    )
}
```