### PR TITLE
fix(autofmt): don't duplicate pretty continuation lines after multi-line source match

### DIFF
--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -888,7 +888,8 @@ impl<'a> Writer<'a> {
         if src_lines.peek().is_none() {
             out = pretty;
         } else {
-            for line in pretty.lines() {
+            let mut pretty_iter = pretty.lines().peekable();
+            while let Some(line) = pretty_iter.next() {
                 let trimmed = line.trim();
                 let compacted = line.replace(" ", "").replace(",", "");
 
@@ -1060,6 +1061,29 @@ impl<'a> Writer<'a> {
                         out.push_str(src_line.trim());
                         if i < ml.len() - 1 {
                             out.push('\n');
+                        }
+                    }
+
+                    // Skip pretty continuation lines whose content was already
+                    // emitted as part of the verbatim multi-line source.
+                    if acc.len() > compacted.len() {
+                        let mut consumed_compact = compacted.clone();
+                        while consumed_compact.len() < acc.len() {
+                            let Some(next_pretty) = pretty_iter.peek() else {
+                                break;
+                            };
+                            let next_trimmed = next_pretty.trim();
+                            if next_trimmed.is_empty() || next_trimmed.starts_with("//") {
+                                break;
+                            }
+                            let next_compact = next_pretty.replace(" ", "").replace(",", "");
+                            let candidate = format!("{consumed_compact}{next_compact}");
+                            if acc.starts_with(&candidate) {
+                                consumed_compact = candidate;
+                                pretty_iter.next();
+                                continue;
+                            }
+                            break;
                         }
                     }
                 } else {

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -74,6 +74,7 @@ twoway![
     commented_rsx_block_only,
     commented_rsx_block_between,
     commented_rsx_block_deep,
+    cfg_let_event_block,
 ];
 
 fn assert_idempotent(src: &str) {
@@ -108,4 +109,9 @@ fn comments_attr_expr_blocks_is_idempotent() {
 #[test]
 fn comments_expr_with_strings_is_idempotent() {
     assert_idempotent(include_str!("./samples/comments_expr_with_strings.rsx"));
+}
+
+#[test]
+fn cfg_let_event_block_is_idempotent() {
+    assert_idempotent(include_str!("./samples/cfg_let_event_block.rsx"));
 }

--- a/packages/autofmt/tests/samples/cfg_let_event_block.rsx
+++ b/packages/autofmt/tests/samples/cfg_let_event_block.rsx
@@ -1,0 +1,24 @@
+rsx! {
+    button {
+        onclick: {
+            #[cfg(target_os = "android")]
+            let create_photo_collection_gallery = create_photo_collection.clone();
+
+            move |_| {
+                uploading.set(true);
+                error.set(String::new());
+
+                #[cfg(target_os = "android")]
+                let create_photo_collection_gallery_call =
+                    create_photo_collection_gallery.clone();
+
+                if let Err(err) = Err::<(), _>("x") {
+                    error.set(format!("{}: {}", "err", err));
+                    uploading.set(false);
+                    return;
+                }
+            }
+        },
+        "x"
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #5523.

`dx fmt` corrupted RSX event handler blocks containing `#[cfg]`-gated `let` bindings around a `move |_|` closure. When prettier_please broke a long statement at a different line position than the source did, the multi-line accumulator in `write_partial_expr` consumed every source line for the logical statement but the outer iterator kept walking pretty lines, re-emitted the trailing continuation (`.clone();`), and advanced the source pointer past unrelated statements — producing invalid Rust:

```
let X = Y.clone();
    .clone();
if let Err(err) = ... {
    err
    ));
```

## Fix

`pretty.lines()` → peekable. After emitting a multi-line verbatim source block whose accumulated content extends beyond the matched pretty line, consume the pretty continuation lines whose content is already covered.

## Test plan

- [x] New fixture `tests/samples/cfg_let_event_block.rsx` wired into `twoway!`
- [x] New `cfg_let_event_block_is_idempotent` test
- [x] 84 existing autofmt tests pass
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test --workspace --exclude dioxus-desktop` clean (334 test bins, 0 failures)
- [x] Stress-tested 8 adversarial inputs (cfg-lets in various positions, async closures, long method chains, `format!()` macros) — all produce valid Rust