### PR TITLE
Fix using iOS mobile simulator on Intel Mac.

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -905,7 +905,16 @@ impl BuildRequest {
             let sysroot_location = match triple.environment {
                 target_lexicon::Environment::Sim => xcode_path
                     .join("Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk"),
-                _ => xcode_path.join("Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"),
+                _ => {
+                    // If the target has been determined as the iOS x86 simulator above
+                    if triple.to_string() == "x86_64-apple-ios" {
+                        xcode_path.join(
+                            "Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk",
+                        )
+                    } else {
+                        xcode_path.join("Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk")
+                    }
+                }
             };
 
             if sysroot_location.exists() && !rustflags.flags.iter().any(|f| f == "-isysroot") {


### PR DESCRIPTION
When doing  iOS mobile development on an Intel Mac, could not run the app in the iOS simulator due to the wrong SDK attempting to be linked during build. It was pulling in the `iPhoneOS.sdk` which has no `x86_64` symbols instead of the `iPhoneSimulator.sdk`.

Fixes https://github.com/DioxusLabs/dioxus/issues/5266.