### PR TITLE
fix(build): improve handling of missing rustc args during workspace hotpatch replay

### DIFF
--- a/packages/cli/src/build/link.rs
+++ b/packages/cli/src/build/link.rs
@@ -152,12 +152,15 @@ impl BuildRequest {
         let replayed_crates = self.workspace_hotpatch_replay_order(modified_crates)?;
         tracing::debug!("replaying crates: {replayed_crates:?}");
         for crate_name in &replayed_crates {
-            let rustc_args = self
-                .workspace_hotpatch_replay_args(workspace_rustc_args, crate_name)
-                .with_context(|| format!("Missing rustc args for replay: '{crate_name}'"))?;
-            self.compile_dep_crate(ctx, crate_name, rustc_args)
-                .await
-                .with_context(|| format!("Failed to replay workspace crate '{crate_name}'"))?;
+            if let Some(rustc_args) =
+                self.workspace_hotpatch_replay_args(workspace_rustc_args, crate_name)
+            {
+                self.compile_dep_crate(ctx, crate_name, rustc_args)
+                    .await
+                    .with_context(|| format!("Failed to replay workspace crate '{crate_name}'"))?;
+            } else {
+                tracing::warn!("No captured rustc args for workspace crate '{crate_name}', skipping");
+            }
         }
 
         // Recompile just the tip crate now


### PR DESCRIPTION
Closes #5540 by reverting to the old behavior of warning instead of throwing a hard error when there's no rustc args to be replayed.

Could be a simpler alternative to #5597.