### PR TITLE
Fix hotpatch cascade replaying workspace crates not built for the active target

### DIFF
--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -389,6 +389,15 @@ impl AppBuilder {
             krate == tip_crate_name || artifacts.workspace_rustc.contains_crate(krate)
         };
 
+        // Nothing the user edited is compiled for this target, so it cannot affect the running
+        // binary. Patching anyway would rebuild, relink and reload the client for no change.
+        if edit_cannot_reach_target(&changed_crates, in_target_graph) {
+            tracing::debug!(
+                "Ignoring patch rebuild for {build_id:?} since none of {changed_crates:?} are built for this target."
+            );
+            return;
+        }
+
         // On web, our patches are fully relocatable, so we don't need to worry about ASLR, but
         // for all other platforms, we need to use the ASLR reference to know where to insert the patch.
         let aslr_reference = match self.aslr_reference {
@@ -2221,6 +2230,18 @@ impl AppBuilder {
     }
 }
 
+/// Whether an edit cannot reach the running binary: it mapped to workspace crates, and not one
+/// of them is built for this target.
+///
+/// An empty `changed_crates` means the changed files mapped to no workspace crate at all, which
+/// says nothing about relevance - those edits keep going through the normal patch path.
+fn edit_cannot_reach_target(
+    changed_crates: &[String],
+    in_target_graph: impl Fn(&str) -> bool,
+) -> bool {
+    !changed_crates.is_empty() && !changed_crates.iter().any(|krate| in_target_graph(krate))
+}
+
 /// The crates whose objects a patch must carry: the crates the user edited, plus every workspace
 /// crate that transitively depends on one of them, plus `tip_crate_name` (always rebuilt).
 ///
@@ -2292,6 +2313,59 @@ mod tests {
 
         result.sort();
         result
+    }
+
+    fn cannot_reach(changed: &[&str], outside: &[&str]) -> bool {
+        let changed: Vec<String> = changed.iter().map(|c| c.to_string()).collect();
+        edit_cannot_reach_target(&changed, |krate| !outside.contains(&krate))
+    }
+
+    /// Drive the cascade from a real cargo workspace, as a wasm32 build sees it: `native_ffi` is
+    /// in the metadata graph and reported as a dependent, but is never compiled for this target.
+    fn wasm_replay_set(edited: &str) -> Vec<String> {
+        let (_dir, krates) = crate::test_workspace::native_sibling_workspace();
+        let members = crate::Workspace::member_nids(&krates);
+
+        let mut got: Vec<String> = crates_to_replay(
+            &[edited.to_string()],
+            "app",
+            |krate| crate::workspace::dependents_of(&krates, &members, krate),
+            |krate| krate != "native_ffi",
+        )
+        .into_iter()
+        .collect();
+
+        got.sort();
+        got
+    }
+
+    #[test]
+    fn editing_a_shared_library_patches_the_app_but_not_the_native_sibling() {
+        assert_eq!(wasm_replay_set("shared_lib"), ["app", "shared_lib"]);
+    }
+
+    #[test]
+    fn editing_the_native_sibling_leaves_nothing_to_replay() {
+        assert_eq!(wasm_replay_set("native_ffi"), ["app"]);
+    }
+
+    #[test]
+    fn edit_touching_only_crates_outside_the_target_graph_cannot_reach_it() {
+        assert!(cannot_reach(&["native_ffi"], &["native_ffi"]));
+    }
+
+    #[test]
+    fn edit_touching_one_built_crate_can_reach_the_target() {
+        assert!(!cannot_reach(
+            &["native_ffi", "shared_lib"],
+            &["native_ffi"]
+        ));
+    }
+
+    #[test]
+    fn edit_mapping_to_no_workspace_crate_takes_the_normal_path() {
+        // Says nothing about relevance, so it must not be treated as unreachable.
+        assert!(!cannot_reach(&[], &[]));
     }
 
     #[test]

