### PR TITLE
fix: normalize whitespace in for-loop pattern formatting

### DIFF
--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -153,11 +153,15 @@ impl<'a> Writer<'a> {
     }
 
     fn write_for_loop(&mut self, forloop: &ForLoop) -> std::fmt::Result {
-        write!(
-            self.out,
-            "for {} in ",
-            forloop.pat.clone().into_token_stream(),
-        )?;
+        // Normalize whitespace around commas in patterns like (index, name, value)
+        // since into_token_stream() adds extra spaces before commas: (index , name , value)
+        let pat = forloop
+            .pat
+            .clone()
+            .into_token_stream()
+            .to_string()
+            .replace(" ,", ",");
+        write!(self.out, "for {pat} in ")?;
 
         self.write_inline_expr(&forloop.expr)?;
 

--- a/packages/autofmt/tests/samples/ifchain_forloop.rsx
+++ b/packages/autofmt/tests/samples/ifchain_forloop.rsx
@@ -5,6 +5,11 @@ rsx! {
         div {}
     }
 
+    // Tuple destructuring should not add extra spaces before commas
+    for (index, name, value) in data {
+        div { "{index}: {name}, {value}" }
+    }
+
     // Some ifchain
     if a > 10 {
         //


### PR DESCRIPTION
## Summary
Closes #5348

- `dx fmt` was adding extra spaces before commas in for-loop tuple destructuring patterns
- `for (index, name, value) in data` became `for (index , name , value) in data`
- Root cause: `Pat::into_token_stream().to_string()` adds spaces around punctuation
- Fix: normalize by replacing ` ,` with `,` in the pattern string

## Changes
- `packages/autofmt/src/writer.rs` — Fixed `write_for_loop()` to normalize comma spacing
- `packages/autofmt/tests/samples/ifchain_forloop.rsx` — Added tuple destructuring test case

## Test plan
- [x] `cargo test -p dioxus-autofmt ifchain_forloop` — passes with tuple pattern
- [x] `cargo test -p dioxus-autofmt` — all 68 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)