### PR TITLE
fix(subsecond): gate browser deps on target_os = "unknown" so WASI builds

### DIFF
--- a/packages/subsecond/subsecond/Cargo.toml
+++ b/packages/subsecond/subsecond/Cargo.toml
@@ -14,7 +14,7 @@ serde = { workspace = true, features = ["derive"] }
 subsecond-types = { workspace = true }
 thiserror = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 web-sys = { workspace = true, features = ["FetchEvent", "Request", "Window", "Response", "ResponseType", "console"] }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/packages/subsecond/subsecond/src/lib.rs
+++ b/packages/subsecond/subsecond/src/lib.rs
@@ -547,7 +547,7 @@ pub unsafe fn apply_patch(mut table: JumpTable) -> Result<(), PatchError> {
     };
 
     // On wasm, we need to download the module, compile it, and then run it.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     wasm_bindgen_futures::spawn_local(async move {
         use js_sys::{
             ArrayBuffer, Object, Reflect,


### PR DESCRIPTION
`subsecond` gates its browser deps (wasm-bindgen, js-sys, web-sys, wasm-bindgen-futures) and the `apply_patch` hot-reload path on `cfg(target_arch = "wasm32")`. That also matches non-browser wasm targets like `wasm32-wasip2`/`wasm32-wasip1`, where the `web_sys::window().fetch(...)` path is meaningless and wasm-bindgen's imports don't link — so anything depending on `dioxus-core` (which depends on `subsecond`) fails to build for WASI / component-model targets.

This narrows the gate to `all(target_arch = "wasm32", target_os = "unknown")` (browser only). On WASI, `apply_patch` falls through to its existing `Ok(())` (hot-patch is a no-op there). No change for browser or native targets.

Tested: a dioxus 0.7 cdylib then builds as a valid wasm32-wasip2 component with no wasm-bindgen in the dependency tree.

---
This patch was written with Claude (AI assistant) and reviewed + explicitly approved by me before submitting.