### PR TITLE
chore: add TOML schema reference to Dioxus.toml template and examples

### DIFF
--- a/examples/01-app-demos/file-explorer/Dioxus.toml
+++ b/examples/01-app-demos/file-explorer/Dioxus.toml
@@ -1,3 +1,5 @@
+#:schema ../../../packages/cli/schema.json
+
 [application]
 
 # App (Project) Name

--- a/examples/01-app-demos/hotdog/Dioxus.toml
+++ b/examples/01-app-demos/hotdog/Dioxus.toml
@@ -1,3 +1,5 @@
+#:schema ../../../packages/cli/schema.json
+
 [application]
 
 # App (Project) Name

--- a/examples/10-integrations/pwa/Dioxus.toml
+++ b/examples/10-integrations/pwa/Dioxus.toml
@@ -1,3 +1,5 @@
+#:schema ../../../packages/cli/schema.json
+
 [application]
 
 # App (Project) Name

--- a/packages/cli/assets/dioxus.toml
+++ b/packages/cli/assets/dioxus.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/DioxusLabs/dioxus/main/packages/cli/schema.json
+
 [application]
 
 # Web `build` & `serve` dist path


### PR DESCRIPTION
## Summary

Closes #5376

Prepends `#:schema` to the CLI-generated `Dioxus.toml` template and to existing example projects. IDEs with TOML schema support (e.g. [Taplo](https://taplo.tamasfe.dev/) / [Tombi](https://tombi-toml.github.io/)) will now offer autocompletion and inline validation out of the box — no manual configuration needed.

**Changed files:**
- `packages/cli/assets/dioxus.toml` — template used by `dx config init`, gets the remote schema URL so it works in any new project
- `examples/01-app-demos/file-explorer/Dioxus.toml`
- `examples/01-app-demos/hotdog/Dioxus.toml`
- `examples/10-integrations/pwa/Dioxus.toml`

Example projects use a repo-relative path (`../../../packages/cli/schema.json`) so the schema stays in sync with local changes during development.

## Test plan

- [ ] Run `dx config init` in a new project and verify the generated `Dioxus.toml` starts with the schema comment
- [ ] Open any of the updated example `Dioxus.toml` files in an editor with Taplo/Tombi installed and confirm autocompletion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)