### PR TITLE
Fix multiple Set-Cookie response header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,6 +4003,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dioxus-playwright-fullstack-headers-test"
+version = "0.1.0"
+dependencies = [
+ "dioxus",
+ "http",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "dioxus-playwright-fullstack-hydration-order-test"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "packages/playwright-tests/wasm-split-harness",
     "packages/playwright-tests/default-features-disabled",
     "packages/playwright-tests/fullstack-error-codes",
+    "packages/playwright-tests/fullstack-headers",
     "packages/playwright-tests/windows-headless",
 
     # manganis

--- a/packages/fullstack-core/src/streaming.rs
+++ b/packages/fullstack-core/src/streaming.rs
@@ -193,6 +193,8 @@ impl FullstackContext {
     }
 
     /// Add a header to the response. This will be sent to the client when the response is committed.
+    /// Set-Cookie headers will be appended to any existing Set-Cookie headers (compliance with RFC 6265),
+    /// while all other headers will overwrite any existing header with the same name.
     pub fn add_response_header(
         &self,
         key: impl Into<http::header::HeaderName>,
@@ -200,7 +202,12 @@ impl FullstackContext {
     ) {
         let mut lock = self.lock.write();
         if let Some(headers) = lock.response_headers.as_mut() {
-            headers.insert(key.into(), value.into());
+            let key_into = key.into();
+            if key_into == http::header::SET_COOKIE {
+                headers.append(key_into, value.into());
+            } else {
+                headers.insert(key_into, value.into());
+            }
         }
     }
 

--- a/packages/playwright-tests/fullstack-headers.spec.js
+++ b/packages/playwright-tests/fullstack-headers.spec.js
@@ -1,0 +1,45 @@
+// @ts-check
+const { test, expect } = require("@playwright/test");
+
+test("Set-Cookie headers are appended per RFC 6265", async ({ page }) => {
+  await page.goto("http://localhost:3636", { waitUntil: "networkidle" });
+
+  await page.click("#set-cookie-btn");
+
+  const responsePromise = page.waitForResponse((resp) => {
+    return resp.url().includes("/api/test_set_cookie") && resp.status() === 200;
+  });
+
+  const response = await responsePromise;
+  const headers = await response.headersArray();
+  const setCookies = headers.filter(
+    (h) => h.name.toLowerCase() === "set-cookie",
+  );
+  expect(setCookies.length).toBe(2);
+  const setCookieValues = setCookies.map((h) => h.value);
+  expect(setCookieValues).toEqual([
+    "session_id=abc123; Path=/",
+    "theme=dark; Path=/",
+  ]);
+});
+
+test("non-Set-Cookie headers are overwritten", async ({ page }) => {
+  await page.goto("http://localhost:3636", { waitUntil: "networkidle" });
+
+  await page.click("#override-header-btn");
+
+  const responsePromise = page.waitForResponse((resp) => {
+    return (
+      resp.url().includes("/api/test_override_header") && resp.status() === 200
+    );
+  });
+
+  const response = await responsePromise;
+  const headers = await response.headersArray();
+  const xCustomHeader = headers.filter(
+    (h) => h.name.toLowerCase() === "x-custom-header",
+  );
+  expect(xCustomHeader.length).toBe(1);
+  const xCustomHeaderValues = xCustomHeader.map((h) => h.value);
+  expect(xCustomHeaderValues[0]).toBe("second");
+});

--- a/packages/playwright-tests/fullstack-headers/.gitignore
+++ b/packages/playwright-tests/fullstack-headers/.gitignore
@@ -1,0 +1,3 @@
+.dioxus
+dist
+target

--- a/packages/playwright-tests/fullstack-headers/Cargo.toml
+++ b/packages/playwright-tests/fullstack-headers/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "dioxus-playwright-fullstack-headers-test"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+dioxus = { workspace = true, features = ["fullstack"] }
+http.workspace = true
+serde = { workspace = true }
+tokio = { workspace = true, features = ["full"], optional = true }
+
+[features]
+default = []
+server = ["dioxus/server", "dep:tokio"]
+web = ["dioxus/web"]

--- a/packages/playwright-tests/fullstack-headers/Dioxus.toml
+++ b/packages/playwright-tests/fullstack-headers/Dioxus.toml
@@ -1,0 +1,2 @@
+[application]
+asset_dir = "assets"

--- a/packages/playwright-tests/fullstack-headers/src/main.rs
+++ b/packages/playwright-tests/fullstack-headers/src/main.rs
@@ -1,0 +1,62 @@
+// This test fixture is used by the fullstack-headers playwright test
+// Tests:
+// - add_response_header Set-Cookie append behavior (RFC 6265)
+// - add_response_header non-Set-Cookie overwrite behavior
+
+#![allow(non_snake_case)]
+use dioxus::prelude::*;
+
+fn main() {
+    #[cfg(feature = "server")]
+    dioxus::serve(|| async move {
+        let cfg = dioxus::server::ServeConfig::builder().enable_out_of_order_streaming();
+        let router = dioxus::server::axum::Router::new().serve_dioxus_application(cfg, app);
+        Ok(router)
+    });
+    #[cfg(not(feature = "server"))]
+    launch(app);
+}
+
+fn app() -> Element {
+    rsx! {
+        button {
+            id: "set-cookie-btn",
+            onclick: move |_| async move {
+                _ = test_set_cookie().await;
+            },
+            "Set Cookie"
+        }
+        button {
+            id: "override-header-btn",
+            onclick: move |_| async move {
+                _ = test_override_header().await;
+            },
+            "Override Header"
+        }
+    }
+}
+
+#[server(endpoint = "test_set_cookie")]
+async fn test_set_cookie() -> ServerFnResult {
+    use dioxus::fullstack::FullstackContext;
+    let ctx = FullstackContext::current().unwrap();
+    ctx.add_response_header(
+        http::header::SET_COOKIE,
+        http::HeaderValue::from_static("session_id=abc123; Path=/"),
+    );
+    ctx.add_response_header(
+        http::header::SET_COOKIE,
+        http::HeaderValue::from_static("theme=dark; Path=/"),
+    );
+    Ok(())
+}
+
+#[server(endpoint = "test_override_header")]
+async fn test_override_header() -> ServerFnResult {
+    use dioxus::fullstack::FullstackContext;
+    let ctx = FullstackContext::current().unwrap();
+    let name = http::header::HeaderName::from_static("x-custom-header");
+    ctx.add_response_header(name.clone(), http::HeaderValue::from_static("first"));
+    ctx.add_response_header(name, http::HeaderValue::from_static("second"));
+    Ok(())
+}

--- a/packages/playwright-tests/playwright.config.js
+++ b/packages/playwright-tests/playwright.config.js
@@ -28,6 +28,7 @@ const ALL_SERVERS = [
   { specs: ["web-hash-routing.spec.js"], port: 2021, cwd: "web-hash-routing", command: `${dx} run --force-sequential --web --addr 127.0.0.1 --port 2021` },
   { specs: ["fullstack.spec.js"], port: 3333, cwd: "fullstack", command: `${dx} run --force-sequential --web --addr 127.0.0.1 --port 3333 --release` },
   { specs: ["fullstack-errors.spec.js"], port: 3232, cwd: "fullstack-errors", command: `${dx} run --force-sequential --web --addr 127.0.0.1 --port 3232` },
+  { specs: ["fullstack-headers.spec.js"], port: 3636, cwd: "fullstack-headers", command: `${dx} run --force-sequential --web --addr 127.0.0.1 --port 3636` },
   { specs: ["fullstack-mounted.spec.js"], port: 7777, cwd: "fullstack-mounted", command: `${dx} run --force-sequential --web --addr 127.0.0.1 --port 7777` },
   { specs: ["fullstack-routing.spec.js"], port: 8888, cwd: "fullstack-routing", command: `${dx} run --force-sequential --web --addr 127.0.0.1 --port 8888` },
   { specs: ["fullstack-spread.spec.js"], port: 7980, cwd: "fullstack-spread", command: `${dx} run --verbose --force-sequential --web --addr 127.0.0.1 --port 7980` },


### PR DESCRIPTION
When a Set-Cookie header is passed as an argument to `add_response_header()`, it modify to use the `add()` instead of the `insert()`. And, add browser test for check response headers.

Fixes #5541