### PR TITLE
Forward `-B` linker search path in thin/patch link args on Linux

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -2704,8 +2704,12 @@ impl BuildRequest {
 
                 // Preserve the original args. We only preserve:
                 // -L <path>
-                // -arch
                 // -lxyz
+                // -m (arch/emulation)
+                // -B<path>  (gcc program search path — Rust 1.86+ injects -B/gcc-ld + -fuse-ld=lld
+                //            so that cc picks up the bundled lld; we must forward it for the patch
+                //            linker invocation too, otherwise cc falls back to the system `ld`)
+                // -fuse-ld  (linker selection)
                 // There might be more, but some flags might break our setup.
                 for (idx, arg) in original_args.iter().enumerate() {
                     if *arg == "-L" {
@@ -2718,6 +2722,7 @@ impl BuildRequest {
                         || arg.starts_with("-Wl,--target=")
                         || arg.starts_with("-Wl,-fuse-ld")
                         || arg.starts_with("-fuse-ld")
+                        || arg.starts_with("-B")
                         || arg.contains("-ld-path")
                     {
                         out_args.push(arg.to_string());


### PR DESCRIPTION
Since Rust 1.86, the toolchain injects two flags when linking on Linux to use the bundled lld instead of the system `ld`:

- `B/path/to/rustup/.../gcc-ld` — tells `cc` where to find linker programs
- `fuse-ld=lld` — tells `cc` to select lld

The fat link captures the full set of args from the initial cargo build and replays them verbatim, so it already picked up both flags and worked correctly on systems without binutils installed.

The patch link (thin) builds its own arg list in `thin_link_args`. It forwarded `-fuse-ld` but not `-B`, so `cc -fuse-ld=lld` could not locate `ld.lld` from the Rust toolchain and fell back to the system `ld`, failing with:

```
collect2: fatal error: cannot find 'ld'
```

Fix: add `-B` to the pass-through filter so the patch linker invocation forwards the same gcc-ld search path that cargo injects.

[Implementation notes - Rust RFC ](https://doc.rust-lang.org/rustc/codegen-options/index.html#implementation-notes)
> On the `x86_64-unknown-linux-gnu` target, when using the default linker flavor (using `cc` as the linker driver) and linker features (to try using `lld`), `rustc` will try to use the self-contained linker by passing a `-B /path/to/sysroot/` link argument to the driver to find `rust-lld` in the sysroot. For backwards-compatibility, and to limit name and `PATH` collisions, this is done using a shim executable (the `lld-wrapper` tool) that forwards execution to the `rust-lld` executable itself.

Thanks to:
- @marc2332 , for testing on Ubuntu 24.04 with Rust 1.94
- @SergioRibera , for testing on NixOS 26.03
- @MarioYellowy , for testing on PopOS 24.04 with Rust 1.94.1
I tested it on MacOS 23.3.1(a) with Rust 1.93