### PR TITLE
fix(server): don't redirect error responses from #[get] server functions

### DIFF
--- a/packages/fullstack-server/src/serverfn.rs
+++ b/packages/fullstack-server/src/serverfn.rs
@@ -113,9 +113,11 @@ impl ServerFunction {
                                 response.headers_mut().extend(headers);
                             }
 
-                            // if it accepts text/html (i.e., is a plain form post) and doesn't already have a
-                            // Location set, then redirect to Referer
-                            if accepts_html {
+                            // If the response is successful and accepts text/html (i.e., is a
+                            // plain form post) and doesn't already have a Location set, then
+                            // redirect to Referer. Only redirect on success so that error
+                            // responses (4xx, 5xx) propagate correctly to the client.
+                            if accepts_html && response.status().is_success() {
                                 if let Some(referrer) = referrer {
                                     let has_location = response.headers().get(LOCATION).is_some();
                                     if !has_location {


### PR DESCRIPTION
## Summary

- Add `response.status().is_success()` guard to the Post/Redirect/Get redirect logic in `serverfn.rs`
- Error responses (4xx, 5xx) from `#[get]` server functions now propagate correctly instead of being silently converted to 302 redirects

## Problem

The redirect logic in `make_handler` unconditionally converts any response to a `302 Found` redirect when the request has `Accept: text/html` and a `Referer` header. This breaks `#[get]` endpoints used as OAuth callbacks or any endpoint that needs to return error status codes when accessed via browser navigation.

## Fix

Guard the redirect with `response.status().is_success()` so only successful responses get the Post/Redirect/Get treatment. Error responses pass through unchanged.

Fixes #5428

## Test plan

- [ ] `cargo check -p dioxus-server` passes
- [ ] Verify with curl: `curl -v -H "Accept: text/html" -H "Referer: http://localhost:8080/" <error-endpoint>` returns the error status (not 302)
- [ ] Successful responses with `Referer` still redirect correctly (existing behavior preserved)