### PR TITLE
feat(core): memoize Elements passed as props by value

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -910,6 +910,9 @@ Finally, call `.build()` to create the instance of `{name}`.
                     fn memoize(&mut self, new: &Self) -> bool {
                         #memoize
                     }
+                    fn props_eq(&self, new: &Self) -> bool {
+                        self == new
+                    }
                 }
             })
         }
@@ -1523,6 +1526,9 @@ Finally, call `.build()` to create the instance of `{name}`.
                         }
                         fn memoize(&mut self, new: &Self) -> bool {
                             self.inner.memoize(&new.inner)
+                        }
+                        fn props_eq(&self, new: &Self) -> bool {
+                            self.inner.props_eq(&new.inner)
                         }
                     }
 

--- a/packages/core/src/any_props.rs
+++ b/packages/core/src/any_props.rs
@@ -9,6 +9,8 @@ pub(crate) trait AnyProps: 'static {
     fn render(&self) -> Element;
     /// Make the old props equal to the new type erased props. Return if the props were equal and should be memoized.
     fn memoize(&mut self, other: &dyn Any) -> bool;
+    /// Check if the internal props are equal to the new type erased props without mutating either set.
+    fn props_eq(&self, other: &dyn Any) -> bool;
     /// Get the props as a type erased `dyn Any`.
     fn props(&self) -> &dyn Any;
     /// Get the props as a type erased `dyn Any`.
