### PR TITLE
feat(desktop): expose navigation_handler in Config

### DIFF
--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub(crate) background_color: Option<(u8, u8, u8, u8)>,
     pub(crate) last_window_close_behavior: WindowCloseBehaviour,
     pub(crate) custom_event_handler: Option<CustomEventHandler>,
+    pub(crate) navigation_handler: Option<Box<dyn Fn(String) -> bool + 'static>>,
 }
 
 impl LaunchConfig for Config {}
@@ -108,6 +109,7 @@ impl Config {
             background_color: None,
             last_window_close_behavior: WindowCloseBehaviour::LastWindowExitsApp,
             custom_event_handler: None,
+            navigation_handler: None,
         }
     }
 
@@ -274,6 +276,37 @@ impl Config {
                 self.menu = MenuBuilderState::Set(menu.into())
             }
         }
+        self
+    }
+
+    /// Set a custom navigation handler to control which URLs the WebView is allowed to navigate to.
+    ///
+    /// The handler receives the target URL as a `String` and must return `true` to allow navigation
+    /// or `false` to block it.
+    ///
+    /// When not set, the default behavior applies: internal `dioxus://` URLs are allowed, and
+    /// external `http://` or `https://` URLs are opened in the system browser via
+    /// [`webbrowser::open`](https://docs.rs/webbrowser) and blocked in the WebView.
+    ///
+    /// This is useful for applications that embed web content (e.g. via `<iframe>`) and need
+    /// fine-grained control over navigation, or that want to suppress the automatic
+    /// system-browser-open behavior.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use dioxus_desktop::Config;
+    /// let cfg = Config::new()
+    ///     .with_navigation_handler(|url| {
+    ///         // Allow dioxus internal URLs and a specific external domain
+    ///         url.starts_with("dioxus://") || url.starts_with("https://trusted.example.com")
+    ///     });
+    /// ```
+    pub fn with_navigation_handler(
+        mut self,
+        handler: impl Fn(String) -> bool + 'static,
+    ) -> Self {
+        self.navigation_handler = Some(Box::new(handler));
         self
     }
 }

--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -63,6 +63,7 @@ pub struct Config {
     pub(crate) background_color: Option<(u8, u8, u8, u8)>,
     pub(crate) last_window_close_behavior: WindowCloseBehaviour,
     pub(crate) custom_event_handler: Option<CustomEventHandler>,
+    pub(crate) disable_file_drop_handler: bool,
     pub(crate) navigation_handler: Option<Box<dyn Fn(String) -> bool + 'static>>,
 }
 
@@ -109,6 +110,7 @@ impl Config {
             background_color: None,
             last_window_close_behavior: WindowCloseBehaviour::LastWindowExitsApp,
             custom_event_handler: None,
+            disable_file_drop_handler: false,
             navigation_handler: None,
         }
     }

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -321,6 +321,7 @@ impl WebviewInstance {
             webview = webview.with_browser_accelerator_keys(false);
         }
 
+        let navigation_handler = cfg.navigation_handler.take();
         webview = webview
             .with_bounds(wry::Rect {
                 position: wry::dpi::Position::Logical(wry::dpi::LogicalPosition::new(0.0, 0.0)),
@@ -332,9 +333,13 @@ impl WebviewInstance {
             .with_transparent(cfg.window.window.transparent)
             .with_url("dioxus://index.html/")
             .with_ipc_handler(ipc_handler)
-            .with_navigation_handler(|var| {
-                // We don't want to allow any navigation
-                // We only want to serve the index file and assets
+            .with_navigation_handler(move |var| {
+                // If the app supplied a custom handler, delegate entirely to it.
+                if let Some(handler) = &navigation_handler {
+                    return handler(var);
+                }
+                // Default behaviour: allow internal dioxus URLs; open external http(s) URLs
+                // in the system browser and block them inside the WebView.
                 if var.starts_with("dioxus://") || var.starts_with("http://dioxus.") {
                     true
                 } else {


### PR DESCRIPTION
## Summary

The navigation handler in `dioxus-desktop` is currently hardcoded in `webview.rs`:

```rust
.with_navigation_handler(|var| {
    if var.starts_with("dioxus://") || var.starts_with("http://dioxus.") {
        true
    } else {
        if var.starts_with("http://") || var.starts_with("https://") {
            _ = webbrowser::open(&var);
        }
        false
    }
})
```

This unconditionally opens every external `http`/`https` URL in the system browser and blocks it in the WebView. Apps that intentionally embed web content (e.g. via `<iframe>`) have no way to opt out of this behavior or to allow specific URLs.

## Changes

- **`config.rs`**: adds `navigation_handler: Option<Box<dyn Fn(String) -> bool + 'static>>` field to `Config`, initialized to `None`.
- **`config.rs`**: adds `pub fn with_navigation_handler(mut self, handler: impl Fn(String) -> bool + 'static) -> Self` builder method with full doc-comment and example.
- **`webview.rs`**: if `cfg.navigation_handler` is `Some`, the closure delegates entirely to the user-supplied handler; otherwise the existing hardcoded behavior is preserved exactly.

## Non-breaking

When `with_navigation_handler` is not called (the default), behavior is **identical** to before — no existing apps are affected.

## Example

```rust
let cfg = Config::new()
    .with_navigation_handler(|url| {
        // Allow dioxus internal URLs and a trusted external origin
        url.starts_with("dioxus://") || url.starts_with("https://trusted.example.com")
    });
```