### PR TITLE
feat(manganis): add with_width/with_height for auto aspect-ratio image sizing

### DIFF
--- a/packages/cli/src/opt/image.rs
+++ b/packages/cli/src/opt/image.rs
@@ -15,8 +15,24 @@ pub(crate) fn process_image(
         .decode();
 
     if let Ok(image) = &mut image {
-        if let ImageSize::Manual { width, height } = image_options.size() {
-            *image = image.resize_exact(width, height, image::imageops::FilterType::Lanczos3);
+        match image_options.size() {
+            ImageSize::Manual { width, height } => {
+                *image =
+                    image.resize_exact(*width, *height, image::imageops::FilterType::Lanczos3);
+            }
+            ImageSize::WidthOnly { width } => {
+                let ratio = image.height() as f64 / image.width() as f64;
+                let height = (*width as f64 * ratio).round() as u32;
+                *image =
+                    image.resize_exact(*width, height, image::imageops::FilterType::Lanczos3);
+            }
+            ImageSize::HeightOnly { height } => {
+                let ratio = image.width() as f64 / image.height() as f64;
+                let width = (*height as f64 * ratio).round() as u32;
+                *image =
+                    image.resize_exact(width, *height, image::imageops::FilterType::Lanczos3);
+            }
+            ImageSize::Automatic => {}
         }
     }
 

--- a/packages/manganis/manganis-core/src/images.rs
+++ b/packages/manganis/manganis-core/src/images.rs
@@ -51,6 +51,16 @@ pub enum ImageSize {
         /// The height of the image in pixels
         height: u32,
     },
+    /// Only the width is specified; the height will be derived from the image's aspect ratio
+    WidthOnly {
+        /// The width of the image in pixels
+        width: u32,
+    },
+    /// Only the height is specified; the width will be derived from the image's aspect ratio
+    HeightOnly {
+        /// The height of the image in pixels
+        height: u32,
+    },
     /// The size will be automatically determined from the image source
     Automatic,
 }
@@ -222,6 +232,36 @@ impl AssetOptionsBuilder<ImageAssetOptions> {
     /// ```
     pub const fn with_size(mut self, size: ImageSize) -> Self {
         self.variant.size = size;
+        self
+    }
+
+    /// Sets the width of the image and derives the height from the aspect ratio
+    ///
+    /// This is useful when you want to resize an image to a specific width but maintain
+    /// its original aspect ratio. The height will be computed at build time from the
+    /// actual image dimensions.
+    ///
+    /// ```rust
+    /// # use manganis::{asset, Asset, AssetOptions};
+    /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_width(52));
+    /// ```
+    pub const fn with_width(mut self, width: u32) -> Self {
+        self.variant.size = ImageSize::WidthOnly { width };
+        self
+    }
+
+    /// Sets the height of the image and derives the width from the aspect ratio
+    ///
+    /// This is useful when you want to resize an image to a specific height but maintain
+    /// its original aspect ratio. The width will be computed at build time from the
+    /// actual image dimensions.
+    ///
+    /// ```rust
+    /// # use manganis::{asset, Asset, AssetOptions};
+    /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_height(52));
+    /// ```
+    pub const fn with_height(mut self, height: u32) -> Self {
+        self.variant.size = ImageSize::HeightOnly { height };
         self
     }
 


### PR DESCRIPTION
## Summary

Closes #5458

Adds the ability to specify only one dimension (`with_width` or `with_height`) when resizing image assets, and have the other dimension automatically derived from the image's aspect ratio at build time.

## Changes

### `packages/manganis/manganis-core/src/images.rs`
- Added `ImageSize::WidthOnly { width }` and `ImageSize::HeightOnly { height }` variants to the `ImageSize` enum
- Added `with_width(width: u32)` and `with_height(height: u32)` `const` methods to `AssetOptionsBuilder<ImageAssetOptions>`

### `packages/cli/src/opt/image.rs`
- Updated `process_image` to handle the new `ImageSize` variants by reading the decoded image's actual dimensions and computing the missing dimension from the aspect ratio

## Usage

```rust
// Resize to a specific width, height derived from aspect ratio
pub const RESIZED_PNG_ASSET: Asset =
    asset!("/assets/image.png", AssetOptions::image().with_width(52));

// Resize to a specific height, width derived from aspect ratio
pub const RESIZED_PNG_ASSET: Asset =
    asset!("/assets/image.png", AssetOptions::image().with_height(52));

// Existing API still works — both dimensions explicit
pub const RESIZED_PNG_ASSET: Asset =
    asset!("/assets/image.png", AssetOptions::image().with_size(ImageSize::Manual { width: 512, height: 512 }));
```

## Implementation Notes

- The aspect ratio is computed from the decoded image at build time (in the CLI processor), so the original image must be readable when `dx` runs
- Uses `resize_exact` (same as `Manual`) for consistency
- The new `ImageSize` variants are `#[repr(C, u8)]` compatible with the existing serialization infrastructure
- All methods are `const fn` to match the existing API convention