### PR TITLE
use $CARGO_HOME for installation if set

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -93,7 +93,7 @@ else
 fi
 bin_dir="$dx_install/bin"
 exe="$bin_dir/dx"
-cargo_bin_dir="$HOME/.cargo/bin"
+cargo_bin_dir="${CARGO_HOME:-$HOME/.cargo}/bin"
 cargo_bin_exe="$cargo_bin_dir/dx"
 
 if [ ! -d "$bin_dir" ]; then


### PR DESCRIPTION
The current installation script fails if the user sets [`$CARGO_HOME`](https://doc.rust-lang.org/cargo/guide/cargo-home.html) to anything other than `$HOME/.cargo`.
The proposed change makes it use `$CARGO_HOME`, falling back to `$HOME/.cargo` if `$CARGO_HOME` is not set