### PR TITLE
feat: provide api to customize server address

### DIFF
--- a/examples/07-fullstack/custom_axum_serve.rs
+++ b/examples/07-fullstack/custom_axum_serve.rs
@@ -11,9 +11,9 @@
 //! `dioxus::serve` is most useful for customizing the server setup, such as adding middleware,
 //! custom routes, or integrating with existing axum backend code.
 //!
-//! Note that `dioxus::serve` is accepts a Router from `axum`. Dioxus will use the IP and PORT
+//! Note that `dioxus::serve` accepts a Router from `axum`. Dioxus will use the IP and PORT
 //! environment variables to determine where to bind the server. To customize the port, use environment
-//! variables or a `.env` file.
+//! variables, a `.env` file, or `dioxus::serve_router` to bind a `SocketAddr` from your own async runtime.
 //!
 //! On other platforms (like desktop or mobile), you'll want to use `dioxus::launch` instead and then
 //! handle async loading of data through hooks like `use_future` or `use_resource` and give the user

--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -88,6 +88,9 @@ pub use dioxus_server as server;
 #[cfg(feature = "server")]
 pub use dioxus_server::serve;
 
+#[cfg(feature = "server")]
+pub use dioxus_server::serve_router;
+
 #[cfg(feature = "devtools")]
 #[cfg_attr(docsrs, doc(cfg(feature = "devtools")))]
 pub use dioxus_devtools as devtools;
@@ -215,7 +218,9 @@ pub mod prelude {
     #[cfg(feature = "server")]
     #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
     #[doc(inline)]
-    pub use dioxus_server::{self, DioxusRouterExt, ServeConfig, ServerFunction, serve};
+    pub use dioxus_server::{
+        self, DioxusRouterExt, ServeConfig, ServerFunction, serve, serve_router,
+    };
 
     #[cfg(feature = "router")]
     #[cfg_attr(docsrs, doc(cfg(feature = "router")))]

--- a/packages/dioxus/src/lib.rs
+++ b/packages/dioxus/src/lib.rs
@@ -88,6 +88,9 @@ pub use dioxus_server as server;
 #[cfg(feature = "server")]
 pub use dioxus_server::serve;
 
+#[cfg(feature = "server")]
+pub use dioxus_server::serve_router;
+
 #[cfg(feature = "devtools")]
 #[cfg_attr(docsrs, doc(cfg(feature = "devtools")))]
 pub use dioxus_devtools as devtools;
@@ -225,7 +228,9 @@ pub mod prelude {
     #[cfg(feature = "server")]
     #[cfg_attr(docsrs, doc(cfg(feature = "server")))]
     #[doc(inline)]
-    pub use dioxus_server::{self, DioxusRouterExt, ServeConfig, ServerFunction, serve};
+    pub use dioxus_server::{
+        self, DioxusRouterExt, ServeConfig, ServerFunction, serve, serve_router,
+    };
 
     #[cfg(feature = "router")]
     #[cfg_attr(docsrs, doc(cfg(feature = "router")))]

--- a/packages/fullstack-server/src/launch.rs
+++ b/packages/fullstack-server/src/launch.rs
@@ -69,14 +69,14 @@ async fn serve_server(
 
     let cb = move || {
         let cfg = cfg.clone();
-        Box::pin(async move {
+        async move {
             Ok(apply_base_path(
                 Router::new().serve_dioxus_application(cfg.clone(), original_root),
                 original_root,
                 cfg.clone(),
                 base_path().map(|s| s.to_string()),
             ))
-        }) as _
+        }
     };
 
     serve_router(cb, dioxus_cli_config::fullstack_address_or_localhost()).await;
@@ -111,16 +111,20 @@ pub fn router(app: fn() -> Element) -> Router {
 /// The axum router will be bound to the address specified by the `IP` and `PORT` environment variables,
 /// defaulting to `127.0.0.1:8080` if not set.
 ///
+/// To bind to a specific address from your own async runtime, use [`serve_router`] instead.
+///
 /// This function uses axum to block on serving the application, and will not return.
-pub fn serve<F>(mut serve_it: impl FnMut() -> F) -> !
+pub fn serve<F>(serve_it: impl FnMut() -> F) -> !
 where
     F: Future<Output = Result<Router, anyhow::Error>> + 'static,
 {
-    let cb = move || Box::pin(serve_it()) as _;
-
-    block_on(
-        async move { serve_router(cb, dioxus_cli_config::fullstack_address_or_localhost()).await },
-    );
+    block_on(async move {
+        serve_router(
+            serve_it,
+            dioxus_cli_config::fullstack_address_or_localhost(),
+        )
+        .await
+    });
 
     unreachable!("Serving a fullstack app should never return")
 }
@@ -131,10 +135,15 @@ where
 ///
 /// To enable hot-reloading of the router, the provided `serve_callback` should return a new `Router`
 /// each time it is called.
-pub async fn serve_router(
-    mut serve_callback: impl FnMut() -> Pin<Box<dyn Future<Output = Result<Router, anyhow::Error>>>>,
-    addr: SocketAddr,
-) {
+pub async fn serve_router<F>(mut serve_callback: impl FnMut() -> F, addr: SocketAddr)
+where
+    F: Future<Output = Result<Router, anyhow::Error>> + 'static,
+{
+    // Box internally so the hot-reload path (`HotFn`) still gets a type-erased future.
+    let mut serve_callback = move || {
+        Box::pin(serve_callback()) as Pin<Box<dyn Future<Output = Result<Router, anyhow::Error>>>>
+    };
+
     dioxus_logger::initialize_default();
 
     let listener = TcpListener::bind(addr)

--- a/packages/fullstack-server/src/lib.rs
+++ b/packages/fullstack-server/src/lib.rs
@@ -39,6 +39,7 @@ pub(crate) mod streaming;
 
 pub use launch::router;
 pub use launch::serve;
+pub use launch::serve_router;
 
 pub mod serverfn;
 pub use serverfn::*;


### PR DESCRIPTION
Fixes #5263

Before 0.7, `fullstack::Config::new().addr(...)` allowed setting the server address programmatically. This was removed in the 0.7 refactoring, leaving `IP`/`PORT` env vars as the only option. On Rust edition 2024, that means calling `unsafe { std::env::set_var(...) }` before `serve()`.

`serve_at` is a new entry point that takes a `SocketAddr` and a callback, which is just wrapped by `serve()`, so existing behavior is unchanged. It is re-exported as `dioxus::serve_at` and included in the prelude.