### PR TITLE
#5768: wasm-split-cli silently drops call-graph edges to individually-unresolvable children

### DIFF
--- a/packages/wasm-split/wasm-split-cli/src/lib.rs
+++ b/packages/wasm-split/wasm-split-cli/src/lib.rs
@@ -966,6 +966,25 @@ impl<'a> Splitter<'a> {
         //
         // wasm-bindgen will dissolve describe functions into the shim functions, but we don't have a
         // sense of lining up old to new, so we just assume everything ends up in the main chunk.
+        // Collect everything reachable from a node we couldn't line up between the old and new
+        // modules. Its callees are as reachable as it is, so dropping them silently would make
+        // wasm-split read a live subtree as dead code.
+        fn descend(
+            lost_children: &mut HashSet<Node>,
+            old_graph: &HashMap<Node, HashSet<Node>>,
+            node: Node,
+        ) {
+            if !lost_children.insert(node) {
+                return;
+            }
+
+            if let Some(children) = old_graph.get(&node) {
+                for child in children {
+                    descend(lost_children, old_graph, *child);
+                }
+            }
+        }
+
         let mut lost_children = HashSet::new();
         self.call_graph = original
             .call_graph
@@ -974,22 +993,6 @@ impl<'a> Splitter<'a> {
                 // If the old function isn't in the new module, we need to move all its descendents into the main chunk
                 let Some(new) = get_old(old) else {
                     for child in children {
-                        fn descend(
-                            lost_children: &mut HashSet<Node>,
-                            old_graph: &HashMap<Node, HashSet<Node>>,
-                            node: Node,
-                        ) {
-                            if !lost_children.insert(node) {
-                                return;
-                            }
-
-                            if let Some(children) = old_graph.get(&node) {
-                                for child in children {
-                                    descend(lost_children, old_graph, *child);
-                                }
-                            }
-                        }
-
                         descend(&mut lost_children, &original.call_graph, *child);
                     }
                     return None;
@@ -997,8 +1000,13 @@ impl<'a> Splitter<'a> {
 
                 let mut new_children = HashSet::new();
                 for child in children {
-                    if let Some(new) = get_old(child) {
-                        new_children.insert(new);
+                    match get_old(child) {
+                        Some(new) => {
+                            new_children.insert(new);
+                        }
+                        // Same as a dropped parent above, one edge at a time: recover the child's
+                        // descendants rather than dropping the edge with no trace.
+                        None => descend(&mut lost_children, &original.call_graph, *child),
                     }
                 }
 


### PR DESCRIPTION
Claude authored fixes for #5768.

I hit a crash in my own component library while building with `--wasm-split`, and
asked Claude to debug it. It turned out to be three separate bugs, so there's one
PR per fix. I don't know this crate's internals well enough to vouch for the
implementation - I did verify each fix solves the problem in my project. Please
review accordingly.

| Bug | Fix | Relation to the corruption |
|---|---|---|
| #5764 growable table panic | Unconditional `.unwrap()` on a table that can lack a max | Blocked builds; not the corruption itself |
| #5768 dropped child edges | One unresolvable call-graph child edge silently discarded | Real and measurable (228/run), confirmed *not* the cause |
| #5769 data symbol overlap | Pruning a dead symbol zeroes bytes a live one still owns | **This is it** - the actual truncation/crash root cause |

## Environment

- Dioxus `0.7.10` (tag `57d6794`), wasm-bindgen-cli `0.2.127`
- `rustc 1.99.0-nightly (1a98b1e13 2026-08-07)`, Arch Linux, x86_64

## Problem

`build_call_graph()` correlates the pre- and post-`wasm-bindgen` modules by
function name. When a *parent* node has no name match in the new module, its known
children are recovered into `main` via a `descend()` walk - but when a single
*child* reference inside an otherwise-resolvable parent has no name match, that
one edge is dropped with no fallback and no log line. An unresolvable child is
exactly as reachable as the parent calling it, so losing the edge can make
`wasm-split` read a live subtree as dead code.

## Root cause

`build_call_graph()` (`packages/wasm-split/wasm-split-cli/src/lib.rs`):

```rust
let mut new_children = HashSet::new();
for child in children {
    if let Some(new) = get_old(child) {
        new_children.insert(new);
    }
    // no `else` - a resolution miss here is just... gone.
}
```

...versus the parent-side handling a few lines above, which *does* have a recovery
path (`descend()` walking into `lost_children`, later reattached to main) for
exactly the same kind of resolution miss.

## Measured, not hypothetical

Instrumented the `else`-less branch above and ran `Splitter::new(original,
bindgened)?.emit()` on a real 28-route Dioxus site's actual `(original,
bindgened)` pair:

```rust
// Added temporarily at the site of the missing `else`:
} else if std::env::var("COUNT_DROPPED_CHILDREN").is_ok() {
    eprintln!("DROPPED_CHILD_EDGE: {child:?}");
}
```

**228 child edges dropped**, all silently. With the patch below and an equivalent
counter on the recovery branch: **228 recovered, 0 dropped** - a 1:1 match,
confirming the fix covers exactly the cases the bug loses.

This didn't change the final `main` module's reachability set enough to flip any
function from present to `unreachable`-trap in this particular app (A/B tested).
But 228 silently dropped edges in a single build isn't a corner case - it's a
routinely hit path that happened to have a safe landing spot here, not in general.

## Patch

```diff
+        // Collect everything reachable from a node we couldn't line up between the old and new
+        // modules. Its callees are as reachable as it is, so dropping them silently would make
+        // wasm-split read a live subtree as dead code.
+        fn descend(lost_children: &mut HashSet<Node>, old_graph: &HashMap<Node, HashSet<Node>>, node: Node) {
+            if !lost_children.insert(node) { return; }
+            if let Some(children) = old_graph.get(&node) {
+                for child in children { descend(lost_children, old_graph, *child); }
+            }
+        }
+
         let mut lost_children = HashSet::new();
         self.call_graph = original.call_graph.iter().flat_map(|(old, children)| {
             let Some(new) = get_old(old) else {
                 for child in children {
-                    fn descend(...) { ... } // was defined inline here only
                     descend(&mut lost_children, &original.call_graph, *child);
                 }
                 return None;
             };

             let mut new_children = HashSet::new();
             for child in children {
-                if let Some(new) = get_old(child) {
-                    new_children.insert(new);
+                match get_old(child) {
+                    Some(new) => { new_children.insert(new); }
+                    // Same as a dropped parent above, one edge at a time: recover the child's
+                    // descendants rather than dropping the edge with no trace.
+                    None => descend(&mut lost_children, &original.call_graph, *child),
                 }
             }
             Some((new, new_children))
         }).collect();
```

(full diff on `fix/dropped-callgraph-edges`)

## Why this fixes it

`descend()` already existed and was already proven correct for the "whole node
unresolvable" case - it walks the *original* module's call graph, which has
complete edges, and marks everything reachable as `lost_children`, later
reattached to `main` so it's never treated as dead code. This patch hoists the
helper out of its single call site and reuses it for "one unresolvable child of an
otherwise-resolvable parent", since both failure modes need identical recovery: an
edge you can't map to the new module by name is not evidence the target is dead,
only that name correlation missed it.

## Verified against dioxus `main`

`wasm-split-cli`'s logic is unchanged between the `0.7.10` tag and current `main`
(`24f6a829d` at time of writing) - the only diff is cosmetic import/macro
reformatting. This patch cherry-picks cleanly onto `main` with no conflicts.
Re-ran the same 228-dropped/228-recovered check against `main`'s build of the same
app: identical counts, and `emit()`'s output is byte-for-byte identical to the
same run against `0.7.10`.
