### PR TITLE
feat: add HTML attribute support to GoBackButton and GoForwardButton

### DIFF
--- a/packages/router/src/components/history_buttons.rs
+++ b/packages/router/src/components/history_buttons.rs
@@ -1,6 +1,6 @@
-use dioxus_core::{prelude::*, Element, VNode};
+use dioxus_core::{Attribute, Element, VNode};
 use dioxus_core_macro::{rsx, Props};
-use dioxus_html::{self as dioxus_elements, prelude::GlobalAttributes};
+use dioxus_html as dioxus_elements;
 
 use tracing::error;
 


### PR DESCRIPTION
## Summary
Closes #5269

- `GoBackButton` and `GoForwardButton` now accept HTML attributes (e.g., `class`, `style`, `id`) via `#[props(extends = GlobalAttributes)]`
- This matches the existing pattern used by the `Link` component in the same package
- Previously these buttons only accepted `children`, making it impossible to style or customize them with standard HTML attributes

## Changes
- Added `attributes: Vec<Attribute>` field with `#[props(extends = GlobalAttributes)]` to `HistoryButtonProps`
- Spread attributes into the rendered `button` element via `..attributes`
- Import pattern follows `link.rs` (`dioxus_core::Attribute` + `dioxus_html as dioxus_elements`)

## Test plan
- [x] `cargo check -p dioxus-router` passes
- [x] Full `cargo check` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)