### PR TITLE
Run Playwright tests on macOS (stable + beta)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -385,8 +385,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { os: warp-ubuntu-latest-x64-8x, name: "Linux (stable)", toolchain: "${{ needs.rust.outputs.rust_stable }}" }
-          - { os: warp-ubuntu-latest-x64-8x, name: "Linux (beta)", toolchain: beta }
+          - { os: warp-ubuntu-latest-x64-8x, name: "Linux (stable)", toolchain: "${{ needs.rust.outputs.rust_stable }}", targets: "x86_64-unknown-linux-gnu,wasm32-unknown-unknown" }
+          - { os: warp-ubuntu-latest-x64-8x, name: "Linux (beta)", toolchain: beta, targets: "x86_64-unknown-linux-gnu,wasm32-unknown-unknown" }
+          - { os: warp-macos-latest-arm64-6x, name: "macOS (stable)", toolchain: "${{ needs.rust.outputs.rust_stable }}", targets: "aarch64-apple-darwin,wasm32-unknown-unknown" }
+          - { os: warp-macos-latest-arm64-6x, name: "macOS (beta)", toolchain: beta, targets: "aarch64-apple-darwin,wasm32-unknown-unknown" }
     steps:
       # Do our best to cache the toolchain and node install steps
       - uses: actions/checkout@v5
@@ -405,7 +407,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          targets: x86_64-unknown-linux-gnu,wasm32-unknown-unknown
+          targets: ${{ matrix.targets }}
       - uses: Swatinem/rust-cache@v2
         with:
           key: "playwright-${{ matrix.toolchain }}-${{ runner.os }}"


### PR DESCRIPTION
## Summary
Adds macOS (stable) and macOS (beta) entries to the `playwright` job matrix on `warp-macos-latest-arm64-6x`, alongside the existing Linux stable/beta and Windows jobs. Rust targets are now a matrix field (`x86_64-unknown-linux-gnu` vs `aarch64-apple-darwin`, both with wasm32); the apt-package, disk-space, and dx-cache steps already gate on `runner.os == 'Linux'` so they skip on macOS.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/fc783203e3af4fa4a8308fa10ed2bdff
Requested by: @jkelleyrtp