@@ -21,6 +23,7 @@ pub(crate) trait AnyProps: 'static {
 pub(crate) struct VProps<F: ComponentFunction<P, M>, P, M> {
     render_fn: F,
     memo: fn(&mut P, &P) -> bool,
+    props_eq: fn(&P, &P) -> bool,
     props: P,
     name: &'static str,
     phantom: std::marker::PhantomData<M>,
@@ -31,6 +34,7 @@ impl<F: ComponentFunction<P, M>, P: Clone, M> Clone for VProps<F, P, M> {
         Self {
             render_fn: self.render_fn.clone(),
             memo: self.memo,
+            props_eq: self.props_eq,
             props: self.props.clone(),
             name: self.name,
             phantom: std::marker::PhantomData,
@@ -43,12 +47,14 @@ impl<F: ComponentFunction<P, M> + Clone, P: Clone + 'static, M: 'static> VProps<
     pub fn new(
         render_fn: F,
         memo: fn(&mut P, &P) -> bool,
+        props_eq: fn(&P, &P) -> bool,
         props: P,
         name: &'static str,
     ) -> VProps<F, P, M> {
         VProps {
             render_fn,
             memo,
+            props_eq,
             props,
             name,
             phantom: std::marker::PhantomData,
@@ -62,6 +68,13 @@ impl<F: ComponentFunction<P, M> + Clone, P: Clone + 'static, M: 'static> AnyProp
     fn memoize(&mut self, other: &dyn Any) -> bool {
         match other.downcast_ref::<P>() {
             Some(other) => (self.memo)(&mut self.props, other),
+            None => false,
+        }
+    }
+
+    fn props_eq(&self, other: &dyn Any) -> bool {
+        match other.downcast_ref::<P>() {
+            Some(other) => (self.props_eq)(&self.props, other),
             None => false,
         }
     }
@@ -102,6 +115,7 @@ impl<F: ComponentFunction<P, M> + Clone, P: Clone + 'static, M: 'static> AnyProp
         Box::new(Self {
             render_fn: self.render_fn.clone(),
             memo: self.memo,
+            props_eq: self.props_eq,
             props: self.props.clone(),
             name: self.name,
             phantom: std::marker::PhantomData,

--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -38,7 +38,7 @@ impl VNode {
         self.move_mount_to(new, dom);
 
         // If the templates are the same, we don't need to do anything, except copy over the mount information
-        if self == new {
+        if self.ptr_eq(new) {
             return;
         }
 

--- a/packages/core/src/fragment.rs
+++ b/packages/core/src/fragment.rs
@@ -57,9 +57,10 @@ impl<const A: bool> FragmentBuilder<A> {
 /// or classes. If you want to generate nodes instead of accepting them as a list, consider declaring a closure
 /// on the props that takes Context.
 ///
-/// If a parent passes children into a component, the child will always re-render when the parent re-renders. In other
-/// words, a component cannot be automatically memoized if it borrows nodes from its parent, even if the component's
-/// props are valid for the static lifetime.
+/// Children passed into a component are compared by value when the parent re-renders. If the
+/// children are equivalent, the component that received them is memoized and does not re-render.
+/// Parts of the children that cannot be compared cheaply, like event listeners pointing to
+/// different closures, cause the comparison to fail and the component re-renders as usual.
 ///
 /// ## Example
 ///
@@ -96,5 +97,8 @@ impl Properties for FragmentProps {
             self.0 = new_clone.0;
         }
         equal
+    }
+    fn props_eq(&self, new: &Self) -> bool {
+        self == new
     }
 }

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -107,8 +107,25 @@ impl Default for VNode {
 }
 
 impl PartialEq for VNode {
+    /// Compare two [`VNode`]s by value.
+    ///
+    /// Two [`VNode`]s are equal if they point to the same underlying allocation, or if their
+    /// templates, keys, dynamic nodes and dynamic attributes are all equal. Parts of the tree
+    /// that cannot be compared cheaply, like event listeners that point to different closures,
+    /// compare unequal.
+    ///
+    /// This makes it possible to memoize components that accept [`Element`]s in their props: if
+    /// a parent component re-renders but produces equivalent children, the child component that
+    /// receives them will not re-render.
     fn eq(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.vnode, &other.vnode)
+        if Rc::ptr_eq(&self.vnode, &other.vnode) {
+            return true;
+        }
+
+        self.vnode.key == other.vnode.key
+            && self.vnode.template == other.vnode.template
+            && self.vnode.dynamic_nodes == other.vnode.dynamic_nodes
+            && self.vnode.dynamic_attrs == other.vnode.dynamic_attrs
     }
 }
 
@@ -220,6 +237,26 @@ impl VNode {
             .mounted_attributes
             .get(dynamic_attribute_idx)
             .copied()
+    }
+
+    /// Check if two [`VNode`]s point to the same underlying allocation.
+    ///
+    /// Unlike the [`PartialEq`] implementation, which compares nodes by value, this only checks
+    /// identity, which is much cheaper and is the right comparison to use when checking if a
+    /// node has already been rendered, like during diffing.
+    ///
+    /// ```rust
+    /// # use dioxus::prelude::*;
+    /// let node = rsx! { div { "hello" } }.unwrap();
+    /// let clone = node.clone();
+    /// assert!(node.ptr_eq(&clone));
+    ///
+    /// let other = rsx! { div { "hello" } }.unwrap();
+    /// assert!(!node.ptr_eq(&other));
+    /// assert_eq!(node, other);
+    /// ```
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.vnode, &other.vnode)
     }
 
     /// Create a deep clone of this VNode
@@ -626,6 +663,18 @@ impl Default for DynamicNode {
     }
 }
 
+impl PartialEq for DynamicNode {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Component(l), Self::Component(r)) => l == r,
+            (Self::Text(l), Self::Text(r)) => l == r,
+            (Self::Placeholder(l), Self::Placeholder(r)) => l == r,
+            (Self::Fragment(l), Self::Fragment(r)) => l == r,
+            _ => false,
+        }
+    }
+}
+
 /// An instance of a child component
 pub struct VComponent {
     /// The name of this component
@@ -662,6 +711,7 @@ impl VComponent {
         let props = Box::new(VProps::new(
             component,
             <P as Properties>::memoize,
+            <P as Properties>::props_eq,
             props,
             fn_name,
         ));
@@ -712,6 +762,17 @@ impl VComponent {
     }
 }
 
+impl PartialEq for VComponent {
+    /// Compare two [`VComponent`]s by value.
+    ///
+    /// Two [`VComponent`]s are equal if they share the same render function and their props
+    /// compare equal through [`crate::Properties::props_eq`]. Props that cannot be compared
+    /// without being mutated, like event handlers, compare unequal.
+    fn eq(&self, other: &Self) -> bool {
+        self.render_fn == other.render_fn && self.props.props_eq(other.props.props())
+    }
+}
+
 impl std::fmt::Debug for VComponent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("VComponent")
@@ -721,7 +782,7 @@ impl std::fmt::Debug for VComponent {
 }
 
 /// A text node
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct VText {
     /// The actual text itself
     pub value: String,
@@ -743,7 +804,7 @@ impl From<Arguments<'_>> for VText {
 }
 
 /// A placeholder node, used by suspense and fragments
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[non_exhaustive]
 pub struct VPlaceholder {}
 

--- a/packages/core/src/properties.rs
+++ b/packages/core/src/properties.rs
@@ -56,6 +56,22 @@ pub trait Properties: Clone + Sized + 'static {
     /// Make the old props equal to the new props. Return if the props were equal and should be memoized.
     fn memoize(&mut self, other: &Self) -> bool;
 
+    /// Compare two sets of props without mutating either one. Return `true` only if rendering a
+    /// component with `other` is guaranteed to produce the same output as rendering it with `self`.
+    ///
+    /// This powers memoization by value of [`Element`]s passed as props: when a parent component
+    /// re-renders, any [`Element`] it passes down is only considered changed if the components
+    /// inside of it report their props as unequal through this method.
+    ///
+    /// Unlike [`Properties::memoize`], this must not update `self` in place, so implementations
+    /// that cannot compare some of their fields (like event handlers) must return `false`. The
+    /// default implementation is conservative and always returns `false`, which keeps the
+    /// previous behavior of re-rendering the component. The [`Props`](dioxus_core_macro::Props)
+    /// derive macro overrides it with a full [`PartialEq`] comparison.
+    fn props_eq(&self, _other: &Self) -> bool {
+        false
+    }
+
     /// Create a component from the props.
     fn into_vcomponent<M: 'static>(self, render_fn: impl ComponentFunction<Self, M>) -> VComponent {
         let type_name = std::any::type_name_of_val(&render_fn);
@@ -69,6 +85,9 @@ impl Properties for () {
         EmptyBuilder {}
     }
     fn memoize(&mut self, _other: &Self) -> bool {
+        true
+    }
+    fn props_eq(&self, _other: &Self) -> bool {
         true
     }
 }

--- a/packages/core/src/suspense/component.rs
+++ b/packages/core/src/suspense/component.rs
@@ -57,6 +57,9 @@ where
         }
         equal
     }
