### PR TITLE
Lock cargo-msrv installation dependencies in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
           components: rustfmt, clippy
       - uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-msrv
-        run: cargo binstall cargo-msrv -y --force
+        run: cargo binstall cargo-msrv -y --force --locked
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: "true"


### PR DESCRIPTION
## Summary

- Pass `--locked` when CI installs `cargo-msrv`.
- Prevent installer dependency updates from increasing the required Rust version.

## Context

The lint job used Rust 1.94.0. The unlocked install selected AWS dependencies that require Rust 1.94.1.

Failed job: https://github.com/DioxusLabs/dioxus/actions/runs/30748691408/job/91498767107
