### PR TITLE
fix(cli) replace installation_url with application_id in launch_ios_app_paused

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -1170,9 +1170,7 @@ impl AppBuilder {
                 );
             }
 
-            bail!(
-                "Failed to install app to device {device_uuid}: {stderr}"
-            );
+            bail!("Failed to install app to device {device_uuid}: {stderr}");
         }
 
         Ok(())
@@ -1191,7 +1189,7 @@ impl AppBuilder {
                 "--verbose",
                 "--device",
                 device_uuid,
-                &application_id,
+                application_id,
                 "--json-output",
             ])
             .arg(tmpfile.path())

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -5286,10 +5286,9 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
         let mut provisioning_profile_path = None;
         if entitlements_file.is_none() {
             let bundle_id = self.bundle_identifier();
-            let (entitlements_xml, profile_path) =
-                Self::auto_provision_entitlements(&bundle_id)
-                    .await
-                    .context("Failed to auto-provision entitlements for Apple codesigning.")?;
+            let (entitlements_xml, profile_path) = Self::auto_provision_entitlements(&bundle_id)
+                .await
+                .context("Failed to auto-provision entitlements for Apple codesigning.")?;
             let entitlements_temp_file = tempfile::NamedTempFile::new()?;
             std::fs::write(entitlements_temp_file.path(), entitlements_xml)?;
             entitlements_file = Some(entitlements_temp_file.path().to_path_buf());
@@ -5322,9 +5321,8 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
         if self.bundle == BundleFormat::Ios {
             if let Some(profile_path) = &provisioning_profile_path {
                 let dest = target_exe.join("embedded.mobileprovision");
-                std::fs::copy(profile_path, &dest).context(
-                    "Failed to embed provisioning profile into .app bundle",
-                )?;
+                std::fs::copy(profile_path, &dest)
+                    .context("Failed to embed provisioning profile into .app bundle")?;
             }
         }
 


### PR DESCRIPTION
When running `dx serve --ios --device "iPhone"` the `launch_ios_app_paused` function would fail because `devicectl device process launch` required the `bundle identifier`, not the `installation_url`.  
(`xcrun devicectl device process launch --device <UDID> <BundleID>.`)

I replaced the parameter, and also renamed the `get_ios_installation_url` into `install_ios_app`, since we didn't need the function to return `installation_url` anymore


```
ERROR: The application failed to launch. (com.apple.dt.CoreDeviceError error 10002 (0x2712))\n       NSURL = file%3A///private/var/containers/Bundle/Application/F4001132-AF8C-4897-B278-D61AA94AB99E/Taptap.app/ -- file:///Users/serban/projects/teelsy/taptap/\n       NSLocalizedRecoverySuggestion = Provide a path to a application bundle.\n       NSLocalizedFailureReason = The provided path does not contain an application bundle that can be launched.\n       ----------------------------------------\n           The operation couldn’t be completed. (OSStatus error -9499.) (NSOSStatusErrorDomain error -9499 (0xFFFFDAE5))\n           _LSFile = LSBundleProxy.m\n           _LSLine = 178\n           _LSFunction = _LSFindBundleWithInfo_NoIOFiltered\n
```