### PR TITLE
fix(cli): disable Google Fonts imports blocked in China (#5403)

### DIFF
--- a/packages/cli/assets/web/dev.index.html
+++ b/packages/cli/assets/web/dev.index.html
@@ -7,7 +7,7 @@
         <meta charset="UTF-8">
         <style>
             /* Inter Font */
-            @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap') layer;
+            /* @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap') layer; */
 
             #dx-toast-template {
                 display: none;

--- a/packages/cli/assets/web/dev.loading.html
+++ b/packages/cli/assets/web/dev.loading.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/png" href="https://avatars.githubusercontent.com/u/79236386?s=200&v=4">
   <style>
     /* Fira Mono Font */
-    @import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&display=swap');
+    /* @import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&display=swap'); */
 
     body {
       margin: 0;


### PR DESCRIPTION
The dev.index.html and dev.loading.html loaded fonts from fonts.googleapis.com,
which is inaccessible in China, causing pages to hang or load indefinitely.

Commented out the @import rules for Inter font in dev.index.html and Fira Mono
font in dev.loading.html.

Fixes #5403