### PR TITLE
Support relative linking of resources so applications can be hosted at any base_path without rebuilding

### DIFF
--- a/packages/asset-resolver/src/web.rs
+++ b/packages/asset-resolver/src/web.rs
@@ -24,7 +24,7 @@ impl WebAssetResolveError {
 }
 
 pub(crate) async fn resolve_web_asset(path: &str) -> Result<Vec<u8>, WebAssetResolveError> {
-    let url = if path.starts_with("/") {
+    let url = if path.starts_with('/') || path.starts_with("./") || path.starts_with("../") {
         path.to_string()
     } else {
         format!("/{path}")

--- a/packages/cli-config/src/lib.rs
+++ b/packages/cli-config/src/lib.rs
@@ -63,6 +63,8 @@ pub const DEVSERVER_IP_ENV: &str = "DIOXUS_DEVSERVER_IP";
 pub const DEVSERVER_PORT_ENV: &str = "DIOXUS_DEVSERVER_PORT";
 pub const ALWAYS_ON_TOP_ENV: &str = "DIOXUS_ALWAYS_ON_TOP";
 pub const ASSET_ROOT_ENV: &str = "DIOXUS_ASSET_ROOT";
+/// When set (for example to `1`), bundled web assets use `./…` URLs instead of `/{base}/…`.
+pub const RELATIVE_ASSETS_ENV: &str = "DIOXUS_RELATIVE_ASSETS";
 pub const APP_TITLE_ENV: &str = "DIOXUS_APP_TITLE";
 pub const PRODUCT_NAME_ENV: &str = "DIOXUS_PRODUCT_NAME";
 
@@ -233,6 +235,41 @@ pub fn base_path() -> Option<String> {
     }
 
     read_env_config!("DIOXUS_ASSET_ROOT")
+}
+
+/// Whether the CLI built this crate with [`RELATIVE_ASSETS_ENV`] (`dx build --relative` / `dx serve --relative`).
+///
+/// Always read at compile time: `dx` sets the env var when invoking `cargo`/`rustc` for the wasm
+/// target. In the browser, `std::env::var` is not available in debug builds, so a runtime-only
+/// check would ignore `--relative` during `dx serve`.
+pub fn relative_assets() -> bool {
+    matches!(
+        option_env!("DIOXUS_RELATIVE_ASSETS"),
+        Some("1") | Some("true")
+    )
+}
+
+/// URL prefix for bundled web assets (includes trailing slash), e.g. `./assets/` or `/myapp/assets/`.
+#[allow(unreachable_code)]
+pub fn web_asset_prefix() -> String {
+    let relative = relative_assets();
+    let base = base_path();
+    let trimmed = base
+        .as_deref()
+        .map(|p| p.trim_matches('/'))
+        .filter(|p| !p.is_empty());
+
+    if relative {
+        match trimmed {
+            Some(bp) => format!("./{bp}/assets/"),
+            None => "./assets/".to_string(),
+        }
+    } else {
+        let root = trimmed
+            .map(|bp| format!("/{bp}"))
+            .unwrap_or_default();
+        format!("{root}/assets/")
+    }
 }
 
 #[cfg(feature = "web")]

--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -614,6 +614,10 @@ impl AppBuilder {
             ));
         }
 
+        if krate.relative {
+            envs.push((dioxus_cli_config::RELATIVE_ASSETS_ENV.into(), "1".to_string()));
+        }
+
         if let Some(env_filter) = env::var_os("RUST_LOG").and_then(|e| e.into_string().ok()) {
             envs.push(("RUST_LOG".into(), env_filter));
         }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -207,7 +207,7 @@ use cargo_metadata::diagnostic::Diagnostic;
 use cargo_toml::{Profile, Profiles, StripSetting};
 use depinfo::RustcDepInfo;
 use dioxus_cli_config::PRODUCT_NAME_ENV;
-use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV};
+use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV, RELATIVE_ASSETS_ENV};
 use krates::{NodeId, cm::TargetKind};
 use manganis::BundledAsset;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
