### PR TITLE
chore: add .gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Auto detect text files and normalize line endings to LF
+* text=auto eol=lf
+
+# Rust sources
+*.rs text eol=lf
+*.toml text eol=lf
+*.lock text eol=lf
+
+# Web assets
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf
+*.ts text eol=lf
+*.json text eol=lf
+
+# Config
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf
+*.sh text eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.wasm binary
+*.avif binary


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` to normalize line endings to LF across all platforms
- Marks binary file types (png, jpg, gif, ico, wasm, avif) explicitly

## Problem
Windows contributors currently get CRLF warnings on checkout and after running tests (especially from generated `cli-harnesses` files). This is noisy and can lead to accidental line ending changes in PRs.

## Test plan
- [x] Verified warnings are silenced after adding the file
- [ ] Existing CI should pass unchanged since repo already uses LF