--- a/packages/cli/src/build/builder.rs
+++ b/packages/cli/src/build/builder.rs
@@ -354,8 +354,8 @@ impl AppBuilder {
     /// the latest version of *every* crate modified since the fat build, not just the one that
     /// changed this iteration. We BFS `workspace_dependents_of` from `changed_crates` to catch
     /// the cascade — e.g. editing a leaf crate forces parent crates' generic instantiations to
-    /// change too. (`compile_workspace_deps` does its own walk to decide what to *compile* now;
-    /// this set tracks what to *link* into the patch.)
+    /// change too. Crates outside the active build's target graph are excluded, since there is no
+    /// captured rustc invocation to replay for them.
     ///
     /// Then aborts any in-flight build and spawns a fresh task with [`BuildMode::Thin`], handing
     /// it the fat build's `workspace_rustc_args`/`artifact_paths` (so rustc gets re-invoked with
@@ -373,6 +373,20 @@ impl AppBuilder {
                 "Ignoring patch rebuild for {build_id:?} since there is no existing build."
             );
             return;
+        };
+
+        // Track the tip by *package* name — that's the identity used by the file→crate
+        // mapping and the workspace dependents graph (the bin target name can differ).
+        let tip_crate_name = self.build.tip_package_name();
+
+        // Whether a crate belongs to *this* build's target graph, i.e. the fat build captured a
+        // rustc invocation we can replay for it. Workspace dependency graphs are target-agnostic,
+        // so a crate can be watched (and report as changed) without ever being compiled here —
+        // e.g. a dependency behind `[target.'cfg(...)'.dependencies]`. The tip always belongs: it
+        // is tracked by package name, which can differ from its captured `.bin` target name (see
+        // `workspace_hotpatch_replay_order`).
+        let in_target_graph = |krate: &str| {
+            krate == tip_crate_name || artifacts.workspace_rustc.contains_crate(krate)
         };
 
         // On web, our patches are fully relocatable, so we don't need to worry about ASLR, but