+    fn props_eq(&self, new: &Self) -> bool {
+        self == new
+    }
 }
 #[doc(hidden)]
 #[allow(dead_code, non_camel_case_types, non_snake_case)]
@@ -194,6 +197,9 @@ impl Properties for SuspenseBoundaryPropsWithOwner {
     }
     fn memoize(&mut self, new: &Self) -> bool {
         self.inner.memoize(&new.inner)
+    }
+    fn props_eq(&self, new: &Self) -> bool {
+        self.inner.props_eq(&new.inner)
     }
 }
 #[allow(dead_code, non_camel_case_types, missing_docs)]

--- a/packages/core/src/virtual_dom.rs
+++ b/packages/core/src/virtual_dom.rs
@@ -288,7 +288,7 @@ impl VirtualDom {
         root_props: P,
     ) -> Self {
         let render_fn = root.fn_ptr();
-        let props = VProps::new(root, |_, _| true, root_props, "Root");
+        let props = VProps::new(root, |_, _| true, |_, _| true, root_props, "Root");
         Self::new_with_component(VComponent {
             name: "root",
             render_fn,
@@ -318,6 +318,7 @@ impl VirtualDom {
 
         let root = VProps::new(
             RootScopeWrapper,
+            |_, _| true,
             |_, _| true,
             RootProps(root),
             "RootWrapper",

--- a/packages/core/tests/diff_dynamic_node.rs
+++ b/packages/core/tests/diff_dynamic_node.rs
@@ -76,8 +76,13 @@ fn toggle_template() {
     let mut dom = VirtualDom::new(app);
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
-    // Rendering again should replace the placeholder with an text node
+    // Re-rendering the parent doesn't rerun Comp: the children it passes down are
+    // equal by value, so Comp is memoized
     dom.mark_dirty(ScopeId::APP);
+    assert_eq!(dom.render_immediate_to_vec().edits, []);
+
+    // Rendering Comp again should replace the text node with a placeholder
+    dom.mark_dirty(ScopeId(ScopeId::APP.0 + 1));
     assert_eq!(
         dom.render_immediate_to_vec().edits,
         [

--- a/packages/core/tests/element_memoization.rs
+++ b/packages/core/tests/element_memoization.rs
@@ -1,0 +1,247 @@
+#![allow(non_snake_case)]
+
+//! Regression tests for <https://github.com/DioxusLabs/dioxus/issues/1929>: `Element`s passed as
+//! props are memoized by value, so a component receiving equivalent children from a re-rendered
+//! parent does not re-render.
+
+use dioxus::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn static_children_are_memoized() {
+    static PARENT_RUNS: AtomicUsize = AtomicUsize::new(0);
+    static CHILD_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        PARENT_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            Takes {
+                div { "hello" }
+            }
+        }
+    }
+
+    #[component]
+    fn Takes(children: Element) -> Element {
+        CHILD_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            div { {children} }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    assert_eq!(PARENT_RUNS.load(Ordering::SeqCst), 1);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 1);
+
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    assert_eq!(PARENT_RUNS.load(Ordering::SeqCst), 2);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn unchanged_dynamic_children_are_memoized() {
+    static CHILD_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        let value = 42;
+        rsx! {
+            Takes {
+                div { "{value}" }
+            }
+        }
+    }
+
+    #[component]
+    fn Takes(children: Element) -> Element {
+        CHILD_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            div { {children} }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn changed_children_rerun_the_child() {
+    static PARENT_RUNS: AtomicUsize = AtomicUsize::new(0);
+    static CHILD_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        let value = PARENT_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            Takes {
+                div { "{value}" }
+            }
+        }
+    }
+
+    #[component]
+    fn Takes(children: Element) -> Element {
+        CHILD_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            div { {children} }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 1);
+
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    assert_eq!(PARENT_RUNS.load(Ordering::SeqCst), 2);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn children_with_listeners_are_not_memoized() {
+    static CHILD_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        rsx! {
+            Takes {
+                button { onclick: move |_| {}, "click me" }
+            }
+        }
+    }
+
+    #[component]
+    fn Takes(children: Element) -> Element {
+        CHILD_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            div { {children} }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn nested_components_with_equal_props_are_memoized() {
+    static CHILD_RUNS: AtomicUsize = AtomicUsize::new(0);
+    static LEAF_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        rsx! {
+            Takes {
+                Leaf { label: "hi" }
+            }
+        }
+    }
+
+    #[component]
+    fn Takes(children: Element) -> Element {
+        CHILD_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            div { {children} }
+        }
+    }
+
+    #[component]
+    fn Leaf(label: String) -> Element {
+        LEAF_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            p { "{label}" }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 1);
+    assert_eq!(LEAF_RUNS.load(Ordering::SeqCst), 1);
+
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 1);
+    assert_eq!(LEAF_RUNS.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn nested_components_with_changed_props_rerun() {
+    static PARENT_RUNS: AtomicUsize = AtomicUsize::new(0);
+    static CHILD_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        let value = PARENT_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            Takes {
+                Leaf { label: "{value}" }
+            }
+        }
+    }
+
+    #[component]
+    fn Takes(children: Element) -> Element {
+        CHILD_RUNS.fetch_add(1, Ordering::SeqCst);
+        rsx! {
+            div { {children} }
+        }
+    }
+
+    #[component]
+    fn Leaf(label: String) -> Element {
+        rsx! {
+            p { "{label}" }
+        }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    assert_eq!(CHILD_RUNS.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn vnode_partial_eq_compares_by_value() {
+    let value = "x";
+    let a = rsx! { div { class: "{value}", "hello" } };
+    let b = rsx! { div { class: "{value}", "hello" } };
+    let c = rsx! { div { class: "y", "hello" } };
+    let d = rsx! { div { class: "{value}", "goodbye" } };
+
+    assert_eq!(a, a);
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+    assert_ne!(a, d);
+}
+
+#[test]
+fn vnode_ptr_eq_compares_by_identity() {
+    let a = rsx! { div { "hello" } }.unwrap();
+    let clone = a.clone();
+    let b = rsx! { div { "hello" } }.unwrap();
+
+    assert!(a.ptr_eq(&clone));
+    assert!(!a.ptr_eq(&b));
+    assert_eq!(a, b);
+}
+
+#[test]
+fn fragments_and_keyed_lists_compare_by_value() {
+    let make = |labels: &[&str]| {
+        let labels = labels.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        rsx! {
+            ul {
+                for label in labels {
+                    li { key: "{label}", "{label}" }
+                }
+            }
+        }
+    };
+
+    assert_eq!(make(&["a", "b"]), make(&["a", "b"]));
+    assert_ne!(make(&["a", "b"]), make(&["a", "c"]));
+    assert_ne!(make(&["a", "b"]), make(&["a"]));
+}


### PR DESCRIPTION
Closes #1929

## Problem

`VNode`'s `PartialEq` compared by `Rc` pointer, so any component receiving an `Element` prop (most commonly `children`) re-rendered every time its parent re-rendered, even when the passed nodes were identical. As discussed in #1929, a deeper comparison was suggested by @ealmloff and @jkelleyrtp.

## Solution

- **`VNode: PartialEq` now compares by value**: pointer equality as a fast path, then key, template (content hash), dynamic nodes, and dynamic attributes.
- **Nested components** compare through a new non-mutating `Properties::props_eq(&self, &Self) -> bool`, exposed to the type-erased layer as `AnyProps::props_eq`. The `Props` derive generates it as a plain `PartialEq` comparison; the trait default is a conservative `false`, so manual `Properties` impls keep their current behavior unless they opt in (`FragmentProps` and `SuspenseBoundaryProps` do).
- **Anything that can't be compared without mutation stays conservative**: event listeners and `EventHandler`/`Callback` props pointing at fresh closures compare unequal, so those subtrees re-render exactly as before. Memoizing them as equal would skip the in-place `__point_to` handler updates and leave stale closures mounted.
- **Diffing keeps identity semantics** via a new `VNode::ptr_eq`: the `diff_node` fast path must not treat content-equal-but-distinct nodes as interchangeable, because the new node's children would never receive the mount information of the old ones.

With this, the example from the issue only prints `"Why am I running?"` when the parent re-runs — `Whatever` is memoized.

## Behavior/perf notes

- The deep comparison only runs when pointers differ, i.e. in the props-memoization path where the previous behavior was "assume changed and re-render the whole subtree", so a successful comparison replaces strictly more expensive work; a failed one adds a walk bounded by the subtree size.
- `toggle_template` (regression test for #2815) relied on the old behavior: it marked the parent dirty to rerun a child whose children were value-equal. It now asserts the child is memoized in that case and drives the toggle through the child's own scope, preserving the original regression coverage.

## Testing

- New `packages/core/tests/element_memoization.rs`: static children memoized, unchanged dynamic children memoized, changed children re-render, children with listeners re-render, nested components memoized/re-rendered through `props_eq`, plus `PartialEq`/`ptr_eq` semantics for fragments and keyed lists.
- Full `dioxus-core`, `dioxus-core-macro`, `dioxus-hooks`, `dioxus-signals`, and `dioxus-ssr` suites (incl. doctests) pass; `cargo fmt` and `cargo clippy --all-features` clean (the two `core-macro` clippy warnings are pre-existing on `main`).