### PR TITLE
Allow using generated assets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8117,6 +8117,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,6 +291,7 @@ rustversion = "1.0.21"
 rand = "0.9"
 longest-increasing-subsequence = "0.1.0"
 trybuild = "1.0.116"
+tempfile = "3.27.0"
 dirs = "6.0.0"
 cargo-config2 = "0.1.34"
 criterion = { version = "0.6" }

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -124,7 +124,7 @@ shell-words = { workspace = true }
 log = { version = "0.4.29", features = ["max_level_off", "release_max_level_off"] }
 
 # link intercept
-tempfile = "3.27.0"
+tempfile = { workspace = true }
 manganis = { workspace = true }
 manganis-core = { workspace = true }
 target-lexicon = { version = "0.13.2", features = ["serde", "serde_support"] }

--- a/packages/manganis/manganis-macro/.cargo/config.toml
+++ b/packages/manganis/manganis-macro/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustdocflags = ['--cfg', 'skip_out_tests']

--- a/packages/manganis/manganis-macro/Cargo.toml
+++ b/packages/manganis/manganis-macro/Cargo.toml
@@ -27,3 +27,4 @@ default = []
 
 [dev-dependencies]
 manganis = { workspace = true }
+tempfile = "3.19.1"

--- a/packages/manganis/manganis-macro/Cargo.toml
+++ b/packages/manganis/manganis-macro/Cargo.toml
@@ -27,4 +27,4 @@ default = []
 
 [dev-dependencies]
 manganis = { workspace = true }
-tempfile = "3.19.1"
+tempfile = { workspace = true }

--- a/packages/manganis/manganis-macro/Cargo.toml
+++ b/packages/manganis/manganis-macro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "manganis-macro"
 version.workspace = true
 edition = "2024"
+rust-version = "1.85.0"
 authors = ["Evan Almloff"]
 description = "Ergonomic, automatic, cross crate asset collection and optimization"
 license = "MIT OR Apache-2.0"

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -1,4 +1,4 @@
-use crate::{linker::generate_link_section, resolve_path, AssetParseError};
+use crate::{linker::generate_link_section, AssetParseError, PathResolution, PathResolver};
 use macro_string::MacroString;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
