### PR TITLE
fix(cli): use correct registry root for dependency asset copying

### DIFF
--- a/packages/cli/src/cli/component.rs
+++ b/packages/cli/src/cli/component.rs
@@ -477,7 +477,7 @@ impl ComponentRegistry {
     async fn read_components(&self) -> Result<Vec<ResolvedComponent>> {
         let path = self.resolve().await?;
 
-        let root = read_component(&path).await?;
+        let root = read_component(&path, &path).await?;
         let mut components = discover_components(root).await?;
 
         // Filter out any virtual components with members
@@ -495,6 +495,8 @@ impl ComponentRegistry {
 /// A component that has been downloaded and resolved at a specific path
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct ResolvedComponent {
+    /// The root of the registry that this component belongs to
+    registry_root: PathBuf,
     path: PathBuf,
     component: Component,
 }
@@ -598,7 +600,9 @@ async fn add_component(
 
     // Copy any global assets
     let assets_root = global_assets_root(assets_path, config).await?;
-    copy_global_assets(registry_root, &assets_root, component).await?;
+    // Copy any global assets
+    let assets_root = global_assets_root(assets_path, config).await?;
+    copy_global_assets(&assets_root, component).await?;
 
     // Add the module to the components mod.rs
     let mod_rs_path = components_root.join("mod.rs");
@@ -742,7 +746,7 @@ async fn ensure_components_module_exists(components_dir: &Path) -> Result<bool> 
 }
 
 /// Read a component from the given path
-async fn read_component(path: &Path) -> Result<ResolvedComponent> {
+async fn read_component(path: &Path, registry_root: &Path) -> Result<ResolvedComponent> {
     let json_path = path.join("component.json");
     let bytes = tokio::fs::read(&json_path).await.with_context(|| {
         format!(
@@ -754,6 +758,7 @@ async fn read_component(path: &Path) -> Result<ResolvedComponent> {
     let component = serde_json::from_slice(&bytes)?;
     let absolute_path = dunce::canonicalize(path)?;
     Ok(ResolvedComponent {
+        registry_root: registry_root.to_path_buf(),
         path: absolute_path,
         component,
     })
@@ -762,15 +767,19 @@ async fn read_component(path: &Path) -> Result<ResolvedComponent> {
 /// Recursively discover all components starting from the root component
 async fn discover_components(root: ResolvedComponent) -> Result<Vec<ResolvedComponent>> {
     // Create a queue of members to read
-    let mut queue = root.member_paths();
+    let mut queue = root
+        .member_paths()
+        .into_iter()
+        .map(|path| (path, root.registry_root.clone()))
+        .collect::<Vec<_>>();
     // The list of discovered components
     let mut components = vec![root];
     // The set of pending read tasks
     let mut pending = JoinSet::new();
     loop {
         // First, spawn tasks for all queued paths
-        while let Some(root_path) = queue.pop() {
-            pending.spawn(async move { read_component(&root_path).await });
+        while let Some((root_path, registry_root)) = queue.pop() {
+            pending.spawn(async move { read_component(&root_path, &registry_root).await });
         }
         // Then try to join the next task
         let Some(component) = pending.join_next().await else {
@@ -778,7 +787,12 @@ async fn discover_components(root: ResolvedComponent) -> Result<Vec<ResolvedComp
         };
         let component = component??;
         // And add the result to the queue and list
-        queue.extend(component.member_paths());
+        queue.extend(
+            component
+                .member_paths()
+                .into_iter()
+                .map(|path| (path, component.registry_root.clone())),
+        );
         components.push(component);
     }
     Ok(components)
@@ -786,10 +800,10 @@ async fn discover_components(root: ResolvedComponent) -> Result<Vec<ResolvedComp
 
 /// Copy any global assets for the component
 async fn copy_global_assets(
-    registry_root: &Path,
     assets_root: &Path,
     component: &ResolvedComponent,
 ) -> Result<()> {
+    let registry_root = &component.registry_root;
     let canonical_registry_root = dunce::canonicalize(registry_root)?;
     for path in &component.global_assets {
         let src = component.path.join(path);


### PR DESCRIPTION
The `dx components add` command failed to copy assets for dependencies that resolved to a different registry than the primary component.

This happened because `add_component` used a single `registry_root` (that of the primary component) to calculate the relative paths of assets for all components, matching the legacy assumption that all components came from the same source tree.

However, dependencies can be resolved from different registries. For example, if `date_picker` is requested from a specific git revision but depends on `calendar` (referenced as a builtin), `calendar` is loaded from the default registry cache. Attempting to strip the `date_picker` registry root from the `calendar` asset path fails, causing the command to error or silently skip assets.

This patch:
- Adds a `registry_root` field to `ResolvedComponent` to track the origin of each component instance.
- Updates `read_component` and `discover_components` to populate and propagate this field during loading.
- Updates `copy_global_assets` to use the component's own stored `registry_root` for path calculations instead of the argument passed to `add_component`.