### PR TITLE
Fix `dx serve` printing the ready banner before the first build completes

### DIFF
--- a/packages/cli/src/serve/mod.rs
+++ b/packages/cli/src/serve/mod.rs
@@ -1,8 +1,6 @@
 use crate::{
     AppBuilder, BuildId, BuildMode, BuilderUpdate, BundleFormat, Result, ServeArgs,
-    TraceController,
-    build::PatchError,
-    styles::{GLOW_STYLE, LINK_STYLE},
+    TraceController, build::PatchError,
 };
 
 mod ansi_buffer;
@@ -47,33 +45,9 @@ pub(crate) async fn serve_all(args: ServeArgs, tracer: &TraceController) -> Resu
     let mut devserver = WebServer::start(&builder)?;
     let mut screen = Output::start(builder.interactive).await?;
 
-    // This is our default splash screen. We might want to make this a fancier splash screen in the future
-    // Also, these commands might not be the most important, but it's all we've got enabled right now
-    tracing::info!(
-        r#"-----------------------------------------------------------------
-                Serving your app: {binname}! 🚀
-                • Press {GLOW_STYLE}`ctrl+c`{GLOW_STYLE:#} to exit the server
-                • Press {GLOW_STYLE}`r`{GLOW_STYLE:#} to rebuild the app
-                • Press {GLOW_STYLE}`p`{GLOW_STYLE:#} to change hotreload mode
-                • Press {GLOW_STYLE}`v`{GLOW_STYLE:#} to toggle verbose logging
-                • Press {GLOW_STYLE}`/`{GLOW_STYLE:#} for more commands and shortcuts{extra}
-               ----------------------------------------------------------------"#,
-        binname = builder.client.build.executable_name(),
-        extra = if builder.client.build.using_dioxus_explicitly {
-            format!(
-                "\n                Learn more at {LINK_STYLE}https://dioxuslabs.com/learn/0.7/getting_started{LINK_STYLE:#}"
-            )
-        } else {
-            String::new()
-        }
-    );
-
-    // Let people know hotpatching is enabled by default now.
-    if builder.hotreload_mode == HotReloadMode::Hotpatch {
-        tracing::warn!(
-            "Note: {GLOW_STYLE}Rust hot-patching{GLOW_STYLE:#} is now enabled by default! Unexpected behavior might occur. Press `p` to change modes."
-        );
-    }
+    // The "Serving your app" readiness banner is shown later, in `AppBuilder::open`, once the
+    // first build has actually completed and (for non-web platforms) the app has launched -
+    // printing it here would claim readiness before the build even starts.
 
     builder.initialize();
 

--- a/packages/cli/src/serve/runner.rs
+++ b/packages/cli/src/serve/runner.rs
@@ -716,7 +716,7 @@ impl AppServer {
         let should_open = self.client.stage == BuildStage::Success
             && (self.server.as_ref().map(|s| s.stage == BuildStage::Success)).unwrap_or(true);
 
-        use crate::cli::styles::GLOW_STYLE;
+        use crate::cli::styles::{GLOW_STYLE, LINK_STYLE};
 
         if should_open {
             let time_taken = self.client.total_build_time().unwrap_or_else(|| {
@@ -731,6 +731,34 @@ impl AppServer {
                     "Build completed successfully in {GLOW_STYLE}{}{GLOW_STYLE:#}, launching app! 💫",
                     format_duration_ms(time_taken)
                 );
+
+                // Only now is the app actually ready to be used - this is the first point at
+                // which the bundle exists on disk and (for non-web platforms) the process has
+                // been launched, so this is when we tell the user the app is truly being served.
+                tracing::info!(
+                    r#"-----------------------------------------------------------------
+                Serving your app: {binname}! 🚀
+                • Press {GLOW_STYLE}`ctrl+c`{GLOW_STYLE:#} to exit the server
+                • Press {GLOW_STYLE}`r`{GLOW_STYLE:#} to rebuild the app
+                • Press {GLOW_STYLE}`p`{GLOW_STYLE:#} to change hotreload mode
+                • Press {GLOW_STYLE}`v`{GLOW_STYLE:#} to toggle verbose logging
+                • Press {GLOW_STYLE}`/`{GLOW_STYLE:#} for more commands and shortcuts{extra}
+               ----------------------------------------------------------------"#,
+                    binname = self.client.build.executable_name(),
+                    extra = if self.client.build.using_dioxus_explicitly {
+                        format!(
+                            "\n                Learn more at {LINK_STYLE}https://dioxuslabs.com/learn/0.7/getting_started{LINK_STYLE:#}"
+                        )
+                    } else {
+                        String::new()
+                    }
+                );
+
+                if self.hotreload_mode == HotReloadMode::Hotpatch {
+                    tracing::warn!(
+                        "Note: {GLOW_STYLE}Rust hot-patching{GLOW_STYLE:#} is now enabled by default! Unexpected behavior might occur. Press `p` to change modes."
+                    );
+                }
             } else {
                 tracing::info!(
                     "Build completed in {GLOW_STYLE}{}{GLOW_STYLE:#}",


### PR DESCRIPTION
`dx serve` printed the "Serving your app" readiness banner right after the dev server socket came up, before `builder.initialize()` was even called - so it fired well before the first build (and thus the bundle on disk) existed. Anything that treats the banner as a readiness signal (a script tailing CLI output, a human copying the built bundle) can race the real build.

Move the banner into `AppServer::open()`, gated by the existing `builds_opened == 0` check that already distinguishes the first successful open from subsequent ones, so it only prints once the app has actually been built and opened.

Verified manually: before the fix the banner printed ~27s before "Build completed successfully"; after the fix both print at the same instant, in the right order.

Closes #5744
