### PR TITLE
fix: allow let chains in rsx! by updating rust editions

### DIFF
--- a/packages/core-macro/Cargo.toml
+++ b/packages/core-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dioxus-core-macro"
 version = { workspace = true }
 authors = ["Jonathan Kelley"]
-edition = "2021"
+edition = "2024"
 description = "Core macro for Dioxus Virtual DOM"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/DioxusLabs/dioxus/"

--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote, ToTokens, TokenStreamExt};
+use quote::{ToTokens, TokenStreamExt, format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;

--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -575,7 +575,7 @@ fn rebind_mutability(f: &FnArg) -> TokenStream {
 fn strip_pat_mutability(pat: &Pat) -> Pat {
     let mut pat = pat.clone();
     // rip off mutability, but still write it out eventually
-    if let Pat::Ident(ref mut pat_ident) = &mut pat {
+    if let Pat::Ident(pat_ident) = &mut pat {
         pat_ident.mutability = None;
     }
 

--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -349,20 +349,20 @@ impl ComponentBody {
     }
 
     fn is_explicit_props_ident(&self) -> bool {
-        if let Some(FnArg::Typed(PatType { pat, .. })) = self.item_fn.sig.inputs.first() {
-            if let Pat::Ident(ident) = pat.as_ref() {
-                return ident.ident == "props";
-            }
+        if let Some(FnArg::Typed(PatType { pat, .. })) = self.item_fn.sig.inputs.first()
+            && let Pat::Ident(ident) = pat.as_ref()
+        {
+            return ident.ident == "props";
         }
 
         false
     }
 
     fn has_struct_parameter_pattern(&self) -> bool {
-        if let Some(FnArg::Typed(PatType { pat, .. })) = self.item_fn.sig.inputs.first() {
-            if matches!(pat.as_ref(), Pat::Struct(_)) {
-                return true;
-            }
+        if let Some(FnArg::Typed(PatType { pat, .. })) = self.item_fn.sig.inputs.first()
+            && matches!(pat.as_ref(), Pat::Struct(_))
+        {
+            return true;
         }
 
         false

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -1729,10 +1729,10 @@ fn strip_option(type_: &Type) -> Option<Type> {
         let option_segment = segments_iter.next()?;
         if option_segment.ident == "Option" && segments_iter.next().is_none() {
             // It should have a single generic argument
-            if let PathArguments::AngleBracketed(generic_arg) = &option_segment.arguments {
-                if let Some(syn::GenericArgument::Type(ty)) = generic_arg.args.first() {
-                    return Some(ty.clone());
-                }
+            if let PathArguments::AngleBracketed(generic_arg) = &option_segment.arguments
+                && let Some(syn::GenericArgument::Type(ty)) = generic_arg.args.first()
+            {
+                return Some(ty.clone());
             }
         }
     }

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -767,11 +767,11 @@ mod struct_info {
 
         pub fn builder_creation_impl(&self) -> Result<TokenStream, Error> {
             let StructInfo {
-                ref vis,
-                ref name,
-                ref builder_name,
+                vis,
+                name,
+                builder_name,
                 ..
-            } = *self;
+            } = self;
 
             let generics = self.generics.clone();
             let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
@@ -1235,14 +1235,11 @@ Finally, call `.build()` to create the instance of `{name}`.
 
         pub fn required_field_impl(&self, field: &FieldInfo) -> Result<TokenStream, Error> {
             let StructInfo {
-                ref name,
-                ref builder_name,
-                ..
+                name, builder_name, ..
             } = self;
 
             let FieldInfo {
-                name: ref field_name,
-                ..
+                name: field_name, ..
             } = field;
             let mut builder_generics: Vec<syn::GenericArgument> = self
                 .generics

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -10,10 +10,10 @@ use proc_macro2::TokenStream;
 
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
-use syn::{parse::Error, PathArguments};
+use syn::{PathArguments, parse::Error};
 
 use quote::quote;
-use syn::{parse_quote, GenericArgument, Ident, PathSegment, Type};
+use syn::{GenericArgument, Ident, PathSegment, Type, parse_quote};
 
 pub fn impl_my_derive(ast: &syn::DeriveInput) -> Result<TokenStream, Error> {
     let data = match &ast.data {
@@ -53,20 +53,20 @@ pub fn impl_my_derive(ast: &syn::DeriveInput) -> Result<TokenStream, Error> {
                 return Err(Error::new(
                     ast.span(),
                     "Props is not supported for tuple structs",
-                ))
+                ));
             }
             syn::Fields::Unit => {
                 return Err(Error::new(
                     ast.span(),
                     "Props is not supported for unit structs",
-                ))
+                ));
             }
         },
         syn::Data::Enum(_) => {
-            return Err(Error::new(ast.span(), "Props is not supported for enums"))
+            return Err(Error::new(ast.span(), "Props is not supported for enums"));
         }
         syn::Data::Union(_) => {
-            return Err(Error::new(ast.span(), "Props is not supported for unions"))
+            return Err(Error::new(ast.span(), "Props is not supported for unions"));
         }
     };
     Ok(data)
@@ -176,8 +176,8 @@ mod field_info {
     use proc_macro2::TokenStream;
     use quote::{format_ident, quote};
     use syn::spanned::Spanned;
+    use syn::{Expr, Path, parse_quote};
     use syn::{parse::Error, punctuated::Punctuated};
-    use syn::{parse_quote, Expr, Path};
 
     use super::util::{
         expr_to_single_string, ident_to_type, path_to_single_string, strip_raw_ident_prefix,
@@ -551,11 +551,11 @@ fn extract_inner_type_from_segment(segment: &PathSegment) -> Option<&Type> {
 mod struct_info {
     use convert_case::{Case, Casing};
     use proc_macro2::TokenStream;
-    use quote::{quote, ToTokens};
+    use quote::{ToTokens, quote};
     use syn::parse::Error;
     use syn::punctuated::Punctuated;
     use syn::spanned::Spanned;
-    use syn::{parse_quote, Expr, Ident};
+    use syn::{Expr, Ident, parse_quote};
 
     use crate::props::strip_option;
 
@@ -833,8 +833,8 @@ Finally, call `.build()` to create the instance of `{name}`.
                     Some(ref doc) => quote!(#[doc = #doc]),
                     None => {
                         let doc = format!(
-                        "Builder for [`{name}`] instances.\n\nSee [`{name}::builder()`] for more info.",
-                    );
+                            "Builder for [`{name}`] instances.\n\nSee [`{name}::builder()`] for more info.",
+                        );
                         quote!(#[doc = #doc])
                     }
                 }
@@ -1072,7 +1072,10 @@ Finally, call `.build()` to create the instance of `{name}`.
                 name: field_name, ..
             } = field;
             if *field_name == "key" {
-                return Err(Error::new_spanned(field_name, "Naming a prop `key` is not allowed because the name can conflict with the built in key attribute. See https://dioxuslabs.com/learn/0.7/essentials/ui/iteration for more information about keys"));
+                return Err(Error::new_spanned(
+                    field_name,
+                    "Naming a prop `key` is not allowed because the name can conflict with the built in key attribute. See https://dioxuslabs.com/learn/0.7/essentials/ui/iteration for more information about keys",
+                ));
             }
             let StructInfo {
                 ref builder_name, ..

--- a/packages/core-macro/src/utils.rs
+++ b/packages/core-macro/src/utils.rs
@@ -1,7 +1,7 @@
 use quote::ToTokens;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parse_quote, Expr, Lit, Meta, Token, Type};
+use syn::{Expr, Lit, Meta, Token, Type, parse_quote};
 
 /// Attempts to convert the given literal to a string.
 /// Converts ints and floats to their base 10 counterparts.

--- a/packages/core/tests/diff_dynamic_node.rs
+++ b/packages/core/tests/diff_dynamic_node.rs
@@ -6,8 +6,12 @@ use pretty_assertions::assert_eq;
 #[test]
 fn toggle_option_text() {
     let mut dom = VirtualDom::new(|| {
-        let gen = generation();
-        let text = if gen % 2 != 0 { Some("hello") } else { None };
+        let generation_count = generation();
+        let text = if generation_count % 2 != 0 {
+            Some("hello")
+        } else {
+            None
+        };
         println!("{:?}", text);
 
         rsx! {

--- a/packages/core/tests/diff_element.rs
+++ b/packages/core/tests/diff_element.rs
@@ -6,8 +6,8 @@ use dioxus_core::generation;
 #[test]
 fn text_diff() {
     fn app() -> Element {
-        let gen = generation();
-        rsx!( h1 { "hello {gen}" } )
+        let generation_count = generation();
+        rsx!( h1 { "hello {generation_count}" } )
     }
 
     let mut vdom = VirtualDom::new(app);
@@ -35,9 +35,9 @@ fn text_diff() {
 #[test]
 fn element_swap() {
     fn app() -> Element {
-        let gen = generation();
+        let generation_count = generation();
 
-        match gen % 2 {
+        match generation_count % 2 {
             0 => rsx!( h1 { "hello 1" } ),
             1 => rsx!( h2 { "hello 2" } ),
             _ => unreachable!(),
@@ -87,10 +87,10 @@ fn element_swap() {
 #[test]
 fn attribute_diff() {
     fn app() -> Element {
-        let gen = generation();
+        let generation_count = generation();
 
         // attributes have to be sorted by name
-        let attrs = match gen % 5 {
+        let attrs = match generation_count % 5 {
             0 => vec![Attribute::new(
                 "a",
                 AttributeValue::Text("hello".into()),

--- a/packages/core/tests/diff_unkeyed_list.rs
+++ b/packages/core/tests/diff_unkeyed_list.rs
@@ -8,11 +8,11 @@ use pretty_assertions::assert_eq;
 #[test]
 fn list_creates_one_by_one() {
     let mut dom = VirtualDom::new(|| {
-        let gen = generation();
+        let generation_count = generation();
 
         rsx! {
             div {
-                for i in 0..gen {
+                for i in 0..generation_count {
                     div { "{i}" }
                 }
             }
@@ -82,11 +82,11 @@ fn list_creates_one_by_one() {
 #[test]
 fn removes_one_by_one() {
     let mut dom = VirtualDom::new(|| {
-        let gen = 3 - generation() % 4;
+        let generation_count = 3 - generation() % 4;
 
         rsx! {
             div {
-                for i in 0..gen {
+                for i in 0..generation_count {
                     div { "{i}" }
                 }
             }
@@ -231,11 +231,11 @@ fn list_shrink_multiroot() {
 #[test]
 fn removes_one_by_one_multiroot() {
     let mut dom = VirtualDom::new(|| {
-        let gen = 3 - generation() % 4;
+        let generation_count = 3 - generation() % 4;
 
         rsx! {
             div {
-                {(0..gen).map(|i| rsx! {
+                {(0..generation_count).map(|i| rsx! {
                     div { "{i}" }
                     div { "{i}" }
                 })}

--- a/packages/rsx/Cargo.toml
+++ b/packages/rsx/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dioxus-rsx"
 version = { workspace = true }
 authors = ["Jonathan Kelley", "Evan Almloff"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Core functionality for Dioxus - a concurrent renderer-agnostic Virtual DOM for interactive user experiences"
 repository = "https://github.com/DioxusLabs/dioxus/"

--- a/packages/rsx/src/attribute.rs
+++ b/packages/rsx/src/attribute.rs
@@ -311,13 +311,10 @@ impl Attribute {
         // Or if it is a builtin attribute with a single ident value
         if let (AttributeName::BuiltIn(name), AttributeValue::AttrExpr(expr)) =
             (&self.name, &self.value)
-        {
-            if let Ok(Expr::Path(path)) = expr.as_expr() {
-                if path.path.get_ident() == Some(name) {
-                    return true;
-                }
+            && let Ok(Expr::Path(path)) = expr.as_expr()
+            && path.path.get_ident() == Some(name) {
+                return true;
             }
-        }
 
         false
     }

--- a/packages/rsx/src/attribute.rs
+++ b/packages/rsx/src/attribute.rs
@@ -18,15 +18,15 @@ use super::literal::HotLiteral;
 use crate::{innerlude::*, partial_closure::PartialClosure};
 
 use proc_macro2::{Span, TokenStream as TokenStream2};
-use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
+use quote::{ToTokens, TokenStreamExt, quote, quote_spanned};
 use std::fmt::Display;
 use syn::{
+    Block, Expr, ExprBlock, ExprClosure, ExprIf, Ident, Lit, LitBool, LitFloat, LitInt, LitStr,
+    Stmt, Token,
     ext::IdentExt,
     parse::{Parse, ParseStream},
     parse_quote,
     spanned::Spanned,
-    Block, Expr, ExprBlock, ExprClosure, ExprIf, Ident, Lit, LitBool, LitFloat, LitInt, LitStr,
-    Stmt, Token,
 };
 
 /// A property value in the from of a `name: value` pair with an optional comma.
@@ -312,9 +312,10 @@ impl Attribute {
         if let (AttributeName::BuiltIn(name), AttributeValue::AttrExpr(expr)) =
             (&self.name, &self.value)
             && let Ok(Expr::Path(path)) = expr.as_expr()
-            && path.path.get_ident() == Some(name) {
-                return true;
-            }
+            && path.path.get_ident() == Some(name)
+        {
+            return true;
+        }
 
         false
     }
@@ -877,31 +878,35 @@ mod tests {
     fn call_with_explicit_closure() {
         let mut a: Attribute = parse2(quote! { onclick: |e| {} }).unwrap();
         a.el_name = Some(parse_quote!(button));
-        assert!(a
-            .rendered_as_dynamic_attr()
-            .to_string()
-            .contains("call_with_explicit_closure"));
+        assert!(
+            a.rendered_as_dynamic_attr()
+                .to_string()
+                .contains("call_with_explicit_closure")
+        );
 
         let mut a: Attribute = parse2(quote! { onclick: { let a = 1; |e| {} } }).unwrap();
         a.el_name = Some(parse_quote!(button));
-        assert!(a
-            .rendered_as_dynamic_attr()
-            .to_string()
-            .contains("call_with_explicit_closure"));
+        assert!(
+            a.rendered_as_dynamic_attr()
+                .to_string()
+                .contains("call_with_explicit_closure")
+        );
 
         let mut a: Attribute = parse2(quote! { onclick: { let b = 2; { |e| { b } } } }).unwrap();
         a.el_name = Some(parse_quote!(button));
-        assert!(a
-            .rendered_as_dynamic_attr()
-            .to_string()
-            .contains("call_with_explicit_closure"));
+        assert!(
+            a.rendered_as_dynamic_attr()
+                .to_string()
+                .contains("call_with_explicit_closure")
+        );
 
         let mut a: Attribute = parse2(quote! { onclick: { let r = |e| { b }; r } }).unwrap();
         a.el_name = Some(parse_quote!(button));
-        assert!(!a
-            .rendered_as_dynamic_attr()
-            .to_string()
-            .contains("call_with_explicit_closure"));
+        assert!(
+            !a.rendered_as_dynamic_attr()
+                .to_string()
+                .contains("call_with_explicit_closure")
+        );
     }
 
     /// Make sure reserved keywords are parsed as attributes

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -19,12 +19,13 @@
 use crate::innerlude::*;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro2_diagnostics::SpanDiagnosticExt;
-use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
+use quote::{ToTokens, TokenStreamExt, quote, quote_spanned};
 use std::{collections::HashSet, vec};
 use syn::{
+    AngleBracketedGenericArguments, Expr, Ident, PathArguments, Result,
     parse::{Parse, ParseStream},
     spanned::Spanned,
-    token, AngleBracketedGenericArguments, Expr, Ident, PathArguments, Result,
+    token,
 };
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -1,14 +1,14 @@
 use crate::innerlude::*;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use proc_macro2_diagnostics::SpanDiagnosticExt;
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::{ToTokens, TokenStreamExt, quote};
 use std::fmt::{Display, Formatter};
 use syn::{
+    Ident, LitStr, Result, Token,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     spanned::Spanned,
     token::Brace,
-    Ident, LitStr, Result, Token,
 };
 
 /// Parse the VNode::Element type
@@ -704,11 +704,13 @@ mod tests {
         assert_eq!(parsed.diagnostics.len(), 3);
 
         // style should not generate a diagnostic
-        assert!(!parsed
-            .diagnostics
-            .diagnostics
-            .into_iter()
-            .any(|f| f.emit_as_item_tokens().to_string().contains("style")));
+        assert!(
+            !parsed
+                .diagnostics
+                .diagnostics
+                .into_iter()
+                .any(|f| f.emit_as_item_tokens().to_string().contains("style"))
+        );
     }
 
     #[test]

--- a/packages/rsx/src/expr_node.rs
+++ b/packages/rsx/src/expr_node.rs
@@ -1,5 +1,5 @@
 use crate::{DynIdx, PartialExpr};
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::{ToTokens, TokenStreamExt, quote};
 use syn::parse::Parse;
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/packages/rsx/src/forloop.rs
+++ b/packages/rsx/src/forloop.rs
@@ -1,7 +1,7 @@
 use super::*;
 use location::DynIdx;
 use proc_macro2::TokenStream as TokenStream2;
-use syn::{braced, token::Brace, Expr, Pat};
+use syn::{Expr, Pat, braced, token::Brace};
 
 #[non_exhaustive]
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/packages/rsx/src/ifchain.rs
+++ b/packages/rsx/src/ifchain.rs
@@ -3,9 +3,9 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use quote::{ToTokens, TokenStreamExt};
 use syn::{
+    Expr, Result, Token,
     parse::{Parse, ParseStream},
     token::Brace,
-    Expr, Result, Token,
 };
 
 use crate::TemplateBody;

--- a/packages/rsx/src/ifmt.rs
+++ b/packages/rsx/src/ifmt.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
+use quote::{ToTokens, TokenStreamExt, quote, quote_spanned};
 use std::collections::HashMap;
 use syn::{
     parse::{Parse, ParseStream},

--- a/packages/rsx/src/ifmt.rs
+++ b/packages/rsx/src/ifmt.rs
@@ -220,11 +220,11 @@ impl ToTokens for IfmtInput {
         }
 
         // Try to turn it into a single _.to_string() call
-        if !cfg!(debug_assertions) {
-            if let Some(single_dynamic) = self.try_to_string() {
-                tokens.extend(single_dynamic);
-                return;
-            }
+        if !cfg!(debug_assertions)
+            && let Some(single_dynamic) = self.try_to_string()
+        {
+            tokens.extend(single_dynamic);
+            return;
         }
 
         // If the segments are not complex exprs, we can just use format! directly to take advantage of RA rename/expansion
@@ -316,10 +316,10 @@ pub enum FormattedSegmentType {
 
 impl FormattedSegmentType {
     fn parse(input: &str) -> Result<Self> {
-        if let Ok(ident) = parse_str::<Ident>(input) {
-            if ident == input {
-                return Ok(Self::Ident(ident));
-            }
+        if let Ok(ident) = parse_str::<Ident>(input)
+            && ident == input
+        {
+            return Ok(Self::Ident(ident));
         }
         if let Ok(expr) = parse_str(input) {
             Ok(Self::Expr(Box::new(expr)))

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -78,10 +78,10 @@ pub use partial_closure::PartialClosure;
 pub use rsx_call::*;
 pub use template_body::TemplateBody;
 
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::{ToTokens, TokenStreamExt, quote};
 use syn::{
-    parse::{Parse, ParseStream},
     Result, Token,
+    parse::{Parse, ParseStream},
 };
 
 pub use innerlude::*;

--- a/packages/rsx/src/literal.rs
+++ b/packages/rsx/src/literal.rs
@@ -1,14 +1,14 @@
 use proc_macro2::Span;
-use quote::quote;
 use quote::ToTokens;
+use quote::quote;
 use std::fmt::Display;
 use std::ops::Deref;
 use syn::{
-    parse::{Parse, ParseStream},
     Lit, LitBool, LitFloat, LitInt, LitStr,
+    parse::{Parse, ParseStream},
 };
 
-use crate::{location::DynIdx, IfmtInput, Segment};
+use crate::{IfmtInput, Segment, location::DynIdx};
 use proc_macro2::TokenStream as TokenStream2;
 
 /// A literal value in the rsx! macro
@@ -70,7 +70,7 @@ impl Parse for HotLiteral {
                 return Err(syn::Error::new(
                     raw.span(),
                     "Only string, int, float, and bool literals are supported",
-                ))
+                ));
             }
         };
 

--- a/packages/rsx/src/node.rs
+++ b/packages/rsx/src/node.rs
@@ -2,11 +2,11 @@ use crate::innerlude::*;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::ToTokens;
 use syn::{
+    Ident, LitStr, Result, Token,
     ext::IdentExt,
     parse::{Parse, ParseStream},
     spanned::Spanned,
     token::{self},
-    Ident, LitStr, Result, Token,
 };
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/packages/rsx/src/partial_closure.rs
+++ b/packages/rsx/src/partial_closure.rs
@@ -3,9 +3,9 @@ use proc_macro2::TokenStream;
 use quote::ToTokens;
 use std::hash::{Hash, Hasher};
 use syn::{
+    Attribute, Expr, Pat, PatType, Result, ReturnType, Token, Type,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    Attribute, Expr, Pat, PatType, Result, ReturnType, Token, Type,
 };
 use syn::{BoundLifetimes, ExprClosure};
 

--- a/packages/rsx/src/raw_expr.rs
+++ b/packages/rsx/src/raw_expr.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Delimiter, TokenStream as TokenStream2, TokenTree};
 use quote::ToTokens;
 use std::hash;
-use syn::{parse::Parse, spanned::Spanned, token::Brace, Expr};
+use syn::{Expr, parse::Parse, spanned::Spanned, token::Brace};
 
 /// A raw expression potentially wrapped in curly braces that is parsed from the input stream.
 ///

--- a/packages/rsx/src/rsx_block.rs
+++ b/packages/rsx/src/rsx_block.rs
@@ -10,11 +10,11 @@ use crate::innerlude::*;
 use proc_macro2::Span;
 use proc_macro2_diagnostics::SpanDiagnosticExt;
 use syn::{
+    Expr, Ident, LitStr, Token,
     ext::IdentExt,
     parse::{Parse, ParseBuffer, ParseStream},
     spanned::Spanned,
     token::{self, Brace},
-    Expr, Ident, LitStr, Token,
 };
 
 /// An item in the form of

--- a/packages/rsx/src/rsx_call.rs
+++ b/packages/rsx/src/rsx_call.rs
@@ -7,8 +7,8 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::ToTokens;
 use std::{cell::Cell, fmt::Debug};
 use syn::{
-    parse::{Parse, ParseStream},
     Result,
+    parse::{Parse, ParseStream},
 };
 
 use crate::{BodyNode, TemplateBody};

--- a/packages/rsx/src/text_node.rs
+++ b/packages/rsx/src/text_node.rs
@@ -1,11 +1,11 @@
-use crate::{literal::HotLiteral, location::DynIdx, HotReloadFormattedSegment, IfmtInput};
+use crate::{HotReloadFormattedSegment, IfmtInput, literal::HotLiteral, location::DynIdx};
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::ToTokens;
-use quote::{quote, TokenStreamExt};
+use quote::{TokenStreamExt, quote};
 use syn::Result;
 use syn::{
-    parse::{Parse, ParseStream},
     LitStr,
+    parse::{Parse, ParseStream},
 };
 
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]

--- a/packages/rsx/src/util.rs
+++ b/packages/rsx/src/util.rs
@@ -3,9 +3,9 @@
 use proc_macro2::TokenStream as TokenStream2;
 use std::{fmt::Debug, hash::Hash};
 use syn::{
+    Ident,
     ext::IdentExt,
     parse::{Parse, ParseBuffer},
-    Ident,
 };
 
 /// Parse a raw ident and return a new ident with the r# prefix added


### PR DESCRIPTION
I noticed that I couldn't use let chains in my dioxus project despite it using rust edition 2024. This is due to a couple of packages in dioxus still using rust edition 2021 which I have updated.