### PR TITLE
Implement `DataTransfer::items()`

### DIFF
--- a/packages/html/src/data_transfer.rs
+++ b/packages/html/src/data_transfer.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "serialize")]
 pub use ser::*;
 #[cfg(feature = "serialize")]
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 pub struct DataTransfer {
     inner: Box<dyn NativeDataTransfer>,


### PR DESCRIPTION
Adds an `items()` method that can be used to iterate over dropped data.