### PR TITLE
fix(desktop): resolve main from the application library instead of RTLD_DEFAULT (android)

### DIFF
--- a/packages/desktop/src/mobile.rs
+++ b/packages/desktop/src/mobile.rs
@@ -76,7 +76,7 @@ pub extern "C" fn start_app() {
             let info = info.assume_init();
             if info.dli_fname.is_null() {
                 panic!("Current shared library has no filename");
-            }            
+            }
 
             let handle = libc::dlopen(info.dli_fname, libc::RTLD_NOW);
             if handle.is_null() {

--- a/packages/desktop/src/mobile.rs
+++ b/packages/desktop/src/mobile.rs
@@ -67,10 +67,27 @@ pub extern "C" fn start_app() {
         }
 
         stop_unwind(|| unsafe {
-            let mut main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"main\0".as_ptr() as _);
+            let mut info = std::mem::MaybeUninit::<libc::Dl_info>::uninit();
+
+            if libc::dladdr(root as *const () as *const libc::c_void, info.as_mut_ptr()) == 0 {
+                panic!("Failed to resolve the current shared library");
+            }
+
+            let info = info.assume_init();
+            if info.dli_fname.is_null() {
+                panic!("Current shared library has no filename");
+            }            
+
+            let handle = libc::dlopen(info.dli_fname, libc::RTLD_NOW);
+            if handle.is_null() {
+                let error = std::ffi::CStr::from_ptr(libc::dlerror()).to_string_lossy();
+                panic!("Failed to open current shared library: {error}");
+            }
+
+            let mut main_fn_ptr = libc::dlsym(handle, b"main\0".as_ptr() as _);
 
             if main_fn_ptr.is_null() {
-                main_fn_ptr = libc::dlsym(libc::RTLD_DEFAULT, b"_main\0".as_ptr() as _);
+                main_fn_ptr = libc::dlsym(handle, b"_main\0".as_ptr() as _);
             }
 
             if main_fn_ptr.is_null() {


### PR DESCRIPTION
## Problem

On some Android devices, the Android runtime loads system libraries that export a global `main` symbol.

The current implementation resolves the application entry point with:

```rust
libc::dlsym(libc::RTLD_DEFAULT, b"main\0".as_ptr() as _)
```

On the device below, this resolves to `/system/lib/libopus.so` instead of the application's `libmain.so`, causing an immediate crash when the function pointer is invoked.

```
#00 /system/lib/libopus.so (main+33)
#01 dioxus_desktop::mobile::start_app::root::{closure}
```

## Root cause

`RTLD_DEFAULT` searches the global symbol namespace. If another shared library exports `main`, `dlsym` may resolve that symbol instead of the application's entry point.

The application entry point should instead be resolved from the application library itself.

## Fix

Resolve `main` from the application's shared library handle instead of using `RTLD_DEFAULT`.

This keeps the existing `main` symbol and only changes the lookup scope, making the change minimal and avoiding symbol collisions with unrelated shared libraries.

## Reproduced on

* Android 7.1.2 (API 25)
* ABI: `armeabi-v7a`
* Manufacturer: `rockchip`
* Model: `S7`

After resolving `main` from `libmain.so`, the application starts successfully on the same device.

<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus/pull/5714?analyze=true)

> 💡 [Connect your GitHub account](https://dioxus.staging.devinenterprise.com/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus/pull/5714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->