### PR TITLE
Fixed issue #5438: Added FIPS Compliance flag to candle.exe command

### DIFF
--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -248,6 +248,11 @@ impl BundleContext<'_> {
             .arg("-o")
             .arg(&wixobj_path)
             .arg(&wxs_path);
+
+        if wix_settings.fips_compliant {
+            candle_cmd.arg("-fips");
+        }
+
         candle_cmd.arg("-ext").arg("WixUIExtension");
 
         tracing::debug!("candle command: {:?}", candle_cmd);


### PR DESCRIPTION
- Optionally add FIPS Compliance flag to `candle.exe` command when set via `WixSettings`

Fixes #5438 