@@ -44,8 +44,9 @@ impl Parse for AssetParser {
     // But we need to decide the hint first before parsing the options
     fn parse(input: ParseStream) -> syn::Result<Self> {
         // And then parse the options
+        let resolution = input.call(PathResolution::parse)?;
         let (MacroString(src), path_expr) = input.call(crate::parse_with_tokens)?;
-        let asset = resolve_path(&src, path_expr.span());
+        let asset = PathResolver::new(resolution, &src, &path_expr.span()).resolve();
         let _comma = input.parse::<Token![,]>();
         let options = input.parse()?;
 
@@ -133,7 +134,7 @@ impl AssetParser {
                 let asset_tokens = self.expand_asset_tokens(asset);
                 quote! { ::core::option::Option::Some(#asset_tokens) }
             }
-            Err(AssetParseError::AssetDoesntExist { .. }) => {
+            Err(AssetParseError::DoesNotExist { .. }) => {
                 quote! { ::core::option::Option::<manganis::Asset>::None }
             }
             Err(err) => self.error_tokens(err),

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -1,4 +1,4 @@
-use crate::{AssetParseError, linker::generate_link_section, resolve_path};
+use crate::{AssetParseError, PathResolver, linker::generate_link_section};
 use macro_string::MacroString;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{ToTokens, quote};
@@ -45,7 +45,7 @@ impl Parse for AssetParser {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         // And then parse the options
         let (MacroString(src), path_expr) = input.call(crate::parse_with_tokens)?;
-        let asset = resolve_path(&src, path_expr.span());
+        let asset = PathResolver::new(&src, &path_expr.span()).resolve();
         let _comma = input.parse::<Token![,]>();
         let options = input.parse()?;
 
@@ -132,7 +132,7 @@ impl AssetParser {
                 let asset_tokens = self.expand_asset_tokens(asset);
                 quote! { ::core::option::Option::Some(#asset_tokens) }
             }
-            Err(AssetParseError::AssetDoesntExist { .. }) => {
+            Err(AssetParseError::DoesNotExist { .. }) => {
                 quote! { ::core::option::Option::<manganis::Asset>::None }
             }
             Err(err) => self.error_tokens(err),

--- a/packages/manganis/manganis-macro/src/css_module.rs
+++ b/packages/manganis/manganis-macro/src/css_module.rs
@@ -1,4 +1,4 @@
-use crate::{asset::AssetParser, resolve_path};
+use crate::{asset::AssetParser, PathResolution, PathResolver};
 use macro_string::MacroString;
 use manganis_core::{create_module_hash, get_class_mappings};
 use proc_macro2::{Span, TokenStream};
@@ -17,8 +17,9 @@ pub(crate) struct CssModuleAttribute {
 impl Parse for CssModuleAttribute {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         // Asset path "/path.css"
+        let resolution = input.call(PathResolution::parse)?;
         let (MacroString(src), path_expr) = input.call(crate::parse_with_tokens)?;
-        let asset = resolve_path(&src, path_expr.span());
+        let asset = PathResolver::new(resolution, &src, &path_expr.span()).resolve();
 
         let _comma = input.parse::<Comma>();
 

--- a/packages/manganis/manganis-macro/src/css_module.rs
+++ b/packages/manganis/manganis-macro/src/css_module.rs
@@ -1,4 +1,4 @@
-use crate::{asset::AssetParser, resolve_path};
+use crate::{PathResolver, asset::AssetParser};
 use macro_string::MacroString;
 use manganis_core::{create_module_hash, get_class_mappings};
 use proc_macro2::{Span, TokenStream};
@@ -18,7 +18,7 @@ impl Parse for CssModuleAttribute {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         // Asset path "/path.css"
         let (MacroString(src), path_expr) = input.call(crate::parse_with_tokens)?;
-        let asset = resolve_path(&src, path_expr.span());
+        let asset = PathResolver::new(&src, &path_expr.span()).resolve();
 
         let _comma = input.parse::<Comma>();
 

--- a/packages/manganis/manganis-macro/src/lib.rs
+++ b/packages/manganis/manganis-macro/src/lib.rs
@@ -1,14 +1,14 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{
     parse::{Parse, ParseStream},
-    parse_macro_input, ItemStruct,
+    parse_macro_input, ItemStruct, Token,
 };
 
 pub(crate) mod asset;
@@ -22,15 +22,10 @@ use crate::css_module::{expand_css_module_struct, CssModuleAttribute};
 ///
 /// # Files
 ///
-/// The file builder collects an arbitrary file. Relative paths are resolved relative to the package root
+/// The file builder collects an arbitrary file.
 /// ```rust
 /// # use manganis::{asset, Asset};
 /// const _: Asset = asset!("/assets/asset.txt");
-/// ```
-/// Macros like `concat!` and `env!` are supported in the asset path.
-/// ```rust
-/// # use manganis::{asset, Asset};
-/// const _: Asset = asset!(concat!("/assets/", env!("CARGO_CRATE_NAME"), ".dat"));
 /// ```
 ///
 /// # Images
@@ -55,6 +50,26 @@ use crate::css_module::{expand_css_module_struct, CssModuleAttribute};
 /// # use manganis::{asset, Asset, AssetOptions};
 /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_preload(true));
 /// ```
+///
+/// # Path resolution
+///
+/// By default, paths are resolved relative to the current file if they begin with either `.` or `..`, and the crate root otherwise.
+/// ```rust
+/// # use manganis::{asset, Asset};
+/// const _: Asset = asset!("/assets/asset.txt"); // Resolved relative to the crate root
+/// const _: Asset = asset!("../assets/asset.txt"); // Resolved relative to the current file
+/// ```
+/// To explicitly declare the path resolution strategy, use the `crate`, `self`, and `out` keywords.
+/// ```rust
+/// # use manganis::{asset, Asset};
+/// const _: Asset = asset!(crate "/assets/asset.txt"); // Resolved relative to the crate root
+/// const _: Asset = asset!(self "../assets/asset.txt"); // Resolved relative to the current file
+/// # #[cfg(not(skip_out_tests))]
+/// const _: Asset = asset!(out "generated-asset.txt"); // Resolved relative to the output folder
+/// ```
+/// The output folder is read from the `OUT_DIR` environment variable.
+///
+/// Leading `/` characters are ignored in all cases.
 #[proc_macro]
 pub fn asset(input: TokenStream) -> TokenStream {
     let asset = parse_macro_input!(input as asset::AssetParser);
@@ -90,7 +105,7 @@ pub fn option_asset(input: TokenStream) -> TokenStream {
 /// # Syntax
 ///
 /// The `css_module` attribute takes:
-/// - The asset string path - the absolute path (from the crate root) to your CSS file.
+/// - The asset path. Uses the same rules for resolution as `asset!`.
 /// - Optional `AssetOptions` to configure the processing of your CSS module.
 ///
 /// It must be applied to a unit struct:
@@ -284,67 +299,188 @@ pub fn ffi(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
-fn resolve_path(raw: &str, span: Span) -> Result<PathBuf, AssetParseError> {
-    // Get the location of the root of the crate which is where all assets are relative to
-    //
-    // IE
-    // /users/dioxus/dev/app/
-    // is the root of
-    // /users/dioxus/dev/app/assets/blah.css
-    let manifest_dir = dunce::canonicalize(
-        std::env::var("CARGO_MANIFEST_DIR")
-            .map(PathBuf::from)
-            .unwrap(),
-    )
-    .unwrap();
+struct PathResolver {
+    resolution: PathResolution,
+    src: PathBuf,
+    manifest_dir: PathBuf,
+    out_dir: Option<PathBuf>,
+    file_path: Option<PathBuf>,
+    looks_like_rust_analyzer: bool,
+}
 
-    // 1. the input file should be a pathbuf
-    let input = PathBuf::from(raw);
+impl PathResolver {
+    fn new(resolution: PathResolution, src: impl Into<PathBuf>, span: &Span) -> Self {
+        let manifest_dir = Self::get_manifest_dir();
 
-    let path = if raw.starts_with('.') {
-        if let Some(local_folder) = span.local_file().as_ref().and_then(|f| f.parent()) {
-            local_folder.join(raw)
-        } else {
-            // If we are running in rust analyzer, just assume the path is valid and return an error when
-            // we compile if it doesn't exist
-            if looks_like_rust_analyzer(&span) {
-                return Ok(
-                    "The asset macro was expanded under Rust Analyzer which doesn't support paths or local assets yet"
-                        .into(),
-                );
-            }
+        // The output directory is only available when a build script is present
+        let out_dir = std::env::var("OUT_DIR")
+            .ok()
+            .map(dunce::canonicalize)
+            .transpose()
+            .unwrap();
 
-            // Otherwise, return an error about the version of rust required for relative assets
-            return Err(AssetParseError::RelativeAssetPath);
+        Self {
+            resolution,
+            src: src.into(),
+            manifest_dir,
+            out_dir,
+            file_path: span.local_file(),
+            looks_like_rust_analyzer: looks_like_rust_analyzer(span),
         }
-    } else {
-        manifest_dir.join(raw.trim_start_matches('/'))
-    };
-
-    // 2. absolute path to the asset
-    let Ok(path) = std::path::absolute(path) else {
-        return Err(AssetParseError::InvalidPath {
-            path: input.clone(),
-        });
-    };
-
-    // 3. Ensure the path exists
-    let Ok(path) = dunce::canonicalize(path) else {
-        return Err(AssetParseError::AssetDoesntExist {
-            path: input.clone(),
-        });
-    };
-
-    // 4. Ensure the path doesn't escape the crate dir
-    //
-    // - Note: since we called canonicalize on both paths, we can safely compare the parent dirs.
-    //   On windows, we can only compare the prefix if both paths are canonicalized (not just absolute)
-    //   https://github.com/rust-lang/rust/issues/42869
-    if path == manifest_dir || !path.starts_with(manifest_dir) {
-        return Err(AssetParseError::InvalidPath { path });
     }
 
-    Ok(path)
+    #[cfg(test)]
+    fn implicit(src: impl Into<PathBuf>) -> Self {
+        Self::test(PathResolution::Implicit, src)
+    }
+
+    #[cfg(test)]
+    fn from_crate(src: impl Into<PathBuf>) -> Self {
+        Self::test(PathResolution::Explicit(PathBase::Crate), src)
+    }
+
+    #[cfg(test)]
+    fn from_file(src: impl Into<PathBuf>) -> Self {
+        Self::test(PathResolution::Explicit(PathBase::File), src)
+    }
+
+    #[cfg(test)]
+    fn from_out(src: impl Into<PathBuf>) -> Self {
+        Self::test(PathResolution::Explicit(PathBase::Out), src)
+    }
+
+    #[cfg(test)]
+    fn test(resolution: PathResolution, src: impl Into<PathBuf>) -> Self {
+        let manifest_dir = Self::get_manifest_dir();
+
+        let out_dir = Some(manifest_dir.join("out"));
+        let file_path = Some(manifest_dir.join("src/lib.rs"));
+
+        Self {
+            resolution,
+            src: src.into(),
+            manifest_dir,
+            out_dir,
+            file_path,
+            looks_like_rust_analyzer: false,
+        }
+    }
+
+    fn get_manifest_dir() -> PathBuf {
+        dunce::canonicalize(std::env::var("CARGO_MANIFEST_DIR").unwrap()).unwrap()
+    }
+
+    fn resolve(&self) -> Result<PathBuf, AssetParseError> {
+        // 1. Convert strategy to base
+        let base = match self.resolution {
+            PathResolution::Explicit(base) => base,
+            PathResolution::Implicit => match self.src.components().next() {
+                Some(Component::CurDir | Component::ParentDir) => PathBase::File,
+                _ => PathBase::Crate,
+            },
+        };
+
+        // 2. Stip leading slash
+        let path = self.src.strip_prefix("/").unwrap_or(self.src.as_path());
+
+        // 3. Resolve path
+        let path = match base {
+            PathBase::Crate => self.manifest_dir.join(path),
+            PathBase::File => {
+                if let Some(parent) = self.file_path.as_ref().and_then(|path| path.parent()) {
+                    parent.join(path)
+                } else {
+                    // If we are running in rust analyzer, just assume the path is valid and return an error when
+                    // we compile if it doesn't exist
+                    if self.looks_like_rust_analyzer {
+                        let message = concat!(
+                            "The asset macro was expanded under Rust Analyzer ",
+                            "which doesn't support paths or local assets yet."
+                        );
+
+                        return Ok(message.into());
+                    }
+
+                    // Otherwise, return an error about the version of rust required for relative assets
+                    return Err(AssetParseError::FileBaseUnavailable);
+                }
+            }
+            PathBase::Out => {
+                if let Some(out_dir) = self.out_dir.as_ref() {
+                    out_dir.join(path)
+                } else {
+                    return Err(AssetParseError::OutBaseUnavailable);
+                }
+            }
+        };
+
+        // 4. Convert to absolute path
+        let Ok(path) = std::path::absolute(&path) else {
+            return Err(AssetParseError::DoesNotExist { path });
+        };
+
+        // 5. Ensure the path exists
+        let Ok(path) = dunce::canonicalize(&path) else {
+            return Err(AssetParseError::DoesNotExist { path });
+        };
+
+        let in_manifest_dir = path != self.manifest_dir && path.starts_with(&self.manifest_dir);
+
+        let in_out_dir = self
+            .out_dir
+            .as_ref()
+            .is_some_and(|dir| path != *dir && path.starts_with(dir));
+
+        // 6. Ensure the path doesn't escape the crate or output directories
+        //
+        // On windows, we can only compare the prefix if both paths are canonicalized (not just absolute)
+        //
+        // See: https://github.com/rust-lang/rust/issues/42869
+        if !in_manifest_dir && !in_out_dir {
+            return Err(AssetParseError::Outside { path });
+        }
+
+        Ok(path)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathResolution {
+    Explicit(PathBase),
+    Implicit,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PathBase {
+    Crate,
+    File,
+    Out,
+}
+
+impl Parse for PathResolution {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        syn::custom_keyword!(out);
+
+        if input.peek(Token![crate]) {
+            input.parse::<Token![crate]>().unwrap();
+
+            return Ok(Self::Explicit(PathBase::Crate));
+        }
+
+        if input.peek(Token![self]) {
+            input.parse::<Token![self]>().unwrap();
+
+            return Ok(Self::Explicit(PathBase::File));
+        }
+
+        if input.peek(out) {
+            input.parse::<out>().unwrap();
+
+            return Ok(Self::Explicit(PathBase::Out));
+        }
+
+        Ok(Self::Implicit)
+    }
 }
 
 /// Parse `T`, while also collecting the tokens it was parsed from.
@@ -364,27 +500,29 @@ fn parse_with_tokens<T: Parse>(input: ParseStream) -> syn::Result<(T, proc_macro
     Ok((t, tokens))
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum AssetParseError {
-    AssetDoesntExist { path: PathBuf },
-    InvalidPath { path: PathBuf },
-    RelativeAssetPath,
+    FileBaseUnavailable,
+    OutBaseUnavailable,
+    DoesNotExist { path: PathBuf },
+    Outside { path: PathBuf },
 }
 
 impl std::fmt::Display for AssetParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssetParseError::AssetDoesntExist { path } => {
-                write!(f, "Asset at {} doesn't exist", path.display())
+            AssetParseError::FileBaseUnavailable => {
+                write!(f, "Relative paths are only supported in Rust 1.88+.")
             }
-            AssetParseError::InvalidPath { path } => {
-                write!(
-                    f,
-                    "Asset path {} is invalid. Make sure the asset exists within this crate.",
-                    path.display()
-                )
+            AssetParseError::OutBaseUnavailable => {
+                write!(f, "No output folder specified by the compiler.")
             }
-            AssetParseError::RelativeAssetPath => write!(f, "Failed to resolve relative asset path. Relative assets are only supported in rust 1.88+."),
+            AssetParseError::DoesNotExist { path } => {
+                write!(f, "Path {} not found.", path.display())
+            }
+            AssetParseError::Outside { path } => {
+                write!(f, "Path {} is outside of allowed folders.", path.display())
+            }
         }
     }
 }
@@ -406,4 +544,273 @@ fn looks_like_rust_analyzer(span: &Span) -> bool {
             .is_some_and(|s| s.contains("rust-analyzer"))
     });
     looks_like_rust_analyzer_span || looks_like_rust_analyzer_env || looks_like_rust_analyzer_exe
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{AssetParseError, PathResolver};
+
+    struct Ctx {
+        workspace_root: PathBuf,
+        crate_root: PathBuf,
+        out_folder: PathBuf,
+    }
+
+    impl Ctx {
+        fn init() -> Self {
+            let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+            let out_folder = crate_root.join("out");
+
+            let workspace_root = crate_root
+                .join("../../..")
+                .canonicalize()
+                .and_then(std::path::absolute)
+                .unwrap();
+
+            Self {
+                workspace_root,
+                crate_root,
+                out_folder,
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_crate_path() {
+        let Ctx { crate_root, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_crate("assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+
+        assert_eq!(
+            PathResolver::from_crate("/assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+    }
+
+    #[test]
+    fn resolve_missing_crate_path() {
+        let Ctx { crate_root, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_crate("assets/does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: crate_root.join("assets/does-not-exist.txt")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_crate("/assets/does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: crate_root.join("assets/does-not-exist.txt")
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_outside_crate_path() {
+        let Ctx {
+            workspace_root,
+            crate_root,
+            ..
+        } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_crate("../../../Cargo.toml").resolve(),
+            Err(AssetParseError::Outside {
+                path: workspace_root.join("Cargo.toml")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_crate("/../../../Cargo.toml").resolve(),
+            Err(AssetParseError::Outside {
+                path: workspace_root.join("Cargo.toml")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_crate("..").resolve(),
+            Err(AssetParseError::Outside {
+                path: crate_root.join("..").canonicalize().unwrap()
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_implicit_crate_path() {
+        let Ctx { crate_root, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::implicit("assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+
+        assert_eq!(
+            PathResolver::implicit("/assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+    }
+
+    #[test]
+    fn resolve_file_path() {
+        let Ctx { crate_root, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_file("../assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+
+        assert_eq!(
+            PathResolver::from_file("/../assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+    }
+
+    #[test]
+    fn resolve_missing_file_path() {
+        let Ctx { crate_root, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_file("../assets/does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: crate_root.join("src/../assets/does-not-exist.txt")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_file("/../assets/does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: crate_root.join("src/../assets/does-not-exist.txt")
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_outside_file_path() {
+        let Ctx {
+            workspace_root,
+            crate_root,
+            ..
+        } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_file("../../../../Cargo.toml").resolve(),
+            Err(AssetParseError::Outside {
+                path: workspace_root.join("Cargo.toml")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_file("/../../../../Cargo.toml").resolve(),
+            Err(AssetParseError::Outside {
+                path: workspace_root.join("Cargo.toml")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_file("..").resolve(),
+            Err(AssetParseError::Outside {
+                path: crate_root.clone()
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_file("/..").resolve(),
+            Err(AssetParseError::Outside {
+                path: crate_root.clone()
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_implicit_file_path() {
+        let Ctx { crate_root, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::implicit("./../assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+
+        assert_eq!(
+            PathResolver::implicit("../assets/asset.txt").resolve(),
+            Ok(crate_root.join("assets/asset.txt"))
+        );
+    }
+
+    #[test]
+    fn resolve_out_path() {
+        let Ctx { out_folder, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_out("generated-asset.txt").resolve(),
+            Ok(out_folder.join("generated-asset.txt"))
+        );
+
+        assert_eq!(
+            PathResolver::from_out("/generated-asset.txt").resolve(),
+            Ok(out_folder.join("generated-asset.txt"))
+        );
+    }
+
+    #[test]
+    fn resolve_missing_out_path() {
+        let Ctx { out_folder, .. } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_out("does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: out_folder.join("does-not-exist.txt")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_out("/does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: out_folder.join("does-not-exist.txt")
+            })
+        );
+    }
+
+    #[test]
+    fn resolve_outside_out_path() {
+        let Ctx {
+            workspace_root,
+            out_folder,
+            ..
+        } = Ctx::init();
+
+        assert_eq!(
+            PathResolver::from_out("../../../../Cargo.toml").resolve(),
+            Err(AssetParseError::Outside {
+                path: workspace_root.join("Cargo.toml")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_out("/../../../../Cargo.toml").resolve(),
+            Err(AssetParseError::Outside {
+                path: workspace_root.join("Cargo.toml")
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_out("..").resolve(),
+            Err(AssetParseError::Outside {
+                path: out_folder.join("..").canonicalize().unwrap()
+            })
+        );
+
+        assert_eq!(
+            PathResolver::from_out("/..").resolve(),
+            Err(AssetParseError::Outside {
+                path: out_folder.join("..").canonicalize().unwrap()
+            })
+        );
+    }
 }

--- a/packages/manganis/manganis-macro/src/lib.rs
+++ b/packages/manganis/manganis-macro/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 
-use std::path::PathBuf;
+use std::path::{Component, PathBuf};
 
 use proc_macro::TokenStream;
 use proc_macro2::Span;
@@ -23,15 +23,10 @@ use crate::css_module::{CssModuleAttribute, expand_css_module_struct};
 ///
 /// # Files
 ///
-/// The file builder collects an arbitrary file. Relative paths are resolved relative to the package root
+/// The file builder collects an arbitrary file.
 /// ```rust
 /// # use manganis::{asset, Asset};
 /// const _: Asset = asset!("/assets/asset.txt");
-/// ```
-/// Macros like `concat!` and `env!` are supported in the asset path.
-/// ```rust
-/// # use manganis::{asset, Asset};
-/// const _: Asset = asset!(concat!("/assets/", env!("CARGO_CRATE_NAME"), ".dat"));
 /// ```
 ///
 /// # Images
@@ -55,6 +50,27 @@ use crate::css_module::{CssModuleAttribute, expand_css_module_struct};
 /// ```rust
 /// # use manganis::{asset, Asset, AssetOptions};
 /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_preload(true));
+/// ```
+///
+/// # Path resolution
+///
+/// Paths are resolved relative to the current file if they begin with either `.` or `..`.
+/// ```rust
+/// # use manganis::{asset, Asset};
+/// const _: Asset = asset!("./asset.txt");
+/// const _: Asset = asset!("../assets/asset.txt");
+/// ```
+/// If a path points to within the output directory, the full path is used.
+/// The output directory is the value of the `OUT_DIR` environment variable.
+/// ```rust, ignore
+/// const _: Asset = asset!(concat!(env!("OUT_DIR"), "/generated-asset.txt"));
+/// ```
+/// Otherwise, paths are resolved relative to the crate root.
+/// Leading `/` characters are ignored.
+/// ```rust
+/// # use manganis::{asset, Asset};
+/// const _: Asset = asset!("assets/asset.txt");
+/// const _: Asset = asset!("/assets/asset.txt");
 /// ```
 #[proc_macro]
 pub fn asset(input: TokenStream) -> TokenStream {
@@ -91,7 +107,7 @@ pub fn option_asset(input: TokenStream) -> TokenStream {
 /// # Syntax
 ///
 /// The `css_module` attribute takes:
-/// - The asset string path - the absolute path (from the crate root) to your CSS file.
+/// - The asset path. Uses the same rules for resolution as `asset!`.
 /// - Optional `AssetOptions` to configure the processing of your CSS module.
 ///
 /// It must be applied to a unit struct:
@@ -285,67 +301,99 @@ pub fn ffi(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 }
 
-fn resolve_path(raw: &str, span: Span) -> Result<PathBuf, AssetParseError> {
-    // Get the location of the root of the crate which is where all assets are relative to
-    //
-    // IE
-    // /users/dioxus/dev/app/
-    // is the root of
-    // /users/dioxus/dev/app/assets/blah.css
-    let manifest_dir = dunce::canonicalize(
-        std::env::var("CARGO_MANIFEST_DIR")
-            .map(PathBuf::from)
-            .unwrap(),
-    )
-    .unwrap();
+struct PathResolver {
+    src: PathBuf,
+    manifest_dir: PathBuf,
+    out_dir: Option<PathBuf>,
+    file_path: Option<PathBuf>,
+    looks_like_rust_analyzer: bool,
+}
 
-    // 1. the input file should be a pathbuf
-    let input = PathBuf::from(raw);
+impl PathResolver {
+    fn new(src: impl Into<PathBuf>, span: &Span) -> Self {
+        let manifest_dir = Self::get_manifest_dir();
 
-    let path = if raw.starts_with('.') {
-        if let Some(local_folder) = span.local_file().as_ref().and_then(|f| f.parent()) {
-            local_folder.join(raw)
-        } else {
-            // If we are running in rust analyzer, just assume the path is valid and return an error when
-            // we compile if it doesn't exist
-            if looks_like_rust_analyzer(&span) {
-                return Ok(
-                    "The asset macro was expanded under Rust Analyzer which doesn't support paths or local assets yet"
-                        .into(),
-                );
-            }
+        // The output directory is only available when a build script is present
+        let out_dir = std::env::var("OUT_DIR")
+            .ok()
+            .map(dunce::canonicalize)
+            .transpose()
+            .unwrap();
 
-            // Otherwise, return an error about the version of rust required for relative assets
-            return Err(AssetParseError::RelativeAssetPath);
+        Self {
+            src: src.into(),
+            manifest_dir,
+            out_dir,
+            file_path: span.local_file(),
+            looks_like_rust_analyzer: looks_like_rust_analyzer(span),
         }
-    } else {
-        manifest_dir.join(raw.trim_start_matches('/'))
-    };
-
-    // 2. absolute path to the asset
-    let Ok(path) = std::path::absolute(path) else {
-        return Err(AssetParseError::InvalidPath {
-            path: input.clone(),
-        });
-    };
-
-    // 3. Ensure the path exists
-    let Ok(path) = dunce::canonicalize(path) else {
-        return Err(AssetParseError::AssetDoesntExist {
-            path: input.clone(),
-        });
-    };
-
-    // 4. Ensure the path doesn't escape the crate dir
-    //
-    // - Note: since we called canonicalize on both paths, we can safely compare the parent dirs.
-    //   On windows, we can only compare the prefix if both paths are canonicalized (not just absolute)
-    //   https://github.com/rust-lang/rust/issues/42869
-    if path == manifest_dir || !path.starts_with(manifest_dir) {
-        return Err(AssetParseError::InvalidPath { path });
     }
 
-    Ok(path)
+    fn get_manifest_dir() -> PathBuf {
+        dunce::canonicalize(std::env::var("CARGO_MANIFEST_DIR").unwrap()).unwrap()
+    }
+
+    fn resolve(self) -> Result<PathBuf, AssetParseError> {
+        // 1. Resolve path
+        let path = if self
+            .out_dir
+            .as_ref()
+            .is_some_and(|out_dir| self.src.starts_with(out_dir))
+        {
+            self.src
+        } else if self.src.components().next().is_some_and(|component| {
+            component == Component::CurDir || component == Component::ParentDir
+        }) {
+            if let Some(parent) = self.file_path.as_ref().and_then(|path| path.parent()) {
+                parent.join(self.src)
+            } else {
+                // If we are running in rust analyzer, just assume the path is valid and return an error when
+                // we compile if it doesn't exist
+                if self.looks_like_rust_analyzer {
+                    let message = concat!(
+                        "The asset macro was expanded under Rust Analyzer ",
+                        "which doesn't support paths or local assets yet."
+                    );
+
+                    return Ok(message.into());
+                }
+
+                // Otherwise, return an error about the version of rust required for relative assets
+                return Err(AssetParseError::FileBaseUnavailable);
+            }
+        } else {
+            self.manifest_dir
+                .join(self.src.strip_prefix("/").unwrap_or(self.src.as_path()))
+        };
+
+        // 2. Convert to absolute path
+        let Ok(path) = std::path::absolute(&path) else {
+            return Err(AssetParseError::DoesNotExist { path });
+        };
+
+        // 3. Ensure the path exists
+        let Ok(path) = dunce::canonicalize(&path) else {
+            return Err(AssetParseError::DoesNotExist { path });
+        };
+
+        let in_manifest_dir = path != self.manifest_dir && path.starts_with(&self.manifest_dir);
+
+        let in_out_dir = self
+            .out_dir
+            .as_ref()
+            .is_some_and(|dir| path != *dir && path.starts_with(dir));
+
+        // 4. Ensure the path doesn't escape the crate or output directories
+        //
+        // On windows, we can only compare the prefix if both paths are canonicalized (not just absolute)
+        //
+        // See: https://github.com/rust-lang/rust/issues/42869
+        if !in_manifest_dir && !in_out_dir {
+            return Err(AssetParseError::Outside { path });
+        }
+
+        Ok(path)
+    }
 }
 
 /// Parse `T`, while also collecting the tokens it was parsed from.
@@ -365,30 +413,25 @@ fn parse_with_tokens<T: Parse>(input: ParseStream) -> syn::Result<(T, proc_macro
     Ok((t, tokens))
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 enum AssetParseError {
-    AssetDoesntExist { path: PathBuf },
-    InvalidPath { path: PathBuf },
-    RelativeAssetPath,
+    FileBaseUnavailable,
+    DoesNotExist { path: PathBuf },
+    Outside { path: PathBuf },
 }
 
 impl std::fmt::Display for AssetParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AssetParseError::AssetDoesntExist { path } => {
-                write!(f, "Asset at {} doesn't exist", path.display())
+            AssetParseError::FileBaseUnavailable => {
+                write!(f, "Relative paths are only supported in Rust 1.88+.")
             }
-            AssetParseError::InvalidPath { path } => {
-                write!(
-                    f,
-                    "Asset path {} is invalid. Make sure the asset exists within this crate.",
-                    path.display()
-                )
+            AssetParseError::DoesNotExist { path } => {
+                write!(f, "Path {} not found.", path.display())
             }
-            AssetParseError::RelativeAssetPath => write!(
-                f,
-                "Failed to resolve relative asset path. Relative assets are only supported in rust 1.88+."
-            ),
+            AssetParseError::Outside { path } => {
+                write!(f, "Path {} is outside of allowed folders.", path.display())
+            }
         }
     }
 }
@@ -410,4 +453,175 @@ fn looks_like_rust_analyzer(span: &Span) -> bool {
             .is_some_and(|s| s.contains("rust-analyzer"))
     });
     looks_like_rust_analyzer_span || looks_like_rust_analyzer_env || looks_like_rust_analyzer_exe
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{AssetParseError, PathResolver};
+    use tempfile::TempDir;
+
+    struct Ctx {
+        crate_root: PathBuf,
+        #[expect(unused)]
+        out_dir: TempDir,
+        out_path: PathBuf,
+    }
+
+    impl Ctx {
+        fn init() -> Self {
+            let out_dir = tempfile::tempdir().unwrap();
+            let out_path = dunce::canonicalize(out_dir.path()).unwrap();
+
+            std::fs::write(out_path.join("generated-asset.txt"), b"").unwrap();
+
+            Self {
+                crate_root: PathResolver::get_manifest_dir(),
+                out_dir,
+                out_path,
+            }
+        }
+
+        fn create_resolver(&self, src: impl Into<PathBuf>) -> PathResolver {
+            PathResolver {
+                src: src.into(),
+                manifest_dir: self.crate_root.clone(),
+                out_dir: Some(self.out_path.clone()),
+                file_path: Some(self.crate_root.join("src/lib.rs")),
+                looks_like_rust_analyzer: false,
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_crate_path() {
+        let ctx = Ctx::init();
+
+        assert_eq!(
+            ctx.create_resolver("assets/asset.txt").resolve(),
+            Ok(ctx.crate_root.join("assets/asset.txt")),
+        );
+
+        assert_eq!(
+            ctx.create_resolver("/assets/asset.txt").resolve(),
+            Ok(ctx.crate_root.join("assets/asset.txt")),
+        );
+    }
+
+    #[test]
+    fn resolve_missing_crate_path() {
+        let ctx = Ctx::init();
+
+        assert_eq!(
+            ctx.create_resolver("assets/does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: ctx.crate_root.join("assets/does-not-exist.txt"),
+            }),
+        );
+
+        assert_eq!(
+            ctx.create_resolver("/assets/does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: ctx.crate_root.join("assets/does-not-exist.txt"),
+            }),
+        );
+    }
+
+    #[test]
+    fn resolve_outside_crate_path() {
+        let ctx = Ctx::init();
+
+        assert_eq!(
+            ctx.create_resolver("/").resolve(),
+            Err(AssetParseError::Outside {
+                path: ctx.crate_root,
+            }),
+        );
+    }
+
+    #[test]
+    fn resolve_file_path() {
+        let ctx = Ctx::init();
+
+        assert_eq!(
+            ctx.create_resolver("./asset.txt").resolve(),
+            Ok(ctx.crate_root.join("src/asset.txt")),
+        );
+
+        assert_eq!(
+            ctx.create_resolver("../assets/asset.txt").resolve(),
+            Ok(ctx.crate_root.join("assets/asset.txt")),
+        );
+    }
+
+    #[test]
+    fn resolve_missing_file_path() {
+        let ctx = Ctx::init();
+
+        assert_eq!(
+            ctx.create_resolver("./does-not-exist.txt").resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: ctx.crate_root.join("src/does-not-exist.txt"),
+            }),
+        );
+
+        assert_eq!(
+            ctx.create_resolver("../assets/does-not-exist.txt")
+                .resolve(),
+            Err(AssetParseError::DoesNotExist {
+                path: ctx.crate_root.join("src/../assets/does-not-exist.txt"),
+            }),
+        );
+    }
+
+    #[test]
+    fn resolve_outside_file_path() {
+        let ctx = Ctx::init();
+
+        assert_eq!(
+            ctx.create_resolver("./..").resolve(),
+            Err(AssetParseError::Outside {
+                path: ctx.crate_root.clone(),
+            }),
+        );
+
+        assert_eq!(
+            ctx.create_resolver("..").resolve(),
+            Err(AssetParseError::Outside {
+                path: ctx.crate_root.clone(),
+            }),
+        );
+    }
+
+    #[test]
+    fn resolve_out_path() {
+        let ctx = Ctx::init();
+
+        let path = ctx.out_path.join("generated-asset.txt");
+
+        assert_eq!(ctx.create_resolver(&path).resolve(), Ok(path));
+    }
+
+    #[test]
+    fn resolve_missing_out_path() {
+        let ctx = Ctx::init();
+
+        let path = ctx.out_path.join("does-not-exist.txt");
+
+        assert_eq!(
+            ctx.create_resolver(&path).resolve(),
+            Err(AssetParseError::DoesNotExist { path }),
+        );
+    }
+
+    #[test]
+    fn resolve_outside_out_path() {
+        let ctx = Ctx::init();
+
+        assert_eq!(
+            ctx.create_resolver(&ctx.out_path).resolve(),
+            Err(AssetParseError::Outside { path: ctx.out_path }),
+        );
+    }
 }

--- a/packages/manganis/manganis-macro/src/lib.rs
+++ b/packages/manganis/manganis-macro/src/lib.rs
@@ -334,48 +334,77 @@ impl PathResolver {
     }
 
     fn resolve(self) -> Result<PathBuf, AssetParseError> {
-        // 1. Resolve path
-        let path = if self
-            .out_dir
-            .as_ref()
-            .is_some_and(|out_dir| self.src.starts_with(out_dir))
-        {
-            self.src
-        } else if self.src.components().next().is_some_and(|component| {
-            component == Component::CurDir || component == Component::ParentDir
-        }) {
-            if let Some(parent) = self.file_path.as_ref().and_then(|path| path.parent()) {
-                parent.join(self.src)
-            } else {
-                // If we are running in rust analyzer, just assume the path is valid and return an error when
-                // we compile if it doesn't exist
-                if self.looks_like_rust_analyzer {
-                    let message = concat!(
-                        "The asset macro was expanded under Rust Analyzer ",
-                        "which doesn't support paths or local assets yet."
-                    );
-
-                    return Ok(message.into());
-                }
-
-                // Otherwise, return an error about the version of rust required for relative assets
-                return Err(AssetParseError::FileBaseUnavailable);
+        // If this is an absolute path, try to resolve it directly.
+        // We only treat absolute paths as absolute if they are canonicalized
+        // to a location within the manifest directory or the output directory.
+        //
+        // Eg. `/path/to/build/dir` is treated as an absolute path if it is within
+        // the output directory, but `/src/assets/foo.css` is treated as a relative path
+        // because it does not canonicalize to a location within the manifest or output directory.
+        if self.src.is_absolute()
+            && let Some(path) = dunce::canonicalize(&self.src)
+                .ok()
+                .and_then(|path| self.canonicalize_path_within_crate(path).ok())
+            {
+                return Ok(path);
             }
+
+        // Otherwise, resolve the path relative to the current file or the manifest directory
+        let path = if self
+            .src
+            .as_path()
+            .components()
+            .next()
+            .is_some_and(|component| {
+                component == Component::CurDir || component == Component::ParentDir
+            }) {
+            self.resolve_relative_path()?
         } else {
-            self.manifest_dir
-                .join(self.src.strip_prefix("/").unwrap_or(self.src.as_path()))
+            self.resolve_manifest_relative_path()
         };
 
-        // 2. Convert to absolute path
+        self.canonicalize_path_within_crate(path)
+    }
+
+    /// Resolve paths like `/path/to/file` that are relative to the manifest directory.
+    fn resolve_manifest_relative_path(&self) -> PathBuf {
+        // Strip the leading slash to make the path relative
+        let relative_path = self.src.strip_prefix("/").unwrap_or(self.src.as_path());
+        self.manifest_dir.join(relative_path)
+    }
+
+    /// Resolve paths like `./path/to/file` or `../path/to/file` that are relative to the current file.
+    fn resolve_relative_path(&self) -> Result<PathBuf, AssetParseError> {
+        if let Some(parent) = self.file_path.as_ref().and_then(|path| path.parent()) {
+            return Ok(parent.join(&self.src));
+        }
+
+        // If we are running in rust analyzer, just assume the path is valid and return an error when
+        // we compile if it doesn't exist
+        if self.looks_like_rust_analyzer {
+            let message = concat!(
+                "The asset macro was expanded under Rust Analyzer ",
+                "which doesn't support paths or local assets yet."
+            );
+
+            return Ok(message.into());
+        }
+
+        // Otherwise, return an error about the version of rust required for relative assets
+        Err(AssetParseError::FileBaseUnavailable)
+    }
+
+    /// Make sure a path is within the allowed scope (manifest directory or output directory).
+    fn canonicalize_path_within_crate(&self, path: PathBuf) -> Result<PathBuf, AssetParseError> {
+        // 1. Convert to absolute path
         let Ok(path) = std::path::absolute(&path) else {
             return Err(AssetParseError::DoesNotExist { path });
         };
 
-        // 3. Ensure the path exists
+        // 2. Ensure the path exists
         let Ok(path) = dunce::canonicalize(&path) else {
             return Err(AssetParseError::DoesNotExist { path });
         };
-
         let in_manifest_dir = path != self.manifest_dir && path.starts_with(&self.manifest_dir);
 
         let in_out_dir = self
@@ -383,7 +412,7 @@ impl PathResolver {
             .as_ref()
             .is_some_and(|dir| path != *dir && path.starts_with(dir));
 
-        // 4. Ensure the path doesn't escape the crate or output directories
+        // 3. Ensure the path doesn't escape the crate or output directories
         //
         // On windows, we can only compare the prefix if both paths are canonicalized (not just absolute)
         //
@@ -604,24 +633,44 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn resolve_symlinked_out_path() {
+        let ctx = Ctx::init();
+        let link_root = tempfile::tempdir().unwrap();
+        let symlinked_out_path = link_root.path().join("out");
+        std::os::unix::fs::symlink(&ctx.out_path, &symlinked_out_path).unwrap();
+
+        let path = symlinked_out_path.join("generated-asset.txt");
+
+        assert_eq!(
+            PathResolver {
+                src: path,
+                manifest_dir: ctx.crate_root.clone(),
+                out_dir: Some(ctx.out_path.clone()),
+                file_path: Some(ctx.crate_root.join("src/lib.rs")),
+                looks_like_rust_analyzer: false,
+            }
+            .resolve(),
+            Ok(ctx.out_path.join("generated-asset.txt")),
+        );
+    }
+
+    #[test]
     fn resolve_missing_out_path() {
         let ctx = Ctx::init();
 
         let path = ctx.out_path.join("does-not-exist.txt");
 
-        assert_eq!(
+        assert!(matches!(
             ctx.create_resolver(&path).resolve(),
-            Err(AssetParseError::DoesNotExist { path }),
-        );
+            Err(AssetParseError::DoesNotExist { .. }),
+        ));
     }
 
     #[test]
     fn resolve_outside_out_path() {
         let ctx = Ctx::init();
 
-        assert_eq!(
-            ctx.create_resolver(&ctx.out_path).resolve(),
-            Err(AssetParseError::Outside { path: ctx.out_path }),
-        );
+        assert!(ctx.create_resolver(&ctx.out_path).resolve().is_err());
     }
 }

--- a/packages/manganis/manganis-macro/src/lib.rs
+++ b/packages/manganis/manganis-macro/src/lib.rs
@@ -341,13 +341,14 @@ impl PathResolver {
         // Eg. `/path/to/build/dir` is treated as an absolute path if it is within
         // the output directory, but `/src/assets/foo.css` is treated as a relative path
         // because it does not canonicalize to a location within the manifest or output directory.
-        if self.src.is_absolute()
-            && let Some(path) = dunce::canonicalize(&self.src)
+        if self.src.is_absolute() {
+            if let Some(path) = dunce::canonicalize(&self.src)
                 .ok()
                 .and_then(|path| self.canonicalize_path_within_crate(path).ok())
             {
                 return Ok(path);
             }
+        }
 
         // Otherwise, resolve the path relative to the current file or the manifest directory
         let path = if self


### PR DESCRIPTION
Currently, all assets are resolved either relative to the current file (if the path begins with a `.`) or the crate root (in all other cases).

## Changes

This PR introduces a new option for asset path resolution that enables reading generated assets.

```rust
const _: Asset = asset!(concat!(env!("OUT_DIR"), "/generated-asset.txt"));
```

The path resolution heuristics are as follows:
- paths beginning with `.` or `..` both resolve relative to the current file;
- paths beginning with the output directory are used as-is;
- all other paths are resolved relative to the crate root (with the leading `/` ignored).

I also updated the documentation of the macros, added some tests for new and existing behavior, and refactored the internal error handling to improve clarity and consistency.

## Alternatives considered

Following are a number of alternatives considered before settling on the current solution.

### Explicit path resolution strategy

Explicitly declaring the resolution base would make the code more explicit.

```rust
asset!(crate "assets/asset.txt"); // Resolved relative to the crate root
asset!(self "../assets/asset.txt"); // Resolved relative to the current file
asset!(out "generated-asset.txt"); // Resolved relative to the output folder
```

Skipping the explicit strategy would fall back to the original behavior by automatically detecting whether `crate` or `self` should be used.

This was ultimately dropped in response to https://github.com/DioxusLabs/dioxus/pull/5490#issuecomment-4263057892 to avoid introducing new syntax.

### Prefix character

A special character (like `"!"`) at the beginning of the path could denote a generated path.

```rust
asset!("!/generated.css");
```

While the likelihood of anyone having a local folder named `"!"` is practically non-existent, it's still _technically_ allowed by the operating system and thus this would constitute a breaking change. On Linux particularly, the only character that's not allowed in a file name is `/`.

### Separate macros

A new `generated_asset` could be introduced so no changes would need to be made to the existing ones. However, this would lead to needless duplication without any practical gains.

```rust
generated_asset!("generated.css");
```