### PR TITLE
feat(cli): support custom renderers via [renderer] config

### DIFF
--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -40,6 +40,10 @@
       "description": "Unified permissions configuration. Permissions declared here are automatically mapped to platform-specific identifiers (AndroidManifest.xml, Info.plist, etc.)",
       "$ref": "#/definitions/PermissionsConfig"
     },
+    "renderer": {
+      "description": "Custom renderer configuration for projects that use `dioxus-core` with their own renderer.\n\nWhen present, this overrides the default renderer autodetection and feature injection. Existing Dioxus projects (without this section) are unaffected.\n\n```toml [renderer] name = \"my-renderer\" default_platform = \"desktop\"\n\n[renderer.features] desktop = [] web = [\"my-web\"] ios = [\"my-mobile\"] android = [\"my-mobile\"] ```",
+      "$ref": "#/definitions/RendererConfig"
+    },
     "web": {
       "$ref": "#/definitions/WebConfig"
     },
@@ -2186,6 +2190,36 @@
       "properties": {
         "description": {
           "type": "string"
+        }
+      }
+    },
+    "RendererConfig": {
+      "description": "Configuration for custom (non-dioxus) renderers.\n\nProjects that use `dioxus-core` directly with their own renderer can use this section to declare platform-to-feature mappings so `dx serve`, `dx build`, and `dx bundle` work without pulling in dioxus's built-in renderers.",
+      "type": "object",
+      "properties": {
+        "default_platform": {
+          "description": "Default platform when none is specified on the CLI.\n\nMust be one of: `\"web\"`, `\"macos\"`, `\"windows\"`, `\"linux\"`, `\"ios\"`, `\"android\"`, `\"server\"`, `\"liveview\"`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "features": {
+          "description": "Map from platform name to cargo features to enable.\n\nKeys are platform identifiers (e.g., `\"desktop\"`, `\"web\"`, `\"ios\"`). Values are lists of cargo feature names to pass via `--features`. An empty list means \"build with default features, don't inject any extra\".",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "name": {
+          "description": "Display name for the renderer (shown in TUI).",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -717,13 +717,27 @@ impl BuildRequest {
             }
         }
 
+        // If no platform was specified on the CLI and a custom renderer declares a default, use it.
+        if matches!(platform, Platform::Unknown) {
+            if let Some(ref default) = config.renderer.default_platform {
+                if let Ok(p) = Platform::from_identifier(default) {
+                    platform = p;
+                }
+            }
+        }
+
+        // Helper closure: check if the custom renderer config has features for this platform.
+        let custom_features = |keys: &[&str]| config.renderer.features_for_platform(keys);
+
         // Set the super triple from the platform if it's provided.
         // Otherwise, we attempt to guess it from the rest of their inputs.
         match platform {
             Platform::Unknown => {}
 
             Platform::Web => {
-                if main_package.features.contains_key("web") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["web"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("web") && renderer.is_none() {
                     features.push("web".into());
                 }
                 renderer = renderer.or(Some(Renderer::Web));
@@ -731,7 +745,9 @@ impl BuildRequest {
                 triple = triple.or(Some("wasm32-unknown-unknown".parse()?));
             }
             Platform::MacOS => {
-                if main_package.features.contains_key("desktop") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["macos", "desktop"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("desktop") && renderer.is_none() {
                     features.push("desktop".into());
                 }
                 renderer = renderer.or(Some(Renderer::Webview));
@@ -739,7 +755,9 @@ impl BuildRequest {
                 triple = triple.or(Some(Triple::host()));
             }
             Platform::Windows => {
-                if main_package.features.contains_key("desktop") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["windows", "desktop"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("desktop") && renderer.is_none() {
                     features.push("desktop".into());
                 }
                 renderer = renderer.or(Some(Renderer::Webview));
@@ -747,7 +765,9 @@ impl BuildRequest {
                 triple = triple.or(Some(Triple::host()));
             }
             Platform::Linux => {
-                if main_package.features.contains_key("desktop") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["linux", "desktop"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("desktop") && renderer.is_none() {
                     features.push("desktop".into());
                 }
                 renderer = renderer.or(Some(Renderer::Webview));
@@ -755,7 +775,9 @@ impl BuildRequest {
                 triple = triple.or(Some(Triple::host()));
             }
             Platform::Ios => {
-                if main_package.features.contains_key("mobile") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["ios", "mobile"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("mobile") && renderer.is_none() {
                     features.push("mobile".into());
                 }
                 renderer = renderer.or(Some(Renderer::Webview));
@@ -774,7 +796,9 @@ impl BuildRequest {
                 }
             }
             Platform::Android => {
-                if main_package.features.contains_key("mobile") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["android", "mobile"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("mobile") && renderer.is_none() {
                     features.push("mobile".into());
                 }
 
@@ -803,7 +827,9 @@ impl BuildRequest {
                 }
             }
             Platform::Server => {
-                if main_package.features.contains_key("server") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["server"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("server") && renderer.is_none() {
                     features.push("server".into());
                 }
                 renderer = renderer.or(Some(Renderer::Server));
@@ -811,7 +837,9 @@ impl BuildRequest {
                 triple = triple.or(Some(Triple::host()));
             }
             Platform::Liveview => {
-                if main_package.features.contains_key("liveview") && renderer.is_none() {
+                if let Some(feats) = custom_features(&["liveview"]) {
+                    features.extend(feats);
+                } else if main_package.features.contains_key("liveview") && renderer.is_none() {
                     features.push("liveview".into());
                 }
                 renderer = renderer.or(Some(Renderer::Liveview));
@@ -842,13 +870,17 @@ impl BuildRequest {
             bundle_format.unwrap_or(BundleFormat::host())
         };
 
-        // Add any features required to turn on the client
+        // Add any features required to turn on the client.
+        // When a custom renderer is configured, skip dioxus-specific feature injection since
+        // the custom features were already added in the platform match above.
         if let Some(renderer) = renderer {
-            if let Some(feature) =
-                Self::feature_for_platform_and_renderer(main_package, &triple, renderer)
-            {
-                features.push(feature);
-                features.dedup();
+            if !config.renderer.is_custom() {
+                if let Some(feature) =
+                    Self::feature_for_platform_and_renderer(main_package, &triple, renderer)
+                {
+                    features.push(feature);
+                    features.dedup();
+                }
             }
         }
 

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -3,6 +3,7 @@ use crate::config::component::ComponentConfig;
 use super::*;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub(crate) struct DioxusConfig {
@@ -55,6 +56,72 @@ pub(crate) struct DioxusConfig {
     /// Linux-specific configuration.
     #[serde(default)]
     pub(crate) linux: LinuxConfig,
+
+    /// Custom renderer configuration for projects that use `dioxus-core` with their own renderer.
+    ///
+    /// When present, this overrides the default renderer autodetection and feature injection.
+    /// Existing Dioxus projects (without this section) are unaffected.
+    ///
+    /// ```toml
+    /// [renderer]
+    /// name = "my-renderer"
+    /// default_platform = "desktop"
+    ///
+    /// [renderer.features]
+    /// desktop = []
+    /// web = ["my-web"]
+    /// ios = ["my-mobile"]
+    /// android = ["my-mobile"]
+    /// ```
+    #[serde(default)]
+    pub(crate) renderer: RendererConfig,
+}
+
+/// Configuration for custom (non-dioxus) renderers.
+///
+/// Projects that use `dioxus-core` directly with their own renderer can use this section
+/// to declare platform-to-feature mappings so `dx serve`, `dx build`, and `dx bundle` work
+/// without pulling in dioxus's built-in renderers.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
+pub(crate) struct RendererConfig {
+    /// Display name for the renderer (shown in TUI).
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+
+    /// Default platform when none is specified on the CLI.
+    ///
+    /// Must be one of: `"web"`, `"macos"`, `"windows"`, `"linux"`, `"ios"`, `"android"`,
+    /// `"server"`, `"liveview"`.
+    #[serde(default)]
+    pub(crate) default_platform: Option<String>,
+
+    /// Map from platform name to cargo features to enable.
+    ///
+    /// Keys are platform identifiers (e.g., `"desktop"`, `"web"`, `"ios"`).
+    /// Values are lists of cargo feature names to pass via `--features`.
+    /// An empty list means "build with default features, don't inject any extra".
+    #[serde(default)]
+    pub(crate) features: HashMap<String, Vec<String>>,
+}
+
+impl RendererConfig {
+    /// Returns `true` if a custom renderer is configured.
+    pub(crate) fn is_custom(&self) -> bool {
+        self.name.is_some() || !self.features.is_empty()
+    }
+
+    /// Look up custom features for a platform, trying each key in order.
+    ///
+    /// This allows fallback chains like `["macos", "desktop"]` so platform-specific
+    /// keys take priority over generic ones.
+    pub(crate) fn features_for_platform(&self, keys: &[&str]) -> Option<Vec<String>> {
+        for key in keys {
+            if let Some(feats) = self.features.get(*key) {
+                return Some(feats.clone());
+            }
+        }
+        None
+    }
 }
 
 /// Platform identifier for bundle resolution.
@@ -149,6 +216,7 @@ impl Default for DioxusConfig {
             macos: MacosConfig::default(),
             windows: WindowsConfig::default(),
             linux: LinuxConfig::default(),
+            renderer: RendererConfig::default(),
         }
     }
 }
@@ -189,5 +257,48 @@ mod tests {
 
         let config: DioxusConfig = toml::from_str(source).expect("parse config");
         assert_eq!(config.application.public_dir.as_deref(), None);
+    }
+
+    #[test]
+    fn renderer_config_absent_is_not_custom() {
+        let config = DioxusConfig::default();
+        assert!(!config.renderer.is_custom());
+        assert!(config.renderer.features.is_empty());
+    }
+
+    #[test]
+    fn renderer_config_parses_from_toml() {
+        let source = r#"
+            [renderer]
+            name = "tanzo"
+            default_platform = "desktop"
+
+            [renderer.features]
+            desktop = []
+            web = ["tanzo-web"]
+            ios = ["tanzo-mobile"]
+            android = ["tanzo-mobile"]
+        "#;
+
+        let config: DioxusConfig = toml::from_str(source).expect("parse config");
+        assert!(config.renderer.is_custom());
+        assert_eq!(config.renderer.name.as_deref(), Some("tanzo"));
+        assert_eq!(config.renderer.default_platform.as_deref(), Some("desktop"));
+        assert_eq!(
+            config.renderer.features_for_platform(&["desktop"]),
+            Some(vec![])
+        );
+        assert_eq!(
+            config.renderer.features_for_platform(&["web"]),
+            Some(vec!["tanzo-web".to_string()])
+        );
+        assert_eq!(
+            config.renderer.features_for_platform(&["macos", "desktop"]),
+            Some(vec![])
+        );
+        assert_eq!(
+            config.renderer.features_for_platform(&["nonexistent"]),
+            None
+        );
     }
 }

--- a/packages/cli/src/platform.rs
+++ b/packages/cli/src/platform.rs
@@ -48,7 +48,8 @@ pub(crate) enum Platform {
 }
 
 impl Platform {
-    fn from_identifier(identifier: &str) -> std::result::Result<Self, clap::Error> {
+    /// Parse a platform from a string identifier (e.g., "web", "macos", "desktop").
+    pub(crate) fn from_identifier(identifier: &str) -> std::result::Result<Self, clap::Error> {
         match identifier {
             "web" => Ok(Self::Web),
             "macos" => Ok(Self::MacOS),


### PR DESCRIPTION
## Summary

Adds an optional `[renderer]` section to `Dioxus.toml` so projects using `dioxus-core` with a custom renderer can use `dx serve`, `dx build`, `dx bundle`, and `dx fmt` — without pulling in any built-in dioxus renderers.

Existing projects without this section are completely unaffected.

### Why?

If you use `dioxus-core` for the VirtualDom/signals/hooks but bring your own rendering pipeline (winit+wgpu+vello, Bevy, etc.), `dx` currently can't help you — it expects a recognized renderer feature like `web` or `native`. This makes the detection configurable.

### Example

```toml
[renderer]
name = "my-app"
default_platform = "desktop"

[renderer.features]
desktop = []
web = ["my-web-feature"]
ios = ["my-mobile"]
android = ["my-mobile"]
```

### What changed

- `RendererConfig` struct in `dioxus_config.rs` — `name`, `default_platform`, `features` map with fallback chain lookup
- Each platform arm in `request.rs` checks custom config before the default dioxus feature injection
- `Platform::from_identifier()` made `pub(crate)` for config-driven resolution
- Schema updated
- Tests added

### Backward compat

`RendererConfig` defaults to empty via `#[serde(default)]`. When absent, all code paths are unchanged.

## Test plan

- [x] `cargo test -p dioxus-cli -- config::dioxus_config` — 5 pass (3 existing + 2 new)
- [x] `cargo clippy -p dioxus-cli -- -D warnings` — clean
- [x] `cargo fmt -p dioxus-cli -- --check` — clean
- [x] `dx build` / `dx bundle` work with a custom renderer project
- [ ] CI verifies existing examples still build