### PR TITLE
fix(rsx): evaluate borrow-only formats first and event handlers last

### DIFF
--- a/packages/core-macro/tests/rsx.rs
+++ b/packages/core-macro/tests/rsx.rs
@@ -148,3 +148,106 @@ mod test_optional_signals {
         rsx! { "hi!" }
     }
 }
+
+/// rsx evaluates expressions in three tiers: formatted strings that only borrow, then everything
+/// else in source order, then event handlers. These are compile-time tests for the patterns that
+/// ordering is supposed to keep working.
+///
+/// See https://github.com/DioxusLabs/dioxus/issues/3737
+#[cfg(test)]
+#[allow(unused)]
+mod test_evaluation_order {
+    use dioxus::prelude::*;
+
+    #[component]
+    fn TakesString(text: String) -> Element {
+        rsx! { "{text}" }
+    }
+
+    #[component]
+    fn TakesCallback(label: String, onpick: EventHandler<()>) -> Element {
+        rsx! { "{label}" }
+    }
+
+    fn consume(_: String) {}
+
+    /// An attribute that borrows can be written before a child that moves
+    fn attribute_then_component() -> Element {
+        let text = String::from("hello");
+        rsx! {
+            div { width: "{text}",
+                TakesString { text }
+            }
+        }
+    }
+
+    /// A component that borrows can be written before an attribute that moves
+    fn component_then_attribute() -> Element {
+        let text = String::from("hello");
+        rsx! {
+            div {
+                TakesString { text: "{text}" }
+                div { width: text }
+            }
+        }
+    }
+
+    /// Event handlers are evaluated last, so a handler can move a value that a formatted string
+    /// somewhere else in the template borrows
+    fn handler_then_formatted() -> Element {
+        let text = String::from("hello");
+        rsx! {
+            div {
+                button { onclick: move |_| consume(text.clone()), "pick" }
+                span { "{text}" }
+            }
+        }
+    }
+
+    /// ...including when the formatted string is an attribute, or nested deeper in the tree
+    fn handler_then_nested_formatted() -> Element {
+        let text = String::from("hello");
+        rsx! {
+            div { onclick: move |_| consume(text.clone()),
+                div {
+                    span { class: "{text}", "{text}" }
+                }
+            }
+        }
+    }
+
+    /// Callback props are applied to the props builder after the props that only borrow
+    fn callback_prop_then_prop() -> Element {
+        let text = String::from("hello");
+        rsx! {
+            TakesCallback {
+                onpick: move |_| consume(text.clone()),
+                label: "{text}",
+            }
+        }
+    }
+
+    /// The shape of every list row: a handler that owns the item and a label that displays it
+    fn list_row() -> Element {
+        let items = vec![String::from("a"), String::from("b")];
+        rsx! {
+            for item in items {
+                div { key: "{item}",
+                    button { onclick: move |_| consume(item.clone()), "pick" }
+                    span { "{item}" }
+                }
+            }
+        }
+    }
+
+    /// Formatted strings only borrow, so they can be written after the value is moved elsewhere
+    fn move_then_formatted_sibling() -> Element {
+        let text = String::from("hello");
+        rsx! {
+            div {
+                TakesString { text: text.clone() }
+                span { "{text}" }
+            }
+        }
+    }
+}

--- a/packages/rsx-rosetta/src/lib.rs
+++ b/packages/rsx-rosetta/src/lib.rs
@@ -146,6 +146,7 @@ pub fn collect_svgs(children: &mut [BodyNode], out: &mut Vec<BodyNode>) {
                     brace: Some(Default::default()),
                     dyn_idx: Default::default(),
                     component_literal_dyn_idx: vec![],
+                    prop_bindings: vec![],
                 });
 
                 std::mem::swap(child, &mut new_comp);

--- a/packages/rsx/src/assign_dyn_ids.rs
+++ b/packages/rsx/src/assign_dyn_ids.rs
@@ -1,4 +1,7 @@
+use syn::parse_quote;
+
 use crate::attribute::Attribute;
+use crate::expression_pool::Tier;
 use crate::{
     AttributeValue, BodyNode, HotLiteral, HotReloadFormattedSegment, Segment, TemplateBody,
 };
