### PR TITLE
fix: plug remaining per-render leaks in converted component props

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -621,9 +621,22 @@ mod struct_info {
             generics
         }
 
-        /// Checks if the props have any fields that should be owned by the child. For example, when converting T to `ReadSignal<T>`, the new signal should be owned by the child
-        fn has_child_owned_fields(&self) -> bool {
-            self.fields.iter().any(|f| child_owned_type(f.ty))
+        /// Checks if the props have any fields whose conversions should run under an owner
+        /// tied to the props struct. Signal-like fields always convert (e.g. T to
+        /// `ReadSignal<T>`), but any `into` conversion or default expression may also
+        /// allocate reactive state (e.g. behind a type alias the macro cannot see through),
+        /// so those run under the props owner as well.
+        fn has_owned_fields(&self) -> bool {
+            fn nontrivial_default(attr: &FieldBuilderAttr) -> bool {
+                attr.default.as_ref().is_some_and(|default| {
+                    *default != parse_quote!(::core::default::Default::default())
+                })
+            }
+            self.fields.iter().any(|f| {
+                child_owned_type(f.ty)
+                    || f.builder_attr.auto_into
+                    || nontrivial_default(&f.builder_attr)
+            })
         }
 
         fn memoize_impl(&self) -> Result<TokenStream, Error> {
@@ -865,7 +878,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                     quote!(#name: #ty)
                 })
                 .chain(
-                    self.has_child_owned_fields()
+                    self.has_owned_fields()
                         .then(|| quote!(owner: dioxus_core::PropsOwner)),
                 );
             let global_fields_value = self
@@ -875,7 +888,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                     quote!(#name: Vec::new())
                 })
                 .chain(
-                    self.has_child_owned_fields()
+                    self.has_owned_fields()
                         .then(|| quote!(owner: dioxus_core::PropsOwner::default())),
                 );
 
@@ -1022,7 +1035,7 @@ Finally, call `.build()` to create the instance of `{name}`.
             });
 
             let forward_owner = self
-                .has_child_owned_fields()
+                .has_owned_fields()
                 .then(|| quote!(owner: self.owner))
                 .into_iter();
 
@@ -1163,15 +1176,18 @@ Finally, call `.build()` to create the instance of `{name}`.
             let arg_type = field_type;
             // If the field is auto_into, we need to add a generic parameter to the builder for specialization
             let mut marker = None;
