### PR TITLE
Update README links for version 0.7

### DIFF
--- a/packages/dioxus/README.md
+++ b/packages/dioxus/README.md
@@ -6,7 +6,7 @@
         class="darkmode-image"
     >
     <div>
-        <a href=https://dioxuslabs.com/learn/0.7/getting_started>Getting Started</a> | <a href="https://dioxuslabs.com/learn/0.7/">Book (0.6)</a> | <a href="https://github.com/DioxusLabs/dioxus/tree/main/examples">Examples</a>
+        <a href=https://dioxuslabs.com/learn/0.7/getting_started>Getting Started</a> | <a href="https://dioxuslabs.com/learn/0.7/">Book (0.7)</a> | <a href="https://github.com/DioxusLabs/dioxus/tree/main/examples">Examples</a>
     </div>
 </div>
 


### PR DESCRIPTION
This seems to be out of sync right now, as the link itself points to 0.7, but the name still says 0.6