### PR TITLE
Fix dropped store comparison when coercing into a readsignal

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -661,10 +661,13 @@ mod struct_info {
                 // If they are equal, we don't need to rerun the component we can just update the existing signals
                 #(
                     // Try to memo the signal
-                    let field_eq = {
-                        let old_value: &_ = &*#signal_fields.peek();
-                        let new_value: &_ = &*new.#signal_fields.peek();
-                        (&old_value).compare(&&new_value)
+                    let field_eq = match (#signal_fields.try_peek(), new.#signal_fields.try_peek()) {
+                        (Ok(old_ref), Ok(new_ref)) => {
+                            let old_value: &_ = &*old_ref;
+                            let new_value: &_ = &*new_ref;
+                            (&old_value).compare(&&new_value)
+                        }
+                        _ => false,
                     };
                     // Make the old fields point to the new fields
                     #signal_fields.point_to(new.#signal_fields).unwrap();

--- a/packages/signals/src/boxed.rs
+++ b/packages/signals/src/boxed.rs
@@ -132,10 +132,7 @@ impl<T: ?Sized, S: BoxedSignalStorage<T>> Readable for ReadSignal<T, S> {
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_read_unchecked()
+        self.value.try_peek_unchecked()?.try_read_unchecked()
     }
 
     #[track_caller]
@@ -143,10 +140,7 @@ impl<T: ?Sized, S: BoxedSignalStorage<T>> Readable for ReadSignal<T, S> {
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_peek_unchecked()
+        self.value.try_peek_unchecked()?.try_peek_unchecked()
     }
 
     fn subscribers(&self) -> Subscribers
@@ -367,10 +361,7 @@ impl<T: ?Sized, S: BoxedSignalStorage<T>> Readable for WriteSignal<T, S> {
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_read_unchecked()
+        self.value.try_peek_unchecked()?.try_read_unchecked()
     }
 
     #[track_caller]
@@ -378,10 +369,7 @@ impl<T: ?Sized, S: BoxedSignalStorage<T>> Readable for WriteSignal<T, S> {
     where
         T: 'static,
     {
-        self.value
-            .try_peek_unchecked()
-            .unwrap()
-            .try_peek_unchecked()
+        self.value.try_peek_unchecked()?.try_peek_unchecked()
     }
 
     fn subscribers(&self) -> Subscribers

--- a/packages/stores/src/impls/mod.rs
+++ b/packages/stores/src/impls/mod.rs
@@ -4,5 +4,5 @@ pub mod hashmap;
 pub mod index;
 mod option;
 mod result;
-mod slice;
+pub mod slice;
 mod vec;

--- a/packages/stores/src/impls/slice.rs
+++ b/packages/stores/src/impls/slice.rs
@@ -1,7 +1,13 @@
-use std::iter::FusedIterator;
+//! Additional utilities for `Vec` stores.
 
-use crate::{impls::index::IndexWrite, store::Store};
-use dioxus_signals::{Readable, ReadableExt};
+use std::{iter::FusedIterator, panic::Location};
+
+use crate::{impls::index::IndexSelector, store::Store, ReadStore};
+use dioxus_signals::{
+    AnyStorage, BorrowError, BorrowMutError, ReadSignal, Readable, ReadableExt, UnsyncStorage,
+    Writable, WriteLock, WriteSignal,
+};
+use generational_box::ValueDroppedError;
 
 impl<Lens, I> Store<Vec<I>, Lens>
 where
@@ -46,16 +52,18 @@ where
     ///     println!("{}", item);
     /// }
     /// ```
+    #[track_caller]
     pub fn iter(
         &self,
-    ) -> impl ExactSizeIterator<Item = Store<I, IndexWrite<usize, Lens>>>
+    ) -> impl ExactSizeIterator<Item = Store<I, VecGetWrite<Lens>>>
            + DoubleEndedIterator
            + FusedIterator
            + '_
     where
         Lens: Clone,
     {
-        (0..self.len()).map(move |i| self.clone().index(i))
+        let location = Location::caller();
+        (0..self.len()).map(move |i| self.clone().get_unchecked_at(i, location))
     }
 
     /// Try to get an item from slice. This will only track the shallow state of the slice.
@@ -70,14 +78,130 @@ where
     /// // The indexed store can access the store methods of the indexed store.
     /// assert_eq!(indexed_store(), 2);
     /// ```
-    pub fn get(&self, index: usize) -> Option<Store<I, IndexWrite<usize, Lens>>>
+    pub fn get(&self, index: usize) -> Option<Store<I, VecGetWrite<Lens>>>
     where
         Lens: Clone,
     {
         if index >= self.len() {
             None
         } else {
-            Some(self.clone().index(index))
+            Some(self.clone().get_unchecked(index))
         }
+    }
+
+    /// Get a store for the item at the given index without checking if it is in bounds.
+    ///
+    /// This is not unsafe, but reads will return a [BorrowError::Dropped] error if the index is out of bounds.
+    #[track_caller]
+    pub fn get_unchecked(self, index: usize) -> Store<I, VecGetWrite<Lens>> {
+        self.get_unchecked_at(index, Location::caller())
+    }
+
+    fn get_unchecked_at(
+        self,
+        index: usize,
+        location: &'static Location<'static>,
+    ) -> Store<I, VecGetWrite<Lens>> {
+        <Vec<I>>::scope_selector(self.into_selector(), &index)
+            .map_writer(move |write| VecGetWrite {
+                index,
+                write,
+                created: location,
+            })
+            .into()
+    }
+}
+
+/// A specific index in a `Readable` / `Writable` Vec that uses safe `.get()` / `.get_mut()` access.
+#[derive(Clone, Copy)]
+pub struct VecGetWrite<Write> {
+    index: usize,
+    write: Write,
+    created: &'static Location<'static>,
+}
+
+impl<Write, T> Readable for VecGetWrite<Write>
+where
+    Write: Readable<Target = Vec<T>>,
+    T: 'static,
+{
+    type Target = T;
+    type Storage = Write::Storage;
+
+    fn try_read_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    where
+        Self::Target: 'static,
+    {
+        self.write.try_read_unchecked().and_then(|value| {
+            let index = self.index;
+            Self::Storage::try_map(value, move |value: &Vec<T>| value.get(index))
+                .ok_or_else(|| BorrowError::Dropped(ValueDroppedError::new(self.created)))
+        })
+    }
+
+    fn try_peek_unchecked(&self) -> Result<dioxus_signals::ReadableRef<'static, Self>, BorrowError>
+    where
+        Self::Target: 'static,
+    {
+        self.write.try_peek_unchecked().and_then(|value| {
+            let index = self.index;
+            Self::Storage::try_map(value, move |value: &Vec<T>| value.get(index))
+                .ok_or_else(|| BorrowError::Dropped(ValueDroppedError::new(self.created)))
+        })
+    }
+
+    fn subscribers(&self) -> dioxus_core::Subscribers
+    where
+        Self::Target: 'static,
+    {
+        self.write.subscribers()
+    }
+}
+
+impl<Write, T> Writable for VecGetWrite<Write>
+where
+    Write: Writable<Target = Vec<T>>,
+    T: 'static,
+{
+    type WriteMetadata = Write::WriteMetadata;
+
+    fn try_write_unchecked(
+        &self,
+    ) -> Result<dioxus_signals::WritableRef<'static, Self>, BorrowMutError>
+    where
+        Self::Target: 'static,
+    {
+        self.write.try_write_unchecked().and_then(|value| {
+            let index = self.index;
+            WriteLock::filter_map(value, move |value: &mut Vec<T>| value.get_mut(index))
+                .ok_or_else(|| BorrowMutError::Dropped(ValueDroppedError::new(self.created)))
+        })
+    }
+}
+
+impl<T, Write> ::std::convert::From<Store<T, VecGetWrite<Write>>> for Store<T, WriteSignal<T>>
+where
+    Write: Writable<Target = Vec<T>, Storage = UnsyncStorage> + 'static,
+    Write::WriteMetadata: 'static,
+    T: 'static,
+{
+    fn from(value: Store<T, VecGetWrite<Write>>) -> Self {
+        value
+            .into_selector()
+            .map_writer(|writer| WriteSignal::new(writer))
+            .into()
+    }
+}
+
+impl<T, Write> ::std::convert::From<Store<T, VecGetWrite<Write>>> for ReadStore<T>
+where
+    Write: Readable<Target = Vec<T>, Storage = UnsyncStorage> + 'static,
+    T: 'static,
+{
+    fn from(value: Store<T, VecGetWrite<Write>>) -> Self {
+        value
+            .into_selector()
+            .map_writer(|writer| ReadSignal::new(writer))
+            .into()
     }
 }

--- a/packages/stores/tests/vec_remove.rs
+++ b/packages/stores/tests/vec_remove.rs
@@ -1,0 +1,53 @@
+use dioxus::prelude::*;
+use dioxus_core::generation;
+
+#[derive(Debug, Clone, dioxus_stores::Store)]
+struct ListItem {
+    id: usize,
+    text: String,
+}
+
+/// Removing a non-last item from a Vec store should not panic during memoization.
+#[test]
+fn vec_store_remove_non_last_item() {
+    fn app() -> Element {
+        let mut store = use_store(|| {
+            vec![
+                ListItem {
+                    id: 0,
+                    text: "Item 0".to_string(),
+                },
+                ListItem {
+                    id: 1,
+                    text: "Item 1".to_string(),
+                },
+            ]
+        });
+
+        // On the second render, remove the first item.
+        if generation() > 0 {
+            store.remove(0);
+        }
+
+        rsx! {
+            for item in store.iter() {
+                li { key: "{item.id()}",
+                    ListItemElement { list_item: item }
+                }
+            }
+        }
+    }
+
+    #[component]
+    fn ListItemElement(list_item: ReadSignal<ListItem>) -> Element {
+        rsx! {
+            div { "{list_item.read().text}" }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    // Second render triggers remove(0), which previously panicked during memoization
+    dom.mark_dirty(ScopeId::APP);
+    _ = dom.render_immediate_to_vec();
+}


### PR DESCRIPTION
When diffing between multiple different reactive sources to create a single combined `ReadSignal`, we currently read both sources and panic if they are no longer valid. This causes issues if one is dropped like in this example [reported on discord](https://discord.com/channels/899851952891002890/943190605067079712/1471878537161212117):
```rust
use dioxus::prelude::*;

const MAIN_CSS: Asset = asset!("/assets/main.css");

fn main() {
    dioxus::launch(App);
}

#[derive(Debug, Clone, Store)]
struct ListItem {
    id: usize,
    text: String,
}

#[component]
fn App() -> Element {
    let mut store = use_store(Vec::<ListItem>::new);

    rsx! {
        document::Link { rel: "stylesheet", href: MAIN_CSS }

        ul {
            for (i , item) in store.iter().enumerate() {
                li { key: "{item.id()}",
                    ListItemElement { list_item: item }
                    button {
                        onclick: move |_| {
                            store.remove(i); // this causes a panic next render if a non-last item is removed
                        },
                        "-"
                    }
                }
            }
            li {
                button {
                    onclick: move |_| {
                        let id = next_id();
                        store
                            .push(ListItem {
                                id,
                                text: format!("Item {}", id),
                            });
                    },
                    "+"
                }
            }
        }
    }
}

#[component]
// the Store -> ReadSignal conversion causes a panic, for example: "index out of bounds: the len is 2 but the index is 2"
fn ListItemElement(list_item: ReadSignal<ListItem>) -> Element {
    rsx! {
        li { "{list_item.read().text}" }
    }
}

fn next_id() -> usize {
    static ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
    ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
}
```

This PR fixes the issue by applying a similar fix for dropped indexes as https://github.com/DioxusLabs/dioxus/pull/4950 to stores of vectors. If the index is no longer valid, return an error that the object was dropped. It also adjusts the merge logic to only try to read the signals. If the read fails, it assumes the value has changed.

Unfortunately, this fix is breaking since we now need to return a different type for `iter` on store which only has bounds on the `Index` without the `get` method which returns an Option