### PR TITLE
feat: add blanket IntoAttributeValue impl for references

### DIFF
--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -1123,9 +1123,9 @@ impl<T: IntoAttributeValue> IntoAttributeValue for Option<T> {
     }
 }
 
-impl<T: IntoAttributeValue + Clone> IntoAttributeValue for &T {
+impl<T: ToOwned<Owned = R>, R: IntoAttributeValue> IntoAttributeValue for &T {
     fn into_value(self) -> AttributeValue {
-        self.clone().into_value()
+        self.to_owned().into_value()
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a blanket IntoAttributeValue implementation for &T where T: IntoAttributeValue + Clone.

Closes #5444

This contribution was developed with AI assistance (Claude Code).