### PR TITLE
respect tailwind_input when detecting tailwind v3 or v4

### DIFF
--- a/packages/cli/src/tailwind.rs
+++ b/packages/cli/src/tailwind.rs
@@ -82,7 +82,8 @@ impl TailwindCli {
     /// Note that v3 still uses the tailwind.css file, but usually the accompanying js file indicates
     /// that the project is using v3.
     pub(crate) fn autodetect(manifest_dir: &Path, input_path: &Option<PathBuf>) -> Option<Self> {
-        let dir = input_path.as_ref()
+        let dir = input_path
+            .as_ref()
             .map(|p| manifest_dir.join(p))
             .and_then(|p| p.parent().map(|parent| parent.to_path_buf()))
             .unwrap_or(manifest_dir.to_path_buf());
@@ -91,8 +92,11 @@ impl TailwindCli {
             return Some(Self::v3());
         }
 
-        if input_path.as_ref().map(|p| manifest_dir.join(p).exists())
-            .unwrap_or_else(|| manifest_dir.join("tailwind.css").exists()) {
+        if input_path
+            .as_ref()
+            .map(|p| manifest_dir.join(p).exists())
+            .unwrap_or_else(|| manifest_dir.join("tailwind.css").exists())
+        {
             return Some(Self::v4());
         }
 


### PR DESCRIPTION
Fix: https://github.com/DioxusLabs/dioxus/issues/5152

If you don't have `tailwind.css` in the manifest_dir, it won't detect that you're using tailwind even if you've set a custom tailwind_input.

This makes it respect the tailwind_input var when looking for `tailwind.css` or the v3 config files.