### PR TITLE
fix: remove faulty deserialize

### DIFF
--- a/packages/html/src/transit.rs
+++ b/packages/html/src/transit.rs
@@ -68,7 +68,7 @@ impl HtmlEvent {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[derive(Serialize, Debug, PartialEq)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum EventData {


### PR DESCRIPTION
Closes #5582

Remove faulty `EventData` `#derive(Deserialize)`.

## Why

`Deserialize` derive impl was faulty, due to `#[serde(untagged)]` and the first variant being `Cancel(SerializedCancelData {})` matching ***any*** JSON object. This meant `serde_json::from_str::<EventData>` always returned `Cancel` for all inputs.