### PR TITLE
cli: mirror Cargo's implicit strip default when manually stripping binaries (fixes wasm-opt SIGABRT)

### DIFF
--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -204,7 +204,7 @@ use crate::{
 };
 use anyhow::{Context, bail};
 use cargo_metadata::diagnostic::Diagnostic;
-use cargo_toml::{Profile, Profiles, StripSetting};
+use cargo_toml::{DebugSetting, Profile, Profiles, StripSetting};
 use depinfo::RustcDepInfo;
 use dioxus_cli_config::PRODUCT_NAME_ENV;
 use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV};
@@ -2473,43 +2473,72 @@ impl BuildRequest {
     }
 
     /// Checks the strip setting for the package, resolving profiles recursively
+    ///
+    /// If the profile doesn't set `strip` explicitly, this mirrors Cargo's implicit default:
+    /// since Rust 1.77, Cargo strips debuginfo when the profile has debuginfo disabled
+    /// (as the `release` profile does by default). Since we build with `strip=false` to keep
+    /// symbols alive for the asset system, we need to replicate that default when stripping
+    /// manually afterwards.
     pub(crate) fn get_strip_setting(&self) -> StripSetting {
         let cargo_toml = &self.workspace.cargo_toml;
-        let profile = &self.profile;
         let release = self.release;
-        let profile = match (cargo_toml.profile.custom.get(profile), release) {
-            (Some(custom_profile), _) => Some(custom_profile),
-            (_, true) => cargo_toml.profile.release.as_ref(),
-            (_, false) => cargo_toml.profile.dev.as_ref(),
-        };
+        let profile = cargo_toml.profile.custom.get(&self.profile);
 
-        let Some(profile) = profile else {
-            return StripSetting::None;
-        };
-
-        // Get the strip setting from the profile or the profile it inherits from
-        fn get_strip(profile: &Profile, profiles: &Profiles) -> Option<StripSetting> {
-            profile.strip.as_ref().copied().or_else(|| {
-                // If we can't find the strip setting, check if we inherit from another profile
-                profile.inherits.as_ref().and_then(|inherits| {
-                    let profile = match inherits.as_str() {
-                        "dev" => profiles.dev.as_ref(),
-                        "release" => profiles.release.as_ref(),
-                        "test" => profiles.test.as_ref(),
-                        "bench" => profiles.bench.as_ref(),
-                        other => profiles.custom.get(other),
-                    };
-                    profile.and_then(|p| get_strip(p, profiles))
+        // Resolve a profile setting, following the `inherits` chain
+        fn resolve<T>(
+            profile: Option<&Profile>,
+            profiles: &Profiles,
+            release: bool,
+            get: fn(&Profile) -> Option<T>,
+        ) -> Option<T> {
+            fn resolve_inner<T>(
+                profile: &Profile,
+                profiles: &Profiles,
+                get: fn(&Profile) -> Option<T>,
+            ) -> Option<T> {
+                get(profile).or_else(|| {
+                    // If we can't find the setting, check if we inherit from another profile
+                    profile.inherits.as_ref().and_then(|inherits| {
+                        let profile = match inherits.as_str() {
+                            "dev" => profiles.dev.as_ref(),
+                            "release" => profiles.release.as_ref(),
+                            "test" => profiles.test.as_ref(),
+                            "bench" => profiles.bench.as_ref(),
+                            other => profiles.custom.get(other),
+                        };
+                        profile.and_then(|p| resolve_inner(p, profiles, get))
+                    })
                 })
-            })
+            }
+
+            let base = match (profile, release) {
+                (Some(custom_profile), _) => Some(custom_profile),
+                (_, true) => profiles.release.as_ref(),
+                (_, false) => profiles.dev.as_ref(),
+            };
+            base.and_then(|p| resolve_inner(p, profiles, get))
         }
 
-        let Some(strip) = get_strip(profile, &cargo_toml.profile) else {
-            // If the profile doesn't have a strip option, return None
-            return StripSetting::None;
-        };
+        if let Some(strip) = resolve(profile, &cargo_toml.profile, release, |p| {
+            p.strip.as_ref().copied()
+        }) {
+            return strip;
+        }
 
-        strip
+        // No explicit strip setting: apply Cargo's implicit default. Cargo strips debuginfo
+        // when the resolved debug setting is off, which is the default for release profiles.
+        let debug =
+            resolve(profile, &cargo_toml.profile, release, |p| p.debug).unwrap_or(if release {
+                DebugSetting::None
+            } else {
+                DebugSetting::Full
+            });
+
+        if debug == DebugSetting::None {
+            StripSetting::Debuginfo
+        } else {
+            StripSetting::None
+        }
     }
 
     /// returns the path to root build folder. This will be our working directory for the build.

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1986,6 +1986,9 @@ impl BuildRequest {
             // todo: actually use this to copy over the binary to our staging
             let mut command = Command::new(rustc_objcopy);
             command.env("LD_LIBRARY_PATH", &dylib_path);
+            // macOS's dyld does not read LD_LIBRARY_PATH; rust-objcopy links against
+            // @rpath/libLLVM.dylib which lives in the sysroot's lib dir.
+            command.env("DYLD_FALLBACK_LIBRARY_PATH", &dylib_path);
             command
                 .arg(strip_arg)
                 .arg(&artifacts.exe)


### PR DESCRIPTION
## Summary

Fixes #5119 (`wasm-opt failed with status code signal: 6 (SIGABRT)` / `compile unit size was incorrect` on `dx build --web --release`).

Root cause: since #4966 (0.7.2), dx always builds with `--config profile.<x>.strip=false` (to keep manganis symbols alive) and relies on `post_process_executable`/`get_strip_setting` to strip manually afterwards. But `get_strip_setting` only honored an *explicit* `strip` key in Cargo.toml and returned `StripSetting::None` otherwise — it didn't replicate Cargo's implicit default (since Rust 1.77, Cargo strips debuginfo when the profile's debuginfo is disabled, as `release` is by default). So ~1.3MB of DWARF from the precompiled std stayed in release wasm. wasm-bindgen (`--keep-debug`, on by default via `--debug-symbols`) then rewrites that DWARF, and binaryen's wasm-opt aborts trying to re-emit it (`DWARFEmitter.cpp:201`). In 0.7.1 the linker stripped the debuginfo (Cargo's default), which is why the same flags worked there.

Change in `get_strip_setting`, after resolving the profile's `inherits` chain:

```
explicit strip in profile chain  -> use it (as before)
otherwise                        -> resolve `debug` in profile chain
                                    (default: release=off, dev=full)
   debug off  -> StripSetting::Debuginfo   // Cargo's implicit default
   debug on   -> StripSetting::None
```

## Verification

- Minimal repro (wasm-bindgen 0.2.126 + binaryen): `strip=false` build → `wasm-bindgen --keep-debug` → `wasm-opt --debuginfo` reproduces the exact SIGABRT; the same wasm without the wasm-bindgen rewrite, or with Cargo's default strip, passes.
- Unpatched dx from main reproduces the failure on a hello-world web app in `--release`; with this patch the build succeeds and the output wasm contains no `.debug_*` sections (1.6MB → 471KB).
- `wasm-split` builds are unaffected (`post_process_executable` still returns early), as are dev builds (`debug` resolves to full → no strip).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/819f3522f488427cb8df5f6e12b5af56
Requested by: @nicoburns