### PR TITLE
Ensure cargo_bin_dir exists during install

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -100,6 +100,10 @@ if [ ! -d "$bin_dir" ]; then
 	mkdir -p "$bin_dir"
 fi
 
+if [ ! -d "$cargo_bin_dir" ]; then
+	mkdir -p "$cargo_bin_dir"
+fi
+
 curl --fail --location --progress-bar --output "$exe.zip" "$dx_uri"
 if command -v unzip >/dev/null; then
 	unzip -d "$bin_dir" -o "$exe.zip"


### PR DESCRIPTION
I ran into this issue when doing a fresh install:

```
❯ curl -sSL https://dioxus.dev/install.sh | bash
######################################################################## 100.0%
Archive:  /home/nixos/.dx/bin/dx.zip
  inflating: /home/nixos/.dx/bin/dx
cp: cannot create regular file '/home/nixos/.cargo/bin/dx': No such file or directory
error: Failed to copy dx to /home/nixos/.cargo/bin
```

If the ~/.cargo/bin dir doesn't exist yet, the script gets stuck trying to copy to it.