### PR TITLE
docs: fix broken guide link in desktop README

### DIFF
--- a/packages/desktop/README.md
+++ b/packages/desktop/README.md
@@ -23,7 +23,7 @@
 
 `dioxus-desktop` provides a webview-based desktop renderer for the Dioxus VirtualDom.
 
-This requires that webview is installed on the target system. WebView is installed by default on macOS and iOS devices, but might not come preinstalled on Windows or Linux devices. To fix these issues, follow the [instructions in the guide](guide-url).
+This requires that webview is installed on the target system. WebView is installed by default on macOS and iOS devices, but might not come preinstalled on Windows or Linux devices. To fix these issues, follow the [instructions in the guide][guide-url].
 
 [guide-url]: https://dioxuslabs.com/learn/0.7/getting_started
 


### PR DESCRIPTION
`packages/desktop/README.md` links the setup guide:

    ...follow the [instructions in the guide](guide-url).

`(guide-url)` is an inline link to a relative path `guide-url`, which 404s, while the reference definition just below is left orphaned:

    [guide-url]: https://dioxuslabs.com/learn/0.7/getting_started

This switches the link to reference style so it uses that definition.
