### PR TITLE
feat(signals): add WritableResultExt trait

### DIFF
--- a/packages/signals/src/read.rs
+++ b/packages/signals/src/read.rs
@@ -419,9 +419,19 @@ pub trait ReadableResultExt<T, E>: Readable<Target = Result<T, E>> {
         T: 'static,
         E: 'static,
     {
-        <Self::Storage as AnyStorage>::try_map(self.read(), |v| v.as_ref().ok()).ok_or(
-            <Self::Storage as AnyStorage>::map(self.read(), |v| v.as_ref().err().unwrap()),
-        )
+        let read = self.read();
+        match read.deref() {
+            Ok(_) => Ok(<Self::Storage as AnyStorage>::map(read, |v| {
+                v.as_ref()
+                    .ok()
+                    .expect("Result variant changed between read and map")
+            })),
+            Err(_) => Err(<Self::Storage as AnyStorage>::map(read, |v| {
+                v.as_ref()
+                    .err()
+                    .expect("Result variant changed between read and map")
+            })),
+        }
     }
 }
 

--- a/packages/signals/src/write.rs
+++ b/packages/signals/src/write.rs
@@ -467,19 +467,18 @@ pub trait WritableResultExt<T, E>: Writable<Target = Result<T, E>> {
         T: 'static,
         E: 'static,
     {
-        let is_ok = self.read().is_ok();
-        if is_ok {
-            Ok(WriteLock::map(self.write(), |v| {
+        let write = self.write();
+        match write.as_ref() {
+            Ok(_) => Ok(WriteLock::map(write, |v| {
                 v.as_mut()
                     .ok()
                     .expect("Result variant changed between read and write")
-            }))
-        } else {
-            Err(WriteLock::map(self.write(), |v| {
+            })),
+            Err(_) => Err(WriteLock::map(write, |v| {
                 v.as_mut()
                     .err()
                     .expect("Result variant changed between read and write")
-            }))
+            })),
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds `WritableResultExt` trait for `Writable<Target = Result<T, E>>`, mirroring the existing `ReadableResultExt` on the read side. This provides mutable access to signal values holding `Result<T, E>` without needing an intermediate binding.

### Methods

- **`as_mut()`** — returns `Result<WritableRef<T>, WritableRef<E>>`, giving mutable access to whichever variant the Result holds
- **`unwrap_mut()`** — returns `WritableRef<T>`, panicking if the Result is `Err`

### Pattern

Follows the same extension trait pattern used by `WritableOptionExt` and `ReadableResultExt`:
- Blanket impl over all `W: Writable<Target = Result<T, E>>`
- Uses `WriteLock::map` / `WriteLock::filter_map` for mapped mutable references
- `#[track_caller]` on all methods for better panic diagnostics

Closes #5293