### PR TITLE
Fix manganis-macro resolve_missing_file_path test on Windows

### DIFF
--- a/packages/manganis/manganis-macro/src/lib.rs
+++ b/packages/manganis/manganis-macro/src/lib.rs
@@ -600,7 +600,10 @@ mod tests {
             ctx.create_resolver("../assets/does-not-exist.txt")
                 .resolve(),
             Err(AssetParseError::DoesNotExist {
-                path: ctx.crate_root.join("src/../assets/does-not-exist.txt"),
+                // The reported path is normalized by `std::path::absolute`, which resolves `..`
+                // components on windows but keeps them on unix.
+                path: std::path::absolute(ctx.crate_root.join("src/../assets/does-not-exist.txt"),)
+                    .unwrap(),
             }),
         );
     }

--- a/packages/manganis/manganis-macro/src/lib.rs
+++ b/packages/manganis/manganis-macro/src/lib.rs
@@ -602,7 +602,7 @@ mod tests {
             Err(AssetParseError::DoesNotExist {
                 // The reported path is normalized by `std::path::absolute`, which resolves `..`
                 // components on windows but keeps them on unix.
-                path: std::path::absolute(ctx.crate_root.join("src/../assets/does-not-exist.txt"),)
+                path: std::path::absolute(ctx.crate_root.join("src/../assets/does-not-exist.txt"))
                     .unwrap(),
             }),
         );


### PR DESCRIPTION
## Summary

`manganis-macro`'s `resolve_missing_file_path` test failed on Windows. The `DoesNotExist` path it compares against comes out of `canonicalize_path_within_crate`, which runs the candidate through `std::path::absolute` before the existence check — and `absolute` resolves `..` components on Windows (GetFullPathName semantics) while preserving them on unix. The test hardcoded the unix-shaped expectation:

```rust
path: ctx.crate_root.join("src/../assets/does-not-exist.txt")   // never produced on windows
```

so on Windows the resolver returned `...\manganis-macro\assets\does-not-exist.txt` and the assert failed. Expectation now goes through the same normalization, which is a no-op on unix:

```rust
path: std::path::absolute(ctx.crate_root.join("src/../assets/does-not-exist.txt")).unwrap()
```

Test-only change; no resolver behavior changed. `cargo test -p manganis-macro` passes on Windows (9 unit + 2 integration + 8 doctests).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/1d94217935854234b18efed6ad47624d
Requested by: @jkelleyrtp