-            let (arg_type, arg_expr) = if child_owned_type(arg_type) {
+            let (arg_type, arg_expr) = if child_owned_type(arg_type) || field.builder_attr.auto_into
+            {
                 let marker_ident = syn::Ident::new("__Marker", proc_macro2::Span::call_site());
                 marker = Some(marker_ident.clone());
                 (
                     quote!(impl dioxus_core::SuperInto<#arg_type, #marker_ident>),
-                    // If this looks like a signal type, we automatically convert it with SuperInto and use the props struct as the owner
+                    // Signal-like types always convert, and any into conversion may allocate
+                    // reactive state (e.g. a signal type behind an alias the macro cannot see
+                    // through), so run the conversion with the props struct as the owner
                     quote!(dioxus_core::with_props_owner(self.owner.clone(), move || dioxus_core::SuperInto::super_into(#field_name))),
                 )
-            } else if field.builder_attr.auto_into || field.builder_attr.strip_option {
+            } else if field.builder_attr.strip_option {
                 let marker_ident = syn::Ident::new("__Marker", proc_macro2::Span::call_site());
                 marker = Some(marker_ident.clone());
                 (
@@ -1203,10 +1219,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                     let name = f.extends_vec_ident();
                     quote!(#name: self.#name)
                 })
-                .chain(
-                    self.has_child_owned_fields()
-                        .then(|| quote!(owner: self.owner)),
-                );
+                .chain(self.has_owned_fields().then(|| quote!(owner: self.owner)));
 
             Ok(quote! {
                 #[allow(dead_code, non_camel_case_types, missing_docs)]
@@ -1430,12 +1443,9 @@ Finally, call `.build()` to create the instance of `{name}`.
                     // If field has `into`, apply it to the default value.
                     // Ignore any blank defaults as it causes type inference errors.
                     let is_default = *default == parse_quote!(::core::default::Default::default());
-                    // If this is a signal type, we use super_into and the props struct as the owner
-                    let is_child_owned_type = child_owned_type(field.ty);
-
 
                     let body = if !is_default {
-                        if is_child_owned_type {
+                        if child_owned_type(field.ty) {
                             quote!{ dioxus_core::SuperInto::super_into(#default) }
                         } else if field.builder_attr.auto_into {
                             quote!{ (#default).into() }
@@ -1448,12 +1458,14 @@ Finally, call `.build()` to create the instance of `{name}`.
                         default.to_token_stream()
                     };
 
-                    if field.builder_attr.skip {
-                        quote!(let #name = #body;)
-                    } else if is_child_owned_type {
-                        quote!(let #name = #helper_trait_name::into_value(#name, || dioxus_core::with_props_owner(self.owner.clone(), move || #body));)
-                    } else {
-                        quote!(let #name = #helper_trait_name::into_value(#name, || #body);)
+                    // Default expressions may allocate reactive state, so run them under the
+                    // props owner when the builder has one
+                    let wrap_owner = self.has_owned_fields();
+                    match (field.builder_attr.skip, wrap_owner) {
+                        (true, true) => quote!(let #name = dioxus_core::with_props_owner(self.owner.clone(), move || #body);),
+                        (true, false) => quote!(let #name = #body;),
+                        (false, true) => quote!(let #name = #helper_trait_name::into_value(#name, || dioxus_core::with_props_owner(self.owner.clone(), move || #body));),
+                        (false, false) => quote!(let #name = #helper_trait_name::into_value(#name, || #body);),
                     }
                 } else {
                     quote!(let #name = #name.0;)
@@ -1475,7 +1487,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                 quote!()
             };
 
-            if self.has_child_owned_fields() {
+            if self.has_owned_fields() {
                 let name = Ident::new(&format!("{}WithOwner", name), name.span());
                 let original_name = &self.name;
                 let vis = &self.vis;

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -866,7 +866,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                 })
                 .chain(
                     self.has_child_owned_fields()
-                        .then(|| quote!(owner: dioxus_core::internal::generational_box::Owner)),
+                        .then(|| quote!(owner: dioxus_core::PropsOwner)),
                 );
             let global_fields_value = self
                 .extend_fields()
@@ -874,9 +874,10 @@ Finally, call `.build()` to create the instance of `{name}`.
                     let name = f.extends_vec_ident();
                     quote!(#name: Vec::new())
                 })
-                .chain(self.has_child_owned_fields().then(
-                    || quote!(owner: dioxus_core::internal::generational_box::Owner::default()),
-                ));
+                .chain(
+                    self.has_child_owned_fields()
+                        .then(|| quote!(owner: dioxus_core::PropsOwner::default())),
+                );
 
             Ok(quote! {
                 impl #impl_generics #name #ty_generics #where_clause {
@@ -1168,7 +1169,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                 (
                     quote!(impl dioxus_core::SuperInto<#arg_type, #marker_ident>),
                     // If this looks like a signal type, we automatically convert it with SuperInto and use the props struct as the owner
-                    quote!(dioxus_core::with_owner(self.owner.clone(), move || dioxus_core::SuperInto::super_into(#field_name))),
+                    quote!(dioxus_core::with_props_owner(self.owner.clone(), move || dioxus_core::SuperInto::super_into(#field_name))),
                 )
             } else if field.builder_attr.auto_into || field.builder_attr.strip_option {
                 let marker_ident = syn::Ident::new("__Marker", proc_macro2::Span::call_site());
@@ -1450,7 +1451,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                     if field.builder_attr.skip {
                         quote!(let #name = #body;)
                     } else if is_child_owned_type {
-                        quote!(let #name = #helper_trait_name::into_value(#name, || dioxus_core::with_owner(self.owner.clone(), move || #body));)
+                        quote!(let #name = #helper_trait_name::into_value(#name, || dioxus_core::with_props_owner(self.owner.clone(), move || #body));)
                     } else {
                         quote!(let #name = #helper_trait_name::into_value(#name, || #body);)
                     }
@@ -1486,7 +1487,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                     #[allow(dead_code, non_camel_case_types, missing_docs)]
                     #vis struct #name #generics_with_bounds #where_clause {
                         inner: #original_name #ty_generics,
-                        owner: dioxus_core::internal::generational_box::Owner,
+                        owner: dioxus_core::PropsOwner,
                     }
 
                     impl #original_impl_generics PartialEq for #name #ty_generics #where_clause {

--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -621,11 +621,8 @@ mod struct_info {
             generics
         }
 
-        /// Checks if the props have any fields whose conversions should run under an owner
-        /// tied to the props struct. Signal-like fields always convert (e.g. T to
-        /// `ReadSignal<T>`), but any `into` conversion or default expression may also
-        /// allocate reactive state (e.g. behind a type alias the macro cannot see through),
-        /// so those run under the props owner as well.
+        /// Checks if the props have any fields whose conversions or defaults may allocate
+        /// state that should be owned by the props struct
         fn has_owned_fields(&self) -> bool {
             fn nontrivial_default(attr: &FieldBuilderAttr) -> bool {
                 attr.default.as_ref().is_some_and(|default| {
@@ -1182,9 +1179,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                 marker = Some(marker_ident.clone());
                 (
                     quote!(impl dioxus_core::SuperInto<#arg_type, #marker_ident>),
-                    // Signal-like types always convert, and any into conversion may allocate
-                    // reactive state (e.g. a signal type behind an alias the macro cannot see
-                    // through), so run the conversion with the props struct as the owner
+                    // The conversion may allocate reactive state, so run it with the props struct as the owner
                     quote!(dioxus_core::with_props_owner(self.owner.clone(), move || dioxus_core::SuperInto::super_into(#field_name))),
                 )
             } else if field.builder_attr.strip_option {
@@ -1458,8 +1453,7 @@ Finally, call `.build()` to create the instance of `{name}`.
                         default.to_token_stream()
                     };
 
-                    // Default expressions may allocate reactive state, so run them under the
-                    // props owner when the builder has one
+                    // Default expressions may allocate reactive state, so run them under the props owner
                     let wrap_owner = self.has_owned_fields();
                     match (field.builder_attr.skip, wrap_owner) {
                         (true, true) => quote!(let #name = dioxus_core::with_props_owner(self.owner.clone(), move || #body);),

--- a/packages/core/src/generational_box.rs
+++ b/packages/core/src/generational_box.rs
@@ -18,9 +18,8 @@ pub fn with_owner<S: AnyStorage, F: FnOnce() -> R, R>(owner: Owner<S>, f: F) -> 
     result
 }
 
-/// Owners for both storage types. Generated props structs hold one of these so that any
-/// state allocated while converting props is dropped with the props, regardless of
-/// which storage backs the state.
+/// Owners for both storage types, used by generated props structs so that state
+/// allocated while converting props is dropped with the props
 #[doc(hidden)]
 #[derive(Clone, Default)]
 pub struct PropsOwner {
@@ -29,8 +28,6 @@ pub struct PropsOwner {
 }
 
 /// Run a closure with both owners of the given [`PropsOwner`].
-///
-/// This will override the default owner for the current component for both storage types.
 #[doc(hidden)]
 pub fn with_props_owner<F: FnOnce() -> R, R>(owner: PropsOwner, f: F) -> R {
     let PropsOwner { unsync, sync } = owner;

--- a/packages/core/src/generational_box.rs
+++ b/packages/core/src/generational_box.rs
@@ -18,6 +18,25 @@ pub fn with_owner<S: AnyStorage, F: FnOnce() -> R, R>(owner: Owner<S>, f: F) -> 
     result
 }
 
+/// Owners for both storage types. Generated props structs hold one of these so that any
+/// state allocated while converting props is dropped with the props, regardless of
+/// which storage backs the state.
+#[doc(hidden)]
+#[derive(Clone, Default)]
+pub struct PropsOwner {
+    unsync: Owner<UnsyncStorage>,
+    sync: Owner<SyncStorage>,
+}
+
+/// Run a closure with both owners of the given [`PropsOwner`].
+///
+/// This will override the default owner for the current component for both storage types.
+#[doc(hidden)]
+pub fn with_props_owner<F: FnOnce() -> R, R>(owner: PropsOwner, f: F) -> R {
+    let PropsOwner { unsync, sync } = owner;
+    with_owner(unsync, move || with_owner(sync, f))
+}
+
 /// Set the owner for the current thread.
 fn set_owner<S: AnyStorage>(owner: Option<Owner<S>>) -> Option<Owner<S>> {
     let id = TypeId::of::<S>();

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -97,8 +97,8 @@ pub use crate::innerlude::{
     ComponentFunction, DynamicNode, Element, ElementId, ErrorBoundary, ErrorContext, Event,
     EventHandler, Fragment, HasAttributes, IntoAttributeValue, IntoDynNode, LaunchConfig,
     ListenerCallback, MarkerWrapper, Mutation, Mutations, NoOpMutations, OptionStringFromMarker,
-    Properties, ReactiveContext, RenderError, Result, Runtime, RuntimeGuard, ScopeId, ScopeState,
-    SpawnIfAsync, SubscriberList, Subscribers, SuperFrom, SuperInto, SuspendedFuture,
+    Properties, PropsOwner, ReactiveContext, RenderError, Result, Runtime, RuntimeGuard, ScopeId,
+    ScopeState, SpawnIfAsync, SubscriberList, Subscribers, SuperFrom, SuperInto, SuspendedFuture,
     SuspenseBoundary, SuspenseBoundaryProps, SuspenseContext, Task, Template, TemplateAttribute,
     TemplateNode, VComponent, VNode, VNodeInner, VPlaceholder, VText, VirtualDom, WriteMutations,
     anyhow, consume_context, consume_context_from_scope, current_owner, current_scope_id,
@@ -106,7 +106,7 @@ pub use crate::innerlude::{
     provide_context, provide_create_error_boundary, provide_root_context, queue_effect,
     remove_future, schedule_update, schedule_update_any, spawn, spawn_forever, spawn_isomorphic,
     suspend, throw_error, try_consume_context, use_after_render, use_before_render, use_drop,
-    use_hook, use_hook_with_cleanup, with_owner,
+    use_hook, use_hook_with_cleanup, with_owner, with_props_owner,
 };
 
 /// Equivalent to `Ok::<_, dioxus::CapturedError>(value)`.

--- a/packages/core/src/reactive_context.rs
+++ b/packages/core/src/reactive_context.rs
@@ -252,8 +252,7 @@ impl ReactiveContext {
         }
     }
 
-    /// Unsubscribe this context from a subscriber list. This removes the context from the
-    /// list and drops the context's reference to the list.
+    /// Unsubscribe this context from a subscriber list
     pub fn unsubscribe(&self, subscriptions: impl Into<Subscribers>) {
         let subscriptions = subscriptions.into();
         subscriptions.remove(self);

--- a/packages/core/src/reactive_context.rs
+++ b/packages/core/src/reactive_context.rs
@@ -252,6 +252,16 @@ impl ReactiveContext {
         }
     }
 
+    /// Unsubscribe this context from a subscriber list. This removes the context from the
+    /// list and drops the context's reference to the list.
+    pub fn unsubscribe(&self, subscriptions: impl Into<Subscribers>) {
+        let subscriptions = subscriptions.into();
+        subscriptions.remove(self);
+        if let Ok(mut inner) = self.inner.try_write() {
+            inner.subscribers.remove(&PointerHash(subscriptions.inner));
+        }
+    }
+
     /// Get the scope that inner CopyValue is associated with
     pub fn origin_scope(&self) -> ScopeId {
         self.scope
@@ -365,6 +375,11 @@ impl Subscribers {
     /// Visit all subscribers in the list.
     pub fn visit(&self, mut f: impl FnMut(&ReactiveContext)) {
         self.inner.visit(&mut f);
+    }
+
+    /// Check if two subscriber lists point to the same underlying list.
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        std::ptr::addr_eq(Arc::as_ptr(&self.inner), Arc::as_ptr(&other.inner))
     }
 }
 

--- a/packages/core/src/suspense/component.rs
+++ b/packages/core/src/suspense/component.rs
@@ -26,7 +26,7 @@ impl SuspenseBoundaryProps {
     #[allow(dead_code, clippy::type_complexity)]
     fn builder() -> SuspenseBoundaryPropsBuilder<((), ())> {
         SuspenseBoundaryPropsBuilder {
-            owner: Owner::default(),
+            owner: PropsOwner::default(),
             fields: ((), ()),
             _phantom: ::core::default::Default::default(),
         }
@@ -36,7 +36,7 @@ impl SuspenseBoundaryProps {
 #[doc(hidden)]
 #[allow(dead_code, non_camel_case_types, non_snake_case)]
 pub struct SuspenseBoundaryPropsBuilder<TypedBuilderFields> {
-    owner: Owner,
+    owner: PropsOwner,
     fields: TypedBuilderFields,
     _phantom: (),
 }
@@ -80,7 +80,7 @@ impl<__children> SuspenseBoundaryPropsBuilder<((), __children)> {
         self,
         fallback: impl SuperInto<Callback<SuspenseContext, Element>, __Marker>,
     ) -> SuspenseBoundaryPropsBuilder<((Callback<SuspenseContext, Element>,), __children)> {
-        let fallback = (with_owner(self.owner.clone(), move || {
+        let fallback = (with_props_owner(self.owner.clone(), move || {
             SuperInto::super_into(fallback)
         }),);
         let (_, children) = self.fields;
@@ -155,7 +155,7 @@ impl<__children> SuspenseBoundaryPropsBuilder<((), __children)> {
 #[allow(dead_code, non_camel_case_types, missing_docs)]
 pub struct SuspenseBoundaryPropsWithOwner {
     inner: SuspenseBoundaryProps,
-    owner: Owner,
+    owner: PropsOwner,
 }
 #[automatically_derived]
 #[allow(dead_code, non_camel_case_types, missing_docs)]
@@ -254,7 +254,6 @@ mod SuspenseBoundary_completions {
 }
 #[allow(unused)]
 pub use SuspenseBoundary_completions::Component::SuspenseBoundary;
-use generational_box::Owner;
 
 /// Suspense has a custom diffing algorithm that diffs the suspended nodes in the background without rendering them
 impl SuspenseBoundaryProps {

--- a/packages/core/tests/props_memory_leak.rs
+++ b/packages/core/tests/props_memory_leak.rs
@@ -35,6 +35,9 @@ static ALLOCATOR: CountingAllocator = CountingAllocator;
 const WARMUP: usize = 200;
 const ITERS: usize = 1000;
 
+// Tests in this binary share the global allocator counter, so they must not run concurrently
+static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Rerender the app many times and return the growth in live heap bytes per render.
 fn bytes_leaked_per_render(app: fn() -> Element) -> f64 {
     let mut dom = VirtualDom::new(app);
@@ -103,6 +106,7 @@ fn DefaultStoreProp(#[props(default = Store::new(5))] id: Store<usize>) -> Eleme
 
 #[test]
 fn store_props_do_not_leak() {
+    let _guard = TEST_LOCK.lock().unwrap();
     // Mapped stores passed as Store/ReadStore/WriteStore props (issue #5671)
     assert_no_leak("Store<T> prop from mapped store", || {
         let data: Store<Vec<usize>> = use_store(|| (0..20).collect());
@@ -141,6 +145,7 @@ fn store_props_do_not_leak() {
 
 #[test]
 fn signal_props_do_not_leak() {
+    let _guard = TEST_LOCK.lock().unwrap();
     assert_no_leak("ReadSignal<T> prop from mapped signal", || {
         let data: Signal<Vec<usize>> = use_signal(|| (0..20).collect());
         rsx! {
@@ -169,6 +174,21 @@ fn signal_props_do_not_leak() {
             }
         },
     );
+    // The macro cannot see through type aliases, but explicit `#[props(into)]` conversions
+    // must still run under the props owner so any allocated state dies with the props
+    type AliasSignal = ReadSignal<usize>;
+    #[component]
+    fn AliasSignalProp(#[props(into)] id: AliasSignal) -> Element {
+        rsx!(div { "{id}" })
+    }
+    assert_no_leak("aliased ReadSignal prop with #[props(into)]", || {
+        let data: Signal<Vec<usize>> = use_signal(|| (0..20).collect());
+        rsx! {
+            for i in 0..20 {
+                AliasSignalProp { id: data.map(move |v| &v[i]) }
+            }
+        }
+    });
     // Plain values converted into ReadSignal props create a fresh signal on every render.
     // The point_to memoization must not accumulate stale subscriptions in the child.
     assert_no_leak("ReadSignal<String> prop from plain value", || {

--- a/packages/core/tests/props_memory_leak.rs
+++ b/packages/core/tests/props_memory_leak.rs
@@ -35,7 +35,7 @@ static ALLOCATOR: CountingAllocator = CountingAllocator;
 const WARMUP: usize = 200;
 const ITERS: usize = 1000;
 
-// Tests in this binary share the global allocator counter, so they must not run concurrently
+// Tests share the global allocator counter, so they must not run concurrently
 static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Rerender the app many times and return the growth in live heap bytes per render.
@@ -132,8 +132,7 @@ fn store_props_do_not_leak() {
             }
         }
     });
-    // Store::new allocates sync state for its subscription tree. If a store prop has a
-    // default value, that state must be owned by the props, not leaked into the parent scope.
+    // Store::new allocates sync state that must be owned by the props
     assert_no_leak("Store<T> prop with default value", || {
         rsx! {
             for _ in 0..20 {
@@ -162,7 +161,6 @@ fn signal_props_do_not_leak() {
             }
         }
     });
-    // Sync signals allocate with SyncStorage, which is owned separately from UnsyncStorage
     assert_no_leak(
         "ReadSignal<T, SyncStorage> prop from sync mapped signal",
         || {
@@ -174,8 +172,8 @@ fn signal_props_do_not_leak() {
             }
         },
     );
-    // The macro cannot see through type aliases, but explicit `#[props(into)]` conversions
-    // must still run under the props owner so any allocated state dies with the props
+    // The macro cannot see through type aliases, but `#[props(into)]` conversions
+    // must still run under the props owner
     type AliasSignal = ReadSignal<usize>;
     #[component]
     fn AliasSignalProp(#[props(into)] id: AliasSignal) -> Element {
@@ -189,8 +187,8 @@ fn signal_props_do_not_leak() {
             }
         }
     });
-    // Plain values converted into ReadSignal props create a fresh signal on every render.
-    // The point_to memoization must not accumulate stale subscriptions in the child.
+    // Value-converted props create a fresh signal every render; point_to memoization
+    // must not accumulate stale subscriptions
     assert_no_leak("ReadSignal<String> prop from plain value", || {
         rsx! {
             for i in 0..20 {

--- a/packages/core/tests/props_memory_leak.rs
+++ b/packages/core/tests/props_memory_leak.rs
@@ -1,0 +1,181 @@
+//! Regression tests for per-render memory leaks in converted component props.
+//! https://github.com/DioxusLabs/dioxus/issues/5671
+#![allow(non_snake_case)]
+
+use dioxus::prelude::dioxus_core::NoOpMutations;
+use dioxus::prelude::*;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicIsize, Ordering};
+
+struct CountingAllocator;
+
+static LIVE_BYTES: AtomicIsize = AtomicIsize::new(0);
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        LIVE_BYTES.fetch_add(layout.size() as isize, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        LIVE_BYTES.fetch_sub(layout.size() as isize, Ordering::Relaxed);
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        LIVE_BYTES.fetch_add(
+            new_size as isize - layout.size() as isize,
+            Ordering::Relaxed,
+        );
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+const WARMUP: usize = 200;
+const ITERS: usize = 1000;
+
+/// Rerender the app many times and return the growth in live heap bytes per render.
+fn bytes_leaked_per_render(app: fn() -> Element) -> f64 {
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild_in_place();
+    for _ in 0..WARMUP {
+        dom.mark_dirty(ScopeId::APP);
+        dom.render_immediate(&mut NoOpMutations);
+    }
+    let start = LIVE_BYTES.load(Ordering::Relaxed);
+    for _ in 0..ITERS {
+        dom.mark_dirty(ScopeId::APP);
+        dom.render_immediate(&mut NoOpMutations);
+    }
+    let end = LIVE_BYTES.load(Ordering::Relaxed);
+    (end - start) as f64 / ITERS as f64
+}
+
+#[track_caller]
+fn assert_no_leak(name: &str, app: fn() -> Element) {
+    let per_render = bytes_leaked_per_render(app);
+    assert!(
+        per_render < 16.0,
+        "{name} leaked {per_render} bytes per render"
+    );
+}
+
+#[component]
+fn StoreProp(id: Store<usize>) -> Element {
+    rsx!(div { "{id}" })
+}
+
+#[component]
+fn ReadStoreProp(id: ReadStore<usize>) -> Element {
+    rsx!(div { "{id}" })
+}
+
+#[component]
+fn WriteStoreProp(id: WriteStore<usize>) -> Element {
+    rsx!(div { "{id}" })
+}
+
+#[component]
+fn ReadSignalProp(id: ReadSignal<usize>) -> Element {
+    rsx!(div { "{id}" })
+}
+
+#[component]
+fn SyncReadSignalProp(id: ReadSignal<usize, SyncStorage>) -> Element {
+    rsx!(div { "{id}" })
+}
+
+#[component]
+fn WriteSignalProp(id: WriteSignal<usize>) -> Element {
+    rsx!(div { "{id}" })
+}
+
+#[component]
+fn ReadSignalStringProp(val: ReadSignal<String>) -> Element {
+    rsx!(div { "{val}" })
+}
+
+#[component]
+fn DefaultStoreProp(#[props(default = Store::new(5))] id: Store<usize>) -> Element {
+    rsx!(div { "{id}" })
+}
+
+#[test]
+fn store_props_do_not_leak() {
+    // Mapped stores passed as Store/ReadStore/WriteStore props (issue #5671)
+    assert_no_leak("Store<T> prop from mapped store", || {
+        let data: Store<Vec<usize>> = use_store(|| (0..20).collect());
+        rsx! {
+            for id in data.iter() {
+                StoreProp { id }
+            }
+        }
+    });
+    assert_no_leak("ReadStore<T> prop from mapped store", || {
+        let data: Store<Vec<usize>> = use_store(|| (0..20).collect());
+        rsx! {
+            for id in data.iter() {
+                ReadStoreProp { id }
+            }
+        }
+    });
+    assert_no_leak("WriteStore<T> prop from mapped store", || {
+        let data: Store<Vec<usize>> = use_store(|| (0..20).collect());
+        rsx! {
+            for id in data.iter() {
+                WriteStoreProp { id }
+            }
+        }
+    });
+    // Store::new allocates sync state for its subscription tree. If a store prop has a
+    // default value, that state must be owned by the props, not leaked into the parent scope.
+    assert_no_leak("Store<T> prop with default value", || {
+        rsx! {
+            for _ in 0..20 {
+                DefaultStoreProp {}
+            }
+        }
+    });
+}
+
+#[test]
+fn signal_props_do_not_leak() {
+    assert_no_leak("ReadSignal<T> prop from mapped signal", || {
+        let data: Signal<Vec<usize>> = use_signal(|| (0..20).collect());
+        rsx! {
+            for i in 0..20 {
+                ReadSignalProp { id: data.map(move |v| &v[i]) }
+            }
+        }
+    });
+    assert_no_leak("WriteSignal<T> prop from mapped signal", || {
+        let data: Signal<Vec<usize>> = use_signal(|| (0..20).collect());
+        rsx! {
+            for i in 0..20 {
+                WriteSignalProp { id: data.map_mut(move |v| &v[i], move |v| &mut v[i]) }
+            }
+        }
+    });
+    // Sync signals allocate with SyncStorage, which is owned separately from UnsyncStorage
+    assert_no_leak(
+        "ReadSignal<T, SyncStorage> prop from sync mapped signal",
+        || {
+            let data: Signal<Vec<usize>, SyncStorage> = use_signal_sync(|| (0..20).collect());
+            rsx! {
+                for i in 0..20 {
+                    SyncReadSignalProp { id: data.map(move |v| &v[i]) }
+                }
+            }
+        },
+    );
+    // Plain values converted into ReadSignal props create a fresh signal on every render.
+    // The point_to memoization must not accumulate stale subscriptions in the child.
+    assert_no_leak("ReadSignal<String> prop from plain value", || {
+        rsx! {
+            for i in 0..20 {
+                ReadSignalStringProp { val: format!("value {i}") }
+            }
+        }
+    });
+}

--- a/packages/signals/src/boxed.rs
+++ b/packages/signals/src/boxed.rs
@@ -49,8 +49,7 @@ impl<T: ?Sized + 'static, S: BoxedSignalStorage<T>> ReadSignal<T, S> {
             this_subscribers.visit(|subscriber| this_subscribers_vec.push(*subscriber));
             for subscriber in this_subscribers_vec {
                 subscriber.subscribe(other_subscribers.clone());
-                // Drop the subscription to the old list; the old value is being replaced,
-                // so keeping it would accumulate stale subscriptions on every point_to
+                // Drop the subscription to the old list so stale subscriptions don't accumulate
                 subscriber.unsubscribe(this_subscribers.clone());
             }
         }

--- a/packages/signals/src/boxed.rs
+++ b/packages/signals/src/boxed.rs
@@ -42,12 +42,17 @@ impl<T: ?Sized + 'static, S: BoxedSignalStorage<T>> ReadSignal<T, S> {
     /// Point to another [ReadSignal]. This will subscribe the other [ReadSignal] to all subscribers of this [ReadSignal].
     pub fn point_to(&self, other: Self) -> BorrowResult {
         let this_subscribers = self.subscribers();
-        let mut this_subscribers_vec = Vec::new();
-        // Note we don't subscribe directly in the visit closure to avoid a deadlock when pointing to self
-        this_subscribers.visit(|subscriber| this_subscribers_vec.push(*subscriber));
         let other_subscribers = other.subscribers();
-        for subscriber in this_subscribers_vec {
-            subscriber.subscribe(other_subscribers.clone());
+        if !this_subscribers.ptr_eq(&other_subscribers) {
+            let mut this_subscribers_vec = Vec::new();
+            // Note we don't subscribe directly in the visit closure to avoid a deadlock when pointing to self
+            this_subscribers.visit(|subscriber| this_subscribers_vec.push(*subscriber));
+            for subscriber in this_subscribers_vec {
+                subscriber.subscribe(other_subscribers.clone());
+                // Drop the subscription to the old list; the old value is being replaced,
+                // so keeping it would accumulate stale subscriptions on every point_to
+                subscriber.unsubscribe(this_subscribers.clone());
+            }
         }
         self.value.point_to(other.value)?;
         Ok(())

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -237,8 +237,7 @@ impl<T, S: Storage<SignalData<T>>> Signal<T, S> {
             let this_subscribers = this_subscriber_list.lock().unwrap().clone();
             for subscriber in this_subscribers.iter() {
                 subscriber.subscribe(other_subscriber_list.clone());
-                // Drop the subscription to the old list; the old value is being replaced,
-                // so keeping it would accumulate stale subscriptions on every point_to
+                // Drop the subscription to the old list so stale subscriptions don't accumulate
                 subscriber.unsubscribe(this_subscriber_list.clone());
             }
         }

--- a/packages/signals/src/signal.rs
+++ b/packages/signals/src/signal.rs
@@ -230,11 +230,17 @@ impl<T, S: Storage<SignalData<T>>> Signal<T, S> {
     where
         T: 'static,
     {
-        #[allow(clippy::mutable_key_type)]
-        let this_subscribers = self.inner.value.read().subscribers.lock().unwrap().clone();
-        let other_read = other.inner.value.read();
-        for subscriber in this_subscribers.iter() {
-            subscriber.subscribe(other_read.subscribers.clone());
+        let this_subscriber_list = self.inner.value.read().subscribers.clone();
+        let other_subscriber_list = other.inner.value.read().subscribers.clone();
+        if !std::sync::Arc::ptr_eq(&this_subscriber_list, &other_subscriber_list) {
+            #[allow(clippy::mutable_key_type)]
+            let this_subscribers = this_subscriber_list.lock().unwrap().clone();
+            for subscriber in this_subscribers.iter() {
+                subscriber.subscribe(other_subscriber_list.clone());
+                // Drop the subscription to the old list; the old value is being replaced,
+                // so keeping it would accumulate stale subscriptions on every point_to
+                subscriber.unsubscribe(this_subscriber_list.clone());
+            }
         }
         self.inner.point_to(other.inner)
     }


### PR DESCRIPTION
## Summary

Follow-up to #5711: a counting-allocator harness run over ~28 prop/macro permutations found three more classes of unbounded per-render growth that the child-owned-props fix didn't cover.

**1. Sync-storage allocations escape the props owner.** The generated props owner was a single `Owner<UnsyncStorage>`, and `with_owner` only overrides the thread-local owner for one storage type. Any `SyncStorage` allocation made during a prop conversion fell back to the *parent scope's* sync owner and leaked once per render:

- `ReadSignal<T, SyncStorage>` props converted from sync mapped signals (~2.5 KB/render in the harness — the exact #5671 bug, sync flavor)
- `#[props(default = Store::new(..))]` store props (`StoreSubscriptions` is always `CopyValue<_, SyncStorage>`; ~10 KB/render)

Fix: props now hold a `PropsOwner { unsync: Owner<UnsyncStorage>, sync: Owner<SyncStorage> }` and conversions run under `with_props_owner`, which overrides both thread-local owners. Updated the props macro codegen and the hand-expanded `SuspenseBoundaryProps` builder.

**2. `point_to` memoization accumulates stale subscriptions.** Props like `val: ReadSignal<String>` set from a plain value create a fresh signal (with a fresh subscriber list) every parent render. Memoization then runs `old.point_to(new)`, which did:

```rust
for subscriber in old.subscribers() {
    subscriber.subscribe(new_subscriber_list.clone()); // adds a new Arc to the RC's HashSet
}
```

Since the memoized child never reruns, its `ReactiveContext` never clears subscriptions, so it accumulated one dead subscriber-list `Arc` per render (~5 KB/render for 20 children). Fix: added `ReactiveContext::unsubscribe`, and `ReadSignal::point_to` / `Signal::point_to` now drop the subscription to the old list after moving subscribers to the new one (guarded by `Subscribers::ptr_eq` so pointing at a signal sharing the same list — e.g. mapped signals over the same source — doesn't unsubscribe the child from a live list).

**3. `#[props(into)]` conversions the macro can't classify run in the parent owner.** `child_owned_type` matches on the written type name, so a signal behind a type alias (e.g. `type AliasSignal = ReadSignal<usize>;` + `#[props(into)]`) was treated as a regular into-field and converted *outside* `with_props_owner` (~6 KB/render). Fix: `has_child_owned_fields` was broadened to `has_owned_fields` (signal-like, `auto_into`, or a non-blank default), and all `into` conversions and default expressions now run under the props owner. Structs with only trivial fields (children, plain `Option<T>` props, blank `Default::default()` defaults) still skip owner creation, so the common paths pay no extra allocation.

**Verified:** ~28 permutations flat over 2000 rerenders (mapped store/signal props across Store/ReadStore/WriteStore/ReadSignal/WriteSignal/ReadOnlySignal, sync storage, defaults, aliases, callbacks, Option handlers, spread/extends attrs, SuspenseBoundary fallbacks, pass-through chains, element listeners, use_callback). Added `packages/core/tests/props_memory_leak.rs` as regression coverage.

**Known remaining footgun (not fixable in the macro):** explicitly converting in the render body, e.g. `OptChild { id: Store::from(item) }` or `ReadSignal::from(sig)` for an `Option<...>`-typed prop, allocates under the parent scope and still grows per render — the conversion happens before the setter, same class as calling `Signal::new` in a render body. Option-wrapped signal/store props currently have no `SuperFrom` impls, so the macro never sees an unconverted value for them.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/893180b21fbb4d40874a9ec85d17f4b3
Requested by: @jkelleyrtp