### PR TITLE
CLI: sanitize/validate uses of the bundled app name per context

### DIFF
--- a/packages/cli/src/build/android.rs
+++ b/packages/cli/src/build/android.rs
@@ -433,7 +433,11 @@ impl BuildRequest {
 
         // Rename it to Name-arch.aab
         let from = app_release.join("app-release.aab");
-        let to = app_release.join(format!("{}-{}.aab", self.bundled_app_name(), self.triple));
+        let to = app_release.join(format!(
+            "{}-{}.aab",
+            self.bundled_app_file_name(),
+            self.triple
+        ));
 
         std::fs::rename(from, &to).context("Failed to rename aab")?;
 

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -434,6 +434,10 @@ impl BuildRequest {
             .load_dioxus_config(crate_package, Some(crate_target.src_path.as_std_path()))?
             .unwrap_or_default();
 
+        if let Some(name) = &config.application.name {
+            validate_bundled_app_name(name)?;
+        }
+
         // We usually use the simulator unless --device is passed *or* a device is detected by probing.
         // For now, though, since we don't have probing, it just defaults to false
         // Tools like xcrun/adb can detect devices
@@ -2704,16 +2708,32 @@ impl BuildRequest {
         self.crate_target.kind[0].clone()
     }
 
-    /// The application name. PascalCase version of the crate name by default.
+    /// The application's display name. PascalCase version of the crate name by default.
     /// May be overridden using [`ApplicationConfig::name`][crate::ApplicationConfig::name].
+    ///
+    /// This is what users see (window titles, launcher labels, installer UI, the
+    /// `.app` directory). It may contain spaces and most punctuation, but is
+    /// validated on startup to exclude characters that are invalid in file names
+    /// (see [`validate_bundled_app_name`]). For artifact file names and derived
+    /// identifiers, use [`Self::bundled_app_file_name`] instead.
     pub(crate) fn bundled_app_name(&self) -> String {
-        use convert_case::{Case, Casing};
-
         self.config
             .application
             .name
             .clone()
-            .unwrap_or_else(|| self.executable_name().to_case(Case::Pascal))
+            .unwrap_or_else(|| self.bundled_app_file_name())
+    }
+
+    /// The PascalCase version of the crate name, ignoring any `application.name`
+    /// override.
+    ///
+    /// Use this for artifact file names (`.msi`, `.ipa`, `.aab`, intermediate build
+    /// files) and anything identity-bearing (the default bundle identifier, MSI
+    /// upgrade code seed), so those stay filesystem/shell-friendly and stable even
+    /// when the display name changes.
+    pub(crate) fn bundled_app_file_name(&self) -> String {
+        use convert_case::{Case, Casing};
+        self.executable_name().to_case(Case::Pascal)
     }
 
     /// Get the crate version from Cargo.toml (e.g., "0.1.0")
@@ -2743,7 +2763,7 @@ impl BuildRequest {
             }
         }
 
-        format!("com.example.{}", self.bundled_app_name())
+        format!("com.example.{}", self.bundled_app_file_name())
     }
 
     /// The item that we'll try to run directly if we need to.
@@ -3169,5 +3189,51 @@ impl BuildRequest {
         }
 
         deps
