### PR TITLE
Update tao to version 0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12657,9 +12657,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.35.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
+checksum = "e9fa4618f999c4249db1681cba0a19b890718f274de7fa93c445d46bd3a8a999"
 dependencies = [
  "bitflags 2.11.1",
  "block2 0.6.2",
@@ -12677,6 +12677,7 @@ dependencies = [
  "libc",
  "log",
  "ndk",
+ "ndk-context",
  "ndk-sys",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
@@ -12698,9 +12699,9 @@ dependencies = [
 
 [[package]]
 name = "tao-macros"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
+checksum = "5f7eeb6d99155545da6150a1795945f16ac9c178deb2a5f2e74d776107bd5849"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,7 @@ winnow = "0.7.14"
 
 # desktop
 wry = { version = "0.55.1", default-features = false }
-tao = { version = "0.35.2", features = ["rwh_05"] }
+tao = { version = "0.36.0", features = ["rwh_05"] }
 infer = "0.19.0"
 dunce = "1.0.5"
 percent-encoding = "2.3.2"


### PR DESCRIPTION
This PR updates [tao](https://github.com/tauri-apps/tao) to [v0.36.0](https://github.com/tauri-apps/tao/releases/tag/tao-v0.36.0) which fixes some window decoration issues under Linux that have been discussed in this repository before as well, especially in #4528 and #4957.

I also run `cargo update`, so the `Cargo.lock` has been updated, too.