@@ -35,10 +38,10 @@ impl<'a> DynIdVisitor<'a> {
             BodyNode::Element(el) => {
                 for (idx, attr) in el.merged_attributes.iter().enumerate() {
                     if !attr.is_static_str_literal() {
-                        self.assign_path_to_attribute(attr, idx);
                         if let AttributeValue::AttrLiteral(HotLiteral::Fmted(lit)) = &attr.value {
                             self.assign_formatted_segment(lit);
                         }
+                        self.assign_path_to_attribute(attr, idx);
                     }
                 }
                 // Assign formatted segments to the key which is not included in the merged_attributes
@@ -52,32 +55,52 @@ impl<'a> DynIdVisitor<'a> {
             // Text nodes are dynamic if they contain dynamic segments
             BodyNode::Text(txt) => {
                 if !txt.is_static() {
-                    self.assign_path_to_node(node);
                     self.assign_formatted_segment(&txt.input);
+                    let tier = crate::expression_pool::fmt_tier(&txt.input);
+                    self.assign_path_to_node(node, tier);
                 }
             }
 
             // Raw exprs are always dynamic
             BodyNode::RawExpr(_) | BodyNode::ForLoop(_) | BodyNode::IfChain(_) => {
-                self.assign_path_to_node(node)
+                self.assign_path_to_node(node, Tier::Unknown)
             }
             BodyNode::Component(component) => {
-                self.assign_path_to_node(node);
                 let mut index = 0;
+                let mut prop_index = 0;
                 for property in &component.fields {
+                    let is_key = property.name.is_likely_key();
                     if let AttributeValue::AttrLiteral(literal) = &property.value {
                         if let HotLiteral::Fmted(segments) = literal {
                             self.assign_formatted_segment(segments);
                         }
                         // Don't include keys in the component dynamic pool
-                        if !property.name.is_likely_key() {
+                        if !is_key {
                             component.component_literal_dyn_idx[index]
                                 .set(self.component_literal_index);
                             self.component_literal_index += 1;
                             index += 1;
+
+                            // Props that are provably-borrowing formatted strings get pulled into
+                            // the expression pool on their own so they can be evaluated before the
+                            // nodes and attributes that might move their captures
+                            if let HotLiteral::Fmted(segments) = literal
+                                && crate::expression_pool::fmt_tier(segments) == Tier::Borrowing
+                            {
+                                let value = component.prop_value_tokens(property, index - 1);
+                                let binding = self
+                                    .body
+                                    .expression_pool
+                                    .add_indexed(Tier::Borrowing, parse_quote!({ #value }));
+                                component.prop_bindings[prop_index].set(binding);
+                            }
                         }
                     }
+                    if !is_key {
+                        prop_index += 1;
+                    }
                 }
+                self.assign_path_to_node(node, Tier::Unknown);
             }
         };
     }
@@ -99,12 +122,17 @@ impl<'a> DynIdVisitor<'a> {
 
     /// Assign a path to a node and give it its dynamic index
     /// This simplifies the ToTokens implementation for the macro to be a little less centralized
-    fn assign_path_to_node(&mut self, node: &BodyNode) {
+    fn assign_path_to_node(&mut self, node: &BodyNode, tier: Tier) {
         // Assign the TemplateNode::Dynamic index to the node
         node.set_dyn_idx(self.body.node_paths.len());
 
         // And then save the current path as the corresponding path
         self.body.node_paths.push(self.current_path.clone());
+
+        // Finally, pull the expression into the expression pool so we control the order it is
+        // evaluated in relative to every other dynamic expression in this template
+        let binding = self.body.expression_pool.add(tier, parse_quote!({ #node }));
+        self.body.node_bindings.push(binding);
     }
 
     /// Assign a path to a attribute and give it its dynamic index
@@ -121,6 +149,14 @@ impl<'a> DynIdVisitor<'a> {
         self.body
             .attr_paths
             .push((self.current_path.clone(), attribute_index));
+
+        // And pull the rendered attribute into the expression pool
+        let rendered = attribute.rendered_as_dynamic_attr();
+        let binding = self
+            .body
+            .expression_pool
+            .add(attribute.tier(), parse_quote!({ #rendered }));
+        self.body.attr_bindings.push(binding);
     }
 }
 

--- a/packages/rsx/src/assign_dyn_ids.rs
+++ b/packages/rsx/src/assign_dyn_ids.rs
@@ -86,13 +86,14 @@ impl<'a> DynIdVisitor<'a> {
                             // nodes and attributes that might move their captures
                             if let HotLiteral::Fmted(segments) = literal
                                 && crate::expression_pool::fmt_tier(segments) == Tier::Borrowing
+                                && let Some(slot) = component.prop_bindings.get(prop_index)
                             {
                                 let value = component.prop_value_tokens(property, index - 1);
                                 let binding = self
                                     .body
                                     .expression_pool
                                     .add_indexed(Tier::Borrowing, parse_quote!({ #value }));
-                                component.prop_bindings[prop_index].set(binding);
+                                slot.set(binding);
                             }
                         }
                     }

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -34,6 +34,9 @@ pub struct Component {
     pub generics: Option<AngleBracketedGenericArguments>,
     pub fields: Vec<Attribute>,
     pub component_literal_dyn_idx: Vec<DynIdx>,
+    /// The expression-pool binding for each prop (in `component_props` order), if that prop was
+    /// pulled into the pool
+    pub prop_bindings: Vec<DynIdx>,
     pub spreads: Vec<Spread>,
     pub brace: Option<token::Brace>,
     pub children: TemplateBody,
@@ -63,6 +66,7 @@ impl Parse for Component {
             .filter(|attr| matches!(attr.value, AttributeValue::AttrLiteral(_)))
             .count();
         let component_literal_dyn_idx = vec![DynIdx::default(); literal_properties_count];
+        let prop_bindings = vec![DynIdx::default(); fields.len()];
 
         let mut component = Self {
             dyn_idx: DynIdx::default(),
@@ -72,6 +76,7 @@ impl Parse for Component {
             fields,
             brace: Some(brace),
             component_literal_dyn_idx,
+            prop_bindings,
             spreads,
             diagnostics,
         };
@@ -265,33 +270,62 @@ impl Component {
             .filter(move |attr| !attr.name.is_likely_key())
     }
 
-    fn add_fields_to_builder(&self, manual_props: Option<Ident>) -> TokenStream2 {
-        let mut dynamic_literal_index = 0;
-        let mut tokens = TokenStream2::new();
-        for attribute in self.component_props() {
-            let release_value = attribute.value.to_token_stream();
+    /// The tokens for a single prop value. In debug mode literal props are read out of the dynamic
+    /// literal pool so they can be hot-reloaded.
+    pub(crate) fn prop_value_tokens(
+        &self,
+        attribute: &Attribute,
+        dynamic_literal_index: usize,
+    ) -> TokenStream2 {
+        let release_value = attribute.value.to_token_stream();
 
-            // In debug mode, we try to grab the value from the dynamic literal pool if possible
-            let value = if let AttributeValue::AttrLiteral(literal) = &attribute.value {
-                let idx = self.component_literal_dyn_idx[dynamic_literal_index].get();
-                dynamic_literal_index += 1;
-                let debug_value = quote! { __dynamic_literal_pool.component_property(#idx, &*__template_read, #literal) };
-                quote! {
-                    {
-                        #[cfg(debug_assertions)]
-                        {
-                            #debug_value
-                        }
-                        #[cfg(not(debug_assertions))]
-                        {
-                            #release_value
-                        }
-                    }
+        let AttributeValue::AttrLiteral(literal) = &attribute.value else {
+            return release_value;
+        };
+
+        let idx = self.component_literal_dyn_idx[dynamic_literal_index].get();
+        let debug_value =
+            quote! { __dynamic_literal_pool.component_property(#idx, &*__template_read, #literal) };
+        quote! {
+            {
+                #[cfg(debug_assertions)]
+                {
+                    #debug_value
                 }
-            } else {
-                release_value
-            };
+                #[cfg(not(debug_assertions))]
+                {
+                    #release_value
+                }
+            }
+        }
+    }
 
+    fn add_fields_to_builder(&self, manual_props: Option<Ident>) -> TokenStream2 {
+        // Resolve every prop's value first - the dynamic literal indices follow source order
+        let mut dynamic_literal_index = 0;
+        let mut props: Vec<(&Attribute, TokenStream2)> = Vec::new();
+        for (prop_index, attribute) in self.component_props().enumerate() {
+            // If this prop was pulled into the expression pool, just reference the binding
+            let binding = self.prop_bindings.get(prop_index).map(DynIdx::get);
+            let value = match binding {
+                Some(idx) if idx != usize::MAX => {
+                    let ident = crate::expression_pool::binding_ident(idx, attribute.span());
+                    quote! { #ident }
+                }
+                _ => self.prop_value_tokens(attribute, dynamic_literal_index),
+            };
+            if matches!(attribute.value, AttributeValue::AttrLiteral(_)) {
+                dynamic_literal_index += 1;
+            }
+            props.push((attribute, value));
+        }
+
+        // The builder accepts fields in any order, so we apply the props that always move their
+        // captures (event handlers) after the props that might only borrow
+        props.sort_by_key(|(attribute, _)| attribute.is_event_handler());
+
+        let mut tokens = TokenStream2::new();
+        for (attribute, value) in props {
             match &attribute.name {
                 AttributeName::BuiltIn(name) => {
                     if let Some(manual_props) = &manual_props {
@@ -344,6 +378,7 @@ impl Component {
             spreads: vec![],
             children: TemplateBody::new(vec![]),
             component_literal_dyn_idx: vec![],
+            prop_bindings: vec![],
             dyn_idx: DynIdx::default(),
             diagnostics,
         }

--- a/packages/rsx/src/expression_pool.rs
+++ b/packages/rsx/src/expression_pool.rs
@@ -1,0 +1,139 @@
+//! A pool of the dynamic expressions in a single template body.
+//!
+//! Every dynamic expression in a template is pulled out into a `let __rsx_expr_n = ...;` binding
+//! and the dynamic node/attribute arrays just reference those bindings. That gives us complete
+//! control over the order the user's expressions are *evaluated* in, which is what the borrow
+//! checker actually cares about.
+//!
+//! The order is:
+//!
+//! 1. [`Tier::Borrowing`] - expressions we can prove only ever borrow: formatted strings whose
+//!    interpolations are all place expressions (`{x}`, `{x.y}`, `{*x}`). `format_args!` takes its
+//!    arguments by reference, so these cannot move anything, and evaluating them first can only
+//!    ever make more code compile.
+//! 2. [`Tier::Unknown`] - everything else, depth-first, in the order the user wrote it. We can't
+//!    tell whether these move or borrow, so we use the order that makes borrow errors readable.
+//! 3. [`Tier::Moving`] - expressions we know always move their captures: event handlers, which take
+//!    an `impl FnMut(..) + 'static`. Evaluating them last can only ever make more code compile.
+//!
+//! The sort is stable, so within a tier expressions keep their depth-first source order.
+
+use quote::{ToTokens, quote};
+use syn::{Expr, Ident};
+
+use crate::{
+    FormattedSegmentType, HotLiteral, IfmtInput, PartialExpr, Segment,
+    innerlude::{Attribute, AttributeValue},
+};
+
+/// When an expression is evaluated relative to the other expressions in the same template
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Default, Hash)]
+pub(crate) enum Tier {
+    /// Provably borrow-only: formatted strings made only of place expressions
+    Borrowing = 0,
+    /// Anything we can't reason about: evaluated in the order the user wrote it
+    #[default]
+    Unknown = 1,
+    /// Provably moving: event handlers
+    Moving = 2,
+}
+
+/// Is this formatted string guaranteed to only *borrow* the values it interpolates?
+///
+/// `format_args!` takes all of its arguments by reference, so a formatted string can only move
+/// something if one of its segments is an expression that moves - a call, a method call, a macro.
+/// Place expressions (`x`, `x.y`, `*x`, `x[0]`) never move anything.
+pub(crate) fn ifmt_is_borrow_only(input: &IfmtInput) -> bool {
+    input.segments.iter().all(|segment| match segment {
+        Segment::Literal(_) => true,
+        Segment::Formatted(f) => match &f.segment {
+            FormattedSegmentType::Ident(_) => true,
+            FormattedSegmentType::Expr(expr) => expr_is_place(expr),
+        },
+    })
+}
+
+/// The tier for a formatted string used as a text node, attribute value or component prop
+pub(crate) fn fmt_tier(input: &IfmtInput) -> Tier {
+    match ifmt_is_borrow_only(input) {
+        true => Tier::Borrowing,
+        false => Tier::Unknown,
+    }
+}
+
+/// A conservative "this expression cannot move anything" check
+fn expr_is_place(expr: &Expr) -> bool {
+    match expr {
+        Expr::Path(path) => path.qself.is_none(),
+        Expr::Field(field) => expr_is_place(&field.base),
+        Expr::Paren(paren) => expr_is_place(&paren.expr),
+        Expr::Group(group) => expr_is_place(&group.expr),
+        Expr::Reference(reference) => expr_is_place(&reference.expr),
+        Expr::Unary(unary) => matches!(unary.op, syn::UnOp::Deref(_)) && expr_is_place(&unary.expr),
+        Expr::Index(index) => expr_is_place(&index.expr) && matches!(&*index.index, Expr::Lit(_)),
+        Expr::Lit(_) => true,
+        _ => false,
+    }
+}
+
+impl Attribute {
+    /// Is this attribute an event handler? Event handlers take an `impl FnMut(..) + 'static`, so
+    /// they always move whatever they capture.
+    pub(crate) fn is_event_handler(&self) -> bool {
+        matches!(self.value, AttributeValue::EventTokens(_)) || self.name.is_likely_event()
+    }
+
+    /// When this attribute's value should be evaluated relative to the rest of the template
+    pub(crate) fn tier(&self) -> Tier {
+        if self.is_event_handler() {
+            return Tier::Moving;
+        }
+
+        match &self.value {
+            AttributeValue::AttrLiteral(HotLiteral::Fmted(fmted)) => fmt_tier(fmted),
+            _ => Tier::Unknown,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Default, Hash)]
+pub(crate) struct ExpressionPool {
+    expressions: Vec<(Tier, PartialExpr)>,
+}
+
+impl ExpressionPool {
+    /// Add an expression to the pool, returning the ident it will be bound to
+    pub(crate) fn add(&mut self, tier: Tier, expr: PartialExpr) -> Ident {
+        let idx = self.add_indexed(tier, expr);
+        binding_ident(idx, self.expressions[idx].1.span())
+    }
+
+    /// Add an expression to the pool, returning its index
+    pub(crate) fn add_indexed(&mut self, tier: Tier, expr: PartialExpr) -> usize {
+        let idx = self.expressions.len();
+        self.expressions.push((tier, expr));
+        idx
+    }
+
+    /// The order the bindings are emitted in - by tier, then by depth-first source order
+    fn emission_order(&self) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..self.expressions.len()).collect();
+        order.sort_by_key(|idx| self.expressions[*idx].0);
+        order
+    }
+}
+
+impl ToTokens for ExpressionPool {
+    fn to_tokens(&self, out: &mut proc_macro2::TokenStream) {
+        let assignments = self.emission_order().into_iter().map(|idx| {
+            let (_, expr) = &self.expressions[idx];
+            let ident = binding_ident(idx, expr.span());
+            quote! { let #ident = #expr; }
+        });
+        quote! { #(#assignments)* }.to_tokens(out);
+    }
+}
+
+pub(crate) fn binding_ident(idx: usize, span: proc_macro2::Span) -> Ident {
+    Ident::new(&format!("__rsx_expr_{idx}"), span)
+}

--- a/packages/rsx/src/lib.rs
+++ b/packages/rsx/src/lib.rs
@@ -64,6 +64,7 @@ mod text_node;
 
 mod diagnostics;
 mod expr_node;
+mod expression_pool;
 mod ifmt;
 mod literal;
 mod location;

--- a/packages/rsx/src/template_body.rs
+++ b/packages/rsx/src/template_body.rs
@@ -54,11 +54,12 @@
 //! ```
 
 use self::location::DynIdx;
+use crate::expression_pool::ExpressionPool;
 use crate::innerlude::Attribute;
 use crate::*;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use proc_macro2_diagnostics::SpanDiagnosticExt;
-use syn::parse_quote;
+use syn::{Ident, parse_quote};
 
 type NodePath = Vec<u8>;
 type AttributePath = Vec<u8>;
@@ -81,6 +82,13 @@ pub struct TemplateBody {
     pub attr_paths: Vec<(AttributePath, usize)>,
     pub dynamic_text_segments: Vec<FormattedSegment>,
     pub diagnostics: Diagnostics,
+
+    /// Every dynamic expression in this template, in the order we want them *evaluated*
+    pub(crate) expression_pool: ExpressionPool,
+    /// The pool binding for each dynamic node, in dynamic node order
+    pub(crate) node_bindings: Vec<Ident>,
+    /// The pool binding for each dynamic attribute, in dynamic attribute order
+    pub(crate) attr_bindings: Vec<Ident>,
 }
 
 impl Parse for TemplateBody {
@@ -117,21 +125,17 @@ impl ToTokens for TemplateBody {
         let node_paths = node.node_paths.iter().map(|it| quote!(&[#(#it),*]));
         let attr_paths = node.attr_paths.iter().map(|(it, _)| quote!(&[#(#it),*]));
 
-        // For printing dynamic nodes, we rely on the ToTokens impl
-        // Elements have a weird ToTokens - they actually are the entrypoint for Template creation
-        let dynamic_nodes: Vec<_> = node.dynamic_nodes().collect();
+        // Dynamic nodes and attributes are expanded into the expression pool (in the order we want
+        // them evaluated in) - here we just reference the bindings the pool handed out
+        let dynamic_nodes = &node.node_bindings;
         let dynamic_nodes_len = dynamic_nodes.len();
 
-        // We could add a ToTokens for Attribute but since we use that for both components and elements
-        // They actually need to be different, so we just localize that here
-        let dyn_attr_printer: Vec<_> = node
-            .dynamic_attributes()
-            .map(|attr| attr.rendered_as_dynamic_attr())
-            .collect();
+        let dyn_attr_printer = &node.attr_bindings;
         let dynamic_attr_len = dyn_attr_printer.len();
 
         let dynamic_text = node.dynamic_text_segments.iter();
 
+        let expression_pool = &node.expression_pool;
         let diagnostics = &node.diagnostics;
         let index = node.template_idx.get();
         let hot_reload_mapping = node.hot_reload_mapping();
@@ -188,6 +192,11 @@ impl ToTokens for TemplateBody {
                 // The key needs to be created before the dynamic nodes as it might depend on a borrowed value which gets moved into the dynamic nodes
                 #[cfg(not(debug_assertions))]
                 let __key = #key_tokens;
+
+                // Every dynamic expression in this template, expanded in the order we want them
+                // evaluated in. This must come after the dynamic literal pool (component literals
+                // read from it) and before the dynamic node/attribute arrays that use the bindings.
+                #expression_pool
                 // These items are used in both the debug and release expansions of rsx. Pulling them out makes the expansion
                 // slightly smaller and easier to understand. Rust analyzer also doesn't autocomplete well when it sees an ident show up twice in the expansion
                 let __dynamic_nodes: [dioxus_core::DynamicNode; #dynamic_nodes_len] = [ #( #dynamic_nodes ),* ];
@@ -241,6 +250,9 @@ impl TemplateBody {
             attr_paths: Vec::new(),
             dynamic_text_segments: Vec::new(),
             diagnostics: Diagnostics::new(),
+            expression_pool: Default::default(),
+            node_bindings: Vec::new(),
+            attr_bindings: Vec::new(),
         };
 
         // Assign paths to all nodes in the template


### PR DESCRIPTION
## Summary

An alternative to #3944's evaluation order. Same goal (make `rsx!` stop rejecting code that reads fine), different order — #3944 uses strict depth-first source order, which fixes the attribute-before-child family but breaks every `button { onclick: move |_| .., "{item}" }`, which is why it has to add `to_owned![..]` to `dog_app` and `weather_app`.

Every dynamic expression in a template is now pulled into a `let __rsx_expr_n = ..;` binding, and the bindings are emitted in three tiers (stable, so source order is preserved inside a tier):

```
tier 0  formatted strings whose interpolations are all place expressions   -> hoisted
tier 1  everything else, depth-first source order                          -> = #3944
tier 2  event handlers                                                     -> sunk
```

Both edges are monotone, which is the whole argument:

- `format_args!` takes its args by reference, so `"{x}"`, `"{x.y}"`, `"{*x}"`, `"{x[0]}"` **cannot move anything** — evaluating them early can only make more code compile. `"{x.text()}"` / `"{f(x)}"` are *not* in this tier (`expr_is_place` in `expression_pool.rs`).
- event handlers take `impl FnMut(..) + 'static`, so they **always** move their captures — evaluating them late can only make more code compile.

Everything we can't classify keeps the order the user wrote it in, so borrow errors still read top-to-bottom.

```rust
// this now compiles (it does today; #3944 rejects it)
button { onclick: move |_| pick(item.clone()), "{item}" }

// and so does this (today rejects it; #3944 fixes it too)
div { width: "{v}", Child { data: v } }

// and this - a component prop that only borrows, next to one that moves
Row { label: "{item}", onpick: move |_| pick(item.clone()) }
```

Component props are handled two ways: borrow-only formatted props get their own pool binding, and callback props are applied to the props builder *last* (the builder takes fields in any order, so no `let`-binding of a closure and therefore no inference risk).

`ExpressionPool` is emitted after `__dynamic_literal_pool` and `let __key`, before the `__dynamic_nodes` / `__dynamic_attributes` arrays, which now just list bindings:

```rust
let __rsx_expr_0 = { /* class: "row {item}" */ };
let __rsx_expr_1 = { /* label: "{item}"      */ };
let __rsx_expr_4 = { /* span { "{item}" }    */ };
let __rsx_expr_2 = { /* Row { .. }           */ };
let __rsx_expr_3 = { /* onclick: ..          */ };
let __dynamic_nodes = [__rsx_expr_2, __rsx_expr_4];
let __dynamic_attributes = [__rsx_expr_0, __rsx_expr_3];
```

### Evidence

63 rsx snippets (formats, handlers, props, spreads, merged attrs, keys, loops, if-chains, signals, app-shaped patterns, plus 4 genuine ownership conflicts that must keep failing), compiled against each candidate order in debug and release:

| order | compiles | vs main (debug) |
|---|---|---|
| main | 32/63 | — |
| #3944 | 32/63 | +15 / −15 |
| tier 0 only | 47/63 | +18 / −3 |
| tier 0 + tier 2 | 55/63 | +23 / −1 |
| + component props (this PR) | **57/63** | **+26 / −1** |

No candidate accepted a genuine conflict. The one regression vs today is `div { width: text, Child { text: text.clone() } }` — moving into an attribute and then using the value in a child; main only accepts it because it evaluates *all* nodes before *any* attribute. #3944 rejects it too.

This also removes a debug/release divergence: debug already evaluates every format segment first (the literal pool), so tier 0 makes release agree with debug for the subset that provably can't misbehave.

Test plan: `cargo test -p dioxus-rsx -p dioxus-rsx-hotreload -p dioxus-core-macro -p dioxus-core` (hot reload indices are untouched — only the order of the `let` bindings changes), plus a `test_evaluation_order` module of compile-time tests in `packages/core-macro/tests/rsx.rs` covering the patterns above, including the two cases #3944 added.

Notably, no example or test in the workspace needed touching: unlike #3944 (which patches `dog_app.rs` and `weather_app.rs`), every existing `rsx!` in the repo compiles unchanged.

Related: #3944, #3737.


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/8461d24189d240b099597b0fa62b4e5f
Requested by: @jkelleyrtp