### PR TITLE
Intercept cargo's `-C strip` in the rustc wrapper instead of predicting it

### DIFF
--- a/packages/cli/src/build/link.rs
+++ b/packages/cli/src/build/link.rs
@@ -1454,7 +1454,7 @@ impl BuildRequest {
         }
 
         let scope = RustcWrapperScope {
-            version: 1,
+            version: 2,
             capture_mode: self.rustc_wrapper_capture_mode(build_mode),
             bundle: self.bundle.to_string(),
             triple: self.triple.to_string(),

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -204,7 +204,6 @@ use crate::{
 };
 use anyhow::{Context, bail};
 use cargo_metadata::diagnostic::Diagnostic;
-use cargo_toml::{Profile, Profiles, StripSetting};
 use depinfo::RustcDepInfo;
 use dioxus_cli_config::PRODUCT_NAME_ENV;
 use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV};
@@ -1970,12 +1969,14 @@ impl BuildRequest {
             return Ok(());
         }
 
-        // Use the same format that rust itself does
+        // The rustc wrapper removed cargo's `-C strip=...` flag so symbols survived until
+        // asset extraction, recording the value it computed. Apply that setting manually now,
+        // using the same objcopy flags rust itself does:
         // https://github.com/rust-lang/rust/blob/cb80ff132a0e9aa71529b701427e4e6c243b58df/compiler/rustc_codegen_ssa/src/back/linker.rs#L1433-L1443
