### PR TITLE
Port dioxus to use `objc2` for interacting with macOS/iOS platform apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,35 +3489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cocoa"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "cocoa-foundation",
- "core-foundation 0.10.1",
- "core-graphics 0.24.0",
- "foreign-types 0.5.0",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
- "objc",
-]
-
-[[package]]
 name = "codemap"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3982,19 +3953,6 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types 0.5.0",
- "libc",
-]
-
-[[package]]
-name = "core-graphics"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
  "libc",
 ]
@@ -5069,8 +5027,6 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "cocoa",
- "core-foundation 0.10.1",
  "dioxus",
  "dioxus-asset-resolver",
  "dioxus-cli-config",
@@ -5098,8 +5054,10 @@ dependencies = [
  "ndk 0.9.0",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
- "objc",
- "objc_id",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "percent-encoding",
  "rand 0.9.2",
  "reqwest",
@@ -11214,15 +11172,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -347,6 +347,10 @@ infer = "0.19.0"
 dunce = "1.0.5"
 percent-encoding = "2.3.1"
 muda = "0.17.0"
+objc2 = { version = "0.6.3", features = ["exception"] }
+objc2-foundation = { version = "0.3.2", default-features = false }
+objc2-ui-kit = { version = "0.3.2", default-features = false }
+objc2-app-kit = { version = "0.3.2", default-features = false }
 tray-icon = "0.21.0"
 open = "5.3.2"
 webbrowser = "1.0"

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -68,8 +68,9 @@ muda = { workspace = true }
 tray-icon = { workspace = true }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-objc = "0.2.7"
-objc_id = "0.1.1"
+objc2 = { workspace = true }
+objc2-foundation = { workspace = true, features = ["NSThread"] }
+objc2-ui-kit = { workspace = true, features = ["UIView", "UIViewController"] }
 
 # use rustls on android
 [target.'cfg(target_os = "android")'.dependencies]
@@ -84,9 +85,8 @@ ndk-context = { version = "0.1.1" }
 tungstenite = { workspace = true, features = ["native-tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.26.1"
-core-foundation = "0.10.1"
-objc = "0.2.7"
+objc2 = { workspace = true }
+objc2-app-kit = { workspace = true, features = ["NSView"] }
 
 [build-dependencies]
 lazy-js-bundle = { workspace = true }

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -251,17 +251,13 @@ impl WebviewInstance {
 
         // https://developer.apple.com/documentation/appkit/nswindowcollectionbehavior/nswindowcollectionbehaviormanaged
         #[cfg(target_os = "macos")]
-        #[allow(deprecated)]
         {
-            use cocoa::appkit::NSWindowCollectionBehavior;
-            use cocoa::base::id;
-            use objc::{msg_send, sel, sel_impl};
+            use objc2::rc::Retained;
+            use objc2_app_kit::{NSWindow, NSWindowCollectionBehavior};
             use tao::platform::macos::WindowExtMacOS;
-
-            unsafe {
-                let window: id = window.ns_window() as id;
-                let _: () = msg_send![window, setCollectionBehavior: NSWindowCollectionBehavior::NSWindowCollectionBehaviorManaged];
-            }
+            let ns_window: Retained<NSWindow> =
+                unsafe { Retained::retain(window.ns_window().cast()) }.unwrap();
+            ns_window.setCollectionBehavior(NSWindowCollectionBehavior::Managed)
         }
 
         let mut web_context = WebContext::new(cfg.data_dir.clone().or_else(|| {


### PR DESCRIPTION
Replaces the `objc`, `objc_id`, `cocoa`, and `core_foundation` crates with `objc2`, `objc2_foundation`, `objc2_ui_kit` and `objc2_app_kit`.

This is unfortunately breaking because the `objc` crate is/was in the public API due to the `push_view` function.