### PR TITLE
Set X-Forwarded-Host in the proxy

### DIFF
--- a/packages/cli/src/serve/proxy.rs
+++ b/packages/cli/src/serve/proxy.rs
@@ -150,6 +150,13 @@ pub(crate) fn proxy_to(
 
         let uri = req.uri().clone();
 
+        // Set X-Forwarded-Host for backend if an upstream proxy has not already set it.
+        if !req.headers().contains_key("x-forwarded-host") {
+            if let Some(host) = req.headers().get(HOST).cloned() {
+                req.headers_mut().insert("x-forwarded-host", host);
+            }
+        }
+
         // Set Host header for backend (send_with_retry handles TCP connection via url)
         if let Some(authority) = url.authority() {
             req.headers_mut().insert(


### PR DESCRIPTION
This lets a dioxus app use this header in development, like when it's behind a real proxy.