### PR TITLE
fix(router): preserve query and hash segments on child routes

### DIFF
--- a/packages/router-macro/src/lib.rs
+++ b/packages/router-macro/src/lib.rs
@@ -527,17 +527,17 @@ impl RouteEnum {
 
                 fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
                     let route = s;
-                    let (route, hash) = route.split_once('#').unwrap_or((route, ""));
-                    let (route, query) = route.split_once('?').unwrap_or((route, ""));
+                    let (route, raw_hash) = route.split_once('#').unwrap_or((route, ""));
+                    let (route, raw_query) = route.split_once('?').unwrap_or((route, ""));
                     // Remove any trailing slashes. We parse /route/ and /route in the same way
                     // Note: we don't use trim because it includes more code
                     let route = route.strip_suffix('/').unwrap_or(route);
-                    let query = dioxus_router::exports::percent_encoding::percent_decode_str(query)
+                    let query = dioxus_router::exports::percent_encoding::percent_decode_str(raw_query)
                         .decode_utf8()
-                        .unwrap_or(query.into());
-                    let hash = dioxus_router::exports::percent_encoding::percent_decode_str(hash)
+                        .unwrap_or(raw_query.into());
+                    let hash = dioxus_router::exports::percent_encoding::percent_decode_str(raw_hash)
                         .decode_utf8()
-                        .unwrap_or(hash.into());
+                        .unwrap_or(raw_hash.into());
                     let mut segments = route.split('/').map(|s| {
                         dioxus_router::exports::percent_encoding::percent_decode_str(s)
                             .decode_utf8()

--- a/packages/router-macro/src/route_tree.rs
+++ b/packages/router-macro/src/route_tree.rs
@@ -377,13 +377,13 @@ impl RouteTreeSegmentData<'_> {
                                 trailing += &*seg;
                                 trailing += "/";
                             }
-                            if !query.is_empty() {
+                            if !raw_query.is_empty() {
                                 trailing.push('?');
-                                trailing.push_str(&query);
+                                trailing.push_str(raw_query);
                             }
-                            if !hash.is_empty() {
+                            if !raw_hash.is_empty() {
                                 trailing.push('#');
-                                trailing.push_str(&hash);
+                                trailing.push_str(raw_hash);
                             }
                             match #ty::from_str(&trailing).map_err(|err| #error_enum_name::#enum_variant(#variant_parse_error::ChildRoute(err))) {
                                 Ok(#child_name) => {

--- a/packages/router-macro/src/route_tree.rs
+++ b/packages/router-macro/src/route_tree.rs
@@ -377,6 +377,14 @@ impl RouteTreeSegmentData<'_> {
                                 trailing += &*seg;
                                 trailing += "/";
                             }
+                            if !query.is_empty() {
+                                trailing.push('?');
+                                trailing.push_str(&query);
+                            }
+                            if !hash.is_empty() {
+                                trailing.push('#');
+                                trailing.push_str(&hash);
+                            }
                             match #ty::from_str(&trailing).map_err(|err| #error_enum_name::#enum_variant(#variant_parse_error::ChildRoute(err))) {
                                 Ok(#child_name) => {
                                     #print_route_segment

--- a/packages/router/tests/parsing.rs
+++ b/packages/router/tests/parsing.rs
@@ -211,4 +211,13 @@ fn child_route_preserves_query_and_hash() {
         },
     };
     assert_eq!(Route::from_str(&encoded.to_string()).unwrap(), encoded);
+
+    let reserved = Route::App {
+        child: ChildRoute::Search {
+            query: "a#b".to_string(),
+            word_count: 1,
+        },
+    };
+    assert_eq!(reserved.to_string(), "/search?query=a%23b&word_count=1");
+    assert_eq!(Route::from_str(&reserved.to_string()).unwrap(), reserved);
 }

--- a/packages/router/tests/parsing.rs
+++ b/packages/router/tests/parsing.rs
@@ -162,3 +162,53 @@ fn optional_query_segments_parse() {
         route_without_query_and_other
     );
 }
+
+#[test]
+fn child_route_preserves_query_and_hash() {
+    #[derive(Routable, Clone, PartialEq, Debug)]
+    enum ChildRoute {
+        #[route("/search?:query&:word_count")]
+        Search { query: String, word_count: usize },
+    }
+
+    #[derive(Routable, Clone, PartialEq, Debug)]
+    enum Route {
+        #[child("")]
+        App { child: ChildRoute },
+    }
+
+    #[component]
+    fn Search(query: String, word_count: usize) -> Element {
+        unimplemented!()
+    }
+
+    // A query on a child route must survive parsing.
+    let parsed = Route::from_str("/search?query=hello&word_count=8").unwrap();
+    assert_eq!(
+        parsed,
+        Route::App {
+            child: ChildRoute::Search {
+                query: "hello".to_string(),
+                word_count: 8,
+            }
+        }
+    );
+
+    // to_string -> from_str must round-trip.
+    let original = Route::App {
+        child: ChildRoute::Search {
+            query: "hello".to_string(),
+            word_count: 8,
+        },
+    };
+    assert_eq!(Route::from_str(&original.to_string()).unwrap(), original);
+
+    // Values that percent-encode must round-trip without corruption.
+    let encoded = Route::App {
+        child: ChildRoute::Search {
+            query: "a/b c".to_string(),
+            word_count: 1,
+        },
+    };
+    assert_eq!(Route::from_str(&encoded.to_string()).unwrap(), encoded);
+}


### PR DESCRIPTION
Disclosure: Fix and test case were written with assistance from Claude Code (Opus 4.8). 

Example application demonstrating the issue. Enter `/search?query=hello&word_count=1` into the address bar and see that the input box and counter box don't have the values from query segment. The address bar updates if you then edit the input box, but if you then increment the counter, the address loses the query. Can the fix for this be backported to 0.7 as well?

```rust

use dioxus::prelude::*;

fn main() {
    dioxus::launch(|| {
        rsx! {
            Router::<Route> {}
        }
    });
}

#[derive(Routable, Clone, Debug, PartialEq)]
#[rustfmt::skip]
enum Route {
    #[route("/")]
    Home {},

    #[layout(AppLayout)]
        #[child("")]
        App { child: AppRoutes },
}

#[derive(Routable, Clone, Debug, PartialEq)]
#[rustfmt::skip]
enum AppRoutes {
    #[route("/search?:query&:word_count")]
    Search {
        query: String,
        word_count: usize,
    },
}

#[component]
fn AppLayout() -> Element {
    rsx! {
        div {
            p { "[AppLayout shell — child routes render below]" }
            Outlet::<Route> {}
        }
    }
}

#[component]
fn Home() -> Element {
    rsx! {
        h1 { "Home" }
        ul {
            li {
                Link {
                    to: "/search?query=hello&word_count=1",
                    "Go to /search?query=hello&word_count=1"
                }
            }
        }
    }
}

#[component]
fn Search(query: ReadSignal<String>, word_count: ReadSignal<usize>) -> Element {
    use_effect(move || {
        dioxus::logger::tracing::info!(
            "Search received: query = {:?}, word_count = {}",
            query(),
            word_count()
        );
    });

    const ITEMS: &[&str] = &[
        "hello",
        "world",
        "hello world",
        "hello dioxus",
        "hello dioxus-router",
    ];

    let results = use_memo(move || {
        ITEMS
            .iter()
            .filter(|item| {
                item.contains(&*query.read()) && item.split_whitespace().count() >= word_count()
            })
            .collect::<Vec<_>>()
    });

    rsx! {
        h1 { "parsed query = '{query}'  |  parsed word_count = {word_count}" }
        p {
            "If this shows query = '' and word_count = 0 while the URL says "
            "?query=hello&word_count=1, the query was dropped at the #[child] boundary."
        }

        input {
            oninput: move |e| {
                navigator().replace(AppRoutes::Search {
                    query: e.value(),
                    word_count: word_count(),
                });
            },
            value: "{query}",
        }
        input {
            r#type: "number",
            oninput: move |e| {
                if let Ok(word_count) = e.value().parse() {
                    navigator().replace(AppRoutes::Search {
                        query: query(),
                        word_count,
                    });
                }
            },
            value: "{word_count}",
        }
        for result in results.read().iter() {
            div { "{result}" }
        }
    }
}

```