### PR TITLE
CLI: log build failure errors

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -321,7 +321,8 @@ impl AppBuilder {
                     self.compile_end = Some(SystemTime::now());
                 }
             }
-            BuilderUpdate::BuildFailed { .. } => {
+            BuilderUpdate::BuildFailed { err } => {
+                tracing::error!("Build failed: {}", err);
                 tracing::debug!("Setting builder to failed state");
                 self.stage = BuildStage::Failed;
             }


### PR DESCRIPTION
Blitz Browser builds are failing on Linux CI without a sensible error message. I think this is what I need to debug sensibly (and it generally makes sense to log unrecoverable errors).