### PR TITLE
fix(cli): watch depinfo paths to detect sub-module changes

### DIFF
--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -595,6 +595,12 @@ impl AppServer {
             _ => {}
         }
 
+        // Use depinfo files to watch all source files that cargo actually depends on.
+        // This ensures sub-modules and other nested files trigger rebuilds.
+        if self.watch_fs {
+            self.watch_depinfo_paths(&artifacts.depinfo);
+        }
+
         let should_open = self.client.stage == BuildStage::Success
             && (self.server.as_ref().map(|s| s.stage == BuildStage::Success)).unwrap_or(true);
 
@@ -1051,6 +1057,27 @@ impl AppServer {
             RecursiveMode::NonRecursive,
         ) {
             handle_notify_error(err);
+        }
+    }
+
+    /// Watch paths from cargo's depinfo files after a build completes.
+    ///
+    /// Cargo generates `.d` files that list every source file the compilation depends on.
+    /// By watching the parent directories of these files, we ensure that sub-modules and
+    /// other nested source files properly trigger rebuilds.
+    fn watch_depinfo_paths(&mut self, depinfo: &depinfo::RustcDepInfo) {
+        let mut watched_dirs = std::collections::HashSet::new();
+
+        for file in &depinfo.files {
+            if let Some(parent) = file.parent() {
+                // Only watch directories we haven't already registered
+                if watched_dirs.insert(parent.to_path_buf()) {
+                    tracing::trace!("Watching depinfo path {parent:?}");
+                    if let Err(err) = self.watcher.watch(parent, RecursiveMode::NonRecursive) {
+                        handle_notify_error(err);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Closes #5371

- `dx serve` was not triggering rebuilds when files in nested sub-modules were modified
- Root cause: `watch_paths()` only registered top-level directory entries via `read_dir()`, missing deeper files
- Fix: after each build completes, read cargo's `.d` depinfo files and register their parent directories with the file watcher
- This follows the approach suggested in #5381: use cargo's dependency files instead of watching all workspace members

## Changes
- `packages/cli/src/serve/runner.rs` — Added `watch_depinfo_paths()` that reads depinfo files and registers source directories with the watcher
- Called from `open()` after build artifacts are saved, so the watcher becomes more accurate over time

## Test plan
- [x] `cargo check -p dioxus-cli` — passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)