### PR TITLE
prevent head rendering inside body when components are placed inside `head {}`

### DIFF
--- a/packages/ssr/src/cache.rs
+++ b/packages/ssr/src/cache.rs
@@ -196,6 +196,17 @@ fn from_template_recursive(
             ..
         } => {
             cur_path.push(root_idx);
+
+            // Elements inside the VirtualDOM tree would render as invalid HTML inside
+            // `<div id="main">`. The browser strips these tags, corrupting the DOM and
+            // breaking hydration. Skip the `<head>` tag entirely — document::* components
+            // (Title, Meta, Link, etc.) register metadata via use_hook, and render_head()
+            // pulls that data out separately to build the real <head> section.
+            if *tag == "head" {
+                cur_path.pop();
+                return Ok(());
+            }
+
             write!(chain, "<{tag}")?;
             // we need to collect the styles and write them at the end
             let mut styles = Vec::new();


### PR DESCRIPTION
When a component uses head tag inside it, e.g.

```rs
fn App() -> Element {
    rsx! {
        head {
          Component1 {}
          Component2 {}
          Component3 {}
          Component4 {}
        }
    }
}
```

that many placeholders used to get rendered inside body with the head tags

```html
<div id="main"><script><!-- some js script -->
</script><head data-node-hydration="0"><!--placeholder1--><!--placeholder2--><!--placeholder3--><!--placeholder4--></head><!-- stuff --></div>
```

this fix skips rendering of all stale head tags and placeholders
since all the `document::*` components they are already rendered inside render_head

after fix:
```html
<div id="main"><script><!-- some js script -->
</script><!-- stuff --></div>
```