-        let strip_arg = match self.get_strip_setting() {
-            StripSetting::Debuginfo => Some("--strip-debug"),
-            StripSetting::Symbols => Some("--strip-all"),
-            StripSetting::None => None,
+        let strip_arg = match self.recorded_strip_setting(&artifacts.mode).as_deref() {
+            Some("debuginfo") => Some("--strip-debug"),
+            Some("symbols") => Some("--strip-all"),
+            _ => None,
         };
 
         if let Some(strip_arg) = strip_arg {
@@ -2472,44 +2473,18 @@ impl BuildRequest {
         features
     }
 
-    /// Checks the strip setting for the package, resolving profiles recursively
-    pub(crate) fn get_strip_setting(&self) -> StripSetting {
-        let cargo_toml = &self.workspace.cargo_toml;
-        let profile = &self.profile;
-        let release = self.release;
-        let profile = match (cargo_toml.profile.custom.get(profile), release) {
-            (Some(custom_profile), _) => Some(custom_profile),
-            (_, true) => cargo_toml.profile.release.as_ref(),
-            (_, false) => cargo_toml.profile.dev.as_ref(),
-        };
-
-        let Some(profile) = profile else {
-            return StripSetting::None;
-        };
-
-        // Get the strip setting from the profile or the profile it inherits from
-        fn get_strip(profile: &Profile, profiles: &Profiles) -> Option<StripSetting> {
-            profile.strip.as_ref().copied().or_else(|| {
-                // If we can't find the strip setting, check if we inherit from another profile
-                profile.inherits.as_ref().and_then(|inherits| {
-                    let profile = match inherits.as_str() {
-                        "dev" => profiles.dev.as_ref(),
-                        "release" => profiles.release.as_ref(),
-                        "test" => profiles.test.as_ref(),
-                        "bench" => profiles.bench.as_ref(),
-                        other => profiles.custom.get(other),
-                    };
-                    profile.and_then(|p| get_strip(p, profiles))
-                })
-            })
-        }
-
-        let Some(strip) = get_strip(profile, &cargo_toml.profile) else {
-            // If the profile doesn't have a strip option, return None
-            return StripSetting::None;
-        };
-
-        strip
+    /// The `-C strip=...` value cargo computed for the tip crate, as recorded by the rustc
+    /// wrapper when it removed the flag from the tip's rustc invocation. Since cargo computes
+    /// this itself, it accounts for every source cargo considers: Cargo.toml profile inherit
+    /// chains, `.cargo/config.toml` `[profile]` tables, `CARGO_PROFILE_*` env vars, and the
+    /// implicit default of stripping debuginfo when debuginfo is disabled (since Rust 1.77).
+    fn recorded_strip_setting(&self, build_mode: &BuildMode) -> Option<String> {
+        let path = self
+            .rustc_wrapper_args_scope_dir(build_mode)
+            .ok()?
+            .join(format!("{}.bin.json", self.tip_crate_name()));
+        let contents = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str::<RustcArgs>(&contents).ok()?.strip
     }
 
     /// returns the path to root build folder. This will be our working directory for the build.
@@ -3068,11 +3043,11 @@ impl BuildRequest {
     ///
     /// Note how every platform gets its own profile, and each platform has a dev and release profile.
     fn profile_args(&self) -> Vec<String> {
-        // Always disable stripping so symbols still exist for the asset system. We will apply strip manually
-        // after assets are built
+        // Note: stripping is not disabled here. The rustc wrapper intercepts the `-C strip=...`
+        // flag cargo computes for the tip crate so symbols still exist for the asset system,
+        // and `post_process_executable` applies the recorded setting after assets are built.
         let profile = self.profile.as_str();
         let mut args = Vec::new();
-        args.push(format!(r#"profile.{profile}.strip=false"#));
 
         // If the user defined the profile in the Cargo.toml, we don't need to add it to our adhoc list
         if !self

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -1987,6 +1987,9 @@ impl BuildRequest {
             // todo: actually use this to copy over the binary to our staging
             let mut command = Command::new(rustc_objcopy);
             command.env("LD_LIBRARY_PATH", &dylib_path);
+            // macOS's dyld does not read LD_LIBRARY_PATH; rust-objcopy links against
+            // @rpath/libLLVM.dylib which lives in the sysroot's lib dir.
+            command.env("DYLD_FALLBACK_LIBRARY_PATH", &dylib_path);
             command
                 .arg(strip_arg)
                 .arg(&artifacts.exe)

--- a/packages/cli/src/cli/hotpatch.rs
+++ b/packages/cli/src/cli/hotpatch.rs
@@ -79,6 +79,7 @@ impl HotpatchTip {
                 args: rustc_args,
                 envs: rustc_envs,
                 cwd,
+                strip: None,
             },
         );
 

--- a/packages/cli/src/rustcwrapper.rs
+++ b/packages/cli/src/rustcwrapper.rs
@@ -28,6 +28,10 @@ pub struct RustcArgs {
     pub args: Vec<String>,
     pub envs: Vec<(String, String)>,
     pub cwd: PathBuf,
+    /// The `-C strip=...` value cargo computed for this invocation, removed from `args`
+    /// so that symbols survive until asset extraction. Applied manually after the build.
+    #[serde(default)]
+    pub strip: Option<String>,
 }
 
 /// The environment variable indicating where the args directory is located.
@@ -58,12 +62,20 @@ pub fn run_rustc() -> ExitCode {
 
     // Cargo invokes a workspace wrapper like: `wrapper-name rustc [args...]`
     // We skip our own executable name (`wrapper-name`) to get the args passed to us.
-    let captured_args = args().skip(1).collect::<Vec<_>>();
+    let mut captured_args = args().skip(1).collect::<Vec<_>>();
+
+    // Cargo resolves the profile's strip setting (including the implicit default of stripping
+    // debuginfo when debuginfo is disabled, since Rust 1.77) and passes it as `-C strip=...`.
+    // We need symbols to survive until after asset extraction, so remove the flag before
+    // invoking rustc and record its value. `post_process_executable` applies it manually
+    // with `rust-objcopy` once assets have been extracted.
+    let strip = extract_strip_arg(&mut captured_args);
 
     let rustc_args = RustcArgs {
         args: captured_args.clone(),
         envs: vars().collect::<_>(),
         cwd: std::env::current_dir().expect("Failed to get current dir"),
+        strip,
     };
 
     // Always persist the captured rustc invocation, even for link steps.
@@ -135,6 +147,40 @@ fn write_rustc_args(args_dir: &PathBuf, rustc_args: &RustcArgs) {
             .expect("Failed to write rustc args to file");
         }
     }
+}
+
+/// Remove any `-C strip=...` / `-Cstrip=...` argument from `args`, returning its value.
+fn extract_strip_arg(args: &mut Vec<String>) -> Option<String> {
+    let mut strip = None;
+    let mut filtered = Vec::with_capacity(args.len());
+    let mut idx = 0;
+
+    while idx < args.len() {
+        let arg = &args[idx];
+
+        if let Some(value) = arg.strip_prefix("-Cstrip=") {
+            strip = Some(value.to_string());
+            idx += 1;
+            continue;
+        }
+
+        if arg == "-C" {
+            if let Some(value) = args
+                .get(idx + 1)
+                .and_then(|next| next.strip_prefix("strip="))
+            {
+                strip = Some(value.to_string());
+                idx += 2;
+                continue;
+            }
+        }
+
+        filtered.push(arg.clone());
+        idx += 1;
+    }
+
+    *args = filtered;
+    strip
 }
 
 /// Check if the arguments indicate a linking step, including those in command files.


### PR DESCRIPTION
## Summary

Fixes #5119 (wasm-opt SIGABRT "compile unit size was incorrect" on `dx build --web --release`, and more generally ~1.3MB of leftover std DWARF in release wasm).

Since #4966, dx injects `--config profile.<x>.strip=false` so manganis asset symbols survive the build, then strips manually in `post_process_executable()` based on `get_strip_setting()`. That prediction only honored an explicit `strip` key in Cargo.toml, missing Cargo's implicit default (since Rust 1.77, debuginfo is stripped when the profile's debuginfo is off — as release is by default). The un-stripped DWARF then gets rewritten by wasm-bindgen and crashes binaryen's DWARF re-emitter.

Instead of predicting what Cargo would do, this PR lets Cargo compute the strip setting and intercepts it in the rustc wrapper (`RUSTC_WORKSPACE_WRAPPER`), which dx already uses for Base/Fat builds:

```
run_rustc():
  strip = extract_strip_arg(&mut captured_args)   // removes -C strip=X / -Cstrip=X
  RustcArgs { args: filtered, envs, cwd, strip }  // new #[serde(default)] strip field
  // rustc is invoked without the flag, so symbols survive for asset extraction

post_process_executable():
  match recorded_strip_setting(&artifacts.mode) { // reads {tip}.bin.json from the scope dir
    "debuginfo" => rust-objcopy --strip-debug,
    "symbols"   => rust-objcopy --strip-all,
    _           => no-op,
  }
```

- `profile_args()` no longer injects `strip=false`, and `get_strip_setting()` is deleted.
- Since Cargo itself resolves the value, every source it considers is honored with no duplicated logic: profile `inherits` chains, `.cargo/config.toml` `[profile]` tables, `CARGO_PROFILE_*` env vars, and the implicit 1.77 default.
- Thin builds replay the captured args, which already have the flag removed, so patches stay un-stripped (post-processing only runs for Base/Fat). `wasm_split` builds are still never stripped.
- Bumped the rustc-wrapper scope `version` to 2 so stale captures (with `-C strip` still in `args` and no `strip` field) aren't replayed.

This is the more robust alternative to #5736, which instead mirrors Cargo's implicit default inside `get_strip_setting()` (and cannot see `.cargo/config.toml` / env-var overrides).

## Verification

With a fresh `cargo new` app depending on `dioxus` (feature `web`), using dx built from this branch:

- `dx build --web --release`: output wasm has no `.debug_*` custom sections (on main, ~1.1MB of `.debug_*` remains).
- `dx build --web` (dev): debug sections retained.
- Custom profile with `strip = "symbols"`: binary is fully stripped (`--strip-all`, no `name` section), assets still extracted.
- Custom profile with `debug = true` and no `strip` key: not stripped.
- `CARGO_PROFILE_RELEASE_STRIP=none dx build --web --release`: env override honored, debuginfo retained (the key case #5736 can't handle).
- `dx build --web --fat-binary`: fat build path still works.

`cargo fmt` and `cargo clippy -p dioxus-cli` are clean.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/51b6fb74d9a0452985a2f6840ff2d2bd
Requested by: @nicoburns