### PR TITLE
Preserve JSX tag syntax in autofmt

### DIFF
--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -108,8 +108,19 @@ impl<'a> Writer<'a> {
             children,
             spreads,
             brace,
+            tag_syntax,
             ..
         } = el;
+
+        if *tag_syntax {
+            return self.write_jsx_tag(
+                &name.to_string(),
+                attributes,
+                spreads,
+                children,
+                &brace.unwrap_or_default(),
+            );
+        }
 
         write!(self.out, "{name} ")?;
         self.write_rsx_block(attributes, spreads, children, &brace.unwrap_or_default())?;
@@ -126,23 +137,150 @@ impl<'a> Writer<'a> {
             generics,
             spreads,
             brace,
+            tag_syntax,
             ..
         }: &Component,
     ) -> Result {
         // Write the path by to_tokensing it and then removing all whitespace
         let mut name = name.to_token_stream().to_string();
         name.retain(|c| !c.is_whitespace());
-        write!(self.out, "{name}")?;
 
         // Same idea with generics, write those via the to_tokens method and then remove all whitespace
         if let Some(generics) = generics {
             let mut written = generics.to_token_stream().to_string();
             written.retain(|c| !c.is_whitespace());
-            write!(self.out, "{written}")?;
+
+            // The tag syntax doesn't use the turbofish: `<Outlet<R>>`
+            if *tag_syntax {
+                written = written.trim_start_matches("::").to_string();
+            }
+
+            name.push_str(&written);
         }
 
-        write!(self.out, " ")?;
+        if *tag_syntax {
+            return self.write_jsx_tag(
+                &name,
+                fields,
+                spreads,
+                &children.roots,
+                &brace.unwrap_or_default(),
+            );
+        }
+
+        write!(self.out, "{name} ")?;
         self.write_rsx_block(fields, spreads, &children.roots, &brace.unwrap_or_default())?;
+
+        Ok(())
+    }
+
+    /// Write an element or component that was written using the JSX/XML-like tag syntax,
+    /// preserving the tag style:
+    ///
+    /// `<div class="asd">"hello"</div>` or `<img src="..." />`
+    fn write_jsx_tag(
+        &mut self,
+        name: &str,
+        attributes: &[Attribute],
+        spreads: &[Spread],
+        children: &[BodyNode],
+        brace: &Brace,
+    ) -> Result {
+        write!(self.out, "<{name}")?;
+
+        // Decide if the attributes fit in the opening tag or need to be split across lines
+        let attr_len = self.is_short_attrs(brace, attributes, spreads);
+        let is_short_attr_list = (attr_len + self.out.indent_level * 4) < 80;
+
+        if is_short_attr_list {
+            for attr in attributes {
+                write!(self.out, " ")?;
+                self.write_jsx_attribute(attr)?;
+            }
+            for spread in spreads {
+                write!(self.out, " {{")?;
+                self.write_spread_attribute(&spread.expr)?;
+                write!(self.out, "}}")?;
+            }
+        } else {
+            self.out.indent_level += 1;
+            for attr in attributes {
+                self.out.tabbed_line()?;
+                self.write_jsx_attribute(attr)?;
+            }
+            for spread in spreads {
+                self.out.tabbed_line()?;
+                write!(self.out, "{{")?;
+                self.write_spread_attribute(&spread.expr)?;
+                write!(self.out, "}}")?;
+            }
+            self.out.indent_level -= 1;
+            self.out.tabbed_line()?;
+        }
+
+        // Self-closing tags
+        if children.is_empty() {
+            if is_short_attr_list {
+                write!(self.out, " ")?;
+            }
+            write!(self.out, "/>")?;
+            return Ok(());
+        }
+
+        write!(self.out, ">")?;
+
+        // Inline a single short child: `<h1>"hello"</h1>`
+        let children_len = self
+            .is_short_children(children)
+            .map_err(|_| std::fmt::Error)?;
+        let is_small_children = children_len.is_some_and(|len| {
+            is_short_attr_list && len + attr_len + self.out.indent_level * 4 < 100
+        });
+
+        if is_small_children {
+            for child in children {
+                self.write_ident(child)?;
+            }
+        } else {
+            self.out.new_line()?;
+            self.write_body_indented(children)?;
+            self.out.tabbed_line()?;
+        }
+
+        write!(self.out, "</{name}>")?;
+
+        Ok(())
+    }
+
+    /// Write an attribute in the JSX style: `name`, `name="literal"` or `name={expr}`
+    fn write_jsx_attribute(&mut self, attr: &Attribute) -> Result {
+        match &attr.name {
+            // Dashed custom attributes don't need to be quoted in the tag syntax: `data-count="1"`
+            AttributeName::Custom(name)
+                if name
+                    .value()
+                    .split('-')
+                    .all(|seg| syn::parse_str::<syn::Ident>(seg).is_ok()) =>
+            {
+                write!(self.out, "{}", name.value())?
+            }
+            name => self.write_attribute_name(name)?,
+        }
+
+        if attr.can_be_shorthand() {
+            return Ok(());
+        }
+
+        write!(self.out, "=")?;
+
+        match &attr.value {
+            AttributeValue::AttrLiteral(value) => write!(self.out, "{value}")?,
+            value => {
+                write!(self.out, "{{")?;
+                self.write_attribute_value(value)?;
+                write!(self.out, "}}")?;
+            }
+        }
 
         Ok(())
     }

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -77,6 +77,7 @@ twoway![
     long_if_else_attr,
     empty_component_body,
     empty_braces_oneliner,
+    jsx,
 ];
 
 fn assert_idempotent(src: &str) {

--- a/packages/autofmt/tests/samples/jsx.rsx
+++ b/packages/autofmt/tests/samples/jsx.rsx
@@ -1,0 +1,40 @@
+use dioxus::prelude::*;
+
+pub fn app() -> Element {
+    rsx! {
+        <div class="container">
+            <h1>"Hello, world!"</h1>
+            <img src="image.png" />
+            <button disabled onclick={move |_| println!("clicked")}>"Click me"</button>
+            <my-web-component data-count="1" "custom^attr"="value" />
+            <div {..attrs} />
+            <MyComponent prop="value">"children"</MyComponent>
+            <some::cool::Component />
+            <Outlet<R>>"child"</Outlet<R>>
+
+            // The regular syntax can be mixed in freely
+            div { class: "inner", "More content" }
+            for item in items {
+                <span>"{item}"</span>
+            }
+            if cond {
+                <span>"conditional"</span>
+            }
+            <section>
+                p { class: "regular", "regular child" }
+                {some_expr}
+                <ul>
+                    <li>"one"</li>
+                    <li>"two"</li>
+                </ul>
+            </section>
+            <div
+                class="a-very-long-class-name-that-pushes-this-over-the-line-length-limit"
+                id="some-long-id-attribute-value"
+                onclick={move |_| println!("clicked")}
+            >
+                "Attributes split across lines"
+            </div>
+        </div>
+    }
+}

--- a/packages/autofmt/tests/wrong.rs
+++ b/packages/autofmt/tests/wrong.rs
@@ -42,3 +42,4 @@ twoway!("skipfail" => skipfail (IndentOptions::new(IndentType::Spaces, 4, false)
 twoway!("comments-inline-4sp" => comments_inline_4sp (IndentOptions::new(IndentType::Spaces, 4, false)));
 twoway!("comments-attributes-4sp" => comments_attributes_4sp (IndentOptions::new(IndentType::Spaces, 4, false)));
 twoway!("comments-big" => comments_big (IndentOptions::new(IndentType::Spaces, 4, false)));
+twoway!("jsx-4sp" => jsx_4sp (IndentOptions::new(IndentType::Spaces, 4, false)));

--- a/packages/autofmt/tests/wrong/jsx-4sp.rsx
+++ b/packages/autofmt/tests/wrong/jsx-4sp.rsx
@@ -1,0 +1,12 @@
+use dioxus::prelude::*;
+
+pub fn app() -> Element {
+    rsx! {
+        <div class="container">
+            <h1>"Hello, world!"</h1>
+            <img src="image.png" />
+            <button disabled onclick={move |_| println!("clicked")}>"Click me"</button>
+            <MyComponent prop="value">"children"</MyComponent>
+        </div>
+    }
+}

--- a/packages/autofmt/tests/wrong/jsx-4sp.wrong.rsx
+++ b/packages/autofmt/tests/wrong/jsx-4sp.wrong.rsx
@@ -1,0 +1,13 @@
+use dioxus::prelude::*;
+
+pub fn app() -> Element {
+    rsx! {
+        <div    class="container"   >
+        <h1  >"Hello, world!"</h1>
+                <img src="image.png"/>
+          <button disabled={disabled} onclick={move |_|    println!("clicked")}>"Click me"</button>
+            <MyComponent
+                prop="value" >"children"</MyComponent>
+        </div>
+    }
+}

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -39,6 +39,11 @@ pub struct Component {
     pub children: TemplateBody,
     pub dyn_idx: DynIdx,
     pub diagnostics: Diagnostics,
+
+    /// Whether this component was written using the JSX/XML-like tag syntax (`<MyComponent />`)
+    ///
+    /// Used by autofmt to print the component back out in the same style it was written in
+    pub tag_syntax: bool,
 }
 
 impl Parse for Component {
@@ -125,6 +130,7 @@ impl Component {
             component_literal_dyn_idx,
             spreads,
             diagnostics,
+            tag_syntax: false,
         };
 
         // We've received a valid rsx block, but it's not necessarily a valid component
@@ -367,6 +373,7 @@ impl Component {
             component_literal_dyn_idx: vec![],
             dyn_idx: DynIdx::default(),
             diagnostics,
+            tag_syntax: false,
         }
     }
 }

--- a/packages/rsx/src/element.rs
+++ b/packages/rsx/src/element.rs
@@ -41,6 +41,11 @@ pub struct Element {
     /// but not technically a valid element - these diagnostics tell us what's wrong and then are used
     /// when rendering
     pub diagnostics: Diagnostics,
+
+    /// Whether this element was written using the JSX/XML-like tag syntax (`<div />`)
+    ///
+    /// Used by autofmt to print the element back out in the same style it was written in
+    pub tag_syntax: bool,
 }
 
 impl Parse for Element {
@@ -207,6 +212,7 @@ impl Element {
             diagnostics,
             spreads: spreads.clone(),
             merged_attributes: Vec::new(),
+            tag_syntax: false,
         };
 
         // And then merge the various attributes together

--- a/packages/rsx/src/jsx.rs
+++ b/packages/rsx/src/jsx.rs
@@ -93,14 +93,17 @@ fn parse_element(stream: ParseStream) -> syn::Result<BodyNode> {
         Ok(())
     })?;
 
-    Ok(BodyNode::Element(Element::from_parts(
+    let mut element = Element::from_parts(
         name,
         attributes,
         spreads,
         children,
         Some(brace),
         Diagnostics::new(),
-    )))
+    );
+    element.tag_syntax = true;
+
+    Ok(BodyNode::Element(element))
 }
 
 fn parse_component(stream: ParseStream) -> syn::Result<BodyNode> {
@@ -126,7 +129,7 @@ fn parse_component(stream: ParseStream) -> syn::Result<BodyNode> {
         Ok(())
     })?;
 
-    Ok(BodyNode::Component(Component::from_parts(
+    let mut component = Component::from_parts(
         name,
         generics,
         fields,
@@ -134,7 +137,10 @@ fn parse_component(stream: ParseStream) -> syn::Result<BodyNode> {
         children,
         Some(brace),
         Diagnostics::new(),
-    )))
+    );
+    component.tag_syntax = true;
+
+    Ok(BodyNode::Component(component))
 }
 
 /// Parse the attributes of an open tag, stopping at `/>` or `>`


### PR DESCRIPTION
## Summary

Stacked on #5730. Makes `dx fmt`/autofmt keep rsx written in the JSX/XML tag syntax in that style instead of rewriting it into block syntax.

- `dioxus-rsx`: `Element` and `Component` gain a `tag_syntax: bool` field, set by the JSX parser, so downstream consumers know which style the node was written in.
- `dioxus-autofmt`: `write_element`/`write_component` dispatch to a new `write_jsx_tag` when `tag_syntax` is set:
  - self-closing tags for empty children: `<img src="image.png" />`
  - single short child inlined: `<h1>"Hello"</h1>`
  - attributes inline in the opening tag when short, otherwise one per line with the closing `>` on its own line
  - attribute values printed as `name="literal"` / `name={expr}`, shorthand collapsing (`disabled={disabled}` → `disabled`), spreads as `{..attrs}`, dashed custom attributes unquoted (`data-count="1"`), and components printed without the turbofish (`<Outlet<R>>`)

Mixed block/JSX styles are preserved as written, since dispatch happens per node.

Tests: idempotency sample (`tests/samples/jsx.rsx`) and a normalization test (`tests/wrong/jsx-4sp*`).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/418cbef546c844b6b40c575b1ae28376
Requested by: @nicoburns