### PR TITLE
fix: propagate response body read errors

### DIFF
--- a/packages/fullstack/src/magic.rs
+++ b/packages/fullstack/src/magic.rs
@@ -264,7 +264,7 @@ mod decode_ok {
                     Ok(res) => {
                         let status = res.status();
 
-                        let bytes = res.bytes().await.unwrap();
+                        let bytes = res.bytes().await?;
                         let as_bytes = if bytes.is_empty() {
                             b"null".as_slice()
                         } else {


### PR DESCRIPTION
## Summary

Closes #5585.

This replaces the bare `unwrap()` while reading the fullstack client response body with normal `RequestError` propagation. `ClientResponse::bytes()` already returns `Result<Bytes, RequestError>`, and this decoder already returns an outer `Result<_, RequestError>`, so `?` routes body-read failures through the existing error path instead of panicking the application.

I did not add a separate regression test because forcing `bytes()` to fail would require a custom `ClientResponseDriver` mock just to exercise the same type-level propagation this change uses. The existing fullstack tests and compile-only test still pass.

## Verification

- `cargo check -p dioxus-fullstack`
- `cargo test -p dioxus-fullstack --lib`
- `cargo test -p dioxus-fullstack --no-run`
