### PR TITLE
native-dom: Add a way to generate synthetic click events

### DIFF
--- a/packages/native-dom/src/events.rs
+++ b/packages/native-dom/src/events.rs
@@ -518,3 +518,9 @@ impl InteractionLocation for NativeWheelData {
         PagePoint::new(self.0.page_x() as f64, self.0.page_y() as f64)
     }
 }
+
+pub fn synthetic_click_event(node: &Node, modifiers: Modifiers) -> Box<dyn Any> {
+    Box::new(NativePointerData(
+        node.synthetic_click_event_data(modifiers),
+    ))
+}

--- a/packages/native-dom/src/lib.rs
+++ b/packages/native-dom/src/lib.rs
@@ -15,7 +15,7 @@ mod mutation_writer;
 mod write_once_attr;
 pub use blitz_dom::DocumentConfig;
 pub use dioxus_document::DioxusDocument;
-pub use events::NodeHandle;
+pub use events::{NodeHandle, synthetic_click_event};
 pub use write_once_attr::{CustomWidgetAttr, SubDocumentAttr};
 
 use blitz_dom::{LocalName, Namespace, QualName, ns};


### PR DESCRIPTION
This is needed for the new dioxus testing library. Tests need a way to interact with the the system under test -- in this case, to tell them that the user has clicked a component. Previously there was no way to construct the required `NativePointerData` struct outside the native-dom crate itself.