@@ -264,6 +264,8 @@ pub(crate) struct BuildRequest {
     pub(crate) debug_symbols: bool,
     pub(crate) keep_names: bool,
     pub(crate) inject_loading_scripts: bool,
+    /// Emit `./…` asset URLs instead of `/{base_path}/…` in generated web output.
+    pub(crate) relative: bool,
     pub(crate) custom_linker: Option<PathBuf>,
     pub(crate) base_path: Option<String>,
     pub(crate) using_dioxus_explicitly: bool,
@@ -917,6 +919,7 @@ impl BuildRequest {
             debug_symbols: args.debug_symbols,
             keep_names: args.keep_names,
             inject_loading_scripts: args.inject_loading_scripts,
+            relative: args.relative,
             apple_entitlements: args.apple_entitlements.clone(),
             apple_team_id: args.apple_team_id.clone(),
             raw_json_diagnostics: args.raw_json_diagnostics,
@@ -1917,6 +1920,10 @@ impl BuildRequest {
 
         // If this is a release build, bake the base path and title into the binary with env vars.
         // todo: should we even be doing this? might be better being a build.rs or something else.
+        if self.relative {
+            env_vars.push((RELATIVE_ASSETS_ENV.into(), "1".into()));
+        }
+
         if self.release {
             if let Some(base_path) = self.trimmed_base_path() {
                 env_vars.push((ASSET_ROOT_ENV.into(), base_path.to_string().into()));
@@ -2999,6 +3006,27 @@ impl BuildRequest {
         self.trimmed_base_path().unwrap_or(".")
     }
 
+    /// Format a URL for a file under the web `assets/` directory.
+    ///
+    /// `asset_path` is the path within `assets/` (for example `app-dxh….js`).
+    pub(crate) fn format_web_asset_url(&self, asset_path: &str) -> String {
+        format_web_asset_url_parts(
+            self.relative,
+            self.trimmed_base_path(),
+            self.base_path_or_default(),
+            asset_path,
+        )
+    }
+
+    /// Format a URL for a bundled web resource (for example `assets/app.js` or `wasm/app.js`).
+    pub(crate) fn format_web_resource_url(&self, resource_path: &str) -> String {
+        format_web_resource_url_parts(
+            self.relative,
+            self.base_path_or_default(),
+            resource_path,
+        )
+    }
+
     /// Get the path to the package manifest directory
     pub(crate) fn package_manifest_dir(&self) -> PathBuf {
         self.workspace.krates[self.crate_package]
@@ -3152,5 +3180,82 @@ impl BuildRequest {
         }
 
         deps
+    }
+}
+
+fn format_web_asset_url_parts(
+    relative: bool,
+    trimmed_base_path: Option<&str>,
+    base_path_or_default: &str,
+    asset_path: &str,
+) -> String {
+    if relative {
+        match trimmed_base_path {
+            Some(base_path) => format!("./{base_path}/assets/{asset_path}"),
+            None => format!("./assets/{asset_path}"),
+        }
+    } else {
+        format!("/{base_path_or_default}/assets/{asset_path}")
+    }
+}
+
+fn format_web_resource_url_parts(
+    relative: bool,
+    base_path_or_default: &str,
+    resource_path: &str,
+) -> String {
+    if relative {
+        if resource_path.starts_with("./") {
+            resource_path.to_string()
+        } else {
+            format!("./{resource_path}")
+        }
+    } else {
+        format!("/{base_path_or_default}/{resource_path}")
+    }
+}
+
+#[cfg(test)]
+mod web_url_format_tests {
+    use super::{format_web_asset_url_parts, format_web_resource_url_parts};
+
+    #[test]
+    fn absolute_asset_url_default_base() {
+        assert_eq!(
+            format_web_asset_url_parts(false, None, ".", "app.js"),
+            "/./assets/app.js"
+        );
+    }
+
+    #[test]
+    fn relative_asset_url_default_base() {
+        assert_eq!(
+            format_web_asset_url_parts(true, None, ".", "app.js"),
+            "./assets/app.js"
+        );
+    }
+
+    #[test]
+    fn relative_asset_url_with_subpath() {
+        assert_eq!(
+            format_web_asset_url_parts(true, Some("functions"), "functions", "app.js"),
+            "./functions/assets/app.js"
+        );
+    }
+
+    #[test]
+    fn relative_wasm_resource_url() {
+        assert_eq!(
+            format_web_resource_url_parts(true, ".", "assets/app_bg.wasm"),
+            "./assets/app_bg.wasm"
+        );
+    }
+
+    #[test]
+    fn absolute_wasm_resource_url() {
+        assert_eq!(
+            format_web_resource_url_parts(false, ".", "assets/app_bg.wasm"),
+            "/./assets/app_bg.wasm"
+        );
     }
 }

--- a/packages/cli/src/build/web.rs
+++ b/packages/cli/src/build/web.rs
@@ -172,13 +172,14 @@ impl BuildRequest {
             for (idx, chunk) in modules.chunks.iter().enumerate() {
                 let path = bindgen_outdir.join(format!("chunk_{}_{}.wasm", idx, chunk.module_name));
                 wasm_opt::write_wasm(&chunk.bytes, &path, &wasm_opt_options).await?;
-                writeln!(
-                    glue,
-                    "export const __wasm_split_load_chunk_{idx} = makeLoad(\"/{base_path}/assets/{url}\", [], fusedImports);",
-                    base_path = self.base_path_or_default(),
-                    url = assets
+                let url = self.format_web_asset_url(
+                    assets
                         .register_asset(&path, AssetOptions::builder().into_asset_options())?
                         .bundled_path(),
+                );
+                writeln!(
+                    glue,
+                    "export const __wasm_split_load_chunk_{idx} = makeLoad(\"{url}\", [], fusedImports);",
                 )?;
             }
 
@@ -197,16 +198,16 @@ impl BuildRequest {
                     .hash_id
                     .as_ref()
                     .context("generated wasm-split bindgen module has no hash id?")?;
-
-                writeln!(
-                    glue,
-                    "export const __wasm_split_load_{module}_{hash_id}_{comp_name} = makeLoad(\"/{base_path}/assets/{url}\", [{deps}], fusedImports);",
-                    module = module.module_name,
-                    base_path = self.base_path_or_default(),
-                    // Again, register this wasm with the asset system
-                    url = assets
+                // Again, register this wasm with the asset system
+                let url = self.format_web_asset_url(
+                    assets
                         .register_asset(&path, AssetOptions::builder().into_asset_options())?
                         .bundled_path(),
+                );
+                writeln!(
+                    glue,
+                    "export const __wasm_split_load_{module}_{hash_id}_{comp_name} = makeLoad(\"{url}\", [{deps}], fusedImports);",
+                    module = module.module_name,
                     // This time, make sure to write the dependencies of this chunk
                     // The names here are again, hardcoded in wasm-split - fix this eventually.
                     deps = module
@@ -288,13 +289,14 @@ impl BuildRequest {
             .append(true)
             .open(self.wasm_bindgen_js_output_file())?;
         let mut buf_writer = std::io::BufWriter::new(&mut js);
+        let wasm_url = self.format_web_resource_url(&wasm_path);
         writeln!(
             buf_writer,
             r#"
 globalThis.__wasm_split_main_initSync = initSync;
 
 // Actually perform the load
-__wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
+__wbg_init({{module_or_path: "{wasm_url}"}}).then((wasm) => {{
     // assign this module to be accessible globally
     globalThis.__dx_mainWasm = wasm;
     globalThis.__dx_mainInit = __wbg_init;
@@ -306,7 +308,6 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
     }}
 }});
 "#,
-            self.base_path_or_default(),
         )?;
 
         Ok(())
@@ -460,30 +461,33 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
             let asset_path = asset.bundled_path();
             match asset.options().variant() {
                 AssetVariant::Css(css_options) => {
+                    let href = self.format_web_asset_url(asset_path);
                     if css_options.preloaded() {
                         _ = write!(
                             head_resources,
-                            r#"<link rel="preload" as="style" href="/{{base_path}}/assets/{asset_path}" crossorigin>"#
+                            r#"<link rel="preload" as="style" href="{href}" crossorigin>"#
                         );
                     }
                     if css_options.static_head() {
                         _ = write!(
                             head_resources,
-                            r#"<link rel="stylesheet" href="/{{base_path}}/assets/{asset_path}" type="text/css">"#
+                            r#"<link rel="stylesheet" href="{href}" type="text/css">"#
                         );
                     }
                 }
                 AssetVariant::Image(image_options) if image_options.preloaded() => {
+                    let href = self.format_web_asset_url(asset_path);
                     _ = write!(
                         head_resources,
-                        r#"<link rel="preload" as="image" href="/{{base_path}}/assets/{asset_path}" crossorigin>"#
+                        r#"<link rel="preload" as="image" href="{href}" crossorigin>"#
                     );
                 }
                 AssetVariant::Js(js_options) => {
+                    let href = self.format_web_asset_url(asset_path);
                     if js_options.preloaded() {
                         _ = write!(
                             head_resources,
-                            r#"<link rel="preload" as="script" href="/{{base_path}}/assets/{asset_path}" crossorigin>"#
+                            r#"<link rel="preload" as="script" href="{href}" crossorigin>"#
                         );
                     }
                     if js_options.static_head() {
@@ -495,7 +499,7 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
                         };
                         _ = write!(
                             head_resources,
-                            r#"<script{module_attr} src="/{{base_path}}/assets/{asset_path}"></script>"#
+                            r#"<script{module_attr} src="{href}"></script>"#
                         );
                     }
                 }
@@ -519,13 +523,12 @@ __wbg_init({{module_or_path: "/{}/{wasm_path}"}}).then((wasm) => {{
         }
 
         // If not, insert the script
+        let js_src = self.format_web_resource_url(&self.bundled_js_path(assets));
         *html = html.replace(
             "</body",
             &format!(
-                r#"<script type="module" async src="/{}/{}"></script>
+                r#"<script type="module" async src="{js_src}"></script>
             </body"#,
-                self.base_path_or_default(),
-                self.bundled_js_path(assets)
             ),
         );
     }

--- a/packages/cli/src/cli/target.rs
+++ b/packages/cli/src/cli/target.rs
@@ -124,6 +124,11 @@ pub(crate) struct TargetArgs {
     #[clap(long, help_heading = HELP_HEADING)]
     pub(crate) base_path: Option<String>,
 
+    /// Use relative URLs (starting with `./`) instead of root-absolute URLs (`/`) for
+    /// wasm/js loading, asset preloads, and other generated web bundle paths.
+    #[clap(long, default_value_t = false, help_heading = HELP_HEADING)]
+    pub(crate) relative: bool,
+
     /// Should dx attempt to codesign the app bundle?
     #[clap(long, default_value_t = false, help_heading = HELP_HEADING, num_args = 0..=1)]
     pub(crate) codesign: bool,
@@ -201,6 +206,7 @@ impl Anonymized for TargetArgs {
             "keep_names": self.keep_names,
             "device": self.device,
             "base_path": self.base_path.is_some(),
+            "relative": self.relative,
             "cargo_args": self.cargo_args.is_some(),
             "rustc_args": self.rustc_args.is_some(),
             "raw_json_diagnostics": self.raw_json_diagnostics,

--- a/packages/manganis/manganis-core/src/asset.rs
+++ b/packages/manganis/manganis-core/src/asset.rs
@@ -196,17 +196,7 @@ impl Asset {
         }
 
         #[cfg(feature = "dioxus")]
-        let bundle_root = {
-            let base_path = dioxus_cli_config::base_path();
-            let base_path = base_path
-                .as_deref()
-                .map(|base_path| {
-                    let trimmed = base_path.trim_matches('/');
-                    format!("/{trimmed}")
-                })
-                .unwrap_or_default();
-            PathBuf::from(format!("{base_path}/assets/"))
-        };
+        let bundle_root = PathBuf::from(dioxus_cli_config::web_asset_prefix());
         #[cfg(not(feature = "dioxus"))]
         let bundle_root = PathBuf::from("/assets/");
 


### PR DESCRIPTION
Add support for a --relative command line flag that results in relative linking of resources, which should allow applications to be hosted in any base_path without needing application to be rebuilt.

This addresses https://github.com/DioxusLabs/dioxus/issues/5511