### PR TITLE
fix: title tag rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ tmp/
 
 # External macos drives have extra ._ files
 ._*
+
+# Nix build output
+result

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1773189535,
-        "narHash": "sha256-E1G/Or6MWeP+L6mpQ0iTFLpzSzlpGrITfU2220Gq47g=",
+        "lastModified": 1784407669,
+        "narHash": "sha256-gcFMcRjw0ZSn380Rx2QLlU1goUQeSrKX/DF12omI6+o=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "6fa2fb4cf4a89ba49fc9dd5a3eb6cde99d388269",
+        "rev": "1316b7d278ad77a16aec024b71d971366e123bec",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1765835352,
-        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766870016,
-        "narHash": "sha256-fHmxAesa6XNqnIkcS6+nIHuEmgd/iZSP/VXxweiEuQw=",
+        "lastModified": 1784525419,
+        "narHash": "sha256-yocJ4I4Kd4as0UPMFs9P7laPvvA2x/Bj8EW46iW3VVM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5c2bc52fb9f8c264ed6c93bd20afa2ff5e763dce",
+        "rev": "a16c3fde2ffeab7f6326f50f460aaffde7ae066d",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1765674936,
-        "narHash": "sha256-k00uTP4JNfmejrCLJOwdObYC9jHRrr/5M/a/8L2EIdo=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "2075416fcb47225d9b68ac469a5c4801a9c4dd85",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1779333539,
-        "narHash": "sha256-lpmN2lrBDZDPjov2cbD3bOOJsI0fkKolKXasYPCqSys=",
+        "lastModified": 1784526465,
+        "narHash": "sha256-L37teKC6oINWG4PGZLIqbphMWvSQ0PEz+aWxAk+rIDw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "672fa5fc5608d5cd82286a6f69aaf84a40b4fe41",
+        "rev": "58c6334db52d51fc5dd8877c90b01f00cf8a696b",
         "type": "github"
       },
       "original": {

--- a/packages/fullstack-server/src/index_html.rs
+++ b/packages/fullstack-server/src/index_html.rs
@@ -104,12 +104,14 @@ impl IndexHtml {
     /// This will not include any customizations to the HTML nor any JavaScript to bootstrap a client-side app.
     pub fn ssr_only() -> Self {
         const DEFAULT: &str = r#"<!DOCTYPE html>
-        <html>
-            <head> </head>
-            <body>
-                <div id="main"></div>
-            </body>
-        </html>"#;
+<html>
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <div id="main"></div>
+    </body>
+</html>"#;
 
         Self::new(DEFAULT, "main").expect("Failed to load default index.html")
     }


### PR DESCRIPTION
The `IndexHtml::new()` parser splits on `<title>` to find where to inject the dynamic title. Without a `<title>` tag, it can't find a split point, so the dynamic title gets placed before `<html>`.

Before: `<title>` is getting rendered before every html elements
```html
<title>Your Title ...</title><!DOCTYPE html>
        <html>
            <head> <!-- stuff --></head>
            <body>
                <!-- stuff -->
            </body>
        </html>
```

After: `<title>` is rendered inside `<head>` tag
```html
<!DOCTYPE html>
<html>
    <head>
        <title>Your Title ...</title>
    <!-- stuff --></head>
    <body>
        <!-- stuff -->
    </body>
</html>
```
