### PR TITLE
test(native-dom): reproduce "invalid key" panic from stale node_id_mapping (#5182)

### DIFF
--- a/packages/native-dom/tests/stale_node_mapping.rs
+++ b/packages/native-dom/tests/stale_node_mapping.rs
@@ -1,0 +1,234 @@
+//! Regression tests for stale `node_id_mapping` entries after node removal.
+//! See https://github.com/DioxusLabs/dioxus/pull/5182
+//!
+//! When `remove_node` (or `replace_node_with`) detaches a node, the
+//! `node_id_mapping` entries for the node's subtree are (intentionally) not
+//! cleared, so that dioxus-core can reuse the detached DOM nodes. However,
+//! when the detached subtree is later dropped via `remove_node_if_unparented`
+//! (called from `assign_node_id`), only the mapping for the ElementId being
+//! reassigned is updated. Any *descendant* of the dropped subtree that has its
+//! own ElementId mapping is left pointing at a freed slab slot.
+//!
+//! When that slab slot is reused for a brand-new (not yet parented) node and
+//! the stale ElementId is then reused by dioxus-core via `AssignId`,
+//! `remove_node_if_unparented` incorrectly drops the new node, causing an
+//! "invalid key" slab panic in blitz-dom's `DocumentMutator` later in the
+//! same render (matching the stack trace reported in the PR).
+
+use blitz_dom::DocumentConfig;
+use blitz_traits::shell::{ColorScheme, Viewport};
+use dioxus::prelude::*;
+use dioxus_core::ScopeId;
+use dioxus_native_dom::DioxusDocument;
+use std::cell::Cell;
+
+thread_local! {
+    static GENERATION: Cell<usize> = const { Cell::new(0) };
+}
+
+fn generation() -> usize {
+    GENERATION.with(|g| g.get())
+}
+
+fn make_doc(app: fn() -> Element) -> DioxusDocument {
+    GENERATION.with(|g| g.set(0));
+    let vdom = VirtualDom::new(app);
+    let mut doc = DioxusDocument::new(
+        vdom,
+        DocumentConfig {
+            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+            ..Default::default()
+        },
+    );
+    doc.initial_build();
+    doc
+}
+
+fn step(doc: &mut DioxusDocument) {
+    use blitz_dom::Document as _;
+    GENERATION.with(|g| g.set(g.get() + 1));
+    doc.vdom.mark_dirty(ScopeId::APP);
+    doc.poll(None);
+}
+
+/// Check that every ElementId -> NodeId mapping points at a node that still
+/// exists in the document. A mapping pointing at a freed slab slot will cause
+/// an "invalid key" panic (or worse: silent deletion of an unrelated node
+/// that happens to reuse the slot) on a later render.
+fn assert_no_stale_mappings(doc: &DioxusDocument, context: &str) {
+    let inner = doc.inner.borrow();
+    let mut stale = Vec::new();
+    for raw_id in 0..4096 {
+        let element_id = dioxus_core::ElementId(raw_id);
+        if let Some(node_id) = doc.vdom_state.try_element_to_node_id(element_id)
+            && inner.get_node(node_id).is_none()
+        {
+            stale.push((raw_id, node_id));
+        }
+    }
+    assert!(
+        stale.is_empty(),
+        "stale node_id_mapping entries (ElementId, NodeId) after {context}: {stale:?}"
+    );
+}
+
+fn bare_text() -> Element {
+    let generation = generation();
+    rsx! { "bare text {generation}" }
+}
+
+fn section_with_list(n: usize) -> Element {
+    let generation = generation();
+    rsx! {
+        section {
+            header { id: "gen-{generation}", "header" }
+            for i in 0..n {
+                div { key: "{i}", "item {i}" }
+            }
+        }
+    }
+}
+
+fn nested_divs() -> Element {
+    let generation = generation();
+    rsx! {
+        article {
+            div { class: "gen-{generation}",
+                div { id: "gen-{generation}", "deep {generation}" }
+            }
+        }
+        aside { "aside" }
+    }
+}
+
+/// Minimal deterministic sequence of template swaps that panics with
+/// "invalid key" inside blitz-dom's `DocumentMutator` (in `node_at_path`
+/// via `assign_node_id`) on the 3rd re-render.
+fn minimal_panic_app() -> Element {
+    match generation() {
+        0 => nested_divs(),
+        1 => bare_text(),
+        2 => section_with_list(0),
+        _ => nested_divs(),
+    }
+}
+
+#[test]
+fn template_swaps_do_not_panic() {
+    let mut doc = make_doc(minimal_panic_app);
+    for _ in 0..3 {
+        step(&mut doc);
+    }
+}
+
+/// Toggles between templates where one variant has a nested element with a
+/// dynamic attribute (which is assigned an ElementId via `AssignId`).
+/// Detects the stale mapping (the precursor to the panic) directly.
+fn toggle_app() -> Element {
+    let generation = generation();
+    let class = format!("gen-{generation}");
+    match generation % 3 {
+        0 => rsx! {
+            div {
+                div { class: "{class}",
+                    span { "nested {generation}" }
+                }
+                "text {generation}"
+            }
+            div { "sibling" }
+        },
+        1 => rsx! {
+            p { "different template {generation}" }
+        },
+        _ => rsx! {
+            section {
+                header { id: "{class}", "header" }
+                for i in 0..(generation % 5) {
+                    div { key: "{i}", "item {i}" }
+                }
+            }
+        },
+    }
+}
+
+#[test]
+fn template_swaps_do_not_leave_stale_mappings() {
+    let mut doc = make_doc(toggle_app);
+    for i in 0..20 {
+        step(&mut doc);
+        assert_no_stale_mappings(&doc, &format!("step {i}"));
+    }
+}
+
+/// Pseudo-random mix of templates designed to maximise ElementId and NodeId
+/// (slab slot) reuse. Panics with "invalid key" within a handful of steps.
+fn fuzz_app() -> Element {
+    let generation = generation();
+    // Simple LCG for deterministic pseudo-random variety
+    let r = generation
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    let variant = (r >> 33) % 6;
+    let n = (r >> 40) % 7;
+    let class = format!("gen-{generation}");
+    match variant {
+        0 => rsx! {
+            div {
+                div { class: "{class}", span { "nested {generation}" } }
+                "text {generation}"
+            }
+        },
+        1 => rsx! {
+            p { "different template {generation}" }
+        },
+        2 => section_with_list(n),
+        3 => rsx! {
+            ul {
+                for i in 0..n {
+                    li { key: "{i}", class: "item-{i}-{generation}",
+                        span { "item {i} gen {generation}" }
+                    }
+                }
+            }
+        },
+        4 => nested_divs(),
+        _ => bare_text(),
+    }
+}
+
+#[test]
+fn fuzz_template_swaps_do_not_panic() {
+    let mut doc = make_doc(fuzz_app);
+    for _ in 0..1000 {
+        step(&mut doc);
+    }
+}
+
+/// A keyed list where items are removed and re-added, forcing ElementId reuse
+/// in dioxus-core and NodeId (slab slot) reuse in blitz-dom.
+fn list_app() -> Element {
+    let generation = generation();
+    // Vary the list length up and down so nodes are removed and recreated
+    let len = [5usize, 0, 3, 1, 6, 2, 0, 4][generation % 8];
+    rsx! {
+        ul {
+            for i in 0..len {
+                li { key: "{i}", class: "item-{i}-{generation}",
+                    span { "item {i} gen {generation}" }
+                }
+            }
+        }
+        if generation.is_multiple_of(2) {
+            footer { "footer {generation}" }
+        }
+    }
+}
+
+#[test]
+fn keyed_list_grow_shrink() {
+    let mut doc = make_doc(list_app);
+    for i in 0..300 {
+        step(&mut doc);
+        assert_no_stale_mappings(&doc, &format!("step {i}"));
+    }
+}

--- a/packages/native-dom/tests/stale_node_mapping.rs
+++ b/packages/native-dom/tests/stale_node_mapping.rs
@@ -23,10 +23,16 @@ use dioxus_native_dom::DioxusDocument;
 use std::cell::Cell;
 use std::rc::Rc;
 
-#[derive(Props, Clone, PartialEq)]
+#[derive(Props, Clone)]
 struct AppProps {
     generation: Rc<Cell<usize>>,
     view: fn(usize) -> Element,
+}
+
+impl PartialEq for AppProps {
+    fn eq(&self, other: &Self) -> bool {
+        self.generation == other.generation && std::ptr::fn_addr_eq(self.view, other.view)
+    }
 }
 
 fn app(props: AppProps) -> Element {

--- a/packages/native-dom/tests/stale_node_mapping.rs
+++ b/packages/native-dom/tests/stale_node_mapping.rs
@@ -21,34 +21,50 @@ use dioxus::prelude::*;
 use dioxus_core::ScopeId;
 use dioxus_native_dom::DioxusDocument;
 use std::cell::Cell;
+use std::rc::Rc;
 
-thread_local! {
-    static GENERATION: Cell<usize> = const { Cell::new(0) };
+#[derive(Props, Clone, PartialEq)]
+struct AppProps {
+    generation: Rc<Cell<usize>>,
+    view: fn(usize) -> Element,
 }
 
-fn generation() -> usize {
-    GENERATION.with(|g| g.get())
+fn app(props: AppProps) -> Element {
+    (props.view)(props.generation.get())
 }
 
-fn make_doc(app: fn() -> Element) -> DioxusDocument {
-    GENERATION.with(|g| g.set(0));
-    let vdom = VirtualDom::new(app);
-    let mut doc = DioxusDocument::new(
-        vdom,
-        DocumentConfig {
-            viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
-            ..Default::default()
-        },
-    );
-    doc.initial_build();
-    doc
+struct Harness {
+    doc: DioxusDocument,
+    generation: Rc<Cell<usize>>,
 }
 
-fn step(doc: &mut DioxusDocument) {
-    use blitz_dom::Document as _;
-    GENERATION.with(|g| g.set(g.get() + 1));
-    doc.vdom.mark_dirty(ScopeId::APP);
-    doc.poll(None);
+impl Harness {
+    fn new(view: fn(usize) -> Element) -> Self {
+        let generation = Rc::new(Cell::new(0));
+        let vdom = VirtualDom::new_with_props(
+            app,
+            AppProps {
+                generation: Rc::clone(&generation),
+                view,
+            },
+        );
+        let mut doc = DioxusDocument::new(
+            vdom,
+            DocumentConfig {
+                viewport: Some(Viewport::new(800, 600, 1.0, ColorScheme::Light)),
+                ..Default::default()
+            },
+        );
+        doc.initial_build();
+        Self { doc, generation }
+    }
+
+    fn step(&mut self) {
+        use blitz_dom::Document as _;
+        self.generation.set(self.generation.get() + 1);
+        self.doc.vdom.mark_dirty(ScopeId::APP);
+        self.doc.poll(None);
+    }
 }
 
 /// Check that every ElementId -> NodeId mapping points at a node that still
@@ -72,13 +88,11 @@ fn assert_no_stale_mappings(doc: &DioxusDocument, context: &str) {
     );
 }
 
-fn bare_text() -> Element {
-    let generation = generation();
+fn bare_text(generation: usize) -> Element {
     rsx! { "bare text {generation}" }
 }
 
-fn section_with_list(n: usize) -> Element {
-    let generation = generation();
+fn section_with_list(generation: usize, n: usize) -> Element {
     rsx! {
         section {
             header { id: "gen-{generation}", "header" }
@@ -89,8 +103,7 @@ fn section_with_list(n: usize) -> Element {
     }
 }
 
-fn nested_divs() -> Element {
-    let generation = generation();
+fn nested_divs(generation: usize) -> Element {
     rsx! {
         article {
             div { class: "gen-{generation}",
@@ -104,28 +117,27 @@ fn nested_divs() -> Element {
 /// Minimal deterministic sequence of template swaps that panics with
 /// "invalid key" inside blitz-dom's `DocumentMutator` (in `node_at_path`
 /// via `assign_node_id`) on the 3rd re-render.
-fn minimal_panic_app() -> Element {
-    match generation() {
-        0 => nested_divs(),
-        1 => bare_text(),
-        2 => section_with_list(0),
-        _ => nested_divs(),
+fn minimal_panic_app(generation: usize) -> Element {
+    match generation {
+        0 => nested_divs(generation),
+        1 => bare_text(generation),
+        2 => section_with_list(generation, 0),
+        _ => nested_divs(generation),
     }
 }
 
 #[test]
 fn template_swaps_do_not_panic() {
-    let mut doc = make_doc(minimal_panic_app);
+    let mut harness = Harness::new(minimal_panic_app);
     for _ in 0..3 {
-        step(&mut doc);
+        harness.step();
     }
 }
 
 /// Toggles between templates where one variant has a nested element with a
 /// dynamic attribute (which is assigned an ElementId via `AssignId`).
 /// Detects the stale mapping (the precursor to the panic) directly.
-fn toggle_app() -> Element {
-    let generation = generation();
+fn toggle_app(generation: usize) -> Element {
     let class = format!("gen-{generation}");
     match generation % 3 {
         0 => rsx! {
@@ -153,17 +165,16 @@ fn toggle_app() -> Element {
 
 #[test]
 fn template_swaps_do_not_leave_stale_mappings() {
-    let mut doc = make_doc(toggle_app);
+    let mut harness = Harness::new(toggle_app);
     for i in 0..20 {
-        step(&mut doc);
-        assert_no_stale_mappings(&doc, &format!("step {i}"));
+        harness.step();
+        assert_no_stale_mappings(&harness.doc, &format!("step {i}"));
     }
 }
 
 /// Pseudo-random mix of templates designed to maximise ElementId and NodeId
 /// (slab slot) reuse. Panics with "invalid key" within a handful of steps.
-fn fuzz_app() -> Element {
-    let generation = generation();
+fn fuzz_app(generation: usize) -> Element {
     // Simple LCG for deterministic pseudo-random variety
     let r = generation
         .wrapping_mul(6364136223846793005)
@@ -181,7 +192,7 @@ fn fuzz_app() -> Element {
         1 => rsx! {
             p { "different template {generation}" }
         },
-        2 => section_with_list(n),
+        2 => section_with_list(generation, n),
         3 => rsx! {
             ul {
                 for i in 0..n {
@@ -191,23 +202,22 @@ fn fuzz_app() -> Element {
                 }
             }
         },
-        4 => nested_divs(),
-        _ => bare_text(),
+        4 => nested_divs(generation),
+        _ => bare_text(generation),
     }
 }
 
 #[test]
 fn fuzz_template_swaps_do_not_panic() {
-    let mut doc = make_doc(fuzz_app);
+    let mut harness = Harness::new(fuzz_app);
     for _ in 0..1000 {
-        step(&mut doc);
+        harness.step();
     }
 }
 
 /// A keyed list where items are removed and re-added, forcing ElementId reuse
 /// in dioxus-core and NodeId (slab slot) reuse in blitz-dom.
-fn list_app() -> Element {
-    let generation = generation();
+fn list_app(generation: usize) -> Element {
     // Vary the list length up and down so nodes are removed and recreated
     let len = [5usize, 0, 3, 1, 6, 2, 0, 4][generation % 8];
     rsx! {
@@ -226,9 +236,9 @@ fn list_app() -> Element {
 
 #[test]
 fn keyed_list_grow_shrink() {
-    let mut doc = make_doc(list_app);
+    let mut harness = Harness::new(list_app);
     for i in 0..300 {
-        step(&mut doc);
-        assert_no_stale_mappings(&doc, &format!("step {i}"));
+        harness.step();
+        assert_no_stale_mappings(&harness.doc, &format!("step {i}"));
     }
 }


### PR DESCRIPTION
## Summary

Adds `packages/native-dom/tests/stale_node_mapping.rs` with tests that reproduce the "invalid key" slab panic reported in #5182, on latest `main` (blitz-dom `0.3.0-beta.1`). **3 of the 4 tests currently fail** — they encode the desired behavior and should pass once the underlying bug is fixed.

Mechanism (confirmed by these tests):
1. `remove_node`/`replace_node_with` detaches a subtree; `node_id_mapping` entries for the subtree are intentionally kept so dioxus-core can reuse the DOM nodes.
2. `assign_node_id` → `remove_node_if_unparented` later drops the detached subtree, but only the mapping for the ElementId being reassigned is updated. Mappings for *descendants* of the dropped subtree now point at freed slab slots.
3. A freed slot gets reused for a brand-new (not-yet-parented) node, and the stale descendant ElementId is reused by dioxus-core via `AssignId` → `remove_node_if_unparented` incorrectly drops the new node → "invalid key" panic later in the same render (`DocumentMutator::node_at_path` / `add_children_to_parent`), matching the stack trace in #5182.

Tests (driven through a real `VirtualDom` + `DioxusDocument`, re-rendering via `mark_dirty(ScopeId::APP)` + `poll`):
- `template_swaps_do_not_panic`: minimal deterministic repro — panics after just 3 re-renders swapping between three simple templates (`article>div>div`, bare text, `section` with keyed list).
- `template_swaps_do_not_leave_stale_mappings`: asserts the invariant that every `node_id_mapping` entry points at a live node; detects the stale-mapping precursor at step 4.
- `fuzz_template_swaps_do_not_panic`: pseudo-random (deterministic LCG) template mix; panics with "invalid key" within a handful of steps.
- `keyed_list_grow_shrink`: keyed list grow/shrink regression guard (currently passes).

Failing output:
```
thread 'fuzz_template_swaps_do_not_panic' panicked at blitz-dom-0.3.0-beta.1/src/mutator.rs:114:42: invalid key
thread 'template_swaps_do_not_leave_stale_mappings' panicked:
  stale node_id_mapping entries (ElementId, NodeId) after step 4: [(7, 38), (10, 43)]
```

Note: I could not reproduce via the earlier proposed fix path with blitz 0.2.4 because latest main already reproduces; the panic site differs slightly from #5182's trace (`node_at_path` vs `add_children_to_parent`) but is the same root cause — a stale mapping resolving to a freed/reused slab slot.


Link to Devin session: https://app.devin.ai/sessions/07ce0796079c4833b0226b4c1f592eab
Requested by: @nicoburns