### PR TITLE
fix: include missing attributes in html source tag

### DIFF
--- a/packages/html/src/elements.rs
+++ b/packages/html/src/elements.rs
@@ -1214,6 +1214,11 @@ builder_constructors! {
     source None {
         src: Uri DEFAULT,
         r#type: Mime "type",
+        srcset: String DEFAULT,
+        media: String DEFAULT,
+        sizes: String DEFAULT,
+        width: usize DEFAULT,
+        height: usize DEFAULT,
     };
 
 


### PR DESCRIPTION
## Description
The html source element takes more attributes than currently defined as per the [linked docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/source). I have just included the missing attributes in the element definition.

## Testing
I have tested this against my current live project, where the motivation was to have a dynamic, color theme aware icon. I used this for testing:
```rs
picture {
    source {
        media: "(prefers-color-scheme: dark)",
        srcset: asset!("/assets/icons/icon_dark.svg"),
    }
    img {
        src:  asset!("/assets/icons/icon_light.svg"),
    }
}
```

which correctly produces:
```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="/assets/icon_dark-dxhe41730c754fb7f4.svg">
  <img src="/assets/icon_light-dxha3936c9c11ef5e9.svg">
</picture>
```