### PR TITLE
feat(cli): add TOML schema comment to bundled dioxus.toml asset

### DIFF
--- a/packages/cli/assets/dioxus.toml
+++ b/packages/cli/assets/dioxus.toml
@@ -1,3 +1,5 @@
+#:schema https://raw.githubusercontent.com/DioxusLabs/dioxus/main/packages/cli/schema.json
+
 [application]
 
 # Web `build` & `serve` dist path


### PR DESCRIPTION
## Summary

Adds the `#:schema` comment to `packages/cli/assets/dioxus.toml` so the bundled template matches the schema URL from DioxusLabs/dioxus#5376.

Related to DioxusLabs/dioxus#5376 (template repo PRs cover Bare-Bones / Jumpstart)

## Test plan

- [ ] `packages/cli/assets/dioxus.toml` starts with the schema comment