### PR TITLE
fix(cli): align SSG server address

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -2089,11 +2089,14 @@ impl AppBuilder {
         }
         let server_exe = self.build.main_exe();
 
-        // Use the address passed in through environment variables or default to localhost:9999. We need
-        // to default to a value that is different than the CLI default address to avoid conflicts
-        let ip = server_ip().unwrap_or_else(|| IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
-        let port = server_port().unwrap_or(9999);
-        let fullstack_address = SocketAddr::new(ip, port);
+        // Use the SSG address baked into release server builds. If this builder was created without
+        // an SSG address (for example from `dx serve`), fall back to the environment or localhost:9999.
+        // The default port intentionally differs from the devserver default to avoid conflicts.
+        let fullstack_address = self.build.ssg_address.unwrap_or_else(|| {
+            let ip = server_ip().unwrap_or_else(|| IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+            let port = server_port().unwrap_or(9999);
+            SocketAddr::new(ip, port)
+        });
         let address = fullstack_address.ip().to_string();
         let port = fullstack_address.port().to_string();
 

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -207,12 +207,12 @@ use cargo_metadata::diagnostic::Diagnostic;
 use cargo_toml::{Profile, Profiles, StripSetting};
 use depinfo::RustcDepInfo;
 use dioxus_cli_config::PRODUCT_NAME_ENV;
-use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV};
+use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV, SERVER_IP_ENV, SERVER_PORT_ENV};
 use krates::{NodeId, cm::TargetKind};
 use manganis::BundledAsset;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use serde::Deserialize;
-use std::{borrow::Cow, collections::VecDeque, ffi::OsString};
+use std::{borrow::Cow, collections::VecDeque, ffi::OsString, net::SocketAddr};
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -272,6 +272,7 @@ pub(crate) struct BuildRequest {
     pub(crate) session_cache_dir: PathBuf,
     pub(crate) raw_json_diagnostics: bool,
     pub(crate) windows_subsystem: Option<String>,
+    pub(crate) ssg_address: Option<SocketAddr>,
 }
 
 /// dx can produce different "modes" of a build. A "regular" build is a "base" build. The Fat and Thin
@@ -911,6 +912,7 @@ impl BuildRequest {
             apple_team_id: args.apple_team_id.clone(),
             raw_json_diagnostics: args.raw_json_diagnostics,
             windows_subsystem: args.windows_subsystem.clone(),
+            ssg_address: None,
         })
     }
 
@@ -1898,6 +1900,14 @@ impl BuildRequest {
                 APP_TITLE_ENV.into(),
                 self.config.web.app.title.clone().into(),
             ));
+        }
+
+        // Release builds read fullstack address configuration at compile time. When SSG runs the
+        // built server binary, make sure the address baked into the binary matches the address the
+        // prerenderer will query.
+        if let Some(addr) = self.ssg_address {
+            env_vars.push((SERVER_IP_ENV.into(), addr.ip().to_string().into()));
+            env_vars.push((SERVER_PORT_ENV.into(), addr.port().to_string().into()));
         }
 
         // Assemble the rustflags by peering into the `.cargo/config.toml` file

--- a/packages/cli/src/cli/build.rs
+++ b/packages/cli/src/cli/build.rs
@@ -1,4 +1,5 @@
 use dioxus_dx_wire_format::StructuredBuildArtifacts;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use crate::{
     Anonymized, AppBuilder, BuildArtifacts, BuildId, BuildMode, BuildRequest, BundleFormat,
@@ -67,6 +68,13 @@ pub struct BuildTargets {
     pub server: Option<BuildRequest>,
 }
 
+fn ssg_address() -> SocketAddr {
+    let ip = dioxus_cli_config::server_ip()
+        .unwrap_or_else(|| IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    let port = dioxus_cli_config::server_port().unwrap_or(9999);
+    SocketAddr::new(ip, port)
+}
+
 impl CommandWithPlatformOverrides<BuildArgs> {
     /// We need to decompose the combined `BuildArgs` into the individual targets that we need to build.
     ///
@@ -124,9 +132,12 @@ impl CommandWithPlatformOverrides<BuildArgs> {
                         .bundle
                         .or(Some(BundleFormat::Server));
 
-                    server = Some(
-                        BuildRequest::new(&server_args.build_arguments, workspace.clone()).await?,
-                    );
+                    let mut request =
+                        BuildRequest::new(&server_args.build_arguments, workspace.clone()).await?;
+                    if self.shared.ssg {
+                        request.ssg_address = Some(ssg_address());
+                    }
+                    server = Some(request);
                 }
                 None if client_args.platform == Platform::Server => {
                     // If the user requests a server build with `--server`, then we don't need to build a separate server binary.
@@ -138,7 +149,11 @@ impl CommandWithPlatformOverrides<BuildArgs> {
                     args.renderer = Some(crate::Renderer::Server);
                     args.bundle = Some(crate::BundleFormat::Server);
                     args.target = Some(target_lexicon::Triple::host());
-                    server = Some(BuildRequest::new(&args, workspace.clone()).await?);
+                    let mut request = BuildRequest::new(&args, workspace.clone()).await?;
+                    if self.shared.ssg {
+                        request.ssg_address = Some(ssg_address());
+                    }
+                    server = Some(request);
                 }
             }
         }

--- a/packages/cli/src/test_harnesses.rs
+++ b/packages/cli/src/test_harnesses.rs
@@ -56,6 +56,11 @@ async fn test_harnesses() {
                 let server = t.server.unwrap();
                 assert_eq!(server.bundle, BundleFormat::Server);
                 assert_eq!(server.triple, Triple::host());
+            })
+            .asrt(r#"dx build --ssg"#, |targets| async move {
+                let t = targets.unwrap();
+                let server = t.server.unwrap();
+                assert!(server.ssg_address.is_some());
             }),
         TestHarnessBuilder::new("harness-simple-fullstack-with-default")
             .deps(r#"dioxus = { workspace = true, features = ["fullstack"] }"#)


### PR DESCRIPTION
Fullstack SSG release builds can bake the server address at compile time, while the prerender step chose the address later at runtime. That left the server listening on its compiled default while `dx build --ssg` queried `127.0.0.1:9999`.

The SSG address is now resolved before the server build, passed into the server build environment, and reused by the prerenderer when it starts and queries the server. Added harness coverage that confirms `dx build --ssg` records an SSG address for fullstack builds.

Verification: `git diff --check`. Could not run cargo tests locally because this environment does not have the Rust toolchain installed.

Fixes #5503
