### PR TITLE
fix(fullstack): use target_arch instead of feature flags for server/web platform detection

### DIFF
--- a/packages/fullstack-core/src/history.rs
+++ b/packages/fullstack-core/src/history.rs
@@ -38,12 +38,14 @@ pub(crate) fn finalize_route() {
         return;
     };
 
-    if cfg!(feature = "server") {
+    // Use target_arch instead of cfg(feature) because cargo feature unification
+    // can enable both "web" and "server" features simultaneously.
+    if cfg!(not(target_arch = "wasm32")) {
         let history = history();
         let route = history.current_route();
         entry.insert(&route, std::panic::Location::caller());
         provide_context(ResolvedRouteContext { route });
-    } else if cfg!(feature = "web") {
+    } else if cfg!(target_arch = "wasm32") {
         let route = entry
             .get()
             .expect("Failed to get initial route from hydration context");

--- a/packages/fullstack-core/src/loader.rs
+++ b/packages/fullstack-core/src/loader.rs
@@ -42,11 +42,13 @@ where
     let storage_entry: crate::transport::SerializeContextEntry<Result<T, CapturedError>> =
         use_hook(|| serialize_context.create_entry());
 
-    #[cfg(feature = "server")]
+    // Use target_arch instead of cfg(feature) because cargo feature unification
+    // can enable both "web" and "server" features simultaneously.
+    #[cfg(not(target_arch = "wasm32"))]
     let caller = std::panic::Location::caller();
 
     // If this is the first run and we are on the web client, the data might be cached
-    #[cfg(feature = "web")]
+    #[cfg(target_arch = "wasm32")]
     let initial_web_result =
         use_hook(|| std::rc::Rc::new(std::cell::RefCell::new(Some(storage_entry.get()))));
 
@@ -55,18 +57,18 @@ where
     let mut loader_state = use_signal(|| LoaderState::Pending);
 
     let resource = use_resource(move || {
-        #[cfg(feature = "server")]
+        #[cfg(not(target_arch = "wasm32"))]
         let storage_entry = storage_entry.clone();
 
         let user_fut = future();
 
-        #[cfg(feature = "web")]
+        #[cfg(target_arch = "wasm32")]
         let initial_web_result = initial_web_result.clone();
 
         #[allow(clippy::let_and_return)]
         async move {
             // If this is the first run and we are on the web client, the data might be cached
-            #[cfg(feature = "web")]
+            #[cfg(target_arch = "wasm32")]
             match initial_web_result.take() {
                 // The data was deserialized successfully from the server
                 Some(Ok(o)) => {
@@ -106,7 +108,7 @@ where
             });
 
             // If this is the first run and we are on the server, cache the data in the slot we reserved for it
-            #[cfg(feature = "server")]
+            #[cfg(not(target_arch = "wasm32"))]
             storage_entry.insert(&out, caller);
 
             match out {

--- a/packages/fullstack-core/src/server_cached.rs
+++ b/packages/fullstack-core/src/server_cached.rs
@@ -45,23 +45,20 @@ where
     #[allow(unused)]
     let entry: SerializeContextEntry<O> = serialize.create_entry();
 
-    #[cfg(feature = "server")]
+    // Use target_arch instead of cfg(feature) because cargo feature unification
+    // can enable both "web" and "server" features simultaneously.
+    #[cfg(not(target_arch = "wasm32"))]
     {
         let data = value();
         entry.insert(&data, location);
         data
     }
 
-    #[cfg(all(not(feature = "server"), feature = "web"))]
+    #[cfg(target_arch = "wasm32")]
     {
         match entry.get() {
             Ok(value) => value,
             Err(_) => value(),
         }
-    }
-
-    #[cfg(not(any(feature = "server", feature = "web")))]
-    {
-        value()
     }
 }

--- a/packages/fullstack-server/src/ssr.rs
+++ b/packages/fullstack-server/src/ssr.rs
@@ -1,4 +1,5 @@
 //! A shared pool of renderers for efficient server side rendering.
+
 use crate::isrg::{
     CachedRender, IncrementalRenderer, IncrementalRendererConfig, IncrementalRendererError,
     RenderFreshness,
@@ -559,8 +560,7 @@ impl SsrRendererPool {
     fn take_from_scope(context: &HydrationContext, vdom: &VirtualDom, scope: ScopeId) {
         vdom.in_scope(scope, || {
             // Grab any serializable server context from this scope
-            let other: Option<HydrationContext> = has_context();
-            if let Some(other) = other {
+            if let Some(other) = has_context::<HydrationContext>() {
                 context.extend(&other);
             }
         });

--- a/packages/web/src/lib.rs
+++ b/packages/web/src/lib.rs
@@ -64,8 +64,8 @@ pub async fn run(mut virtual_dom: VirtualDom, web_config: Config) -> ! {
 
     let runtime = virtual_dom.runtime();
 
-    // If the hydrate feature is enabled, launch the client with hydration enabled
-    let should_hydrate = web_config.hydrate || cfg!(feature = "hydrate");
+    // Respect runtime hydrate config — don't let compile-time feature override it
+    let should_hydrate = web_config.hydrate;
 
     let mut websys_dom = WebsysDom::new(web_config, runtime);
 


### PR DESCRIPTION
## Problem

In fullstack workspaces with multiple crates, Cargo's feature unification enables both `web` and `server` features simultaneously on `dioxus-fullstack-core`. This causes SSR hydration to break because code guarded by `#[cfg(feature = "server")]` and `#[cfg(feature = "web")]` both compiles and executes.

For example, in `history.rs`, the server branch (`entry.insert()`) runs in WASM instead of the client branch (`entry.get()`), causing hydration data to be overwritten instead of read.

## Reproduction

1. Create a fullstack workspace with a shared UI crate:
```
workspace/
  packages/app/     # depends on dioxus with features ["server"] or ["web"]
  packages/ui/      # depends on dioxus with features ["router", "fullstack"]
```

2. The `ui` crate unconditionally enables `fullstack`, which pulls in both `dioxus-fullstack-core/web` and `dioxus-fullstack-core/server` through transitive feature resolution.

3. Run `dx serve` — SSR renders correctly on the server, but WASM hydration fails because server-side code paths execute in the browser (e.g., `entry.insert()` instead of `entry.get()` in history.rs).

## Fix

Replace `cfg(feature = "server")` / `cfg(feature = "web")` with `cfg(not(target_arch = "wasm32"))` / `cfg(target_arch = "wasm32")` in platform-specific code paths.

**Why this works:** `target_arch` is determined by the compilation target, not Cargo features, so it can never be both values simultaneously. `dx serve` compiles the server for native (x86_64/aarch64) and the client for wasm32 — these are separate compilation units immune to feature unification.

**Why this is safe for other platforms:**
- Desktop, mobile, native, and liveview have **no dependency** on `fullstack-core`
- `fullstack-core` is only compiled for server (via `dioxus-server`) and web client (via `dioxus-web` with `hydrate`)
- The `fullstack` crate itself already uses `target_arch = "wasm32"` for websocket transport in `client.rs`, establishing this as the correct pattern

## Changes

- **`fullstack-core/src/history.rs`** — Route finalization: server inserts route, client reads it
- **`fullstack-core/src/loader.rs`** — Data loader serialization direction
- **`fullstack-core/src/server_cached.rs`** — Cache write (server) vs read (client)
- **`fullstack-core/src/server_future.rs`** — Server future serialization direction
- **`fullstack-core/src/transport.rs`** — `is_hydrating()` and `serialize_context()` platform detection
- **`fullstack-server/src/ssr.rs`** — Added explicit type annotation to `has_context::<HydrationContext>()`
- **`web/src/lib.rs`** — `should_hydrate` now respects runtime config only, removing `cfg!(feature = "hydrate")` override that could be incorrectly triggered by feature unification