### PR TITLE
fix: ReadStore from MappedMutSignal requires Lens: Readable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
       - main
 
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
     branches:
       - main
 

--- a/packages/stores/src/store.rs
+++ b/packages/stores/src/store.rs
@@ -204,7 +204,7 @@ where
 impl<__F, __FMut, T: ?Sized, S, Lens> ::std::convert::From<MappedStore<T, Lens, __F, __FMut>>
     for ReadStore<T, S>
 where
-    Lens: Writable<Storage = S> + 'static,
+    Lens: Readable<Storage = S> + 'static,
     __F: Fn(&Lens::Target) -> &T + 'static,
     __FMut: Fn(&mut Lens::Target) -> &mut T + 'static,
     S: BoxedSignalStorage<T> + CreateBoxedSignalStorage<MappedMutSignal<T, Lens, __F, __FMut>>,


### PR DESCRIPTION
Fixes #5603

Please note that I am not well versed in the dioxus codebase. 
Changing the bound on the `From` impl seems to work and compile for my use case, but I do not know if there are any deeper implications of changing that bound.

Also the body of the impl contains `value.selector.map_writer` - should this still be "map_writer" if the value is readable and not writable?

For now i have created the pull-request against v0.7 because that is where i could test in in the context of a bigger codebase, but i can change the base to be main if that is desired.