+    }
+}
+
+/// Validate an `application.name` override from `Dioxus.toml`.
+///
+/// The name is used verbatim as a file/directory name in several bundle outputs
+/// (the macOS/iOS `.app` directory, Windows shortcuts and install directories),
+/// so it must be a valid file name on every supported platform. Display-only
+/// characters like spaces and unicode are allowed.
+fn validate_bundled_app_name(name: &str) -> Result<()> {
+    if name.trim().is_empty() {
+        bail!("`application.name` in Dioxus.toml must not be empty");
+    }
+    if name != name.trim() {
+        bail!("`application.name` in Dioxus.toml must not start or end with whitespace: {name:?}");
+    }
+    if name.ends_with('.') {
+        bail!("`application.name` in Dioxus.toml must not end with a `.`: {name:?}");
+    }
+    if let Some(c) = name.chars().find(|c| {
+        matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|') || c.is_control()
+    }) {
+        bail!(
+            "`application.name` in Dioxus.toml contains the character {c:?}, which is not valid in file names. The name is used as a file name in bundle outputs (e.g. the `.app` directory and installer shortcuts), so it must not contain any of `/ \\ : * ? \" < > |` or control characters."
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_bundled_app_name;
+
+    #[test]
+    fn app_name_validation() {
+        assert!(validate_bundled_app_name("My App").is_ok());
+        assert!(validate_bundled_app_name("Émile's App — 2").is_ok());
+        assert!(validate_bundled_app_name("").is_err());
+        assert!(validate_bundled_app_name("   ").is_err());
+        assert!(validate_bundled_app_name(" My App").is_err());
+        assert!(validate_bundled_app_name("My App.").is_err());
+        assert!(validate_bundled_app_name("My/App").is_err());
+        assert!(validate_bundled_app_name("My\\App").is_err());
+        assert!(validate_bundled_app_name("My: App").is_err());
+        assert!(validate_bundled_app_name("My \"App\"").is_err());
+        assert!(validate_bundled_app_name("My\tApp").is_err());
     }
 }

--- a/packages/cli/src/build/windows.rs
+++ b/packages/cli/src/build/windows.rs
@@ -84,10 +84,7 @@ impl BuildRequest {
             None => (version_str, version),
         };
 
-        let productname = match self.config.application.name.as_ref() {
-            Some(n) => n,
-            None => &self.bundled_app_name(),
-        };
+        let productname = self.bundled_app_name();
 
         let binding = package.description.clone().unwrap_or_default();
         let description = match bundle.short_description.as_ref() {
@@ -102,7 +99,7 @@ impl BuildRequest {
         winres
             .set(Properties::ProductVersion, version_str)
             .set(Properties::FileVersion, file_version_str)
-            .set(Properties::ProductName, productname)
+            .set(Properties::ProductName, &productname)
             .set(Properties::FileDescription, description);
 
         if let Some(value) = &bundle.original_file_name {

--- a/packages/cli/src/bundler/ios.rs
+++ b/packages/cli/src/bundler/ios.rs
@@ -57,7 +57,7 @@ impl BundleContext<'_> {
 
         let ipa_name = format!(
             "{}_{}_{}.ipa",
-            self.product_name(),
+            self.product_file_name(),
             self.version_string(),
             self.binary_arch()
         );

--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -563,13 +563,16 @@ impl BundleContext<'_> {
 
     /// Directory name used for bundled Linux resources.
     fn linux_resource_dir_name(&self) -> String {
-        self.product_name()
+        self.product_file_name()
     }
 
     /// Generate the contents of a .desktop file for the given bundle context.
     fn generate_linux_desktop_file(&self, desktop_template: Option<&Path>) -> Result<String> {
         let mut handlebars = Handlebars::new();
         handlebars.set_strict_mode(false);
+        // `.desktop` files are plain text, not HTML, so Handlebars' default
+        // HTML escaping would corrupt names containing e.g. `&`.
+        handlebars.register_escape_fn(handlebars::no_escape);
 
         let template = match desktop_template {
             // Path to template

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -218,9 +218,17 @@ impl<'a> BundleContext<'a> {
         self.package_types.clone()
     }
 
-    /// The product name.
+    /// The product's display name. Used where users see the name (installer UI,
+    /// shortcuts, the `.app` directory, `.desktop` entries).
     pub(crate) fn product_name(&self) -> String {
         self.build.bundled_app_name()
+    }
+
+    /// The PascalCase crate name. Used for artifact file names and intermediate
+    /// build files so they stay filesystem/shell-friendly and stable even when
+    /// the display name changes.
+    pub(crate) fn product_file_name(&self) -> String {
+        self.build.bundled_app_file_name()
     }
 
     /// The bundle identifier (e.g. "com.example.app").

--- a/packages/cli/src/bundler/updater.rs
+++ b/packages/cli/src/bundler/updater.rs
@@ -42,7 +42,7 @@ impl BundleContext<'_> {
                     for app_path in &bundle.bundle_paths {
                         let tar_path = output_dir.join(format!(
                             "{}_{}.app.tar.gz",
-                            self.product_name(),
+                            self.product_file_name(),
                             self.version_string()
                         ));
                         create_tar_gz(app_path, &tar_path)?;

--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -54,6 +54,7 @@ impl BundleContext<'_> {
         let wix_program_files_folder = arch.wix_program_files_folder();
 
         let product_name = self.product_name();
+        let product_file_name = self.product_file_name();
         let version = wix_version(
             &wix_settings
                 .version
@@ -61,11 +62,11 @@ impl BundleContext<'_> {
                 .unwrap_or_else(|| self.version_string()),
         )?;
 
-        let msi_name = format!("{product_name}_{version}_{arch_str}.msi");
+        let msi_name = format!("{product_file_name}_{version}_{arch_str}.msi");
         let output_path = output_dir.join(&msi_name);
 
         let upgrade_code = wix_settings.upgrade_code.unwrap_or_else(|| {
-            let input = format!("{}.exe.app.{}", product_name, arch_str);
+            let input = format!("{}.exe.app.{}", product_file_name, arch_str);
             Uuid::new_v5(&Uuid::NAMESPACE_DNS, input.as_bytes())
         });
 
@@ -94,7 +95,7 @@ impl BundleContext<'_> {
         let mut data = BTreeMap::new();
         data.insert(
             "product_name".to_string(),
-            serde_json::Value::String(product_name.clone()),
+            serde_json::Value::String(xml_escape(&product_name)),
         );
         data.insert(
             "version".to_string(),
@@ -118,7 +119,7 @@ impl BundleContext<'_> {
         );
         data.insert(
             "short_description".to_string(),
-            serde_json::Value::String(self.short_description()),
+            serde_json::Value::String(xml_escape(&self.short_description())),
         );
         data.insert(
             "bundle_id".to_string(),
@@ -132,7 +133,7 @@ impl BundleContext<'_> {
             .unwrap_or_else(|| product_name.clone());
         data.insert(
             "publisher".to_string(),
-            serde_json::Value::String(publisher),
+            serde_json::Value::String(xml_escape(&publisher)),
         );
 
         data.insert(
@@ -226,7 +227,7 @@ impl BundleContext<'_> {
         let wxs_content =
             render_template(&wix_template, &data).context("Failed to render WiX template")?;
 
-        let wxs_path = output_dir.join(format!("{product_name}.wxs"));
+        let wxs_path = output_dir.join(format!("{product_file_name}.wxs"));
         std::fs::write(&wxs_path, &wxs_content).context("Failed to write WiX source file")?;
 
         let mut fragment_wxs_paths = Vec::new();
@@ -239,7 +240,7 @@ impl BundleContext<'_> {
         }
 
         tracing::info!("Running candle.exe to compile WiX source...");
-        let wixobj_path = output_dir.join(format!("{product_name}.wixobj"));
+        let wixobj_path = output_dir.join(format!("{product_file_name}.wixobj"));
 
         let mut candle_cmd = Command::new(&candle);
         candle_cmd
@@ -392,8 +393,9 @@ impl BundleContext<'_> {
         let arch_str = arch.windows_arch();
 
         let product_name = self.product_name();
+        let product_file_name = self.product_file_name();
         let version = self.version_string();
-        let installer_name = format!("{product_name}_{version}_{arch_str}-setup.exe");
+        let installer_name = format!("{product_file_name}_{version}_{arch_str}-setup.exe");
         let output_path = output_dir.join(&installer_name);
 
         let staging_dir = output_dir.join("_staging");
@@ -427,7 +429,7 @@ impl BundleContext<'_> {
         let mut data = BTreeMap::new();
         data.insert(
             "product_name".to_string(),
-            JsonValue::String(product_name.clone()),
+            JsonValue::String(nsis_escape(&product_name)),
         );
         data.insert("version".to_string(), JsonValue::String(version.clone()));
         data.insert(
@@ -444,7 +446,7 @@ impl BundleContext<'_> {
         );
         data.insert(
             "short_description".to_string(),
-            JsonValue::String(self.short_description()),
+            JsonValue::String(nsis_escape(&self.short_description())),
         );
         data.insert(
             "bundle_id".to_string(),
@@ -456,12 +458,15 @@ impl BundleContext<'_> {
             .map(|s| s.to_string())
             .or_else(|| self.authors_comma_separated())
             .unwrap_or_else(|| product_name.clone());
-        data.insert("publisher".to_string(), JsonValue::String(publisher));
+        data.insert(
+            "publisher".to_string(),
+            JsonValue::String(nsis_escape(&publisher)),
+        );
 
         if let Some(copyright) = self.copyright_string() {
             data.insert(
                 "copyright".to_string(),
-                JsonValue::String(copyright.to_string()),
+                JsonValue::String(nsis_escape(copyright)),
             );
         }
 
@@ -481,7 +486,7 @@ impl BundleContext<'_> {
             .unwrap_or_else(|| product_name.clone());
         data.insert(
             "start_menu_folder".to_string(),
-            JsonValue::String(start_menu_folder),
+            JsonValue::String(nsis_escape(&start_menu_folder)),
         );
 
         if let Some(icon) = &nsis_settings.installer_icon {
@@ -572,7 +577,7 @@ impl BundleContext<'_> {
             render_template(NSIS_TEMPLATE, &data)?
         };
 
-        let nsi_path = output_dir.join(format!("{product_name}.nsi"));
+        let nsi_path = output_dir.join(format!("{product_file_name}.nsi"));
         std::fs::write(&nsi_path, &nsi_content).context("Failed to write NSIS script")?;
 
         tracing::info!("Running makensis to build NSIS installer...");
@@ -926,6 +931,28 @@ fn render_template(template: &str, data: &BTreeMap<String, JsonValue>) -> Result
         .render("template", data)
         .context("Failed to render template")?;
     Ok(rendered.replace(BACKSLASH_PLACEHOLDER, "\\"))
+}
+
+/// Escape a string for use in WiX XML attribute values.
+///
+/// [`render_template`] disables Handlebars' default HTML escaping (paths must be
+/// rendered verbatim), so text values interpolated into the WiX XML must be
+/// escaped at the call site.
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('\"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+/// Escape a string for use inside a double-quoted NSIS string literal.
+///
+/// `$` introduces variables/escapes in NSIS strings and `\"` would terminate the
+/// literal, so both must be escaped when interpolating user-provided text into
+/// the generated `.nsi` script.
+fn nsis_escape(s: &str) -> String {
+    s.replace('$', "$$").replace('\"', "$\\\"")
 }
 
 /// Convert a semver version string to a WiX-compatible version.
@@ -1299,5 +1326,20 @@ mod tests {
         assert!(!rendered.contains("<Directory Id=\"ProgramFilesFolder\">"));
         // Verify \{{ substitution works: registry key should contain actual values
         assert!(rendered.contains("Software\\Dioxus Labs\\Hotdog"));
+    }
+
+    #[test]
+    fn xml_escape_escapes_special_characters() {
+        assert_eq!(
+            super::xml_escape("Tom & Jerry's <App>"),
+            "Tom &amp; Jerry&apos;s &lt;App&gt;"
+        );
+        assert_eq!(super::xml_escape("My App"), "My App");
+    }
+
+    #[test]
+    fn nsis_escape_escapes_special_characters() {
+        assert_eq!(super::nsis_escape("Cash $ App"), "Cash $$ App");
+        assert_eq!(super::nsis_escape("My App"), "My App");
     }
 }


### PR DESCRIPTION
## Summary

Builds on #5533 (its commit is included), which lets `application.name` in Dioxus.toml override the bundled app name. That name flows into many contexts with different rules (file names, XML, NSIS script literals, identifiers), so this PR makes each use context-appropriate instead of interpolating the raw display name everywhere:

- **Split display name vs. file name.** New `BuildRequest::bundled_app_file_name()` / `BundleContext::product_file_name()` always return the PascalCase crate name (pre-#5533 behavior) and are now used for artifact file names and identity-bearing values, so those stay shell-friendly and stable when the display name changes:
  - `.msi`/NSIS installer file names and `.wxs`/`.wixobj`/`.nsi` intermediates
  - the MSI upgrade-code UUID seed (changing `application.name` no longer changes the upgrade code)
  - `.ipa` and `.aab` file names, updater `.app.tar.gz` archives, the Linux resource dir
  - the default bundle identifier fallback, now `com.example.{PascalCrateName}` — a display name with spaces would otherwise produce an invalid CFBundleIdentifier / Android application ID
- **Display name stays verbatim** where users see it (plists, launcher labels, installer UI, shortcuts, install dirs, `.desktop` `Name=`, the `.app` directory), but is validated once at `BuildRequest::new`: `validate_bundled_app_name` rejects empty names, leading/trailing whitespace, a trailing `.`, control chars, and `/ \ : * ? " < > |` (it is used as a file name in the `.app` dir and Windows shortcuts). Spaces and unicode are allowed — that's the point of #5533.
- **Escape template interpolations.** The windows bundler's `render_template` intentionally disables Handlebars escaping (for `\{{...}}` path handling), so text values were injected raw:
  - WiX: `product_name`, `publisher`, `short_description` now go through `xml_escape` (e.g. "Tom & Jerry's" no longer produces invalid XML)
  - NSIS: same values plus `copyright` and `start_menu_folder` go through `nsis_escape` (`$` → `$$`, `"` → `$\"`)
  - Linux `.desktop` generation now uses `handlebars::no_escape` — it previously HTML-escaped names into e.g. `Name=Foo &amp; Bar`
- **Cleanup:** `build/windows.rs` had its own `config.application.name` fallback for the exe's ProductName resource; it now just calls `bundled_app_name()`.

## Testing

- Unit tests for `validate_bundled_app_name`, `xml_escape`, `nsis_escape`
- `cargo fmt --check`, `cargo clippy -p dioxus-cli --all-features --all-targets`, `dx config schema` (no schema changes)

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/05868b37e8e249ecbd616270007bc37a
Requested by: @nicoburns