### PR TITLE
feat(core): memoize components by value of Element props

### DIFF
--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -37,8 +37,10 @@ impl VNode {
 
         self.move_mount_to(new, dom);
 
-        // If the templates are the same, we don't need to do anything, except copy over the mount information
-        if self == new {
+        // If the nodes are the same allocation, we don't need to do anything, except copy over the mount information.
+        // Note: this intentionally uses pointer equality instead of `PartialEq`, which compares by value. The diff
+        // algorithm walks the tree structurally, so a value comparison here would be wasted work.
+        if self.ptr_eq(new) {
             return;
         }
 

--- a/packages/core/src/fragment.rs
+++ b/packages/core/src/fragment.rs
@@ -57,9 +57,11 @@ impl<const A: bool> FragmentBuilder<A> {
 /// or classes. If you want to generate nodes instead of accepting them as a list, consider declaring a closure
 /// on the props that takes Context.
 ///
-/// If a parent passes children into a component, the child will always re-render when the parent re-renders. In other
-/// words, a component cannot be automatically memoized if it borrows nodes from its parent, even if the component's
-/// props are valid for the static lifetime.
+/// If a parent passes children into a component, the child will re-render when the parent
+/// re-renders unless the children are unchanged. Since [`Element`]s are compared by value
+/// (see [`VNode`]'s `PartialEq` impl), a component *can* be automatically memoized even when
+/// it borrows nodes from its parent: if the newly-built children element has the same content
+/// as the previous one, the child skips re-rendering.
 ///
 /// ## Example
 ///

--- a/packages/core/src/nodes.rs
+++ b/packages/core/src/nodes.rs
@@ -108,7 +108,31 @@ impl Default for VNode {
 
 impl PartialEq for VNode {
     fn eq(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.vnode, &other.vnode)
+        // Fast path: the same allocation
+        if Rc::ptr_eq(&self.vnode, &other.vnode) {
+            return true;
+        }
+
+        let a = &*self.vnode;
+        let b = &*other.vnode;
+
+        // Compare the template by content hash, the dynamic attributes, and the
+        // dynamic nodes by value. This allows `Element`s passed as props to be
+        // memoized by value: a freshly-built `Element` with the same content as
+        // the previous one compares equal, so the child component can skip
+        // re-rendering.
+        a.key == b.key
+            && a.template == b.template
+            && a.dynamic_nodes.len() == b.dynamic_nodes.len()
+            && a.dynamic_attrs.len() == b.dynamic_attrs.len()
+            && a.dynamic_nodes
+                .iter()
+                .zip(b.dynamic_nodes.iter())
+                .all(|(left, right)| left.value_eq(right))
+            && a.dynamic_attrs
+                .iter()
+                .zip(b.dynamic_attrs.iter())
+                .all(|(left, right)| left.as_ref() == right.as_ref())
     }
 }
 
@@ -121,6 +145,11 @@ impl Deref for VNode {
 }
 
 impl VNode {
+    /// Whether this node is the same allocation as `other`.
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.vnode, &other.vnode)
+    }
+
     /// Create a template with no nodes that will be skipped over during diffing
     pub fn empty() -> Element {
         Ok(Self::default())
@@ -618,6 +647,23 @@ impl DynamicNode {
     pub fn make_node<'c, I>(into: impl IntoDynNode<I> + 'c) -> DynamicNode {
         into.into_dyn_node()
     }
+
+    /// Compare two dynamic nodes by value.
+    ///
+    /// Unlike [`VNode`]s, dynamic nodes do not have an identity of their own, so
+    /// this comparison is always structural. Components are compared by their
+    /// render function and, through the props `PartialEq`, by value.
+    fn value_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (DynamicNode::Text(left), DynamicNode::Text(right)) => left.value == right.value,
+            (DynamicNode::Component(left), DynamicNode::Component(right)) => left == right,
+            (DynamicNode::Placeholder(_), DynamicNode::Placeholder(_)) => true,
+            (DynamicNode::Fragment(left), DynamicNode::Fragment(right)) => {
+                left.len() == right.len() && left.iter().zip(right).all(|(l, r)| l == r)
+            }
+            _ => false,
+        }
+    }
 }
 
 impl Default for DynamicNode {
@@ -645,6 +691,20 @@ impl Clone for VComponent {
             props: self.props.duplicate(),
             render_fn: self.render_fn,
         }
+    }
+}
+
+impl PartialEq for VComponent {
+    fn eq(&self, other: &Self) -> bool {
+        if self.render_fn != other.render_fn {
+            return false;
+        }
+
+        // Compare the props with the same type-erased equality the renderer uses
+        // for component memoization. This recurses into any `Element` props, which
+        // are compared by value.
+        let mut other_props = other.props.duplicate();
+        other_props.memoize(self.props.props())
     }
 }
 

