### PR TITLE
Sync Blitz/Native (Blitz v0.3.0-beta.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,20 +345,21 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "anyrender"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74dcad75fbef1209804ee5d1cfd7409665c5a7987865c758e45f8c5553f9a75f"
+checksum = "5c79ab67fa5a03a47b088c5c9dfc8ad727e2a3a1921517cdf4b642433f925d50"
 dependencies = [
  "kurbo",
  "peniko",
  "raw-window-handle 0.6.2",
+ "smallvec",
 ]
 
 [[package]]
 name = "anyrender_skia"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b657bff5706b75592df07f1b06f63e19e63f61a674d216be4cd1f5a8464e8a6b"
+checksum = "01f3348aa2a0cc6a797b05773d1c2e50c8220919240dc72b21ac5a88c038eaba"
 dependencies = [
  "anyrender",
  "ash",
@@ -366,7 +367,7 @@ dependencies = [
  "debug_timer",
  "gl",
  "glutin",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "kurbo",
  "oaty",
  "objc2 0.6.4",
@@ -384,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "anyrender_svg"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb301bceaa7b9089211acb35f15b46aad96c433e63043d4a2ec4f2f83c4818df"
+checksum = "b2c1ecd7b35cea3ca88e8310eef73c5c06f7d8b0f878a2ac415ab6cf45de3ec6"
 dependencies = [
  "anyrender",
  "image",
@@ -397,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f495049565a1d1510301bbba7d468a1f0e5c4a9c45c9e75bb99ffa90d2fd07c3"
+checksum = "93f297de95eb39e5e6b38e4f4d0b28a880f9fb56ee095e49d8a365a7eb4d6af8"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -416,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "anyrender_vello_cpu"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0234f657ff09eb6d3154887ea674f34b32a4a7bc03d1ac16567dc6f65ced3d89"
+checksum = "545d02c58581dc659b65bab63aef1aebcbcc442c96a49a599019c93ac03b1e42"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -427,14 +428,15 @@ dependencies = [
  "peniko",
  "pixels_window_renderer",
  "softbuffer_window_renderer",
+ "vello_common",
  "vello_cpu",
 ]
 
 [[package]]
 name = "anyrender_vello_hybrid"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb7175d60a20edfb23d590344c02efb77c9eccbb6a749af3c4b9bf14b092dda"
+checksum = "892ad25d216225508a9b1b559c77503384e3700509def5bb9413cfe090694837"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -1243,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "blitz-dom"
-version = "0.3.0-alpha.4"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38802275fbb85def2369e7c3abf2fea63fdf2dd8821a457264171cb072b7e6dd"
+checksum = "a9f438e914c626f4f56cd58cd88045e164e1ac32e12d7c24d09c25121328161e"
 dependencies = [
  "accesskit",
  "anyrender",
@@ -1268,7 +1270,7 @@ dependencies = [
  "parley",
  "percent-encoding",
  "rayon",
- "selectors 0.38.0",
+ "selectors 0.39.0",
  "skrifa",
  "slab",
  "smallvec",
@@ -1288,9 +1290,9 @@ dependencies = [
 
 [[package]]
 name = "blitz-html"
-version = "0.3.0-alpha.4"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8251f0fddea8d44883ebec049480f44fe68b7c4b917f8f3af8010f53aa0706bc"
+checksum = "f4e13102df7e67fc61122b525b0f7dcc0ee8b88cdd4ea19e2d49ba2c46b51489"
 dependencies = [
  "blitz-dom",
  "blitz-traits",
@@ -1301,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "blitz-net"
-version = "0.3.0-alpha.4"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "594214a6e88384ea7aa2136954073b174305ec6550c1f4bcfd9bfab4ce599b96"
+checksum = "2d9304744317620b6a0f610ca58763cc236624f467ac82d6dcae7da606167358"
 dependencies = [
  "blitz-traits",
  "data-url 0.3.2",
@@ -1315,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "blitz-paint"
-version = "0.3.0-alpha.4"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b42e521d60fb0ad6d627eed4aedab30f8b3d4719cb66ce97a34cd9ee3ed43c2"
+checksum = "38a033d71915e8ded2b046b134c06c8042a0f1907f7624b6b6365bf99977c845"
 dependencies = [
  "anyrender",
  "anyrender_svg",
@@ -1328,6 +1330,7 @@ dependencies = [
  "kurbo",
  "parley",
  "peniko",
+ "smallvec",
  "stylo",
  "taffy",
  "usvg",
@@ -1335,15 +1338,16 @@ dependencies = [
 
 [[package]]
 name = "blitz-shell"
-version = "0.3.0-alpha.4"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840d4beafb9ae791bd05682403cc8a1d9d69a5d4a28588a10c2080eb3f98ce23"
+checksum = "393a06efd2f247e8a16cc4558601cb923fa9c2c64610fa8f75b7773c4c3286b7"
 dependencies = [
  "accesskit",
  "accesskit_xplat",
  "android-activity",
  "anyrender",
  "arboard",
+ "atomic_refcell",
  "blitz-dom",
  "blitz-paint",
  "blitz-traits",
@@ -1360,10 +1364,11 @@ dependencies = [
 
 [[package]]
 name = "blitz-traits"
-version = "0.3.0-alpha.4"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a69aad4292231416c2f1becdff3d9353be59556321c95071b66a0fc57e22d94"
+checksum = "9bbf266d7d6d2cf00e79d2158b0fa399ff38f75c0e2d84caeb2e90ff1d7fb3f8"
 dependencies = [
+ "atomic_refcell",
  "bitflags 2.11.1",
  "bytes",
  "cursor-icon",
@@ -3878,6 +3883,7 @@ dependencies = [
  "keyboard-types 0.7.0",
  "manganis",
  "rustc-hash 2.1.2",
+ "slotmap",
  "tokio",
  "tracing",
  "webbrowser",
@@ -4933,12 +4939,6 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
-
-[[package]]
-name = "font-types"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
@@ -4971,9 +4971,9 @@ dependencies = [
 
 [[package]]
 name = "fontique"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c20b425addb8661e97fe1d51c4d8bcec3ec29ed6ad0db983976a7521276b8f7"
+checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
 dependencies = [
  "hashbrown 0.17.1",
  "linebender_resource_handle",
@@ -6200,13 +6200,12 @@ dependencies = [
 
 [[package]]
 name = "harfrust"
-version = "0.6.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551ed25397e4b444e89686602877d5cf3a7f6e3d548dcac37a8357d1e195f4df"
+checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
 dependencies = [
  "bitflags 2.11.1",
  "bytemuck",
- "core_maths",
  "read-fonts",
  "smallvec",
 ]
@@ -6412,6 +6411,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -8415,6 +8416,7 @@ name = "native-headless"
 version = "0.0.0"
 dependencies = [
  "anyrender_vello",
+ "atomic_refcell",
  "blitz-dom",
  "blitz-paint",
  "blitz-traits",
@@ -8786,11 +8788,11 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oaty"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7890d4a4c9205ee57a5e200658e78ed7d51c9cd48d0f7066596a19cc20e5d2"
+checksum = "cc8f19a1c361e5fb1a57e487b993ff8b3c44321b50ca86c9e2b235e57dc94008"
 dependencies = [
- "font-types 0.10.1",
+ "font-types",
 ]
 
 [[package]]
@@ -9427,9 +9429,9 @@ checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
 
 [[package]]
 name = "parley"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fad031076f48f0d4d85ce1aea9b94b4e715a4d636a030a123038f8f5b5e4343"
+checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
 dependencies = [
  "fontique",
  "harfrust",
@@ -9445,9 +9447,9 @@ dependencies = [
 
 [[package]]
 name = "parley_data"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ab9ace3fad1b9ed603ddac5b595e69931fc50263d7e04e4055015b77b02da5"
+checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
 dependencies = [
  "icu_properties",
 ]
@@ -9756,9 +9758,9 @@ dependencies = [
 
 [[package]]
 name = "pixels_window_renderer"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c3c4c8dec11a1bbf2be6e82322f2c4064bcbcf3b33f2de50c88ac1a53a2393"
+checksum = "87ded35385f65726c281d08118df35f5c8dc24222bab14f3a8de91d61975cbc2"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -10515,7 +10517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
  "bytemuck",
- "font-types 0.11.3",
+ "font-types",
 ]
 
 [[package]]
@@ -11255,9 +11257,9 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+checksum = "bad7c25c97cc59c4858df8724a3789caa6ee509b628dfe6df34e8a8084c8a84e"
 dependencies = [
  "bitflags 2.11.1",
  "cssparser 0.37.0",
@@ -11733,9 +11735,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skia-bindings"
-version = "0.97.0"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e3bcf8f25bf047e83110838463e8d06696c12fccc3d3794adf448b4d81f34b"
+checksum = "e6a38f4d460276ea40588c958396a9de0eec808c679009a5b52afdf6ebf34132"
 dependencies = [
  "bindgen",
  "cc",
@@ -11750,9 +11752,9 @@ dependencies = [
 
 [[package]]
 name = "skia-safe"
-version = "0.97.0"
+version = "0.97.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935d4d174fb749bac9265eb41cad75039d32fda2d9c1a1e81b430df0e210a409"
+checksum = "1ecfc54fcd40dc5dea15dd2a84f8422cdb0f76c6a51ebb8835ce0b7ef590a21f"
 dependencies = [
  "bitflags 2.11.1",
  "skia-bindings",
@@ -11930,9 +11932,9 @@ dependencies = [
 
 [[package]]
 name = "softbuffer_window_renderer"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b268895d4c554e8a5fc6dcf4ee525c6f45e505d0e85a242c9ea83c8ccc9155f8"
+checksum = "7cae3e92b3b12c02b617279601a4d390d447cfbfb1197fc3126ef90b51fd1c25"
 dependencies = [
  "anyrender",
  "debug_timer",
@@ -12346,9 +12348,9 @@ dependencies = [
 
 [[package]]
 name = "stylo"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e791ea1b0ede7a720ac17394e48d1ed29cfcb0c27fe339ead2f392ad111502ac"
+checksum = "049fb023adcc72e8814fed99d225a45faa95b0e54b7f433eabb6e88c66c90ded"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -12376,7 +12378,7 @@ dependencies = [
  "rayon",
  "rayon-core",
  "rustc-hash 2.1.2",
- "selectors 0.38.0",
+ "selectors 0.39.0",
  "serde",
  "servo_arc",
  "smallbitvec",
@@ -12403,9 +12405,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_atoms"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50302033a902062041527b6213259c28217a85ffa8f5da7479b584c98f129bbc"
+checksum = "55651489a0c27f66d08e7c9cf8ee449328c0de291e37227fc1bbcffb2d7e681e"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -12413,9 +12415,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_derive"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2697714b8a3591ca2bd9087fdbf7f228979217c24c0eba91a9f127cfbd276f24"
+checksum = "e39f4962458b9e9efc91684666509a1811bc690f90188508108583187d19e83c"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -12426,9 +12428,9 @@ dependencies = [
 
 [[package]]
 name = "stylo_dom"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8aac516e70921783ec1279cf568cb981177305beb70575c4c00fd6551384f2"
+checksum = "697851c070e9a9630825e99f7a34ac0ffd31cd969aac38281b8d002ebe675be5"
 dependencies = [
  "bitflags 2.11.1",
  "stylo_malloc_size_of",
@@ -12436,14 +12438,14 @@ dependencies = [
 
 [[package]]
 name = "stylo_malloc_size_of"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925c363675afbe6e2b845f571332c860fe9a61bf9896d8ae358c6c68f6e3aefe"
+checksum = "5634944bf69cf6b6900d3f0116c3b2530cf55706b1044ddf5d0da45d5d09a527"
 dependencies = [
  "app_units",
  "cssparser 0.37.0",
  "euclid",
- "selectors 0.38.0",
+ "selectors 0.39.0",
  "servo_arc",
  "smallbitvec",
  "smallvec",
@@ -12454,15 +12456,18 @@ dependencies = [
 
 [[package]]
 name = "stylo_static_prefs"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850ac3401667d004d4a13f9c93dc6d9fe67044c9bfdaf5f1519ff136ed68fbab"
+checksum = "1f62c30d50b9d26dd6dc040d0ae0b1c6139c3547c6689cf6ed201ca21f4c77a3"
+dependencies = [
+ "toml 1.1.2+spec-1.1.0",
+]
 
 [[package]]
 name = "stylo_taffy"
-version = "0.3.0-alpha.4"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95128533e10268e12b17cab58c0c608a3a9c444ed21cb9ff3b9892bc55153fbf"
+checksum = "ba6f8e06f0038eb2e01c558b3004cb07c1ee1ab27f23aecbfbf629f55b0307e1"
 dependencies = [
  "stylo",
  "stylo_atoms",
@@ -12471,16 +12476,16 @@ dependencies = [
 
 [[package]]
 name = "stylo_traits"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f5138147c085644487d71b9bbb274fc7f4d6bbe2289c09744c4bd6018f45e2"
+checksum = "dd00a0e8c8becc53b3a87e31f28836e7467147d6e463a7e69c37fdd97f4e09c0"
 dependencies = [
  "app_units",
  "bitflags 2.11.1",
  "cssparser 0.37.0",
  "euclid",
  "malloc_size_of_derive",
- "selectors 0.38.0",
+ "selectors 0.39.0",
  "serde",
  "servo_arc",
  "stylo_atoms",
@@ -12666,9 +12671,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.11.0-experimental-cache-fix.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87b88128d417cd7c2c75b8a398177fb9efcb2ae5cddad22bcec106ba9c8e1c3"
+checksum = "73afc801dd6bd47529eaa7c7e90557f107527d1b7c9c7ed7d7803c7b8d0c357f"
 dependencies = [
  "arrayvec",
  "grid",
@@ -13010,9 +13015,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "to_shmem"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8eb8396666f8344ad4b8849ac0d493ae960290ba89ba1aaf0cb8045d2023288"
+checksum = "b8c81cee0d28327337a94f3f32a1a77c03bbfd926510f3b42956f9d914e7810c"
 dependencies = [
  "cssparser 0.37.0",
  "servo_arc",
@@ -14821,9 +14826,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu_context"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1352548a4576b7998474fa6fbc54232df5f9ccd90cdea079418c3577e26e220"
+checksum = "8e5a5aafb0eeb7cdf21f6155a77da67b35f848820044a6ba2d4a280392546fc1"
 dependencies = [
  "futures-intrusive",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,23 +187,23 @@ const-serialize-macro = { path = "packages/const-serialize-macro", version = "0.
 warnings = { version = "0.2.1" }
 
 # blitz / native
-blitz-dom = { version = "=0.3.0-alpha.4", default-features = false }
-blitz-net = { version = "=0.3.0-alpha.4" }
-blitz-html = { version = "=0.3.0-alpha.4" }
-blitz-paint = { version = "=0.3.0-alpha.4" }
-blitz-traits = { version = "=0.3.0-alpha.4" }
-blitz-shell = { version = "=0.3.0-alpha.4", default-features = false }
+blitz-dom = { version = "=0.3.0-beta.1", default-features = false }
+blitz-net = { version = "=0.3.0-beta.1" }
+blitz-html = { version = "=0.3.0-beta.1" }
+blitz-paint = { version = "=0.3.0-beta.1" }
+blitz-traits = { version = "=0.3.0-beta.1" }
+blitz-shell = { version = "=0.3.0-beta.1", default-features = false }
 peniko = { version = "0.6.1", default-features = false }
-anyrender = { version = "0.10", default-features = false }
-anyrender_vello = { version = "0.10.1", default-features = false }
-anyrender_vello_cpu = { version = "0.13.0", default-features = false }
-anyrender_vello_hybrid = { version = "0.6.0", default-features = false }
-anyrender_skia = { version = "0.8", default-features = false }
-wgpu_context = { version = "0.6" }
+anyrender = { version = "0.11.0" }
+anyrender_vello = { version = "0.12.0" }
+anyrender_vello_cpu = { version = "0.14.0" }
+anyrender_vello_hybrid = { version = "0.8.0" }
+anyrender_skia = { version = "0.9.0" }
+wgpu_context = { version = "0.7.0" }
 wgpu = { version = "29.0.3" }
 vello = "0.9"
 winit = { version = "=0.31.0-beta.2" }
-
+atomic_refcell = "0.1.13"
 
 # a fork of pretty please for tests - let's get off of this if we can!
 prettier-please = { version = "0.3.0", features = ["verbatim"] }

--- a/examples/10-integrations/native-headless/Cargo.toml
+++ b/examples/10-integrations/native-headless/Cargo.toml
@@ -23,3 +23,4 @@ bytemuck = "1.25"
 blitz-paint = { workspace = true, default-features = true }
 blitz-traits = { workspace = true, default-features = true }
 blitz-dom = { workspace = true, default-features = true }
+atomic_refcell =  { workspace = true }

--- a/examples/10-integrations/native-headless/src/main.rs
+++ b/examples/10-integrations/native-headless/src/main.rs
@@ -4,12 +4,13 @@
 //! (this example is not really intended to be run as-is, and requires you to fill
 //! in the missing pieces)
 use anyrender_vello::VelloScenePainter;
+use atomic_refcell::AtomicRefCell;
 use blitz_dom::{Document as _, DocumentConfig};
 use blitz_paint::paint_scene;
 use blitz_traits::{
     events::{
-        BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, PointerCoords,
-        PointerDetails, UiEvent,
+        BlitzPointerEvent, BlitzPointerId, MouseEventButton, MouseEventButtons, Point,
+        PointerCoords, PointerDetails, UiEvent,
     },
     shell::{ColorScheme, Viewport},
 };
@@ -160,6 +161,8 @@ fn main() {
         buttons: MouseEventButtons::Primary, // keep track of all pressed buttons
         mods: Modifiers::empty(),            // ctrl, alt, shift, etc
         details: PointerDetails::default(),
+        element: Point::default(),
+        active_pointers: Arc::new(AtomicRefCell::new(Vec::new())),
     });
     dioxus_doc.handle_ui_event(event);
 

--- a/packages/native-dom/Cargo.toml
+++ b/packages/native-dom/Cargo.toml
@@ -18,7 +18,9 @@ floats = ["blitz-dom/floats"]
 incremental = ["blitz-dom/incremental"]
 accessibility = ["blitz-dom/accessibility"]
 tracing = ["dep:tracing", "blitz-dom/tracing"]
-system-fonts = ["blitz-dom/system_fonts"]
+system-fonts = ["blitz-dom/system-fonts"]
+# complex-scripts: enable dictionary-based line-breaking
+complex-scripts = ["blitz-dom/complex-scripts"]
 autofocus = ["blitz-dom/autofocus"]
 
 [dependencies]

--- a/packages/native-dom/src/dioxus_document.rs
+++ b/packages/native-dom/src/dioxus_document.rs
@@ -2,7 +2,7 @@
 use crate::NodeId;
 use crate::events::{
     BlitzKeyboardData, NativeConverter, NativeFocusData, NativeFormData, NativePointerData,
-    NativeScrollData, NativeWheelData, NodeHandle,
+    NativeScrollData, NativeTouchData, NativeWheelData, NodeHandle,
 };
 use crate::mutation_writer::{DioxusState, MutationWriter};
 use crate::qual_name;
@@ -275,6 +275,7 @@ impl EventHandler for DioxusEventHandler<'_> {
             DomEventData::PointerMove(mevent)
             | DomEventData::PointerDown(mevent)
             | DomEventData::PointerUp(mevent)
+            | DomEventData::PointerCancel(mevent)
             | DomEventData::PointerLeave(mevent)
             | DomEventData::PointerEnter(mevent)
             | DomEventData::PointerOver(mevent)
@@ -290,6 +291,13 @@ impl EventHandler for DioxusEventHandler<'_> {
             | DomEventData::ContextMenu(mevent)
             | DomEventData::DoubleClick(mevent) => {
                 Some(wrap_event_data(NativePointerData(mevent.clone())))
+            }
+
+            DomEventData::TouchStart(tevent)
+            | DomEventData::TouchMove(tevent)
+            | DomEventData::TouchEnd(tevent)
+            | DomEventData::TouchCancel(tevent) => {
+                Some(wrap_event_data(NativeTouchData(tevent.clone())))
             }
 
             DomEventData::Scroll(sevent) => Some(wrap_event_data(NativeScrollData(sevent.clone()))),
@@ -322,27 +330,26 @@ impl EventHandler for DioxusEventHandler<'_> {
             return;
         };
 
-        for &node_id in chain {
-            // Get dioxus vdom id for node
-            let dioxus_id = doc.inner().get_node(node_id).and_then(get_dioxus_id);
-            let Some(id) = dioxus_id else {
-                continue;
-            };
+        // Get dioxus vdom id for node
+        let dioxus_id = chain
+            .iter()
+            .find_map(|node_id| doc.inner().get_node(*node_id).and_then(get_dioxus_id));
+        let Some(id) = dioxus_id else {
+            return;
+        };
 
-            // Handle event in vdom
-            let dx_event = Event::new(event_data.clone(), event.bubbles);
-            self.vdom
-                .runtime()
-                .handle_event(event.name(), dx_event.clone(), id);
+        // Handle event in vdom
+        let dx_event = Event::new(event_data.clone(), event.bubbles);
+        self.vdom
+            .runtime()
+            .handle_event(event.name(), dx_event.clone(), id);
 
-            // Update event state
-            if !dx_event.default_action_enabled() {
-                event_state.prevent_default();
-            }
-            if !dx_event.propagates() {
-                event_state.stop_propagation();
-                break;
-            }
+        // Update event state
+        if !dx_event.default_action_enabled() {
+            event_state.prevent_default();
+        }
+        if !dx_event.propagates() {
+            event_state.stop_propagation();
         }
     }
 }

--- a/packages/native-dom/src/events.rs
+++ b/packages/native-dom/src/events.rs
@@ -6,10 +6,11 @@ use blitz_traits::events::{
 use dioxus_html::{
     AnimationData, BeforeInputData, CancelData, ClipboardData, CompositionData, DragData,
     FocusData, FormData, FormValue, HasFileData, HasFocusData, HasFormData, HasKeyboardData,
-    HasMouseData, HasPointerData, HasScrollData, HasWheelData, HtmlEventConverter, ImageData,
-    KeyboardData, MediaData, MountedData, MountedError, MountedResult, MouseData,
-    PlatformEventData, PointerData, RenderedElementBacking, ResizeData, ScrollBehavior, ScrollData,
-    ScrollToOptions, SelectionData, ToggleData, TouchData, TransitionData, VisibleData, WheelData,
+    HasMouseData, HasPointerData, HasScrollData, HasTouchData, HasTouchPointData, HasWheelData,
+    HtmlEventConverter, ImageData, KeyboardData, MediaData, MountedData, MountedError,
+    MountedResult, MouseData, PlatformEventData, PointerData, RenderedElementBacking, ResizeData,
+    ScrollBehavior, ScrollData, ScrollToOptions, SelectionData, ToggleData, TouchData, TouchPoint,
+    TransitionData, VisibleData, WheelData,
     geometry::{
         ClientPoint, ElementPoint, PagePoint, PixelsRect, PixelsSize, PixelsVector2D, ScreenPoint,
         WheelDelta,
@@ -117,8 +118,8 @@ impl HtmlEventConverter for NativeConverter {
         unimplemented!("todo: convert_toggle_data in dioxus-native. requires support in blitz")
     }
 
-    fn convert_touch_data(&self, _event: &PlatformEventData) -> TouchData {
-        unimplemented!("todo: convert_touch_data in dioxus-native. requires support in blitz")
+    fn convert_touch_data(&self, event: &PlatformEventData) -> TouchData {
+        event.downcast::<NativeTouchData>().unwrap().clone().into()
     }
 
     fn convert_transition_data(&self, _event: &PlatformEventData) -> TransitionData {
@@ -335,8 +336,7 @@ impl InteractionLocation for NativePointerData {
 
 impl InteractionElementOffset for NativePointerData {
     fn element_coordinates(&self) -> ElementPoint {
-        // TODO: implement element point
-        ElementPoint::new(0.0, 0.0)
+        ElementPoint::new(self.0.element_x() as f64, self.0.element_y() as f64)
     }
 }
 
@@ -414,6 +414,92 @@ impl HasPointerData for NativePointerData {
     }
     fn height(&self) -> f64 {
         1.0
+    }
+}
+
+/// Touch event data exposed to Dioxus Native application code.
+///
+/// Blitz tracks input via pointer events, so a touch event is generated from the
+/// pointer event of the finger that triggered it (`touches_changed`). The full
+/// list of concurrent touches is carried on the triggering event's
+/// [`BlitzPointerEvent::active_pointers`] list and reported via `touches`.
+#[derive(Clone)]
+pub struct NativeTouchData(pub(crate) BlitzPointerEvent);
+
+impl ModifiersInteraction for NativeTouchData {
+    fn modifiers(&self) -> Modifiers {
+        self.0.mods
+    }
+}
+
+impl HasTouchData for NativeTouchData {
+    fn touches(&self) -> Vec<TouchPoint> {
+        // All pointers currently active on the surface (multi-touch).
+        self.0
+            .active_pointers
+            .borrow()
+            .iter()
+            .map(|event| TouchPoint::new(NativeTouchPointData(event.clone())))
+            .collect()
+    }
+
+    fn touches_changed(&self) -> Vec<TouchPoint> {
+        // Just the touch that triggered this event.
+        vec![TouchPoint::new(NativeTouchPointData(self.0.clone()))]
+    }
+
+    fn target_touches(&self) -> Vec<TouchPoint> {
+        // We don't track a per-touch target, so approximate `targetTouches`
+        // (touches that started on the event target) with all active touches.
+        self.touches()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
+    }
+}
+
+#[derive(Clone)]
+pub struct NativeTouchPointData(BlitzPointerEvent);
+
+impl InteractionLocation for NativeTouchPointData {
+    fn client_coordinates(&self) -> ClientPoint {
+        ClientPoint::new(self.0.client_x() as f64, self.0.client_y() as f64)
+    }
+
+    fn screen_coordinates(&self) -> ScreenPoint {
+        ScreenPoint::new(self.0.screen_x() as f64, self.0.screen_y() as f64)
+    }
+
+    fn page_coordinates(&self) -> PagePoint {
+        PagePoint::new(self.0.page_x() as f64, self.0.page_y() as f64)
+    }
+}
+
+impl HasTouchPointData for NativeTouchPointData {
+    fn identifier(&self) -> i32 {
+        match self.0.id {
+            BlitzPointerId::Finger(id) => id as i32,
+            BlitzPointerId::Mouse | BlitzPointerId::Pen => 0,
+        }
+    }
+
+    fn force(&self) -> f64 {
+        self.0.details.pressure
+    }
+
+    fn radius(&self) -> ScreenPoint {
+        // TODO: expose real touch radius once blitz tracks it
+        ScreenPoint::new(1.0, 1.0)
+    }
+
+    fn rotation(&self) -> f64 {
+        // TODO: expose real touch rotation once blitz tracks it
+        0.0
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
     }
 }
 
@@ -500,8 +586,7 @@ impl ModifiersInteraction for NativeWheelData {
 
 impl InteractionElementOffset for NativeWheelData {
     fn element_coordinates(&self) -> ElementPoint {
-        // TODO: implement element point
-        ElementPoint::new(0.0, 0.0)
+        ElementPoint::new(self.0.element_x() as f64, self.0.element_y() as f64)
     }
 }
 
@@ -523,4 +608,79 @@ pub fn synthetic_click_event(node: &Node, modifiers: Modifiers) -> Box<dyn Any> 
     Box::new(NativePointerData(
         node.synthetic_click_event_data(modifiers),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blitz_traits::events::{
+        BlitzPointerId, MouseEventButton, MouseEventButtons, Point, PointerCoords, PointerDetails,
+    };
+
+    fn finger_event(id: u64, x: f32, y: f32) -> BlitzPointerEvent {
+        BlitzPointerEvent {
+            id: BlitzPointerId::Finger(id),
+            is_primary: id == 0,
+            coords: PointerCoords {
+                page_x: x,
+                page_y: y,
+                screen_x: x,
+                screen_y: y,
+                client_x: x,
+                client_y: y,
+            },
+            button: MouseEventButton::Main,
+            buttons: MouseEventButtons::from(MouseEventButton::Main),
+            mods: Default::default(),
+            details: PointerDetails::default(),
+            element: Point::default(),
+            active_pointers: Default::default(),
+        }
+    }
+
+    #[test]
+    fn touches_reports_all_active_pointers() {
+        let f0 = finger_event(0, 10.0, 20.0);
+        let f1 = finger_event(1, 30.0, 40.0);
+
+        // The triggering event (second finger down) carries the list of all
+        // currently-active pointers.
+        let trigger = f1.clone();
+        {
+            let mut list = trigger.active_pointers.borrow_mut();
+            list.push(f0.clone());
+            list.push(f1.clone());
+        }
+
+        let data = NativeTouchData(trigger);
+
+        // `touches` reports every active pointer ...
+        let touches = data.touches();
+        assert_eq!(touches.len(), 2);
+        let coords: Vec<(f64, f64)> = touches
+            .iter()
+            .map(|t| {
+                let c = t.client_coordinates();
+                (c.x, c.y)
+            })
+            .collect();
+        assert!(coords.contains(&(10.0, 20.0)));
+        assert!(coords.contains(&(30.0, 40.0)));
+
+        // ... while `changed_touches` reports only the triggering touch.
+        assert_eq!(data.touches_changed().len(), 1);
+        let changed = data.touches_changed();
+        let changed_coords = changed[0].client_coordinates();
+        assert_eq!((changed_coords.x, changed_coords.y), (30.0, 40.0));
+    }
+
+    #[test]
+    fn touches_is_empty_when_no_pointers_are_active() {
+        // e.g. a `touchend` for the last finger: it has been removed from the
+        // active list before dispatch, so `touches` is empty but
+        // `changed_touches` still reports the finger that ended.
+        let data = NativeTouchData(finger_event(0, 1.0, 2.0));
+        assert!(data.touches().is_empty());
+        assert_eq!(data.touches_changed().len(), 1);
+    }
 }

--- a/packages/native-dom/src/mutation_writer.rs
+++ b/packages/native-dom/src/mutation_writer.rs
@@ -17,8 +17,8 @@ pub struct DioxusState {
     pub(crate) stack: Vec<NodeId>,
     /// Mapping from vdom ElementId -> rdom NodeId
     pub(crate) node_id_mapping: Vec<Option<NodeId>>,
-    /// Count of each handler type
-    pub(crate) event_handler_counts: [u32; 32],
+    /// Count of each handler type (indexed by `DomEventKind` discriminant)
+    pub(crate) event_handler_counts: [u32; 64],
     /// Mounted events queued as elements are mounted
     pub(crate) queued_mounted_events: Vec<ElementId>,
 }
@@ -30,7 +30,7 @@ impl DioxusState {
             templates: FxHashMap::default(),
             stack: vec![root_id],
             node_id_mapping: vec![Some(root_id)],
-            event_handler_counts: [0; 32],
+            event_handler_counts: [0; 64],
             queued_mounted_events: Vec::new(),
         }
     }

--- a/packages/native/Cargo.toml
+++ b/packages/native/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://dioxuslabs.com/learn/0.7/getting_started"
 keywords = ["dom", "ui", "gui", "react"]
 
 [features]
-default = ["accessibility", "hot-reload", "net", "html", "svg", "system-fonts", "clipboard", "file_dialog", "vello-hybrid", "incremental", "woff", "apple-font-embolden"]
+default = ["accessibility", "hot-reload", "net", "html", "svg", "system-fonts", "clipboard", "file-dialog", "vello-hybrid", "incremental", "woff", "apple-font-embolden"]
 prelude = ["dep:dioxus-core-macro", "dep:dioxus-hooks", "dep:dioxus-signals", "dep:dioxus-stores", "dep:manganis"]
 
 # DOM features
@@ -18,15 +18,16 @@ svg = ["blitz-dom/svg", "blitz-paint/svg"]
 floats = ["blitz-dom/floats"]
 incremental = ["blitz-dom/incremental"]
 autofocus = ["blitz-dom/autofocus"]
-system-fonts = ["blitz-dom/system_fonts"]
+system-fonts = ["blitz-dom/system-fonts"]
+# complex-scripts: enable dictionary-based line-breaking
+complex-scripts = ["blitz-dom/complex-scripts"]
 # WOFF/WOFF2 decoder. Default-on so wasm callers (which can't use system fonts)
 # can bundle compressed fonts without extra setup.
 woff = ["blitz-dom/woff"]
 
 # Shell Features
 clipboard = ["blitz-shell/clipboard"]
-file_dialog = ["file-dialog"] # Backwards compat. Remove in next breaking version
-file-dialog = ["blitz-shell/file_dialog"]
+file-dialog = ["blitz-shell/file-dialog"]
 accessibility = ["blitz-shell/accessibility", "blitz-dom/accessibility"]
 data-uri = ["blitz-shell/data-uri"]
 
@@ -41,6 +42,7 @@ vello-cpu-base = ["dep:anyrender_vello_cpu"]
 
 font-embolden = ["blitz-paint/font-embolden"]
 apple-font-embolden = ["blitz-paint/apple-font-embolden"]
+scrollbars = ["blitz-paint/scrollbars"]
 
 # Other features
 # No-op on wasm32 (blitz_net::Provider needs tokio's threaded runtime); launch_cfg
@@ -53,7 +55,7 @@ hot-reload = ["dep:dioxus-devtools"]
 
 # Debug/Logging
 log-times = ["log-phase-times", "log-frame-times"]
-log-phase-times = ["blitz-dom/log_phase_times"]
+log-phase-times = ["blitz-dom/log-phase-times"]
 log-frame-times = [
   "anyrender_vello_cpu?/log_frame_times",
   "anyrender_vello?/log_frame_times",
@@ -111,6 +113,7 @@ tracing = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 futures-util = { workspace = true }
 cfg-if = "1.0.4"
+slotmap = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }

--- a/packages/native/src/dioxus_application.rs
+++ b/packages/native/src/dioxus_application.rs
@@ -12,6 +12,7 @@ use winit::window::WindowId;
 use winit::platform::macos::ApplicationHandlerExtMacOS;
 
 use crate::DioxusNativeWindowRenderer;
+use crate::event_handlers::WindowEventHandlers;
 use crate::{BlitzShellEvent, DioxusDocument, WindowConfig, contexts::DioxusNativeDocument};
 
 /// Dioxus-native specific event type
@@ -34,6 +35,7 @@ pub enum DioxusNativeEvent {
 pub struct DioxusNativeApplication {
     pending_window: Option<WindowConfig<DioxusNativeWindowRenderer>>,
     inner: BlitzApplication<DioxusNativeWindowRenderer>,
+    event_handlers: Rc<WindowEventHandlers>,
 }
 
 impl DioxusNativeApplication {
@@ -45,6 +47,7 @@ impl DioxusNativeApplication {
         Self {
             pending_window: Some(config),
             inner: BlitzApplication::new(proxy, event_queue),
+            event_handlers: Rc::new(WindowEventHandlers::default()),
         }
     }
 
@@ -147,6 +150,7 @@ impl ApplicationHandler for DioxusNativeApplication {
                     window_id,
                 ));
                 provide_context(shared);
+                provide_context(self.event_handlers.clone());
             });
 
             // Add shell provider
@@ -190,6 +194,8 @@ impl ApplicationHandler for DioxusNativeApplication {
         window_id: WindowId,
         event: WindowEvent,
     ) {
+        self.event_handlers
+            .apply_event(window_id, &event, event_loop);
         self.inner.window_event(event_loop, window_id, event);
     }
 

--- a/packages/native/src/event_handlers.rs
+++ b/packages/native/src/event_handlers.rs
@@ -1,0 +1,64 @@
+use slotmap::{DefaultKey, Key, KeyData, SlotMap};
+use std::cell::RefCell;
+use std::rc::Rc;
+use winit::{event::WindowEvent, event_loop::ActiveEventLoop, window::WindowId};
+
+/// The unique identifier of a window event handler. This can be used to later remove the handler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct WinitEventHandlerId(pub(crate) u64);
+
+impl WinitEventHandlerId {
+    /// Unregister this event handler from the window
+    pub fn remove(&self) {
+        let handlers: Rc<WindowEventHandlers> = dioxus_core::consume_context();
+        handlers.remove(*self);
+    }
+}
+
+struct WinitWindowEventHandlerInner {
+    window_id: WindowId,
+
+    #[allow(clippy::type_complexity)]
+    handler: Box<dyn FnMut(&WindowEvent, &dyn ActiveEventLoop) + 'static>,
+}
+
+#[derive(Default)]
+pub(crate) struct WindowEventHandlers {
+    handlers: RefCell<SlotMap<DefaultKey, WinitWindowEventHandlerInner>>,
+}
+
+impl WindowEventHandlers {
+    pub(crate) fn add(
+        &self,
+        window_id: WindowId,
+        handler: impl FnMut(&WindowEvent, &dyn ActiveEventLoop) + 'static,
+    ) -> WinitEventHandlerId {
+        let key = self
+            .handlers
+            .borrow_mut()
+            .insert(WinitWindowEventHandlerInner {
+                window_id,
+                handler: Box::new(handler),
+            });
+        WinitEventHandlerId(key.data().as_ffi())
+    }
+
+    pub(crate) fn remove(&self, id: WinitEventHandlerId) {
+        let key = DefaultKey::from(KeyData::from_ffi(id.0));
+        self.handlers.borrow_mut().remove(key);
+    }
+
+    pub fn apply_event(
+        &self,
+        window_id: WindowId,
+        event: &WindowEvent,
+        target: &dyn ActiveEventLoop,
+    ) {
+        for (_, handler) in self.handlers.borrow_mut().iter_mut() {
+            if handler.window_id != window_id {
+                continue;
+            }
+            (handler.handler)(event, target)
+        }
+    }
+}

--- a/packages/native/src/hooks.rs
+++ b/packages/native/src/hooks.rs
@@ -1,0 +1,49 @@
+use crate::event_handlers::{WindowEventHandlers, WinitEventHandlerId};
+
+use dioxus_core::{Runtime, consume_context, current_scope_id, use_hook_with_cleanup};
+use std::rc::Rc;
+use winit::{
+    event::{ElementState, WindowEvent},
+    event_loop::ActiveEventLoop,
+    keyboard::{Key, NamedKey},
+};
+
+/// Register an event handler that runs when a winit event is processed.
+pub fn use_window_event(
+    mut handler: impl FnMut(&WindowEvent, &dyn ActiveEventLoop) + 'static,
+) -> WinitEventHandlerId {
+    let runtime = Runtime::current();
+    let scope_id = current_scope_id();
+    let window_id = crate::use_window().id();
+
+    use_hook_with_cleanup(
+        move || {
+            let handlers: Rc<WindowEventHandlers> = consume_context();
+            handlers.add(window_id, move |event, target| {
+                runtime.in_scope(scope_id, || handler(event, target))
+            })
+        },
+        move |handler| handler.remove(),
+    )
+}
+
+/// Register a handler that runs when the back button is pressed.
+///
+/// This builds on top of [`use_window_event`]: the back button is delivered by `winit` as a
+/// [`WindowEvent::KeyboardInput`] whose logical key is [`NamedKey::BrowserBack`]. This most
+/// commonly comes from the Android hardware/system back button, but may also be produced by a
+/// keyboard or mouse back key on other platforms. The provided `handler` is called once each
+/// time the button is pressed (key repeats are ignored).
+///
+/// Returns a [`WinitEventHandlerId`] which can be used to remove the handler.
+pub fn use_back_button(mut handler: impl FnMut() + 'static) -> WinitEventHandlerId {
+    use_window_event(move |event, _target| {
+        if let WindowEvent::KeyboardInput { event, .. } = event
+            && event.state == ElementState::Pressed
+            && !event.repeat
+            && event.logical_key == Key::Named(NamedKey::BrowserBack)
+        {
+            handler();
+        }
+    })
+}

--- a/packages/native/src/lib.rs
+++ b/packages/native/src/lib.rs
@@ -14,6 +14,8 @@ mod config;
 mod contexts;
 mod dioxus_application;
 mod dioxus_renderer;
+mod event_handlers;
+mod hooks;
 mod link_handler;
 
 #[cfg(feature = "prelude")]
@@ -55,6 +57,9 @@ pub use {
 
 pub use blitz_dom::{FontContext, Widget, build_single_font_ctx};
 pub use config::Config;
+pub use event_handlers::WinitEventHandlerId;
+pub use hooks::{use_back_button, use_window_event};
+pub use winit;
 pub use winit::dpi::{LogicalSize, PhysicalSize};
 pub use winit::window::WindowAttributes;
 


### PR DESCRIPTION
- Upgrades Blitz to `0.3.0-beta.1`
- Sync `dioxus-native` and `dioxus-native-dom` changes from the Blitz repo

(changes to native/native-dom merged here have already been upstreamed into the Blitz repo and so are included here)