### PR TITLE
Display bundle format instead of undefined in dev loading screen

### DIFF
--- a/packages/cli/assets/web/dev.loading.html
+++ b/packages/cli/assets/web/dev.loading.html
@@ -335,7 +335,7 @@
       } else if (data.type === "ClientInit") {
         // Get project info
         APPLICATION_NAME = data.data.application_name;
-        const platform = data.data.platform;
+        const platform = data.data.bundle;
 
         // Set project info
         let projectInfo = document.getElementById("project-info");


### PR DESCRIPTION
Fixes #5063

In [b257e7e8](https://github.com/DioxusLabs/dioxus/commit/b257e7e8cec00c1b9f3f2017fc342f72aef31e87) `BundleFormat` was introduced but the `dev.loading.html` was not updated to match, still referencing "platform".