### PR TITLE
feat: add onunmounted lifecycle event to close #5108

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6215,6 +6215,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-playwright-fullstack-unmounted-test"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+ "serde",
+ "tokio",
+ "web-sys",
+]
+
+[[package]]
 name = "dioxus-playwright-liveview-test"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ members = [
     "packages/playwright-tests/fullstack",
     "packages/playwright-tests/fullstack-errors",
     "packages/playwright-tests/fullstack-mounted",
+    "packages/playwright-tests/fullstack-unmounted",
     "packages/playwright-tests/fullstack-spread",
     "packages/playwright-tests/fullstack-routing",
     "packages/playwright-tests/fullstack-hydration-order",

--- a/packages/core-types/src/bubbles.rs
+++ b/packages/core-types/src/bubbles.rs
@@ -99,6 +99,7 @@ pub fn event_bubbles(evt: &str) -> bool {
         "toggle" => false,
         "beforetoggle" => false,
         "mounted" => false,
+        "unmounted" => false,
         "visible" => false,
         _ => true,
     }

--- a/packages/html/src/events/mod.rs
+++ b/packages/html/src/events/mod.rs
@@ -223,6 +223,13 @@ impl From<&PlatformEventData> for MountedData {
     }
 }
 
+impl From<&PlatformEventData> for UnmountedData {
+    fn from(_val: &PlatformEventData) -> Self {
+        // UnmountedData contains no element information since the element is already gone
+        UnmountedData::new()
+    }
+}
+
 impl From<&PlatformEventData> for MouseData {
     fn from(val: &PlatformEventData) -> Self {
         with_event_converter(|c| c.convert_mouse_data(val))

--- a/packages/html/src/events/mounted.rs
+++ b/packages/html/src/events/mounted.rs
@@ -280,6 +280,72 @@ impl_event! [
 
 pub use onmounted as onmount;
 
+/// Data associated with an unmounted event.
+///
+/// This event fires after an element has been removed from the DOM.
+/// Since the element no longer exists, no element data is available.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnmountedData {}
+
+impl UnmountedData {
+    /// Create a new UnmountedData
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for UnmountedData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub type UnmountedEvent = Event<UnmountedData>;
+
+impl_event! [
+    UnmountedData;
+
+    /// The onunmounted event is fired when the element is removed from the DOM.
+    ///
+    /// This event is the complement to `onmounted` and allows you to clean up any state
+    /// associated with the element, such as deregistering from an animation engine or
+    /// clearing cached references.
+    ///
+    /// Since the element has already been removed when this event fires, no element data
+    /// is available.
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # use dioxus::prelude::*;
+    /// fn App() -> Element {
+    ///     let mut element_ref = use_signal(|| None as Option<Rc<MountedData>>);
+    ///     let mut show = use_signal(|| true);
+    ///
+    ///     rsx! {
+    ///         button {
+    ///             onclick: move |_| show.toggle(),
+    ///             "Toggle element"
+    ///         }
+    ///
+    ///         if show() {
+    ///             div {
+    ///                 onmounted: move |e| element_ref.set(Some(e.data())),
+    ///                 onunmounted: move |_| {
+    ///                     // Element is gone - clean up the reference
+    ///                     element_ref.set(None);
+    ///                 },
+    ///                 "I can be toggled"
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    onunmounted
+];
+
+pub use onunmounted as onunmount;
+
 /// The MountedResult type for the MountedData
 pub type MountedResult<T> = Result<T, MountedError>;
 

--- a/packages/playwright-tests/fullstack-unmounted.spec.js
+++ b/packages/playwright-tests/fullstack-unmounted.spec.js
@@ -1,0 +1,57 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+test("onunmounted event fires when element is removed", async ({ page }) => {
+  await page.goto("http://localhost:7778");
+
+  // First, verify the element is mounted and visible
+  const testElement = page.locator("#test-element");
+  await expect(testElement).toBeVisible();
+  await expect(testElement).toContainText("Lifecycle test element");
+
+  // Verify mounted event was triggered
+  const mountedStatus = page.locator("#mounted-status");
+  await expect(mountedStatus).toContainText("Element was mounted.");
+
+  // Verify unmounted has NOT been triggered yet
+  const unmountedStatus = page.locator("#unmounted-status");
+  await expect(unmountedStatus).not.toBeVisible();
+
+  // Click the toggle button to remove the element
+  const toggleButton = page.locator("#toggle-button");
+  await toggleButton.click();
+
+  // Verify the element is no longer visible
+  await expect(testElement).not.toBeVisible();
+
+  // Verify the unmounted event was triggered
+  await expect(unmountedStatus).toBeVisible();
+  await expect(unmountedStatus).toContainText("The unmounted event was triggered.");
+});
+
+test("onunmounted event fires correctly on multiple toggle cycles", async ({ page }) => {
+  await page.goto("http://localhost:7778");
+
+  const testElement = page.locator("#test-element");
+  const toggleButton = page.locator("#toggle-button");
+  const mountedStatus = page.locator("#mounted-status");
+  const unmountedStatus = page.locator("#unmounted-status");
+
+  // Wait for hydration to complete by checking mounted event was triggered
+  await expect(mountedStatus).toContainText("Element was mounted.");
+
+  // Initial state: element visible, unmounted not triggered
+  await expect(testElement).toBeVisible();
+  await expect(unmountedStatus).not.toBeVisible();
+
+  // First toggle: remove element
+  await toggleButton.click();
+  await expect(testElement).not.toBeVisible();
+  await expect(unmountedStatus).toBeVisible();
+
+  // Second toggle: add element back (unmounted status stays true from first removal)
+  await toggleButton.click();
+  await expect(testElement).toBeVisible();
+  // The unmounted status should still show the previous unmount was triggered
+  await expect(unmountedStatus).toContainText("The unmounted event was triggered.");
+});

--- a/packages/playwright-tests/fullstack-unmounted/Cargo.toml
+++ b/packages/playwright-tests/fullstack-unmounted/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dioxus-playwright-fullstack-unmounted-test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dioxus = { workspace = true, features = ["fullstack"] }
+serde = "1.0.219"
+tokio = { workspace = true, features = ["full"], optional = true }
+web-sys = { version = "0.3", features = ["console"] }
+
+[features]
+default = []
+server = ["dioxus/server", "dep:tokio"]
+web = ["dioxus/web"]

--- a/packages/playwright-tests/fullstack-unmounted/src/main.rs
+++ b/packages/playwright-tests/fullstack-unmounted/src/main.rs
@@ -1,0 +1,54 @@
+// Regression test for onunmounted event
+// Tests that the onunmounted event fires when an element is removed from the DOM
+
+use dioxus::prelude::*;
+
+fn main() {
+    dioxus::launch(App);
+}
+
+#[component]
+fn App() -> Element {
+    // Track whether the element is shown
+    let mut show_element = use_signal(|| true);
+    // Track whether the unmounted event was triggered
+    let mut unmounted_triggered = use_signal(|| false);
+    // Track the mounted event for completeness
+    let mut mounted_triggered = use_signal(|| false);
+
+    rsx! {
+        div {
+            id: "status",
+            // Show status messages for the test to verify
+            if mounted_triggered() {
+                span { id: "mounted-status", "Element was mounted." }
+            }
+            if unmounted_triggered() {
+                span { id: "unmounted-status", "The unmounted event was triggered." }
+            }
+        }
+
+        button {
+            id: "toggle-button",
+            onclick: move |_| {
+                show_element.set(!show_element());
+            },
+            "Toggle Element"
+        }
+
+        if show_element() {
+            div {
+                id: "test-element",
+                onmounted: move |_| {
+                    web_sys::console::log_1(&"onmounted fired!".into());
+                    mounted_triggered.set(true);
+                },
+                onunmounted: move |_| {
+                    web_sys::console::log_1(&"onunmounted fired!".into());
+                    unmounted_triggered.set(true);
+                },
+                "Lifecycle test element"
+            }
+        }
+    }
+}

--- a/packages/playwright-tests/playwright.config.js
+++ b/packages/playwright-tests/playwright.config.js
@@ -89,6 +89,15 @@ if (process.platform === "win32") {
       stdout: "pipe",
     },
     {
+      cwd: path.join(process.cwd(), "fullstack-unmounted"),
+      command:
+        'cargo run --package dioxus-cli --release -- run --force-sequential --web --addr "127.0.0.1" --port 7778',
+      port: 7778,
+      timeout: 50 * 60 * 1000,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+    },
+    {
       cwd: path.join(process.cwd(), "fullstack-spread"),
       command:
         'cargo run --package dioxus-cli --release -- run --verbose --force-sequential --web --addr "127.0.0.1" --port 7980',

--- a/packages/web/src/dom.rs
+++ b/packages/web/src/dom.rs
@@ -11,7 +11,7 @@ use std::{any::Any, rc::Rc};
 use dioxus_core::Runtime;
 use dioxus_core::{ElementId, Template};
 use dioxus_interpreter_js::unified_bindings::Interpreter;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::{Document, Event, Node};
 
@@ -29,6 +29,11 @@ pub struct WebsysDom {
 
     #[cfg(feature = "mounted")]
     pub(crate) queued_mounted_events: Vec<ElementId>,
+
+    /// Track elements that have onunmounted listeners registered.
+    /// When these elements are removed, we fire the unmounted event.
+    #[cfg(feature = "mounted")]
+    pub(crate) elements_with_unmounted_listeners: FxHashSet<ElementId>,
 
     // We originally started with a different `WriteMutations` for collecting templates during hydration.
     // When profiling the binary size of web applications, this caused a large increase in binary size
@@ -125,6 +130,8 @@ impl WebsysDom {
             runtime,
             #[cfg(feature = "mounted")]
             queued_mounted_events: Default::default(),
+            #[cfg(feature = "mounted")]
+            elements_with_unmounted_listeners: Default::default(),
             #[cfg(feature = "hydrate")]
             skip_mutations: false,
             #[cfg(feature = "hydrate")]


### PR DESCRIPTION
## Summary

Dioxus provides `onmounted` to notify when elements enter the DOM, but no corresponding notification for when an element leaves.

The existing `use_drop` hook doesn't solve this as it operates at component scope, not element level. When a single element conditionally disappears while its parent component remains mounted, `use_drop` never fires. This leaves orphaned entries in animation engines, visualization controllers, and any system tracking element state. Please see Issue #5108 for more detail.

This PR adds `onunmounted` to fire when an element is removed from the DOM, enabling proper cleanup and preventing unbounded state growth.
 
Closes #5108

## Usage

```rust
div {
    onmounted: move |e| engine.register(id, e.data()),
    onunmounted: move |_| engine.deregister(id),
}
```

## Changes

|File|Change|
|---|---|
|`core-types/src/bubbles.rs`|Register `unmounted` as non-bubbling event|
|`html/src/events/mounted.rs`|Add `UnmountedData` struct and `onunmounted` event|
|`html/src/events/mod.rs`|Add `From<&PlatformEventData>` for `UnmountedData`|
|`web/src/dom.rs`|Track elements with unmount listeners|
|`web/src/mutations.rs`|Fire event on `remove_node` / `replace_node_with`; fix hydration bug|
|`playwright-tests/fullstack-unmounted/`|New test verifying the event fires correctly|

## Platform Support

- **Web**: ✅ Implemented

## Test Plan

- [x]  `cargo check -p dioxus-web --features hydrate,mounted`
- [x]  Playwright tests pass (element removal + toggle cycles after hydration)