### PR TITLE
SEO Optimization: Crawler and Indexes Enhancements

### DIFF
--- a/packages/fullstack-server/src/server.rs
+++ b/packages/fullstack-server/src/server.rs
@@ -421,7 +421,7 @@ async fn robots_txt_handler() -> Response {
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "text/plain; charset=utf-8")
         .body(Body::from(default_robots))
-        .unwrap()
+        .expect("Failed to build default robots.txt response")
 }
 
 /// Get the path to the public assets directory to serve static files from


### PR DESCRIPTION
Introduces a handler for /robots.txt requests to ensure the file is always served as plain text. If robots.txt exists in the public directory, it is served; otherwise, a default allowing all crawlers is returned. The handler is registered before static assets to guarantee correct content type and priority.

<img width="1505" height="565" alt="image" src="https://github.com/user-attachments/assets/5d5cc591-a6bb-4e88-8644-5b0874f5983a" />
