### PR TITLE
Fix bundling on aarch64 Alpine Linux 

### DIFF
--- a/packages/cli/src/wasm_bindgen.rs
+++ b/packages/cli/src/wasm_bindgen.rs
@@ -437,7 +437,7 @@ impl WasmBindgen {
         } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
             "x86_64-unknown-linux-musl"
         } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
-            "aarch64-unknown-linux-gnu"
+            "aarch64-unknown-linux-musl"
         } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
             "x86_64-apple-darwin"
         } else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {


### PR DESCRIPTION
Heyo

`dx bundle --release` fails on Alpine Linux on aarch64 CPUs, because we always download the GNU version of wasm-bindgen and it doesn't run on Alpine. Since we already use the musl version for x86_64, I guess we can just switch to musl on aarch64 too.

Also, is it maybe possible to add a musl build of `dioxus-cli` to your CI? I have to compile it from source right now on all my alpine docker builds and it's... not fun :X