### PR TITLE
Introduce a function to create a synthetic form event

### DIFF
--- a/packages/native-dom/src/events.rs
+++ b/packages/native-dom/src/events.rs
@@ -610,6 +610,16 @@ pub fn synthetic_click_event(node: &Node, modifiers: Modifiers) -> Box<dyn Any> 
     ))
 }
 
+pub fn synthetic_form_event(
+    value: impl Into<String>,
+    values: impl Into<Vec<(String, FormValue)>>,
+) -> Box<dyn Any> {
+    Box::new(NativeFormData {
+        value: value.into(),
+        values: values.into(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/native-dom/src/lib.rs
+++ b/packages/native-dom/src/lib.rs
@@ -15,7 +15,7 @@ mod mutation_writer;
 mod write_once_attr;
 pub use blitz_dom::DocumentConfig;
 pub use dioxus_document::DioxusDocument;
-pub use events::{NodeHandle, synthetic_click_event};
+pub use events::{NodeHandle, synthetic_click_event, synthetic_form_event};
 pub use write_once_attr::{CustomWidgetAttr, SubDocumentAttr};
 
 pub use blitz_dom::NodeId;


### PR DESCRIPTION
This introduces `synthetic_form_event` analogously to `synthetic_click_event`. It allows test code to construct a `NativeFormData` which can set the values of form elements. Otherwise test code would have no easy way to generate such events.

This also increases the visibility of `ElementId::new()` so that it is possible to construct `ElementId` from outside Dioxus. The dioxus-test crate namely needs a way to construct these.