@@ -404,29 +418,14 @@ impl AppBuilder {
         // ALL crates modified since the fat build. We compute the full cascade closure here
         // (while we have &mut self) so it doesn't need to be round-tripped through BuildArtifacts.
         //
-        // Note: compile_workspace_deps() independently computes which crates to compile for THIS
-        // patch (starting from changed_crates + cascade). That serves a different purpose — it only
-        // compiles what changed now, not everything ever modified. Both use workspace_dependents_of
-        // for the BFS, so they stay in sync automatically.
-        // Track the tip by *package* name — that's the identity used by the file→crate
-        // mapping and the workspace dependents graph (the bin target name can differ).
-        let tip_crate_name = self.build.tip_package_name();
-        self.modified_crates.insert(tip_crate_name.clone());
-
-        // Add changed crates and their transitive workspace dependents (cascade).
-        let mut to_visit: Vec<String> = changed_crates.clone();
-        let mut visited = HashSet::new();
-        while let Some(c) = to_visit.pop() {
-            if !visited.insert(c.clone()) {
-                continue;
-            }
-            self.modified_crates.insert(c.clone());
-            for dep in self.build.workspace_dependents_of(&c) {
-                if dep != tip_crate_name && !visited.contains(&dep) {
-                    to_visit.push(dep);
-                }
-            }
-        }
+        // `compile_workspace_hotpatch` consumes this set directly, ordering it with
+        // `workspace_hotpatch_replay_order` so dependencies replay before their dependents.
+        self.modified_crates.extend(crates_to_replay(
+            &changed_crates,
+            &tip_crate_name,
+            |krate| self.build.workspace_dependents_of(krate),
+            in_target_graph,
+        ));
 
         tracing::debug!(
             "Patch rebuild: changed_crates={:?}, modified_crates={:?}",
@@ -2219,5 +2218,155 @@ impl AppBuilder {
         drop(_child);
 
         Ok(())
+    }
+}
+
+/// The crates whose objects a patch must carry: the crates the user edited, plus every workspace
+/// crate that transitively depends on one of them, plus `tip_crate_name` (always rebuilt).
+///
+/// `in_target_graph` excludes crates the active build never compiled. Workspace dependency graphs
+/// are target-agnostic, so `dependents_of` can report a crate that has no captured rustc
+/// invocation to replay - e.g. a dependency behind `[target.'cfg(...)'.dependencies]` while
+/// serving wasm. Such a crate is dropped, and the walk is pruned through it: anything reachable
+/// only via a crate this target never compiled does not consume the change on this target either.
+/// A dependent that also has a compiled path back to the edited crate is still reached along that
+/// path, so excluding one route never drops a crate that genuinely needs the patch.
+fn crates_to_replay(
+    changed_crates: &[String],
+    tip_crate_name: &str,
+    dependents_of: impl Fn(&str) -> Vec<String>,
+    in_target_graph: impl Fn(&str) -> bool,
+) -> HashSet<String> {
+    let mut replay = HashSet::from([tip_crate_name.to_string()]);
+    let mut to_visit = changed_crates.to_vec();
+    let mut visited = HashSet::new();
+
+    while let Some(krate) = to_visit.pop() {
+        if !visited.insert(krate.clone()) {
+            continue;
+        }
+
+        if !in_target_graph(&krate) {
+            continue;
+        }
+
+        for dependent in dependents_of(&krate) {
+            if dependent != tip_crate_name && !visited.contains(&dependent) {
+                to_visit.push(dependent);
+            }
+        }
+
+        replay.insert(krate);
+    }
+
+    replay
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    const TIP: &str = "wasm_app";
+
+    /// `edges` maps a crate to the workspace crates that depend on it.
+    fn replay(
+        changed: &[&str],
+        edges: &[(&str, &[&str])],
+        outside_target_graph: &[&str],
+    ) -> Vec<String> {
+        let graph: HashMap<&str, Vec<String>> = edges
+            .iter()
+            .map(|(krate, deps)| (*krate, deps.iter().map(|d| d.to_string()).collect()))
+            .collect();
+
+        let changed: Vec<String> = changed.iter().map(|c| c.to_string()).collect();
+        let mut result: Vec<String> = crates_to_replay(
+            &changed,
+            TIP,
+            |krate| graph.get(krate).cloned().unwrap_or_default(),
+            |krate| !outside_target_graph.contains(&krate),
+        )
+        .into_iter()
+        .collect();
+
+        result.sort();
+        result
+    }
+
+    #[test]
+    fn cascade_reaches_every_dependent_when_all_are_built() {
+        // The baseline the exclusion must not disturb.
+        let got = replay(
+            &["shared_lib"],
+            &[("shared_lib", &["helper", TIP]), ("helper", &[TIP])],
+            &[],
+        );
+        assert_eq!(got, vec!["helper", "shared_lib", "wasm_app"]);
+    }
+
+    #[test]
+    fn dependent_outside_the_target_graph_is_excluded() {
+        let got = replay(
+            &["shared_lib"],
+            &[("shared_lib", &["native_ffi", TIP])],
+            &["native_ffi"],
+        );
+        assert_eq!(got, vec!["shared_lib", "wasm_app"]);
+    }
+
+    #[test]
+    fn edited_crate_outside_the_target_graph_is_excluded() {
+        // The seed path: the user edited the excluded crate itself.
+        let got = replay(&["native_ffi"], &[("native_ffi", &[TIP])], &["native_ffi"]);
+        assert_eq!(got, vec!["wasm_app"]);
+    }
+
+    #[test]
+    fn walk_is_pruned_through_a_crate_outside_the_target_graph() {
+        // `leaf` is reachable only via `native_ffi`, which this target never compiles.
+        let got = replay(
+            &["shared_lib"],
+            &[("shared_lib", &["native_ffi"]), ("native_ffi", &["leaf"])],
+            &["native_ffi"],
+        );
+        assert_eq!(got, vec!["shared_lib", "wasm_app"]);
+    }
+
+    #[test]
+    fn compiled_route_still_reaches_a_dependent_the_pruned_route_dropped() {
+        // Same graph, but `leaf` also depends on `shared_lib` directly - it must survive.
+        let got = replay(
+            &["shared_lib"],
+            &[
+                ("shared_lib", &["native_ffi", "leaf"]),
+                ("native_ffi", &["leaf"]),
+            ],
+            &["native_ffi"],
+        );
+        assert_eq!(got, vec!["leaf", "shared_lib", "wasm_app"]);
+    }
+
+    #[test]
+    fn tip_is_kept_even_when_reported_outside_the_target_graph() {
+        // The tip is tracked by package name, which can differ from its captured `.bin` name.
+        let got = replay(&["shared_lib"], &[("shared_lib", &[TIP])], &[TIP]);
+        assert_eq!(got, vec!["shared_lib", "wasm_app"]);
+    }
+
+    #[test]
+    fn every_edited_crate_is_walked_independently() {
+        let got = replay(
+            &["shared_lib", "native_ffi"],
+            &[("shared_lib", &["helper"]), ("native_ffi", &["leaf"])],
+            &["native_ffi"],
+        );
+        assert_eq!(got, vec!["helper", "shared_lib", "wasm_app"]);
+    }
+
+    #[test]
+    fn a_dependency_cycle_terminates() {
+        let got = replay(&["a"], &[("a", &["b"]), ("b", &["a"])], &[]);
+        assert_eq!(got, vec!["a", "b", "wasm_app"]);
     }
 }

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -2897,46 +2897,7 @@ impl BuildRequest {
     /// as a dependency. Used for cascade detection — when a dep's public symbols change,
     /// its dependents need recompilation too.
     pub(crate) fn workspace_dependents_of(&self, crate_name: &str) -> Vec<String> {
-        let krates = &self.workspace.krates;
-
-        // Find the NodeId for the target crate
-        let target_nid = krates.workspace_members().find_map(|member| {
-            if let krates::Node::Krate { id, krate, .. } = member {
-                if krate.name.replace('-', "_") == crate_name {
-                    return krates.nid_for_kid(id);
-                }
-            }
-            None
-        });
-
-        let Some(target_nid) = target_nid else {
-            return Vec::new();
-        };
-
-        // Use krates' direct_dependents to find reverse deps, filter to workspace members
-        let workspace_names: HashSet<String> = krates
-            .workspace_members()
-            .filter_map(|m| {
-                if let krates::Node::Krate { krate, .. } = m {
-                    Some(krate.name.replace('-', "_"))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        krates
-            .direct_dependents(target_nid)
-            .into_iter()
-            .filter_map(|dep| {
-                let name = dep.krate.name.replace('-', "_");
-                if workspace_names.contains(&name) {
-                    Some(name)
-                } else {
-                    None
-                }
-            })
-            .collect()
+        self.workspace.dependents_of(crate_name)
     }
 
     /// Get the folder where Apple Widget Extensions (.appex bundles) are installed.

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -24,6 +24,8 @@ mod serve;
 mod settings;
 mod tailwind;
 mod test_harnesses;
+#[cfg(test)]
+mod test_workspace;
 mod wasm_bindgen;
 mod wasm_opt;
 mod workspace;

--- a/packages/cli/src/rustcwrapper.rs
+++ b/packages/cli/src/rustcwrapper.rs
@@ -21,6 +21,17 @@ impl WorkspaceRustcArgs {
             rustc_args: Default::default(),
         }
     }
+
+    /// Was a rustc invocation captured for `crate_name` (as a lib or bin) during this build?
+    ///
+    /// Workspace dependency graphs are target-agnostic, so a crate can be a workspace dependent
+    /// of another without ever being part of *this* build's target/crate graph (e.g. a
+    /// native-only sibling crate that a wasm32 build never compiles). This is used to filter such
+    /// crates out before treating them as part of the current build.
+    pub fn contains_crate(&self, crate_name: &str) -> bool {
+        self.rustc_args.contains_key(&format!("{crate_name}.lib"))
+            || self.rustc_args.contains_key(&format!("{crate_name}.bin"))
+    }
 }
 
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -169,4 +180,46 @@ fn has_linking_args() -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_for(names: &[&str]) -> WorkspaceRustcArgs {
+        let mut workspace_args = WorkspaceRustcArgs::new(Vec::new());
+        for name in names {
+            workspace_args
+                .rustc_args
+                .insert(name.to_string(), RustcArgs::default());
+        }
+        workspace_args
+    }
+
+    #[test]
+    fn contains_crate_matches_lib_key() {
+        let workspace_args = args_for(&["shared_lib.lib"]);
+        assert!(workspace_args.contains_crate("shared_lib"));
+    }
+
+    #[test]
+    fn contains_crate_matches_bin_key() {
+        let workspace_args = args_for(&["wasm_app.bin"]);
+        assert!(workspace_args.contains_crate("wasm_app"));
+    }
+
+    #[test]
+    fn contains_crate_false_for_uncaptured_crate() {
+        // Mirrors the hot-patch cascade bug: a workspace dependent (e.g. a native-only sibling
+        // crate) that was never compiled for the active build's target has no captured rustc
+        // invocation at all, so it must not be treated as part of the current build.
+        let workspace_args = args_for(&["shared_lib.lib", "wasm_app.bin"]);
+        assert!(!workspace_args.contains_crate("native_ffi"));
+    }
+
+    #[test]
+    fn contains_crate_false_on_empty_map() {
+        let workspace_args = WorkspaceRustcArgs::new(Vec::new());
+        assert!(!workspace_args.contains_crate("anything"));
+    }
 }

--- a/packages/cli/src/test_workspace.rs
+++ b/packages/cli/src/test_workspace.rs
@@ -1,0 +1,85 @@
+//! Shared fixtures for tests that need a real cargo workspace on disk.
+
+use krates::{Cmd, Krates};
+use std::fs;
+
+/// Write the workspace from the bug report to disk and load its real cargo metadata: an app
+/// served for wasm32, a library it uses, and a native-only sibling that depends on the same
+/// library but is only reachable from the app on non-wasm targets.
+pub(crate) fn native_sibling_workspace() -> (tempfile::TempDir, Krates) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    for (name, manifest, source) in [
+        (
+            "shared-lib",
+            "[package]\nname = \"shared-lib\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+            "pub fn greeting() -> &'static str { \"hi\" }\n",
+        ),
+        (
+            "native_ffi",
+            "[package]\nname = \"native_ffi\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nshared-lib = { path = \"../shared-lib\" }\n",
+            "pub fn native() -> &'static str { shared_lib::greeting() }\n",
+        ),
+        (
+            "app",
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[dependencies]\nshared-lib = { path = \"../shared-lib\" }\n\n[target.'cfg(not(target_arch = \"wasm32\"))'.dependencies]\nnative_ffi = { path = \"../native_ffi\" }\n",
+            "pub fn app() {}\n",
+        ),
+    ] {
+        fs::create_dir_all(root.join(name).join("src")).expect("crate dir");
+        fs::write(root.join(name).join("Cargo.toml"), manifest).expect("manifest");
+        fs::write(root.join(name).join("src").join("lib.rs"), source).expect("source");
+    }
+
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nresolver = \"2\"\nmembers = [\"app\", \"shared-lib\", \"native_ffi\"]\n",
+    )
+    .expect("workspace manifest");
+
+    let mut cmd = Cmd::new();
+    cmd.current_dir(root);
+    cmd.other_options(["--offline".to_string()]);
+    let mut builder = krates::Builder::new();
+    builder.workspace(true);
+    let krates = builder.build(cmd, |_| {}).expect("cargo metadata");
+
+    (dir, krates)
+}
+
+/// A workspace where two distinct packages normalise to the same rustc crate name. Cargo allows
+/// this: `dup-name` and `dup_name` are different package names that both compile as `dup_name`.
+pub(crate) fn colliding_member_names_workspace() -> (tempfile::TempDir, Krates) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    for name in ["dup-name", "dup_name"] {
+        fs::create_dir_all(root.join(name).join("src")).expect("crate dir");
+        fs::write(
+            root.join(name).join("Cargo.toml"),
+            format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n"),
+        )
+        .expect("manifest");
+        fs::write(
+            root.join(name).join("src").join("lib.rs"),
+            "pub fn f() {}\n",
+        )
+        .expect("source");
+    }
+
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nresolver = \"2\"\nmembers = [\"dup-name\", \"dup_name\"]\n",
+    )
+    .expect("workspace manifest");
+
+    let mut cmd = Cmd::new();
+    cmd.current_dir(root);
+    cmd.other_options(["--offline".to_string()]);
+    let mut builder = krates::Builder::new();
+    builder.workspace(true);
+    let krates = builder.build(cmd, |_| {}).expect("cargo metadata");
+
+    (dir, krates)
+}

