### PR TITLE
fix(core): don't hold the elements borrow across event listeners

### DIFF
--- a/packages/core/src/runtime.rs
+++ b/packages/core/src/runtime.rs
@@ -368,9 +368,17 @@ fn MyComponent() -> Element {{
     #[instrument(skip(self, event), level = "trace", name = "Runtime::handle_event")]
     pub fn handle_event(self: &Rc<Self>, name: &str, event: Event<dyn Any>, element: ElementId) {
         let _runtime = RuntimeGuard::new(self.clone());
-        let elements = self.elements.borrow();
 
-        if let Some(Some(parent_path)) = elements.get(element.0).copied() {
+        // Read the path out and drop the borrow before calling user code, as
+        // handle_bubbling_event already does for `mounts`. Held across a
+        // listener, it panics any render that listener triggers, in
+        // VirtualDom::next_element.
+        let parent_path = {
+            let elements = self.elements.borrow();
+            elements.get(element.0).copied().flatten()
+        };
+
+        if let Some(parent_path) = parent_path {
             if event.propagates() {
                 self.handle_bubbling_event(parent_path, name, event);
             } else {


### PR DESCRIPTION
`Runtime::handle_event` takes a shared borrow of `runtime.elements` and holds it for the whole listener call:

```rust
let elements = self.elements.borrow();

if let Some(Some(parent_path)) = elements.get(element.0).copied() {
    if event.propagates() {
        self.handle_bubbling_event(parent_path, name, event);
```

`elements` is borrowed mutably by `VirtualDom::next_element`, which every node creation goes through. So a listener that causes a render aborts the app:

```
panicked at packages/core/src/arena.rs:59:50:
RefCell already borrowed
```

`handle_bubbling_event` already guards against this for the sibling `mounts` borrow, twenty lines below:

> `// We do this in its own block to prevent mounts from staying open while we call user code`

This does the same for `elements`: read the path out, drop the borrow, then dispatch. Same lookup, same branches, no other behaviour change.

We hit it in a web app on iOS, where a button whose handler only toggled a signal took the whole page down (`panic = "abort"` in the wasm release profile). That screen re-renders on a 1 s timer, so a render was nearly always pending when a tap landed, which is probably why it showed up there and nowhere else.

Verified by building 0.7.9 with this change applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

