### PR TITLE
add android_sync_lock to wry event handler to avoid refcell errors

### DIFF
--- a/packages/desktop/src/event_handlers.rs
+++ b/packages/desktop/src/event_handlers.rs
@@ -53,12 +53,17 @@ impl WindowEventHandlers {
         target: &EventLoopWindowTarget<UserWindowEvent>,
     ) {
         for (_, handler) in self.handlers.borrow_mut().iter_mut() {
+            // Avoid interacting with the runtime while something else is using it
+            #[cfg(target_os = "android")]
+            let _lock = crate::android_sync_lock::android_runtime_lock();
+
             // if this event does not apply to the window this listener cares about, continue
             if let Event::WindowEvent { window_id, .. } = event {
                 if *window_id != handler.window_id {
                     continue;
                 }
             }
+
             (handler.handler)(event, target)
         }
     }

--- a/packages/desktop/src/hooks.rs
+++ b/packages/desktop/src/hooks.rs
@@ -28,10 +28,6 @@ pub fn use_wry_event_handler(
     use_hook_with_cleanup(
         move || {
             window().create_wry_event_handler(move |event, target| {
-                // Avoid interacting with the runtime while something else is using it
-                #[cfg(target_os = "android")]
-                let _lock = crate::android_sync_lock::android_runtime_lock();
-
                 runtime.in_scope(scope_id, || handler(event, target))
             })
         },


### PR DESCRIPTION
On Android refcell already borrowed errors were ocassionally happening, due to no check in the wry event handler that would overlap with execution from asset handlers or other functions. 