### PR TITLE
fix(manganis): support 32-bit Android targets in JNI callback

### DIFF
--- a/packages/manganis/manganis/src/android/callback.rs
+++ b/packages/manganis/manganis/src/android/callback.rs
@@ -117,10 +117,12 @@ unsafe extern "C" fn rust_callback<'a>(
     handler_ptr_low: jlong,
     location: JObject<'a>,
 ) {
-    // Reconstruct the pointer from two i64 values (for 64-bit pointers)
-    #[cfg(not(target_pointer_width = "64"))]
-    compile_error!("Only 64-bit Android targets are supported");
-
+    // Reconstruct the handler pointer from the two `jlong` halves it was split
+    // into for the JNI boundary. On 64-bit targets both halves are significant;
+    // on 32-bit targets (e.g. `armv7-linux-androideabi`) the pointer fits in the
+    // low half and the high half is zero, so casting the recombined value to a
+    // pointer-width `usize` drops the unused high bits and yields the original
+    // pointer either way.
     let handler_ptr_raw: usize =
         ((handler_ptr_high as u64) << 32 | handler_ptr_low as u64) as usize;
 


### PR DESCRIPTION
Building dioxus for `armv7-linux-androideabi` (and any 32-bit Android target) fails since #4842 because `rust_callback` gates compilation behind `target_pointer_width = "64"` with a `compile_error!`.

The handler pointer crosses the JNI boundary as two `jlong` halves. The existing reconstruction already yields a pointer-width `usize`: on 64-bit both halves are significant; on 32-bit the pointer fits in the low half (high half zero), so the `as usize` cast drops the unused high bits and recovers the original pointer. Removing the gate lets the same code compile and run on both widths, per @ealmloff's suggestion in the issue.

Verified with `cargo check --target armv7-linux-androideabi -p manganis` (failed before, passes after) and `cargo check --target aarch64-linux-android -p manganis` (unchanged). The encode side that splits the pointer into the two halves lives in plugin-provided DEX bytecode, so this preserves the existing low-half wire contract rather than changing it.

Closes #5637