--- a/packages/cli/src/workspace.rs
+++ b/packages/cli/src/workspace.rs
@@ -7,7 +7,10 @@ use ignore::gitignore::Gitignore;
 use krates::{Cmd, Krates, NodeId};
 use krates::{KrateDetails, LockOptions, semver::Version};
 use std::sync::Arc;
-use std::{collections::HashSet, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
 use std::{path::PathBuf, time::Duration};
 use target_lexicon::Triple;
 use tokio::process::Command;
@@ -21,6 +24,12 @@ pub struct Workspace {
     pub(crate) ignore: Gitignore,
     pub(crate) cargo_toml: cargo_toml::Manifest,
     pub(crate) android_tools: Option<Arc<AndroidTools>>,
+
+    /// Every workspace member's crate name in rustc convention (hyphens as underscores), mapped
+    /// to its node in `krates`. Derived once at load: resolving a name against `krates` means
+    /// scanning and re-normalising every member, which reverse-dependency lookups would
+    /// otherwise repeat on each query.
+    pub(crate) member_nids: HashMap<String, NodeId>,
 }
 
 /// Process-wide cache of the loaded workspace. `Workspace::current()` populates this on first
@@ -30,6 +39,31 @@ static WORKSPACE_CACHE: tokio::sync::Mutex<Option<Arc<Workspace>>> =
     tokio::sync::Mutex::const_new(None);
 
 impl Workspace {
+    /// Workspace members that directly depend on `crate_name`, in rustc convention.
+    pub(crate) fn dependents_of(&self, crate_name: &str) -> Vec<String> {
+        dependents_of(&self.krates, &self.member_nids, crate_name)
+    }
+
+    /// Index every workspace member by its rustc-convention crate name.
+    pub(crate) fn member_nids(krates: &Krates) -> HashMap<String, NodeId> {
+        let mut members = HashMap::new();
+
+        for member in krates.workspace_members() {
+            let krates::Node::Krate { id, krate, .. } = member else {
+                continue;
+            };
+            let Some(nid) = krates.nid_for_kid(id) else {
+                continue;
+            };
+
+            // `foo-bar` and `foo_bar` are distinct packages that share one rustc name, so keep
+            // the first in workspace order - collecting would silently prefer the last.
+            members.entry(krate.name.replace('-', "_")).or_insert(nid);
+        }
+
+        members
+    }
+
     /// Load the workspace from the current directory. This is cached and will only be loaded once.
     pub async fn current() -> Result<Arc<Workspace>> {
         // Lock the workspace to prevent multiple threads from loading it at the same time
@@ -109,6 +143,8 @@ impl Workspace {
 
         let android_tools = AndroidTools::current();
 
+        let member_nids = Self::member_nids(&krates);
+
         let workspace = Arc::new(Self {
             krates,
             settings,
@@ -118,6 +154,7 @@ impl Workspace {
             ignore,
             cargo_toml,
             android_tools,
+            member_nids,
         });
 
         tracing::debug!(
@@ -674,5 +711,87 @@ impl std::fmt::Debug for Workspace {
             .field("sysroot", &self.sysroot)
             .field("wasm_opt", &self.wasm_opt)
             .finish()
+    }
+}
+
+/// Workspace members that directly depend on `crate_name`, in rustc convention.
+///
+/// Answered from the whole-workspace graph, which is target-agnostic: a member that depends on
+/// `crate_name` only for some other target is still reported here.
+pub(crate) fn dependents_of(
+    krates: &Krates,
+    members: &HashMap<String, NodeId>,
+    crate_name: &str,
+) -> Vec<String> {
+    let Some(&target_nid) = members.get(crate_name) else {
+        return Vec::new();
+    };
+
+    // Membership is the same question as "is it in the index", so one lookup table serves both
+    // resolving the crate above and filtering its dependents here.
+    krates
+        .direct_dependents(target_nid)
+        .into_iter()
+        .map(|dep| dep.krate.name.replace('-', "_"))
+        .filter(|name| members.contains_key(name))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_workspace::{colliding_member_names_workspace, native_sibling_workspace};
+
+    #[test]
+    fn members_are_indexed_under_their_rustc_names() {
+        let (_dir, krates) = native_sibling_workspace();
+        let members = Workspace::member_nids(&krates);
+
+        // `shared-lib` is declared with a hyphen but referred to as `shared_lib` everywhere the
+        // cascade looks it up.
+        let mut names: Vec<&str> = members.keys().map(String::as_str).collect();
+        names.sort();
+        assert_eq!(names, ["app", "native_ffi", "shared_lib"]);
+    }
+
+    #[test]
+    fn a_native_only_sibling_is_still_reported_as_a_dependent() {
+        // The premise of the hotpatch bug: this graph has no notion of the target being built,
+        // so a wasm32 build is told `native_ffi` depends on the library it just changed.
+        let (_dir, krates) = native_sibling_workspace();
+        let members = Workspace::member_nids(&krates);
+
+        let mut dependents = dependents_of(&krates, &members, "shared_lib");
+        dependents.sort();
+        assert_eq!(dependents, ["app", "native_ffi"]);
+    }
+
+    #[test]
+    fn a_crate_outside_the_workspace_has_no_dependents() {
+        let (_dir, krates) = native_sibling_workspace();
+        let members = Workspace::member_nids(&krates);
+
+        assert!(dependents_of(&krates, &members, "serde").is_empty());
+    }
+
+    #[test]
+    fn colliding_member_names_resolve_the_same_way_a_scan_would() {
+        let (_dir, krates) = colliding_member_names_workspace();
+        let members = Workspace::member_nids(&krates);
+
+        // Resolving by scanning members, which is what the index replaced.
+        let scanned = krates
+            .workspace_members()
+            .find_map(|member| match member {
+                krates::Node::Krate { id, krate, .. }
+                    if krate.name.replace('-', "_") == "dup_name" =>
+                {
+                    krates.nid_for_kid(id)
+                }
+                _ => None,
+            })
+            .expect("a member normalises to dup_name");
+
+        assert_eq!(members.get("dup_name"), Some(&scanned));
     }
 }


### PR DESCRIPTION
`patch_rebuild`'s cascade decides which workspace crates a hot patch must carry. It walks `workspace_dependents_of`, which reads the whole-workspace Cargo metadata graph — and that graph is target-agnostic. So the cascade could pick up a crate the active build never compiled: a native-only sibling, or a dependency behind `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` while serving wasm. No rustc invocation was captured for such a crate, so `compile_workspace_hotpatch` hard-errored with `Missing rustc args for replay: '<crate>'`, and hot-patching stayed broken until `dx serve` was restarted.

**First commit** excludes those crates on both routes into the replay set — the crates the user edited and the dependents found by walking — and prunes the walk through them, since anything reachable only via a crate this target never compiled doesn't consume the change either. A dependent that also has a compiled path back to the edited crate is still reached along that path, so excluding one route never drops a crate that genuinely needs the patch. The walk is extracted as `crates_to_replay` and covered by eight tests over a fake dependents graph, including the "cascade is unchanged when every crate is built" baseline.

**Second commit** stops the wasted work this exposes: editing an excluded crate still ran a full patch cycle — thin rebuild, relink, jump table, client reload — with an empty replay list, because the tip is always rebuilt. It now returns before starting the build, while leaving behaviour untouched when a changed file maps to no workspace crate at all.

Verified on a workspace with a cfg-gated native-only dependency (`wasm_app` → `shared_lib`, plus `native_ffi` depending on `shared_lib` and reachable from `wasm_app` only for non-wasm targets):

| edit | before | after |
|---|---|---|
| `native_ffi` (never built for wasm32) | `Missing rustc args for replay: 'native_ffi'`, builder stuck | skipped, no patch cycle |
| `shared_lib` (shared, in the graph) | patch applies | patch applies, identical cascade |

`cargo test --workspace --tests` passes (208 suites), as do `cargo fmt` and `cargo clippy --all-targets -- -D warnings`.

Same root cause as #5596, which was closed as a duplicate of #5540 — see the repro and analysis posted there.

Closes #5540
