### PR TITLE
Add FreeBSD target detection for esbuild

### DIFF
--- a/packages/cli/src/esbuild.rs
+++ b/packages/cli/src/esbuild.rs
@@ -151,6 +151,7 @@ impl Esbuild {
     /// - darwin-arm64, darwin-x64
     /// - linux-x64, linux-arm64
     /// - win32-x64, win32-arm64
+    /// - freebsd-x64, freebsd-arm64
     fn npm_platform_package() -> Option<&'static str> {
         if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
             Some("darwin-arm64")
@@ -164,6 +165,10 @@ impl Esbuild {
             Some("win32-x64")
         } else if cfg!(all(target_os = "windows", target_arch = "aarch64")) {
             Some("win32-arm64")
+        } else if cfg!(all(target_os = "freebsd", target_arch = "x86_64")) {
+            Some("freebsd-x64")
+        } else if cfg!(all(target_os = "freebsd", target_arch = "aarch64")) {
+            Some("freebsd-arm64")
         } else {
             None
         }


### PR DESCRIPTION
Adds detection for freebsd-x64 and presumably freebsd-arm64 in the esbuild target logic. This enables the CLI to run on FreeBSD by resolving the correct platform binary, this issue can also be bypassed by changing some settings, but this should let it work out-of-the-box. I tested it on x86 FreeBSD.