### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# borrowed from tauri - only allow core maintainers to approve PRs
-
-* @DioxusLabs/core
-
-.github @DioxusLabs/core


### PR DESCRIPTION
## Summary

Remove `.github/CODEOWNERS` so pull-request ownership is managed through the repository's standard GitHub settings rather than a committed ownership rule.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/dd9f70f185e449b6bbde12ef68eaa454
Requested by: @nicoburns