### PR TITLE
fix(fullstack): honor HTTP status in tuple FromResponse impls

### DIFF
--- a/packages/fullstack/src/request.rs
+++ b/packages/fullstack/src/request.rs
@@ -83,6 +83,22 @@ where
 {
     fn from_response(res: ClientResponse) -> impl Future<Output = Result<Self, ServerFnError>> {
         async move {
+            let status = res.status();
+
+            if !status.is_success() {
+                let ErrorPayload::<serde_json::Value> {
+                    message,
+                    code,
+                    data,
+                } = res.json().await?;
+
+                return Err(ServerFnError::ServerError {
+                    message,
+                    code,
+                    details: data,
+                });
+            }
+
             let mut parts = res.make_parts();
             let a = A::from_response_parts(&mut parts)?;
             let b = B::from_response(res).await?;
@@ -99,6 +115,22 @@ where
 {
     fn from_response(res: ClientResponse) -> impl Future<Output = Result<Self, ServerFnError>> {
         async move {
+            let status = res.status();
+
+            if !status.is_success() {
+                let ErrorPayload::<serde_json::Value> {
+                    message,
+                    code,
+                    data,
+                } = res.json().await?;
+
+                return Err(ServerFnError::ServerError {
+                    message,
+                    code,
+                    details: data,
+                });
+            }
+
             let mut parts = res.make_parts();
             let a = A::from_response_parts(&mut parts)?;
             let b = B::from_response_parts(&mut parts)?;

--- a/packages/fullstack/src/request.rs
+++ b/packages/fullstack/src/request.rs
@@ -325,4 +325,76 @@ mod test {
             );
         });
     }
+
+    #[test]
+    fn tuple_two_path_decodes_ok_on_2xx() {
+        futures::executor::block_on(async {
+            let response = build_response(200, "".to_string());
+            let result = <(TestFromResponse, TestFromResponse)>::from_response(response).await;
+            assert!(
+                result.is_ok(),
+                "expected Ok(..) for HTTP 200 success case, got: {:?}",
+                result
+            );
+        });
+    }
+
+    #[test]
+    fn tuple_two_parses_error_payload_on_http_error() {
+        futures::executor::block_on(async {
+            let body = r#"{
+                "message": "qwerty",
+                "code": 400
+            }"#;
+            let response = build_response(400, body.to_string());
+            let result = <(TestFromResponse, TestFromResponse)>::from_response(response).await;
+            assert!(result.is_err(), "expected Err(..) for HTTP 400 failed case");
+            assert_eq!(
+                result.unwrap_err(),
+                ServerFnError::ServerError {
+                    message: "qwerty".to_string(),
+                    code: 400,
+                    details: None
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn tuple_three_path_decodes_ok_on_2xx() {
+        futures::executor::block_on(async {
+            let response = build_response(200, "".to_string());
+            let result =
+                <(TestFromResponse, TestFromResponse, TestFromResponse)>::from_response(response)
+                    .await;
+            assert!(
+                result.is_ok(),
+                "expected Ok(..) for HTTP 200 success case, got: {:?}",
+                result
+            );
+        });
+    }
+
+    #[test]
+    fn tuple_three_parses_error_payload_on_http_error() {
+        futures::executor::block_on(async {
+            let body = r#"{
+                "message": "qwerty",
+                "code": 400
+            }"#;
+            let response = build_response(400, body.to_string());
+            let result =
+                <(TestFromResponse, TestFromResponse, TestFromResponse)>::from_response(response)
+                    .await;
+            assert!(result.is_err(), "expected Err(..) for HTTP 400 failed case");
+            assert_eq!(
+                result.unwrap_err(),
+                ServerFnError::ServerError {
+                    message: "qwerty".to_string(),
+                    code: 400,
+                    details: None
+                }
+            );
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Fix the tuple `FromResponse` implementations for `(A, B)` and `(A, B, C)` in `dioxus-fullstack` so they honor HTTP status codes, matching the existing single-type `FromResponse` behavior.

When a server function returns a tuple such as `(SetHeader<SetCookie>, Json<T>)` and the server responds with a non-2xx status carrying an `ErrorPayload`, the previous tuple implementations would:

- ignore the HTTP status, and
- attempt to deserialize the error body as the success type `T`, producing `RequestError::Decode(..)` instead of `ServerFnError::ServerError { details: .. }`.

This change checks `status.is_success()` in the tuple impls and, on failure, parses `ErrorPayload<serde_json::Value>` and returns `ServerFnError::ServerError { message, code, details }`. Clients using typed error enums (deserialized from `details`) can now reliably recover their custom error types for tuple server-function responses, just as they already can for non-tuple responses.

## Testing

- `cargo test -p dioxus-fullstack --tests` passes locally (rustc 1.94.0).
- Added unit tests covering the 2xx success path and the non-2xx `ErrorPayload` path for both `(A, B)` and `(A, B, C)`, mirroring the existing single-type `FromResponse` tests.
- `cargo clippy -p dioxus-fullstack --tests --all-features -- -D warnings` and `cargo fmt -- --check` are clean.

## Notes

Supersedes #5342, which was opened from a personal fork. The original fix is preserved here (rebased onto the latest `main`) with added test coverage. The previous PR can be closed in favor of this one.
