### PR TITLE
Pin rhai_codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,6 +3300,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest 0.12.28",
+ "rhai_codegen",
  "rpm",
  "rustls",
  "schemars",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -83,6 +83,9 @@ which = { version = "8.0.0" }
 # plugin packages
 open = { workspace = true }
 cargo-generate = "=0.23.10"
+# cargo-generate pulls in rhai, whose 1.24.0 release accepts newer incompatible
+# rhai_codegen releases in fresh `cargo install --path .` resolutions.
+rhai_codegen = "=3.1.0"
 toml_edit = "0.22.27"
 
 # formatting


### PR DESCRIPTION
rhai_codegen is a transitive dependency of cargo generate which broke in a minor version causing `cargo install --git https://github.com/DioxusLabs/dioxus dioxus-cli` to break without `--locked`