### PR TITLE
fix(fullstack): allow the server URL to be set more than once

### DIFF
--- a/packages/fullstack/src/client.rs
+++ b/packages/fullstack/src/client.rs
@@ -9,7 +9,7 @@ use headers::{ContentType, Header};
 use http::{Extensions, HeaderMap, HeaderName, HeaderValue, Method, StatusCode, response::Parts};
 use send_wrapper::SendWrapper;
 use serde::{Serialize, de::DeserializeOwned};
-use std::sync::{LazyLock, Mutex, OnceLock};
+use std::sync::{LazyLock, Mutex, OnceLock, RwLock};
 use std::{fmt::Display, pin::Pin, prelude::rust_2024::Future};
 use url::Url;
 
@@ -497,16 +497,21 @@ impl ClientResponse {
 /// Set the root server URL that all server function paths are relative to for the client.
 ///
 /// If this is not set, it defaults to the origin.
+///
+/// This may be called more than once; the most recent value wins. Requests read
+/// the URL as they are built, so a change applies to the next server function
+/// call. Clients that talk to more than one backend can switch between them
+/// without restarting the process.
 pub fn set_server_url(url: &'static str) {
-    ROOT_URL.set(url).unwrap();
+    *ROOT_URL.write().unwrap() = Some(url);
 }
 
 /// Returns the root server URL for all server functions.
 pub fn get_server_url() -> &'static str {
-    ROOT_URL.get().copied().unwrap_or("")
+    ROOT_URL.read().unwrap().unwrap_or("")
 }
 
-static ROOT_URL: OnceLock<&'static str> = OnceLock::new();
+static ROOT_URL: RwLock<Option<&'static str>> = RwLock::new(None);
 
 /// Delete the extra request headers for all server functions.
 pub fn clear_request_headers() {


### PR DESCRIPTION
`set_server_url` stored the root URL in a `OnceLock` and unwrapped, so a second call panicked — pinning the base URL for the life of the process. A native client that talks to more than one backend can't work with that.

Swaps the `OnceLock` for an `RwLock<Option<&'static str>>` so the most recent value wins. `fetch_inner` already reads the URL per request, so the change applies to the next server-function call with no restart. `get_server_url` still returns `""` when unset, so `launch`'s devserver-default check is unaffected. Mirrors the neighbouring `REQUEST_HEADERS`, already a re-settable `Mutex`.

Also removes a latent panic: the native and web base-path blocks in `launch` can compile into one binary and both call `set_server_url`, the second unconditionally — panicking whenever `base_path()` is `Some`.

Tested: `cargo fmt`, `check`, `clippy -D warnings`, `test --all` all pass.
