### PR TITLE
Fix memory leak when passing mapped stores as component props

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -1760,7 +1760,10 @@ fn remove_option_wrapper(type_: Type) -> Type {
 
 /// Check if a type should be owned by the child component after conversion
 fn child_owned_type(ty: &Type) -> bool {
-    looks_like_signal_type(ty) || looks_like_write_type(ty) || looks_like_callback_type(ty)
+    looks_like_signal_type(ty)
+        || looks_like_write_type(ty)
+        || looks_like_callback_type(ty)
+        || looks_like_store_type(ty)
 }
 
 /// Check if the path without generics matches the type we are looking for


### PR DESCRIPTION
## Summary

Fixes the unbounded memory growth in #5671.

Store-typed props (`Store`/`ReadStore`/`WriteStore`) get `auto_into = true` in the props macro, so a mapped store (e.g. an item from `store.iter()`) passed as a `Store<T>` prop is converted via `From<MappedStore> for WriteStore`, which boxes the lens with `WriteSignal::new_maybe_sync` → `CopyValue::new_maybe_sync`. Because store types were missing from `child_owned_type`, that conversion ran in the parent scope's owner: since `CopyValue` has no `Drop`, each rerender of the parent leaked one boxed lens per store prop until the parent scope was dropped. In the issue's repro (100 items rerendered on every pointermove), that's ~17 KB leaked per render.

The fix adds `looks_like_store_type` to `child_owned_type`, so store prop conversions run inside `with_owner(props.owner, …)` — the same mechanism already used for `ReadSignal`/`WriteSignal`/callback props — and the boxed lens is freed when the props are dropped.

Verified with a counting-allocator harness running the issue's example for 1000 rerenders: heap delta goes from ~17 MB (growing linearly) to flat.

Note: store props still don't participate in the `point_to`/`mark_dirty` memoization that `signal_fields` get in `memoize_impl`; that's a separate (non-leaking) issue.

Fixes #5671

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/671e48ef36ad4dde9bf93eafa654c32c
Requested by: @ealmloff
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus/pull/5711?analyze=true)

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus/pull/5711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->