### PR TITLE
Fix `android_runtime_lock` not being `cfg` guarded

### DIFF
--- a/packages/desktop/src/android_sync_lock.rs
+++ b/packages/desktop/src/android_sync_lock.rs
@@ -1,6 +1,7 @@
 /// This is a hack to get around the fact that wry is currently not thread safe on android
 ///
 /// We want to acquire this mutex before doing anything with the virtualdom directly
+#[cfg(target_os = "android")]
 pub fn android_runtime_lock() -> std::sync::MutexGuard<'static, ()> {
     use std::sync::{Mutex, OnceLock};
 

--- a/packages/desktop/src/app.rs
+++ b/packages/desktop/src/app.rs
@@ -330,9 +330,9 @@ impl App {
                     {
                         // This is a place where wry says it's threadsafe but it's actually not.
                         // If we're patching the app, we want to make sure it's not going to progress in the interim.
-                        let lock = crate::android_sync_lock::android_runtime_lock();
+                        #[cfg(target_os = "android")]
+                        let _lock = crate::android_sync_lock::android_runtime_lock();
                         dioxus_devtools::apply_changes(&webview.dom, &hr_msg);
-                        drop(lock);
                     }
 
                     webview.poll_vdom();

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -78,6 +78,7 @@ impl WebviewEdits {
         let response = match serde_json::from_slice(&data_from_header) {
             Ok(event) => {
                 // we need to wait for the mutex lock to let us munge the main thread..
+                #[cfg(target_os = "android")]
                 let _lock = crate::android_sync_lock::android_runtime_lock();
                 self.handle_html_event(event)
             }
@@ -557,6 +558,7 @@ impl WebviewInstance {
 
             {
                 // lock the hack-ed in lock sync wry has some thread-safety issues with event handlers and async tasks
+                #[cfg(target_os = "android")]
                 let _lock = crate::android_sync_lock::android_runtime_lock();
                 let fut = self.dom.wait_for_work();
                 pin_mut!(fut);
@@ -568,6 +570,7 @@ impl WebviewInstance {
             }
 
             // lock the hack-ed in lock sync wry has some thread-safety issues with event handlers
+            #[cfg(target_os = "android")]
             let _lock = crate::android_sync_lock::android_runtime_lock();
 
             self.edits


### PR DESCRIPTION
The `android_runtime_lock` wasn't properly `cfg` guarded in various places, so it got included on all operating systems, not just Android by accident. This causes deadlocks when trying to use `muda`.

Update: The reason for the muda deadlock is that while the popup is up, the event loop seems to be re-entrant. As in further up / down the stack the same event loop runs. The lock itself is not re-entrant, so the same thread locks the lock twice and thus it deadlocks.