### PR TITLE
fix: prevent dx fmt from adding trailing whitespace to blank lines

### DIFF
--- a/packages/autofmt/src/prettier_please.rs
+++ b/packages/autofmt/src/prettier_please.rs
@@ -55,7 +55,14 @@ pub fn unparse_expr(expr: &Expr, src: &str, cfg: &IndentOptions) -> String {
                 if multiline || formatted.contains('\n') {
                     formatted = formatted
                         .lines()
-                        .map(|line| format!("{}{line}", self.cfg.indent_str()))
+                        .map(|line| {
+                            // Don't add indentation to blank lines (avoid trailing whitespace)
+                            if line.is_empty() {
+                                String::new()
+                            } else {
+                                format!("{}{line}", self.cfg.indent_str())
+                            }
+                        })
                         .collect::<Vec<_>>()
                         .join("\n");
                 }
@@ -106,8 +113,8 @@ pub fn unparse_expr(expr: &Expr, src: &str, cfg: &IndentOptions) -> String {
         let mut lines = fmted.lines().enumerate().peekable();
 
         while let Some((_idx, fmt_line)) = lines.next() {
-            // Push the indentation
-            if is_multiline {
+            // Push the indentation (but not for blank lines - avoid trailing whitespace)
+            if is_multiline && !fmt_line.is_empty() {
                 out_fmt.push_str(&cfg.indent_str().repeat(whitespace));
             }
 

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -62,4 +62,6 @@ twoway![
     asset,
     collapse,
     expr_on_conditional,
+    blank_lines,
+    blank_lines_preserved,
 ];

--- a/packages/autofmt/tests/samples/blank_lines.rsx
+++ b/packages/autofmt/tests/samples/blank_lines.rsx
@@ -1,0 +1,16 @@
+rsx! {
+    div {
+        match true {
+            true => rsx! {
+                if true {
+                    span { "a" }
+                }
+                if true {
+                    span { "b" }
+                }
+                span { "c" }
+            },
+            false => rsx! {},
+        }
+    }
+}

--- a/packages/autofmt/tests/samples/blank_lines_preserved.rsx
+++ b/packages/autofmt/tests/samples/blank_lines_preserved.rsx
@@ -1,0 +1,9 @@
+rsx! {
+    div {
+        span { "a" }
+
+        span { "b" }
+
+        span { "c" }
+    }
+}


### PR DESCRIPTION
Note from human: this is Claude output, I have limited Dioxus experience:

---

## Summary

This fixes a conflict between `dx fmt` and `cargo fmt` (rustfmt). Previously, `dx fmt` would add indentation whitespace to blank lines inside RSX blocks, but `cargo fmt` removes trailing whitespace from all lines. This made it impossible for code to satisfy both formatters.

## The Problem

Many projects run both formatters as checks in CI or pre-commit hooks:

```bash
cargo fmt --check   # Fails if there's trailing whitespace
dx fmt --check      # Fails if blank lines lack indentation whitespace
```

This creates an impossible cycle:
1. Code formatted by `cargo fmt` has clean blank lines (no trailing whitespace)
2. `dx fmt --check` fails because it wants indentation on those blank lines
3. Running `dx fmt` adds trailing whitespace to blank lines
4. Now `cargo fmt --check` fails because it wants to remove that whitespace

There's no state where both checks pass, so projects either have to:
- Disable one of the formatters
- Skip the checks entirely
- Post-process with `sed` to strip trailing whitespace (hacky)

## The Fix

Skip adding indentation to empty lines in two places in `prettier_please.rs`:
1. When indenting formatted RSX blocks inside expressions (line ~58)
2. When reassembling the final formatted output (line ~113)

Now `dx fmt` produces output that `cargo fmt` also accepts - blank lines stay blank.

## Testing

Added two new test cases:
- `blank_lines` - tests RSX inside match arms
- `blank_lines_preserved` - tests that blank lines between elements are preserved without trailing whitespace

All existing tests continue to pass.

Fixes #5223