### PR TITLE
Fix css_module stylesheets missing from SSR head after the first request

### DIFF
--- a/packages/document/src/elements/link.rs
+++ b/packages/document/src/elements/link.rs
@@ -137,6 +137,31 @@ pub fn Link(props: LinkProps) -> Element {
     VNode::empty()
 }
 
+/// Insert a stylesheet `<link>` element into the head of the current document.
+///
+/// The stylesheet is deduplicated within each document: calling this multiple times with the
+/// same href (or rendering a [`Link`] component with the same href and `rel="stylesheet"`)
+/// only inserts the link once per document.
+pub fn insert_stylesheet(href: &str) {
+    // Deduplicate before creating the head component so that repeated calls with the same
+    // href (e.g. on every render) don't create or consume extra hydration entries.
+    if !should_insert_link(href, Some("stylesheet")) {
+        return;
+    }
+
+    let document = document();
+    if !document.create_head_component() {
+        return;
+    }
+
+    document.create_link(
+        LinkProps::builder()
+            .rel(Some("stylesheet".to_string()))
+            .href(Some(href.to_string()))
+            .build(),
+    );
+}
+
 #[derive(Default, Clone)]
 struct LinkContext(DeduplicationContext);
 

--- a/packages/manganis/manganis-macro/src/css_module.rs
+++ b/packages/manganis/manganis-macro/src/css_module.rs
@@ -112,23 +112,12 @@ pub(crate) fn expand_css_module_struct(
             pub struct __CssIdent { pub inner: &'static str }
 
             use std::ops::Deref;
-            use std::sync::OnceLock;
-            use dioxus::document::{document, LinkProps};
 
             impl Deref for __CssIdent {
                 type Target = str;
 
                 fn deref(&self) -> &Self::Target {
-                    static CELL: OnceLock<()> = OnceLock::new();
-                    CELL.get_or_init(move || {
-                        let doc = document();
-                        doc.create_link(
-                            LinkProps::builder()
-                                .rel(Some("stylesheet".to_string()))
-                                .href(Some(ASSET.to_string()))
-                                .build(),
-                        );
-                    });
+                    dioxus::document::insert_stylesheet(&ASSET.to_string());
 
                     self.inner
                 }


### PR DESCRIPTION
## Summary

Fixes DioxusLabs/dioxus-components#287 ("component rendering takes a while after reloading but is instantaneous after building").

The `#[css_module]`-generated `__CssIdent::deref` injected its stylesheet via `document().create_link(...)` guarded by a **process-global `static OnceLock`**. On a fullstack server the `ServerDocument` collecting head elements is per-request, so only the *first* request after the server boots got the `<link rel="stylesheet">` in the SSR `<head>`. Every subsequent request (i.e. any page reload) was served with no stylesheet link at all, and the page rendered as unstyled text until WASM hydration re-inserted the link client-side.

Reproduced with a minimal fullstack app: the first `curl` of `/` contained the stylesheet link in the head; the second did not.

The fix deduplicates per document (per `VirtualDom`) instead of per process:

- New `dioxus_document::insert_stylesheet(href)` helper that reuses the same root-scope `LinkContext` dedup (keyed `"{href}|stylesheet"`) as the `document::Link` component, then gates on `create_head_component()` so hydration doesn't insert a duplicate link when the server already rendered it:
  ```rust
  pub fn insert_stylesheet(href: &str) {
      // dedup first so repeated calls (deref runs on every render)
      // don't create/consume extra hydration entries
      if !should_insert_link(href, Some("stylesheet")) { return; }
      let document = document();
      if !document.create_head_component() { return; }
      document.create_link(/* rel="stylesheet" href={href} */);
  }
  ```
- The `css_module` macro's generated `Deref` now just calls `dioxus::document::insert_stylesheet(&ASSET.to_string())` instead of the `OnceLock` block.

With this, every SSR request emits the component stylesheet in the head, and hydration skips re-inserting it (previously the client always appended a duplicate link).

Verified: `curl`ing a fullstack repro repeatedly now returns the `<link rel="stylesheet">` in the head on every request; `cargo clippy --workspace --all-features --all-targets -D warnings` and `cargo fmt --check` pass.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/05fa859d90474349a5e9f0880dddbda0
Requested by: @nicoburns
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus/pull/5707?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus/pull/5707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->