### PR TITLE
Support single-dimension image resizing

### DIFF
--- a/packages/cli/src/opt/image.rs
+++ b/packages/cli/src/opt/image.rs
@@ -15,8 +15,18 @@ pub(crate) fn process_image(
         .decode();
 
     if let Ok(image) = &mut image {
-        if let ImageSize::Manual { width, height } = image_options.size() {
-            *image = image.resize_exact(width, height, image::imageops::FilterType::Lanczos3);
+        let filter = image::imageops::FilterType::Lanczos3;
+        match image_options.size() {
+            ImageSize::Manual { width, height } => {
+                *image = image.resize_exact(width, height, filter);
+            }
+            ImageSize::Width(width) => {
+                *image = image.resize(width, u32::MAX, filter);
+            }
+            ImageSize::Height(height) => {
+                *image = image.resize(u32::MAX, height, filter);
+            }
+            ImageSize::Automatic => {}
         }
     }
 
@@ -140,4 +150,45 @@ pub(crate) fn compress_jpg(image: DynamicImage, output_location: &Path) -> anyho
     let w = &mut BufWriter::new(file);
     w.write_all(&jpeg_bytes)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::GenericImageView;
+    use manganis_core::{AssetOptions, AssetVariant};
+
+    #[test]
+    fn resizes_image_to_width_while_preserving_aspect_ratio() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = temp_dir.path().join("source.png");
+        let output = temp_dir.path().join("output.png");
+        DynamicImage::new_rgba8(80, 40).save(&source).unwrap();
+
+        let options = AssetOptions::image().with_width(40).into_asset_options();
+        let AssetVariant::Image(options) = options.variant() else {
+            unreachable!()
+        };
+
+        process_image(options, &source, &output).unwrap();
+
+        assert_eq!(image::open(output).unwrap().dimensions(), (40, 20));
+    }
+
+    #[test]
+    fn resizes_image_to_height_while_preserving_aspect_ratio() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source = temp_dir.path().join("source.png");
+        let output = temp_dir.path().join("output.png");
+        DynamicImage::new_rgba8(80, 40).save(&source).unwrap();
+
+        let options = AssetOptions::image().with_height(20).into_asset_options();
+        let AssetVariant::Image(options) = options.variant() else {
+            unreachable!()
+        };
+
+        process_image(options, &source, &output).unwrap();
+
+        assert_eq!(image::open(output).unwrap().dimensions(), (40, 20));
+    }
 }

--- a/packages/manganis/manganis-core/src/images.rs
+++ b/packages/manganis/manganis-core/src/images.rs
@@ -231,23 +231,37 @@ impl AssetOptionsBuilder<ImageAssetOptions> {
 
     /// Sets the width of the image and preserves its aspect ratio
     ///
+    /// If a height is already set, the image will use both dimensions as a manual size.
+    ///
     /// ```rust
     /// # use manganis::{asset, Asset, AssetOptions};
     /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_width(512));
     /// ```
     pub const fn with_width(mut self, width: u32) -> Self {
-        self.variant.size = ImageSize::Width(width);
+        self.variant.size = match self.variant.size {
+            ImageSize::Height(height) | ImageSize::Manual { height, .. } => {
+                ImageSize::Manual { width, height }
+            }
+            _ => ImageSize::Width(width),
+        };
         self
     }
 
     /// Sets the height of the image and preserves its aspect ratio
+    ///
+    /// If a width is already set, the image will use both dimensions as a manual size.
     ///
     /// ```rust
     /// # use manganis::{asset, Asset, AssetOptions};
     /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_height(512));
     /// ```
     pub const fn with_height(mut self, height: u32) -> Self {
-        self.variant.size = ImageSize::Height(height);
+        self.variant.size = match self.variant.size {
+            ImageSize::Width(width) | ImageSize::Manual { width, .. } => {
+                ImageSize::Manual { width, height }
+            }
+            _ => ImageSize::Height(height),
+        };
         self
     }
 
@@ -257,5 +271,67 @@ impl AssetOptionsBuilder<ImageAssetOptions> {
             add_hash: self.add_hash,
             variant: AssetVariant::Image(self.variant),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image_size(options: AssetOptions) -> ImageSize {
+        let AssetVariant::Image(options) = options.variant() else {
+            unreachable!()
+        };
+        options.size()
+    }
+
+    #[test]
+    fn width_then_height_sets_manual_size() {
+        let options = AssetOptions::image()
+            .with_width(80)
+            .with_height(40)
+            .into_asset_options();
+
+        assert_eq!(
+            image_size(options),
+            ImageSize::Manual {
+                width: 80,
+                height: 40
+            }
+        );
+    }
+
+    #[test]
+    fn height_then_width_sets_manual_size() {
+        let options = AssetOptions::image()
+            .with_height(40)
+            .with_width(80)
+            .into_asset_options();
+
+        assert_eq!(
+            image_size(options),
+            ImageSize::Manual {
+                width: 80,
+                height: 40
+            }
+        );
+    }
+
+    #[test]
+    fn setters_update_existing_manual_size() {
+        let options = AssetOptions::image()
+            .with_width(80)
+            .with_height(40)
+            .with_width(60)
+            .with_height(30)
+            .into_asset_options();
+
+        assert_eq!(
+            image_size(options),
+            ImageSize::Manual {
+                width: 60,
+                height: 30
+            }
+        );
     }
 }

--- a/packages/manganis/manganis-core/src/images.rs
+++ b/packages/manganis/manganis-core/src/images.rs
@@ -53,6 +53,10 @@ pub enum ImageSize {
     },
     /// The size will be automatically determined from the image source
     Automatic,
+    /// A manual width in pixels. The height will be derived from the image's aspect ratio.
+    Width(u32),
+    /// A manual height in pixels. The width will be derived from the image's aspect ratio.
+    Height(u32),
 }
 
 /// Options for an image asset
@@ -222,6 +226,28 @@ impl AssetOptionsBuilder<ImageAssetOptions> {
     /// ```
     pub const fn with_size(mut self, size: ImageSize) -> Self {
         self.variant.size = size;
+        self
+    }
+
+    /// Sets the width of the image and preserves its aspect ratio
+    ///
+    /// ```rust
+    /// # use manganis::{asset, Asset, AssetOptions};
+    /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_width(512));
+    /// ```
+    pub const fn with_width(mut self, width: u32) -> Self {
+        self.variant.size = ImageSize::Width(width);
+        self
+    }
+
+    /// Sets the height of the image and preserves its aspect ratio
+    ///
+    /// ```rust
+    /// # use manganis::{asset, Asset, AssetOptions};
+    /// const _: Asset = asset!("/assets/image.png", AssetOptions::image().with_height(512));
+    /// ```
+    pub const fn with_height(mut self, height: u32) -> Self {
+        self.variant.size = ImageSize::Height(height);
         self
     }
 


### PR DESCRIPTION
## Summary

- add `with_width` and `with_height` image asset options
- preserve the source aspect ratio when the CLI resizes a single dimension
- cover width- and height-constrained output dimensions with focused tests

Closes #5458

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p dioxus-cli opt::image::tests`
- `cargo check -p dioxus-cli`
- `cargo test -p manganis-core`
- `cargo clippy -p dioxus-cli --tests -- -D warnings`
- `cargo test --workspace --tests`
