### PR TITLE
#5764: wasm-split-cli panics on a growable (no-maximum) ifunc table

### DIFF
--- a/packages/wasm-split/wasm-split-cli/src/lib.rs
+++ b/packages/wasm-split/wasm-split-cli/src/lib.rs
@@ -336,13 +336,11 @@ impl<'a> Splitter<'a> {
 
         // We have to make sure our table matches that of the other tables even though we don't call them.
         let ifunc_table_id = self.load_funcref_table(&mut out);
-        let segment_start = self
-            .expand_ifunc_table_max(
-                &mut out,
-                ifunc_table_id,
-                self.split_points.len() + shared_funcs.len(),
-            )
-            .unwrap();
+        let segment_start = self.expand_ifunc_table_max(
+            &mut out,
+            ifunc_table_id,
+            self.split_points.len() + shared_funcs.len(),
+        );
 
         self.convert_shared_to_imports(&mut out, segment_start, &shared_funcs, &symbols_to_import);
 
@@ -402,13 +400,11 @@ impl<'a> Splitter<'a> {
         out.exports.add("__indirect_function_table", ifunc_table);
 
         // Expand the ifunc table to accommodate the new ifuncs
-        let segment_start = self
-            .expand_ifunc_table_max(
-                out,
-                ifunc_table,
-                self.split_points.len() + self.shared_symbols.len(),
-            )
-            .expect("failed to expand ifunc table");
+        let segment_start = self.expand_ifunc_table_max(
+            out,
+            ifunc_table,
+            self.split_points.len() + self.shared_symbols.len(),
+        );
 
         // Delete the split import functions and replace them with local functions
         //
@@ -630,9 +626,11 @@ impl<'a> Splitter<'a> {
         ifuncs: &Vec<Node>,
     ) {
         let ifunc_table_id = self.load_funcref_table(out);
-        let segment_start = self
-            .expand_ifunc_table_max(out, ifunc_table_id, self.split_points.len() + ifuncs.len())
-            .unwrap();
+        let segment_start = self.expand_ifunc_table_max(
+            out,
+            ifunc_table_id,
+            self.split_points.len() + ifuncs.len(),
+        );
 
         // Make sure to re-export the split func
         out.exports.add(&split_export_name, split_export_func);
@@ -837,24 +835,25 @@ impl<'a> Splitter<'a> {
         FunctionKind::Local(builder.local_func(args))
     }
 
-    /// Expand the ifunc table to accommodate the new ifuncs
+    /// Expand the ifunc table to accommodate the new ifuncs.
     ///
-    /// returns the old maximum
-    fn expand_ifunc_table_max(
-        &self,
-        out: &mut Module,
-        table: TableId,
-        num_ifuncs: usize,
-    ) -> Option<usize> {
+    /// Returns the offset the new ifuncs should be written at - the
+    /// table's previous size.
+    fn expand_ifunc_table_max(&self, out: &mut Module, table: TableId, num_ifuncs: usize) -> usize {
         let ifunc_table_ = out.tables.get_mut(table);
 
         if let Some(max) = ifunc_table_.maximum {
             ifunc_table_.maximum = Some(max + num_ifuncs as u64);
             ifunc_table_.initial += num_ifuncs as u64;
-            return Some(max as usize);
+            return max as usize;
         }
 
-        None
+        // A table built with `--growable-table` (a flag `--wasm-split`
+        // itself requires) has no maximum at all - there's no ceiling to
+        // raise, so just grow `initial`, the only size the table has.
+        let start = ifunc_table_.initial as usize;
+        ifunc_table_.initial += num_ifuncs as u64;
+        start
     }
 
     // only keep the target-features and names section so wasm-opt can use it to optimize the output


### PR DESCRIPTION
Claude authored fixes, described in #5764.

I hit a crash in my own component library while building with `--wasm-split`, and
asked Claude to debug it. It turned out to be three separate bugs, so there's one
PR per fix. I don't know this crate's internals well enough to vouch for the
implementation - I did verify each fix solves the problem in my project. Please
review accordingly.

| Bug | Fix | Relation to the corruption |
|---|---|---|
| #5764 growable table panic | Unconditional `.unwrap()` on a table that can lack a max | Blocked builds; not the corruption itself |
| #5768 dropped child edges | One unresolvable call-graph child edge silently discarded | Real and measurable (228/run), confirmed *not* the cause |
| #5769 data symbol overlap | Pruning a dead symbol zeroes bytes a live one still owns | **This is it** - the actual truncation/crash root cause |

## Environment

- Dioxus `0.7.10` (tag `57d6794`), wasm-bindgen-cli `0.2.127`
- `rustc 1.99.0-nightly (1a98b1e13 2026-08-07)`, Arch Linux, x86_64

## Problem

`wasm-split-cli` panics with `Option::unwrap() on a None value` inside
`expand_ifunc_table_max` while emitting a split or chunk module, aborting the
whole build.

## Root cause

`expand_ifunc_table_max()` (`packages/wasm-split/wasm-split-cli/src/lib.rs`) only
handled a funcref table with an explicit `maximum`:

```rust
fn expand_ifunc_table_max(&self, out: &mut Module, table: TableId, num_ifuncs: usize) -> Option<usize> {
    let ifunc_table_ = out.tables.get_mut(table);
    if let Some(max) = ifunc_table_.maximum {
        ifunc_table_.maximum = Some(max + num_ifuncs as u64);
        ifunc_table_.initial += num_ifuncs as u64;
        return Some(max as usize);
    }
    None
}
```

A table with no `maximum` at all - the shape `wasm-ld`'s `--growable-table` flag
produces, and a flag this same codebase's own hot-patch linking path
(`packages/cli/src/build/link.rs`) passes - makes this return `None`. All three
call sites unconditionally `.unwrap()` the result.

## Minimal reproduction

[growable-ifunc-table-repro.sh](https://github.com/user-attachments/files/31330653/growable-ifunc-table-repro.sh)
is a self-contained, runnable reproduction. It needs only `cargo`/`rustup` and
`curl`, touches nothing outside a throwaway temp directory, and uses the
**published, unpatched `wasm-split-cli 0.7.10` from crates.io** - no local fork
involved. It generates a ~30-line crate, builds it under the exact `RUSTFLAGS`
`dx` uses for `--wasm-split` (including `-C link-arg=--growable-table`), runs it
through wasm-bindgen and wasm-split, then repeats the whole thing against a
crates.io checkout with the patch below applied, and checks the actual output
value via `node` rather than just the exit code.

The crate formats with `format!("{}-{hash:x}", ..)`, deliberately the same shape
as #5769's corruption, so this one script exercises both bugs:

```
--- 3/4: wasm-split-cli split, UNPATCHED - expected to fail ---
thread 'main' (...) panicked at .../wasm-split-cli-0.7.10/src/lib.rs:345:14:
called `Option::unwrap()` on a `None` value
Confirmed: unpatched wasm-split-cli failed as expected (exit 101).

--- 4/4: fetching wasm-split-cli 0.7.10 source, patching it, rebuilding, re-running ---
Patched split succeeded (exit 0), where the unpatched one panicked.

--- checking the actual output value, not just the exit code ---
run() returned: "lsx-framework-aaaa"
CORRECT - the patch fixes the data corruption too, not only the crash.
```

The same run's stderr also carries ~35 `Could not find function symbol ...
Ignoring` warnings. That's a third, independently real bug this repro happens to
trigger - relocations resolved by name only, never by the authoritative index the
linking section carries right next to it - not yet filed separately.

## Patch

```diff
-    fn expand_ifunc_table_max(&self, out: &mut Module, table: TableId, num_ifuncs: usize) -> Option<usize> {
+    fn expand_ifunc_table_max(&self, out: &mut Module, table: TableId, num_ifuncs: usize) -> usize {
         let ifunc_table_ = out.tables.get_mut(table);
         if let Some(max) = ifunc_table_.maximum {
             ifunc_table_.maximum = Some(max + num_ifuncs as u64);
             ifunc_table_.initial += num_ifuncs as u64;
-            return Some(max as usize);
+            return max as usize;
         }
-        None
+        // No maximum to raise - just grow `initial`, the only size the
+        // table has.
+        let start = ifunc_table_.initial as usize;
+        ifunc_table_.initial += num_ifuncs as u64;
+        start
     }
```

...plus removing the now-unnecessary `.unwrap()`/`.expect()` at all three call
sites, since the function no longer returns an `Option`.

## Why this fixes it

The function's job is to reserve `num_ifuncs` new table slots and return the
offset they start at. With an explicit `maximum`, that offset is the old maximum,
and the maximum grows to match. With no maximum there's no ceiling to raise - the
table's *only* size is `initial`, so the fix uses that as both the return value
and the field to grow. No `Option` is needed because both branches now always
produce a valid offset.

## Verified against dioxus `main`

`wasm-split-cli`'s logic is unchanged between the `0.7.10` tag and current `main`
(`24f6a829d` at time of writing) - the only diff is cosmetic import/macro
reformatting. This patch cherry-picks cleanly onto `main` with no conflicts.
Separately verified against `main`'s own `Splitter::new()`/`emit()`: forcing a
funcref table's `maximum` to `None` (the exact shape `--growable-table` produces)
panics identically on unpatched `main`, and no longer panics with this applied.
