### PR TITLE
feat(html): add `inert` global HTML attribute

### DIFF
--- a/packages/html/src/attribute_groups.rs
+++ b/packages/html/src/attribute_groups.rs
@@ -301,6 +301,9 @@ mod_methods! {
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode>
     inputmode;
 
+    /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert>
+    inert;
+
     /// <https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is>
     is;
 

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -447,6 +447,7 @@ pub(crate) const BOOL_ATTRS: &[&str] = &[
     "disabled",
     "formnovalidate",
     "hidden",
+    "inert",
     "ismap",
     "itemscope",
     "loop",


### PR DESCRIPTION
## Summary

Added the `inert` boolean attribute to the global HTML attributes and the SSR boolean attributes list. The [HTML `inert` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) makes the browser ignore user input events for an element and its descendants, remove it from the accessibility tree, and skip it in text searches.

## Changes

- `packages/html/src/attribute_groups.rs` - added `inert` to global attributes (alphabetical order)
- `packages/ssr/src/renderer.rs` - added `"inert"` to `BOOL_ATTRS` for correct SSR rendering

Fixes #5455

![CE](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)