### PR TITLE
fix(cli): preserve original image bytes when asset!() requests no transform (#5642)

### DIFF
--- a/packages/cli/src/opt/image.rs
+++ b/packages/cli/src/opt/image.rs
@@ -9,6 +9,20 @@ pub(crate) fn process_image(
     source: &Path,
     output_path: &Path,
 ) -> anyhow::Result<()> {
+    // Copy verbatim if no transform is requested (#5642)
+    if image_options.format() == ImageFormat::Unknown
+        && image_options.size() == ImageSize::Automatic
+    {
+        std::fs::copy(source, output_path).with_context(|| {
+            format!(
+                "Failed to copy image from {} to {}",
+                source.display(),
+                output_path.display()
+            )
+        })?;
+        return Ok(());
+    }
+
     let mut image = image::ImageReader::new(std::io::Cursor::new(&*std::fs::read(source)?))
         .with_guessed_format()
         .context("Failed to guess image format")?
@@ -140,4 +154,50 @@ pub(crate) fn compress_jpg(image: DynamicImage, output_location: &Path) -> anyho
     let w = &mut BufWriter::new(file);
     w.write_all(&jpeg_bytes)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Write a PNG with detectable chunk/compression to verify byte-for-byte copying
+    fn write_source_png(path: &Path) {
+        let file = std::fs::File::create(path).unwrap();
+        let w = BufWriter::new(file);
+        let mut encoder = png::Encoder::new(w, 4, 4);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        encoder.set_compression(png::Compression::Best);
+        encoder
+            .add_text_chunk("Comment".to_string(), "dioxus-asset-test".to_string())
+            .unwrap();
+        let mut writer = encoder.write_header().unwrap();
+        // 4x4 RGBA pixels with varied colors.
+        let mut data = Vec::with_capacity(4 * 4 * 4);
+        for i in 0..16u8 {
+            data.extend_from_slice(&[i.wrapping_mul(16), 255 - i, i, 255]);
+        }
+        writer.write_image_data(&data).unwrap();
+        writer.finish().unwrap();
+    }
+
+    // Test for #5642: `asset!()` must copy bytes verbatim
+    #[test]
+    fn default_options_preserve_source_bytes() {
+        let dir = std::env::temp_dir().join(format!("dx-image-opt-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let source = dir.join("source.png");
+        let output = dir.join("output.png");
+        write_source_png(&source);
+
+        process_image(&ImageAssetOptions::default(), &source, &output).unwrap();
+
+        assert_eq!(
+            std::fs::read(&source).unwrap(),
+            std::fs::read(&output).unwrap(),
+            "asset!() with default options must copy the source bytes verbatim, not re-encode"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }


### PR DESCRIPTION
Fixes #5642.

## Problem

`asset!("image.png")` with no options re-encodes the image by default, which can **significantly increase** the size of an already-optimized PNG (the issue reports 193K → 976K).

## Root cause

An option-less `asset!(...)` resolves to `ImageAssetOptions::default()` = `format: ImageFormat::Unknown`, `size: ImageSize::Automatic`. In `process_image`, `format() == Unknown` falls into the catch-all `(Ok(image), _) => image.save(output_path)` arm, which **decodes and re-encodes** the image with the `image` crate's default PNG encoder — no optimization, and larger output for already-optimized sources.

## Fix

Add an early guard in `process_image`: when no output format conversion and no manual resize are requested (`Unknown` + `Automatic`), copy the source bytes verbatim (the asset is still content-hashed by filename) instead of decoding and re-encoding. This matches the expected behavior in the issue — *preserve the original bytes unless image processing is explicitly requested*.

Explicit `.with_format(...)` / `.with_size(...)` paths are unchanged: those still resize/convert/optimize as before.

```rust
if image_options.format() == ImageFormat::Unknown
    && image_options.size() == ImageSize::Automatic
{
    std::fs::copy(source, output_path)?;
    return Ok(());
}
```

## Test

Added `opt::image::tests::default_options_preserve_source_bytes`: it writes a `Best`-compressed source PNG carrying a `tEXt` chunk (which a decode→re-encode drops), runs `process_image` with default options, and asserts the output is **byte-identical** to the source — so the test fails if the default path ever re-encodes again.

```
test opt::image::tests::default_options_preserve_source_bytes ... ok
```

Ran with `cargo +1.93.0 test -p dioxus-cli` (repo MSRV 1.93).

---

Note: @GPNaslund mentioned interest in the issue — happy to defer if they already have a fix in flight; posting this since no PR was up.