### PR TITLE
fix(rsx): `quote_spanned!` -> `quote!`. Resolves clippy::useless_format lints.

### DIFF
--- a/packages/rsx/src/ifmt.rs
+++ b/packages/rsx/src/ifmt.rs
@@ -230,7 +230,7 @@ impl ToTokens for IfmtInput {
         // If the segments are not complex exprs, we can just use format! directly to take advantage of RA rename/expansion
         if self.is_simple_expr() {
             let raw = &self.source;
-            return quote_spanned! { raw.span() => ::std::format!(#raw) }.to_tokens(tokens);
+            return quote! { ::std::format!(#raw) }.to_tokens(tokens);
         }
 
         // build format_literal


### PR DESCRIPTION
## Problem

`ifmt.rs`'s `is_simple_expr` path emits `format!` with `quote_spanned! { raw.span() => ... }`, giving the call the user's source span. After rust-lang/rust-clippy#17060 , `useless_format` resolves a `format!`'s macro context from its span, so clippy isn't aware of the call's macro-generated context.

## Fix

Using `quote!` gives it the macro's span instead, so clippy treats it as part of the `rsx!` expansion and ignores it.

The `#raw` literal keeps its source span, so rust-analyzer is unaffected.

## Verification

Confirmed: clippy no longer lints bare interpolations as before.

Confirmed rust-analyzer functionality in-editor: renaming a variable still rewrites its `"{var}"` inside `rsx!`.

Fixes #5635
