### PR TITLE
feat:Add opt‑in navigation handler for external URLs

### DIFF
--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -20,6 +20,8 @@ type CustomEventHandler = Box<
         ),
 >;
 
+/// A function taking a URL and returning whether the webview should navigate to it or open it in
+/// the browser. If missing in the config, all URLs will be allowed.
 type NavigationHandler = Box<dyn Fn(&str) -> bool + 'static>;
 
 /// The closing behaviour of specific application window.

--- a/packages/desktop/src/config.rs
+++ b/packages/desktop/src/config.rs
@@ -20,6 +20,8 @@ type CustomEventHandler = Box<
         ),
 >;
 
+type NavigationHandler = Box<dyn Fn(&str) -> bool + 'static>;
+
 /// The closing behaviour of specific application window.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[non_exhaustive]
@@ -70,6 +72,7 @@ pub struct Config {
     pub(crate) disable_dma_buf_on_wayland: bool,
     pub(crate) additional_windows_args: Option<String>,
     pub(crate) tray_icon_show_window_on_click: bool,
+    pub(crate) navigation_handler: Option<NavigationHandler>,
 
     #[allow(clippy::type_complexity)]
     pub(crate) on_window: Option<Box<dyn FnMut(Arc<Window>, &mut VirtualDom) + 'static>>,
@@ -124,6 +127,7 @@ impl Config {
             on_window: None,
             additional_windows_args: None,
             tray_icon_show_window_on_click: true,
+            navigation_handler: None,
         }
     }
 
@@ -348,6 +352,13 @@ impl Config {
     /// activating the main window.
     pub fn with_tray_icon_show_window_on_click(mut self, show: bool) -> Self {
         self.tray_icon_show_window_on_click = show;
+        self
+    }
+
+    /// Set a custom navigation handler for non-dioxus URLs.
+    /// Return true to allow navigation inside the webview, false to block.
+    pub fn with_navigation_handler(mut self, f: impl Fn(&str) -> bool + 'static) -> Self {
+        self.navigation_handler = Some(Box::new(f));
         self
     }
 }

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -364,11 +364,9 @@ impl WebviewInstance {
             .with_url("dioxus://index.html/")
             .with_ipc_handler(ipc_handler)
             .with_navigation_handler(move |var| {
-                // We don't want to allow any navigation
-                // We only want to serve the index file and assets
-                if let Some(handler) = navigation_handler.as_ref() {
-                    return handler(&var);
-                }
+                // By default, no navigation is allowed other than serving the index and assets.
+                // However, allow navigation if the user provides a custom navigation handler. All
+                // other requests will be opened in a browser.
                 if var.starts_with("dioxus://")
                     || var.starts_with("http://dioxus.")
                     || var.starts_with("https://dioxus.")
@@ -376,6 +374,8 @@ impl WebviewInstance {
                     // After the page has loaded once, don't allow any more navigation
                     let page_loaded = page_loaded.swap(true, std::sync::atomic::Ordering::SeqCst);
                     !page_loaded
+                } else if let Some(handler) = navigation_handler.as_ref() {
+                    return handler(&var);
                 } else {
                     if var.starts_with("http://")
                         || var.starts_with("https://")

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -375,7 +375,7 @@ impl WebviewInstance {
                     let page_loaded = page_loaded.swap(true, std::sync::atomic::Ordering::SeqCst);
                     !page_loaded
                 } else if let Some(handler) = navigation_handler.as_ref() {
-                    return handler(&var);
+                    handler(&var)
                 } else {
                     if var.starts_with("http://")
                         || var.starts_with("https://")

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -364,18 +364,25 @@ impl WebviewInstance {
             .with_url("dioxus://index.html/")
             .with_ipc_handler(ipc_handler)
             .with_navigation_handler(move |var| {
-                // By default, no navigation is allowed other than serving the index and assets.
-                // However, allow navigation if the user provides a custom navigation handler. All
-                // other requests will be opened in a browser.
+                // Serve the index and assets.
                 if var.starts_with("dioxus://")
                     || var.starts_with("http://dioxus.")
                     || var.starts_with("https://dioxus.")
                 {
                     // After the page has loaded once, don't allow any more navigation
                     let page_loaded = page_loaded.swap(true, std::sync::atomic::Ordering::SeqCst);
-                    !page_loaded
-                } else if let Some(handler) = navigation_handler.as_ref() {
-                    handler(&var)
+                    return !page_loaded;
+                }
+
+                // By default, navigation is allowed. Users can have more granular control by
+                // providing a navigation handler. If not allowed, valid URLs will be opened in the
+                // browser.
+                let allow_nav = match navigation_handler.as_ref() {
+                    Some(handler) => handler(&var),
+                    None => true,
+                };
+                if allow_nav {
+                    true
                 } else {
                     if var.starts_with("http://")
                         || var.starts_with("https://")

--- a/packages/desktop/src/webview.rs
+++ b/packages/desktop/src/webview.rs
@@ -349,6 +349,7 @@ impl WebviewInstance {
             }
         };
 
+        let navigation_handler = cfg.navigation_handler.take();
         let page_loaded = AtomicBool::new(false);
 
         let mut webview = WebViewBuilder::new_with_web_context(&mut web_context)
@@ -365,6 +366,9 @@ impl WebviewInstance {
             .with_navigation_handler(move |var| {
                 // We don't want to allow any navigation
                 // We only want to serve the index file and assets
+                if let Some(handler) = navigation_handler.as_ref() {
+                    return handler(&var);
+                }
                 if var.starts_with("dioxus://")
                     || var.starts_with("http://dioxus.")
                     || var.starts_with("https://dioxus.")


### PR DESCRIPTION
Pretty much the same as #5231, which was closed without comment.

Without this change, iframes will open in an external browser, breaking existing apps and disallowing many legitimate uses like embedding a YouTube video, etc.

One change was made after discussing it with @jkelleyrtp, which was to make all URLs navigable by default when the handler is not set. That way, only users which need finer control over this have to set the handler.