### PR TITLE
bugfix: Dog images now render correctly in hotdog example

### DIFF
--- a/examples/01-app-demos/hotdog/src/frontend.rs
+++ b/examples/01-app-demos/hotdog/src/frontend.rs
@@ -47,6 +47,8 @@ pub fn DogView() -> Element {
                 .await?
                 .json::<serde_json::Value>()
                 .await?["message"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid response"))?		
                 .to_string(),
         )
     })?;


### PR DESCRIPTION
```
-- a/examples/01-app-demos/hotdog/src/frontend.rs
+++ b/examples/01-app-demos/hotdog/src/frontend.rs
@@ -47,6 +47,8 @@ pub fn DogView() -> Element {
                 .await?
                 .json::<serde_json::Value>()
                 .await?["message"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("Invalid response"))?
                 .to_string(),
         )
     })?;
```