### PR TITLE
fix(ssr): translate initial_value/checked/selected to HTML equivalents

### DIFF
--- a/packages/ssr/src/cache.rs
+++ b/packages/ssr/src/cache.rs
@@ -29,7 +29,7 @@
 //! };
 //!```
 
-use crate::renderer::{BOOL_ATTRS, str_truthy};
+use crate::renderer::{BOOL_ATTRS, ssr_attr_name, str_truthy};
 use dioxus_core::{TemplateAttribute, TemplateNode, VNode};
 use std::{fmt::Write, ops::AddAssign};
 
@@ -210,11 +210,12 @@ fn from_template_recursive(
                         value,
                         namespace,
                     } => {
-                        if *name == "dangerous_inner_html" {
+                        let name = ssr_attr_name(name);
+                        if name == "dangerous_inner_html" {
                             inner_html = Some(value);
                         } else if let Some("style") = namespace {
                             styles.push((name, value));
-                        } else if BOOL_ATTRS.contains(name) {
+                        } else if BOOL_ATTRS.contains(&name) {
                             if str_truthy(value) {
                                 write!(
                                     chain,

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -146,7 +146,7 @@ impl Renderer {
                 Segment::Attr(idx) => {
                     let attrs = &*template.dynamic_attrs[*idx];
                     for attr in attrs {
-                        let translated_name = ssr_attr_name(&attr.name);
+                        let translated_name = ssr_attr_name(attr.name);
                         if attr.name == "dangerous_inner_html" {
                             inner_html = Some(attr);
                         } else if attr.namespace == Some("style") {
@@ -497,7 +497,7 @@ pub(crate) fn write_attribute<W: Write + ?Sized>(
     buf: &mut W,
     attr: &Attribute,
 ) -> std::fmt::Result {
-    let name = ssr_attr_name(&attr.name);
+    let name = ssr_attr_name(attr.name);
     match &attr.value {
         AttributeValue::Text(value) => write!(
             buf,

--- a/packages/ssr/src/renderer.rs
+++ b/packages/ssr/src/renderer.rs
@@ -146,11 +146,12 @@ impl Renderer {
                 Segment::Attr(idx) => {
                     let attrs = &*template.dynamic_attrs[*idx];
                     for attr in attrs {
+                        let translated_name = ssr_attr_name(&attr.name);
                         if attr.name == "dangerous_inner_html" {
                             inner_html = Some(attr);
                         } else if attr.namespace == Some("style") {
                             accumulated_dynamic_styles.push(attr);
-                        } else if BOOL_ATTRS.contains(&attr.name) {
+                        } else if BOOL_ATTRS.contains(&translated_name) {
                             if truthy(&attr.value) {
                                 write_attribute(buf, attr)?;
                             }
@@ -482,11 +483,21 @@ pub(crate) fn truthy(value: &AttributeValue) -> bool {
     }
 }
 
+/// Translate Dioxus virtual attribute names to their HTML equivalents for SSR.
+pub(crate) fn ssr_attr_name(name: &str) -> &str {
+    match name {
+        "initial_value" => "value",
+        "initial_checked" => "checked",
+        "initial_selected" => "selected",
+        other => other,
+    }
+}
+
 pub(crate) fn write_attribute<W: Write + ?Sized>(
     buf: &mut W,
     attr: &Attribute,
 ) -> std::fmt::Result {
-    let name = &attr.name;
+    let name = ssr_attr_name(&attr.name);
     match &attr.value {
         AttributeValue::Text(value) => write!(
             buf,

--- a/packages/ssr/tests/initial_value.rs
+++ b/packages/ssr/tests/initial_value.rs
@@ -42,8 +42,5 @@ fn dynamic_initial_value() {
     let mut dom = VirtualDom::new(app);
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
-    assert_eq!(
-        dioxus_ssr::render(&dom),
-        r#"<input value="dynamic"/>"#
-    );
+    assert_eq!(dioxus_ssr::render(&dom), r#"<input value="dynamic"/>"#);
 }

--- a/packages/ssr/tests/initial_value.rs
+++ b/packages/ssr/tests/initial_value.rs
@@ -1,0 +1,49 @@
+use dioxus::prelude::*;
+
+#[test]
+fn initial_value_renders_as_value() {
+    assert_eq!(
+        dioxus_ssr::render_element(rsx! {
+            input { initial_value: "hello" }
+        }),
+        r#"<input value="hello"/>"#
+    );
+}
+
+#[test]
+fn initial_checked_renders_as_checked() {
+    assert_eq!(
+        dioxus_ssr::render_element(rsx! {
+            input { r#type: "checkbox", initial_checked: true }
+        }),
+        r#"<input type="checkbox" checked=true/>"#
+    );
+}
+
+#[test]
+fn initial_selected_renders_as_selected() {
+    assert_eq!(
+        dioxus_ssr::render_element(rsx! {
+            option { initial_selected: true }
+        }),
+        r#"<option selected=true></option>"#
+    );
+}
+
+#[test]
+fn dynamic_initial_value() {
+    fn app() -> Element {
+        let value = "dynamic";
+        rsx! {
+            input { initial_value: value }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+
+    assert_eq!(
+        dioxus_ssr::render(&dom),
+        r#"<input value="dynamic"/>"#
+    );
+}


### PR DESCRIPTION
## Summary

- Add `ssr_attr_name()` translation for virtual attributes (`initial_value`, `initial_checked`, `initial_selected`) to their HTML equivalents (`value`, `checked`, `selected`)
- Apply translation in both static (cache.rs) and dynamic (renderer.rs) SSR paths

## Why

The SSR renderer writes virtual attributes like `initial_value` literally into the HTML output (producing `<input initial_value="hello">`) instead of translating them to standard HTML attributes (`<input value="hello">`). The client-side interpreter (`set_attribute.ts`) already handles this mapping correctly, but the SSR path was missing it.

## Verification

- 4 new tests covering `initial_value`, `initial_checked`, `initial_selected` (static + dynamic)
- All 21 SSR tests pass (4 new + 17 existing)
- `cargo check -p dioxus-ssr` clean

Fixes #5491