### PR TITLE
Add non-exhaustive to the derived props in #[component]

### DIFF
--- a/packages/core-macro/src/component.rs
+++ b/packages/core-macro/src/component.rs
@@ -245,6 +245,7 @@ impl ComponentBody {
 
         let item_struct = parse_quote! {
             #[derive(Props)]
+            #[non_exhaustive]
             #[allow(non_camel_case_types)]
             #vis struct #struct_ident #generics #where_clause {
                 #(#struct_fields),*


### PR DESCRIPTION
Currently it is a breaking change to add an optional field to a public component with props derived with the #[component] macro even though it isn't breaking for usage within rsx. This PR adds non_exhaustive to the derived props so it isn't breaking in future releases.

Changing this component:

```rust
#[component]
pub fn Button() -> Element {...}
```

To this:

```rust
#[component]
pub fn Button(color: Option<String>) -> Element {...}
```

Is breaking because there is a public generated ButtonProps with public fields that could be constructed manually