### PR TITLE
clippy fixes for rust 1.95

### DIFF
--- a/examples/01-app-demos/calculator.rs
+++ b/examples/01-app-demos/calculator.rs
@@ -49,11 +49,10 @@ fn app() -> Element {
     let mut input_operator = move |key: &str| val.push_str(key);
 
     let handle_key_down_event = move |evt: KeyboardEvent| match evt.key() {
-        Key::Backspace => {
-            if !val().is_empty() {
+        Key::Backspace
+            if !val().is_empty() => {
                 val.pop();
             }
-        }
         Key::Character(character) => match character.as_str() {
             "+" | "-" | "/" | "*" => input_operator(&character),
             "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => input_digit(character),

--- a/examples/01-app-demos/calculator.rs
+++ b/examples/01-app-demos/calculator.rs
@@ -49,10 +49,9 @@ fn app() -> Element {
     let mut input_operator = move |key: &str| val.push_str(key);
 
     let handle_key_down_event = move |evt: KeyboardEvent| match evt.key() {
-        Key::Backspace
-            if !val().is_empty() => {
-                val.pop();
-            }
+        Key::Backspace if !val().is_empty() => {
+            val.pop();
+        }
         Key::Character(character) => match character.as_str() {
             "+" | "-" | "/" | "*" => input_operator(&character),
             "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => input_digit(character),

--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -505,10 +505,9 @@ impl AppBuilder {
                             krate,
                             fresh,
                             ..
+                        } if !fresh => {
+                            tracing::info!("Compiled [{current:>3}/{total}]: {krate}");
                         }
-                            if !fresh => {
-                                tracing::info!("Compiled [{current:>3}/{total}]: {krate}");
-                            }
                         BuildStage::RunningBindgen => tracing::info!("Running wasm-bindgen..."),
                         BuildStage::CopyingAssets {
                             current,

--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -505,11 +505,10 @@ impl AppBuilder {
                             krate,
                             fresh,
                             ..
-                        } => {
-                            if !fresh {
+                        }
+                            if !fresh => {
                                 tracing::info!("Compiled [{current:>3}/{total}]: {krate}");
                             }
-                        }
                         BuildStage::RunningBindgen => tracing::info!("Running wasm-bindgen..."),
                         BuildStage::CopyingAssets {
                             current,

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1136,14 +1136,13 @@ impl BuildRequest {
 
                 // todo: this can occasionally swallow errors, so we should figure out what exactly is going wrong
                 //       since that is a really bad user experience.
-                Message::BuildFinished(finished)
-                    if !finished.success => {
-                        bail!(
-                            "cargo build finished with errors for target: {} [{}]",
-                            self.main_target,
-                            self.triple
-                        );
-                    }
+                Message::BuildFinished(finished) if !finished.success => {
+                    bail!(
+                        "cargo build finished with errors for target: {} [{}]",
+                        self.main_target,
+                        self.triple
+                    );
+                }
                 _ => {}
             }
         }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1136,15 +1136,14 @@ impl BuildRequest {
 
                 // todo: this can occasionally swallow errors, so we should figure out what exactly is going wrong
                 //       since that is a really bad user experience.
-                Message::BuildFinished(finished) => {
-                    if !finished.success {
+                Message::BuildFinished(finished)
+                    if !finished.success => {
                         bail!(
                             "cargo build finished with errors for target: {} [{}]",
                             self.main_target,
                             self.triple
                         );
                     }
-                }
                 _ => {}
             }
         }

--- a/packages/cli/src/build/web.rs
+++ b/packages/cli/src/build/web.rs
@@ -470,13 +470,12 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
                         );
                     }
                 }
-                AssetVariant::Image(image_options)
-                    if image_options.preloaded() => {
-                        _ = write!(
-                            head_resources,
-                            r#"<link rel="preload" as="image" href="/{{base_path}}/assets/{asset_path}" crossorigin>"#
-                        );
-                    }
+                AssetVariant::Image(image_options) if image_options.preloaded() => {
+                    _ = write!(
+                        head_resources,
+                        r#"<link rel="preload" as="image" href="/{{base_path}}/assets/{asset_path}" crossorigin>"#
+                    );
+                }
                 AssetVariant::Js(js_options) => {
                     if js_options.preloaded() {
                         _ = write!(

--- a/packages/cli/src/build/web.rs
+++ b/packages/cli/src/build/web.rs
@@ -470,14 +470,13 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
                         );
                     }
                 }
-                AssetVariant::Image(image_options) => {
-                    if image_options.preloaded() {
+                AssetVariant::Image(image_options)
+                    if image_options.preloaded() => {
                         _ = write!(
                             head_resources,
                             r#"<link rel="preload" as="image" href="/{{base_path}}/assets/{asset_path}" crossorigin>"#
                         );
                     }
-                }
                 AssetVariant::Js(js_options) => {
                     if js_options.preloaded() {
                         _ = write!(

--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -945,16 +945,14 @@ fn wix_version(version: &str) -> Result<String> {
             .parse()
             .with_context(|| format!("Invalid version component: '{part}'"))?;
         match i {
-            0 | 1 => {
-                if num > 255 {
+            0 | 1
+                if num > 255 => {
                     bail!("Version component {part} exceeds maximum value of 255");
                 }
-            }
-            2 | 3 => {
-                if num > 65535 {
+            2 | 3
+                if num > 65535 => {
                     bail!("Version component {part} exceeds maximum value of 65535");
                 }
-            }
             _ => {}
         }
     }

--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -945,14 +945,12 @@ fn wix_version(version: &str) -> Result<String> {
             .parse()
             .with_context(|| format!("Invalid version component: '{part}'"))?;
         match i {
-            0 | 1
-                if num > 255 => {
-                    bail!("Version component {part} exceeds maximum value of 255");
-                }
-            2 | 3
-                if num > 65535 => {
-                    bail!("Version component {part} exceeds maximum value of 65535");
-                }
+            0 | 1 if num > 255 => {
+                bail!("Version component {part} exceeds maximum value of 255");
+            }
+            2 | 3 if num > 65535 => {
+                bail!("Version component {part} exceeds maximum value of 65535");
+            }
             _ => {}
         }
     }

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -83,13 +83,12 @@ impl RunArgs {
                                 total,
                                 krate,
                                 fresh,
-                            } => {
-                                if !fresh {
+                            }
+                                if !fresh => {
                                     tracing::debug!(
                                         "[{bundle_format}] ({current}/{total}) Compiling {krate} ",
                                     )
                                 }
-                            }
                             BuildStage::RunningBindgen => {
                                 tracing::info!("[{bundle_format}] Running WASM bindgen")
                             }

--- a/packages/cli/src/cli/run.rs
+++ b/packages/cli/src/cli/run.rs
@@ -83,12 +83,11 @@ impl RunArgs {
                                 total,
                                 krate,
                                 fresh,
+                            } if !fresh => {
+                                tracing::debug!(
+                                    "[{bundle_format}] ({current}/{total}) Compiling {krate} ",
+                                )
                             }
-                                if !fresh => {
-                                    tracing::debug!(
-                                        "[{bundle_format}] ({current}/{total}) Compiling {krate} ",
-                                    )
-                                }
                             BuildStage::RunningBindgen => {
                                 tracing::info!("[{bundle_format}] Running WASM bindgen")
                             }

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -872,10 +872,10 @@ impl AppServer {
         pid: Option<u32>,
     ) {
         match build_id {
-            BuildId::PRIMARY => {
+            BuildId::PRIMARY
                 // multiple tabs on web can cause this to be called incorrectly, and it doesn't
                 // make any sense anyways
-                if self.client.build.bundle != BundleFormat::Web {
+                if self.client.build.bundle != BundleFormat::Web => {
                     if let Some(aslr_reference) = aslr_reference {
                         self.client.aslr_reference = Some(aslr_reference);
                     }
@@ -883,7 +883,6 @@ impl AppServer {
                         self.client.pid = Some(pid);
                     }
                 }
-            }
             BuildId::SECONDARY => {
                 if let Some(server) = self.server.as_mut() {
                     server.aslr_reference = aslr_reference;
@@ -1292,7 +1291,7 @@ impl AppServer {
             .collect();
 
         // Longer chain = deeper in dep tree = should compile first
-        crates_with_depth.sort_by(|a, b| b.1.cmp(&a.1));
+        crates_with_depth.sort_by_key(|b| std::cmp::Reverse(b.1));
         crates_with_depth.into_iter().map(|(c, _)| c).collect()
     }
 

--- a/packages/cli/src/serve/server.rs
+++ b/packages/cli/src/serve/server.rs
@@ -230,18 +230,17 @@ impl WebServer {
                         total,
                         krate,
                         ..
-                    } => {
+                    }
                         if !matches!(
                             self.build_status.get(),
                             Status::Ready | Status::BuildError { .. }
-                        ) {
+                        ) => {
                             self.build_status.set(Status::Building {
                                 progress: (*current as f64 / *total as f64).clamp(0.0, 1.0),
                                 build_message: format!("{krate} compiling"),
                             });
                             self.send_build_status().await;
                         }
-                    }
                     BuildStage::OptimizingWasm => {}
                     BuildStage::Aborted => {}
                     BuildStage::CopyingAssets { .. } => {}

--- a/packages/cli/src/serve/server.rs
+++ b/packages/cli/src/serve/server.rs
@@ -230,17 +230,17 @@ impl WebServer {
                         total,
                         krate,
                         ..
+                    } if !matches!(
+                        self.build_status.get(),
+                        Status::Ready | Status::BuildError { .. }
+                    ) =>
+                    {
+                        self.build_status.set(Status::Building {
+                            progress: (*current as f64 / *total as f64).clamp(0.0, 1.0),
+                            build_message: format!("{krate} compiling"),
+                        });
+                        self.send_build_status().await;
                     }
-                        if !matches!(
-                            self.build_status.get(),
-                            Status::Ready | Status::BuildError { .. }
-                        ) => {
-                            self.build_status.set(Status::Building {
-                                progress: (*current as f64 / *total as f64).clamp(0.0, 1.0),
-                                build_message: format!("{krate} compiling"),
-                            });
-                            self.send_build_status().await;
-                        }
                     BuildStage::OptimizingWasm => {}
                     BuildStage::Aborted => {}
                     BuildStage::CopyingAssets { .. } => {}

--- a/packages/rsx-rosetta/src/lib.rs
+++ b/packages/rsx-rosetta/src/lib.rs
@@ -96,7 +96,7 @@ pub fn rsx_node_from_html(node: &Node) -> Option<BodyNode> {
             // the html-parser crate we use uses a HashMap for attributes. This leads to a
             // non-deterministic order of attributes.
             // Sort them here
-            attributes.sort_by(|a, b| a.name.to_string().cmp(&b.name.to_string()));
+            attributes.sort_by_key(|a| a.name.to_string());
 
             let children = el.children.iter().filter_map(rsx_node_from_html).collect();
 


### PR DESCRIPTION
I noticed on my newer rust version that our workspace was throwing lots of clippy warnings. this fixes that