--- a/packages/core/tests/diff_dynamic_node.rs
+++ b/packages/core/tests/diff_dynamic_node.rs
@@ -76,25 +76,12 @@ fn toggle_template() {
     let mut dom = VirtualDom::new(app);
     dom.rebuild(&mut dioxus_core::NoOpMutations);
 
-    // Rendering again should replace the placeholder with an text node
+    // Re-rendering the app does not re-render Comp: its children element has
+    // the same content, so it is memoized by value (see #1929).
     dom.mark_dirty(ScopeId::APP);
-    assert_eq!(
-        dom.render_immediate_to_vec().edits,
-        [
-            CreatePlaceholder { id: ElementId(2) },
-            ReplaceWith { id: ElementId(1), m: 1 },
-        ]
-    );
+    assert_eq!(dom.render_immediate_to_vec().edits, []);
 
-    dom.mark_dirty(ScopeId(ScopeId::APP.0 + 1));
-    assert_eq!(
-        dom.render_immediate_to_vec().edits,
-        [
-            CreateTextNode { value: "true".to_string(), id: ElementId(1) },
-            ReplaceWith { id: ElementId(2), m: 1 },
-        ]
-    );
-
+    // Rendering again should replace the placeholder with an text node
     dom.mark_dirty(ScopeId(ScopeId::APP.0 + 1));
     assert_eq!(
         dom.render_immediate_to_vec().edits,
@@ -110,6 +97,15 @@ fn toggle_template() {
         [
             CreateTextNode { value: "true".to_string(), id: ElementId(1) },
             ReplaceWith { id: ElementId(2), m: 1 },
+        ]
+    );
+
+    dom.mark_dirty(ScopeId(ScopeId::APP.0 + 1));
+    assert_eq!(
+        dom.render_immediate_to_vec().edits,
+        [
+            CreatePlaceholder { id: ElementId(2) },
+            ReplaceWith { id: ElementId(1), m: 1 },
         ]
     );
 }

--- a/packages/core/tests/memoize_element_props.rs
+++ b/packages/core/tests/memoize_element_props.rs
@@ -1,0 +1,91 @@
+#![allow(non_snake_case)]
+
+//! Tests for memoizing components by the *value* of their `Element` props.
+//!
+//! When a component re-renders and passes an `Element` to a child component,
+//! the `Element` is rebuilt from scratch: it is a new allocation, so pointer
+//! equality fails. The child should still be able to skip re-rendering when the
+//! new `Element` has the same content as the previous one.
+//!
+//! See https://github.com/DioxusLabs/dioxus/issues/1929.
+
+use dioxus::prelude::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[test]
+fn element_props_memoize_by_value() {
+    static WHATEVER_RENDERS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        rsx! {
+            div {
+                Whatever {
+                    div { "static children" }
+                }
+            }
+        }
+    }
+
+    #[component]
+    fn Whatever(children: Element) -> Element {
+        WHATEVER_RENDERS.fetch_add(1, Ordering::Relaxed);
+        rsx! { div { {children} } }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild_in_place();
+    assert_eq!(WHATEVER_RENDERS.load(Ordering::Relaxed), 1);
+
+    // Re-render the parent a few times. The `children` element is rebuilt with
+    // the same content, so `Whatever` should not re-run even though the
+    // `Element` is a new allocation.
+    for _ in 0..3 {
+        dom.mark_dirty(ScopeId::APP);
+        dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    }
+
+    assert_eq!(
+        WHATEVER_RENDERS.load(Ordering::Relaxed),
+        1,
+        "component with unchanged Element props should not re-render"
+    );
+}
+
+#[test]
+fn element_props_rerender_when_value_changes() {
+    static WHATEVER_RENDERS: AtomicUsize = AtomicUsize::new(0);
+
+    fn app() -> Element {
+        let mut render_count = use_signal(|| 0);
+        // Advance the counter so the children element's content changes
+        // between renders.
+        render_count += 1;
+        rsx! {
+            div {
+                Whatever {
+                    div { "children {render_count}" }
+                }
+            }
+        }
+    }
+
+    #[component]
+    fn Whatever(children: Element) -> Element {
+        WHATEVER_RENDERS.fetch_add(1, Ordering::Relaxed);
+        rsx! { div { {children} } }
+    }
+
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild_in_place();
+    assert_eq!(WHATEVER_RENDERS.load(Ordering::Relaxed), 1);
+
+    // Re-render the parent. The children element now has different content, so
+    // `Whatever` must re-render.
+    dom.mark_dirty(ScopeId::APP);
+    dom.render_immediate(&mut dioxus_core::NoOpMutations);
+    assert_eq!(
+        WHATEVER_RENDERS.load(Ordering::Relaxed),
+        2,
+        "component with changed Element props should re-render"
+    );
+}


### PR DESCRIPTION
Closes #1929

## Problem

When a component re-renders and passes an `Element` (e.g. `children`) to a child component, the `Element` is rebuilt from scratch on every render. `VNode`'s `PartialEq` was pointer-based (`Rc::ptr_eq`), so the new allocation never compared equal to the old one — the child component re-rendered even when its props were completely unchanged.

```rust
fn app() -> Element {
    let mut show = use_signal(|| false);
    rsx!(
        div {
            p { "{show}" }
            Whatever { div { } } // rebuilt each render, new pointer
        }
    )
}

#[component]
fn Whatever(children: Element) -> Element {
    // re-ran on every app re-render, even though children never changed
    rsx!(div { {children} })
}
```

## Change

- `VNode`'s `PartialEq` now compares **by value**:
  - template compared by its content hash,
  - dynamic attributes compared by value,
  - dynamic nodes compared structurally (text, placeholders, fragments, and components — component props are compared with the same type-erased equality the renderer already uses for component memoization).
- The diff fast path in `diff/node.rs` keeps **pointer** equality (`VNode::ptr_eq`), since the diff algorithm walks the tree structurally and a value comparison there would be wasted work.
- The `FragmentProps` doc comment is updated: children are now memoized by value, so borrowing nodes from a parent no longer defeats memoization.

## Tests

- `tests/memoize_element_props.rs`: a child component with unchanged `children` does not re-render across parent re-renders; it does re-render when the children's content changes.
- `tests/diff_dynamic_node.rs` (`toggle_template`, regression for #2815): updated — the first phase (parent re-render) now correctly produces no edits because the child is memoized; the placeholder/text toggling is still covered by driving the child scope directly.

All `dioxus-core` tests pass (including the fuzzing and kitchen-sink suites); clippy and fmt clean.