### PR TITLE
Add support for winit android-game-activity feature (GameActivity)

### DIFF
--- a/packages/cli/assets/android/gen/app/build.gradle.kts.hbs
+++ b/packages/cli/assets/android/gen/app/build.gradle.kts.hbs
@@ -71,7 +71,7 @@ dependencies {
     implementation("androidx.webkit:webkit:1.6.1")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.8.0")
-    implementation("com.google.androidgamesdk:games-activity:2.0.2")   // gameactivity is preferred to native
+    implementation("androidx.games:games-activity:2.0.2")   // gameactivity is preferred to native
     {{#each gradle_dependencies}}
     implementation("{{ this }}")
     {{/each}}


### PR DESCRIPTION
example:

```
package dev.dioxus.main

import com.google.androidgamesdk.GameActivity
import android.os.Bundle
import android.view.SurfaceView
import android.view.View
import android.view.ViewGroup

class MainActivity : GameActivity() {
    // one should probably traverse the view tree to find the rendering surface. this will work regardless of manufacturer.
    // example: if oem wraps those three previous getChildAt will not work.
    // the only thing that matters here is surfaceview.
    private fun findNativeSurfaceView(view: View): View? {
        if (view is SurfaceView) return view
       
        if (view is ViewGroup) {
            for (i in 0 until view.childCount) {
                val found = findNativeSurfaceView(view.getChildAt(i))
                if (found != null) return found
            }
        }
        return null
    }
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
       
        // wait until android has actually finished building the UI layout before search.
        window.decorView.post {
            val nativeView = findNativeSurfaceView(window.decorView)
           
           
            nativeView?.apply {
                isFocusable = true
                isFocusableInTouchMode = true
                requestFocus()
            }
        }
    }
}
```
with this fix, the Dioxus CLI now generates a proper Gradle build when one uses the modern winit backend:

`winit = { version = "0.31.0-beta.2", features = ["android-game-activity"] }`

This should be more robust than the old android-activity / NativeActivity setup (or at least a solid alternative for people who want it).

