### PR TITLE
feat(cli): Set bundle application name from config

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -2694,9 +2694,16 @@ impl BuildRequest {
         self.crate_target.kind[0].clone()
     }
 
+    /// The application name. PascalCase version of the crate name by default.
+    /// May be overridden using [`ApplicationConfig::name`][crate::ApplicationConfig::name].
     pub(crate) fn bundled_app_name(&self) -> String {
         use convert_case::{Case, Casing};
-        self.executable_name().to_case(Case::Pascal)
+
+        self.config
+            .application
+            .name
+            .clone()
+            .unwrap_or_else(|| self.executable_name().to_case(Case::Pascal))
     }
 
     /// Get the crate version from Cargo.toml (e.g., "0.1.0")

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -218,7 +218,7 @@ impl<'a> BundleContext<'a> {
         self.package_types.clone()
     }
 
-    /// The product name (PascalCase).
+    /// The product name.
     pub(crate) fn product_name(&self) -> String {
         self.build.bundled_app_name()
     }


### PR DESCRIPTION
Small PR to set the application name in bundles using the `application::name` config setting in `Dioxus.toml`, if it exists.

Tested with rpm and msi bundles - seems to work well.