### PR TITLE
Bump anyrender_vello_hybrid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello_hybrid"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b6de3eb188f15d7782e37d086b1a06bc835043e52c2f836e64a1de0e1a2ee6"
+checksum = "7bb7175d60a20edfb23d590344c02efb77c9eccbb6a749af3c4b9bf14b092dda"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -444,7 +444,7 @@ dependencies = [
  "peniko",
  "pollster",
  "rustc-hash 2.1.2",
- "vello_common",
+ "vello_common 0.0.9",
  "vello_hybrid",
  "wasm-bindgen-futures",
  "wgpu",
@@ -5841,9 +5841,9 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9d48c6d81526ad2f9d5d6e5fddf5f6949ffbc46fcac0db0d061a6e65097019"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
 dependencies = [
  "bytemuck",
  "foldhash 0.2.0",
@@ -5852,7 +5852,7 @@ dependencies = [
  "peniko",
  "skrifa",
  "smallvec",
- "vello_common",
+ "vello_common 0.0.9",
 ]
 
 [[package]]
@@ -13899,6 +13899,22 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "peniko",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
  "png 0.18.1",
  "smallvec",
  "thiserror 2.0.18",
@@ -13913,7 +13929,7 @@ dependencies = [
  "bytemuck",
  "glifo",
  "hashbrown 0.17.1",
- "vello_common",
+ "vello_common 0.0.8",
 ]
 
 [[package]]
@@ -13931,16 +13947,16 @@ dependencies = [
 
 [[package]]
 name = "vello_hybrid"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644d88a5ccb2280a407eada75a9318920bdee029e293b52c6e8b3fc8c31c70dd"
+checksum = "86ca7acbf6e59ae8c354c524732c73da45239a3a8ee03d0c8a9ad66a6622e488"
 dependencies = [
  "bytemuck",
  "glifo",
  "hashbrown 0.17.1",
  "log",
  "thiserror 2.0.18",
- "vello_common",
+ "vello_common 0.0.9",
  "vello_sparse_shaders",
  "wgpu",
 ]
@@ -13960,9 +13976,9 @@ dependencies = [
 
 [[package]]
 name = "vello_sparse_shaders"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3abf652bc0f42be7b8235bc2b9ae97991ee801bbdbc694485dead5786202c"
+checksum = "e004cfe28eb71738643f60460b9cae2236eba57b351afebf244148256ff25d8b"
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello_cpu"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379caa953b953149c002c4a956443e09771b432b74e1c7074af26a8854a93ae7"
+checksum = "0234f657ff09eb6d3154887ea674f34b32a4a7bc03d1ac16567dc6f65ced3d89"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -444,7 +444,7 @@ dependencies = [
  "peniko",
  "pollster",
  "rustc-hash 2.1.2",
- "vello_common 0.0.9",
+ "vello_common",
  "vello_hybrid",
  "wasm-bindgen-futures",
  "wgpu",
@@ -5852,7 +5852,7 @@ dependencies = [
  "peniko",
  "skrifa",
  "smallvec",
- "vello_common 0.0.9",
+ "vello_common",
 ]
 
 [[package]]
@@ -13889,22 +13889,6 @@ dependencies = [
 
 [[package]]
 name = "vello_common"
-version = "0.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3361bff7f7d82c0c496b92048db83846691f0e844cc28dee92b1c824291b55ee"
-dependencies = [
- "bytemuck",
- "fearless_simd",
- "guillotiere",
- "hashbrown 0.17.1",
- "log",
- "peniko",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "vello_common"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
@@ -13922,14 +13906,14 @@ dependencies = [
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8ded630e8316bb94a55881256506d1f3b9947b5f66db8a7d32ca7ba02decd0"
+checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
 dependencies = [
  "bytemuck",
  "glifo",
  "hashbrown 0.17.1",
- "vello_common 0.0.8",
+ "vello_common",
 ]
 
 [[package]]
@@ -13956,7 +13940,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "thiserror 2.0.18",
- "vello_common 0.0.9",
+ "vello_common",
  "vello_sparse_shaders",
  "wgpu",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ blitz-shell = { version = "=0.3.0-alpha.4", default-features = false }
 peniko = { version = "0.6.1", default-features = false }
 anyrender = { version = "0.10", default-features = false }
 anyrender_vello = { version = "0.10.1", default-features = false }
-anyrender_vello_cpu = { version = "0.12.1", default-features = false }
+anyrender_vello_cpu = { version = "0.13.0", default-features = false }
 anyrender_vello_hybrid = { version = "0.6.0", default-features = false }
 anyrender_skia = { version = "0.8", default-features = false }
 wgpu_context = { version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ peniko = { version = "0.6.1", default-features = false }
 anyrender = { version = "0.10", default-features = false }
 anyrender_vello = { version = "0.10.1", default-features = false }
 anyrender_vello_cpu = { version = "0.12.1", default-features = false }
-anyrender_vello_hybrid = { version = "0.5.1", default-features = false }
+anyrender_vello_hybrid = { version = "0.6.0", default-features = false }
 anyrender_skia = { version = "0.8", default-features = false }
 wgpu_context = { version = "0.6" }
 wgpu = { version = "29.0.3" }


### PR DESCRIPTION
https://github.com/linebender/vello/pull/1687 caused a breaking change bumping vello_common from 0.0.8 to 0.0.9 since the tint vello_common type is exported publicly in [this](https://docs.rs/glifo/0.1.1/glifo/trait.GlyphRenderer.html) `glifo` api. At the same time, this was published as a non-breaking change in `glifo` which was bumped from 0.1.0 to 0.1.1

This is causing the min versions ci to fail.

This PR bumps `anyrender_vello_hybrid` and in turn `vello_common` to 0.0.9 so the versions match to fix that issue