### PR TITLE
`children: Vec<Element>` - iterable children without new syntax

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -204,10 +204,31 @@ mod field_info {
                 let strip_option_auto = builder_attr.strip_option
                     || !builder_attr.ignore_option && type_from_inside_option(&field.ty).is_some();
 
-                // children field is automatically defaulted to an empty VNode unless it is marked as optional (in which case it defaults to None)
-                if name == "children" && !strip_option_auto {
-                    builder_attr.default =
-                        Some(syn::parse(quote!(dioxus_core::VNode::empty()).into()).unwrap());
+                // children field is automatically defaulted to an empty VNode (or an empty Vec, for
+                // a `children: Vec<Element>` field) unless it is marked as optional (in which case
+                // it defaults to None).
+                //
+                // The setter always goes through `SuperInto` (like `#[props(into)]`) rather than
+                // taking the field's exact type, regardless of whether `children` is declared
+                // `Element` or `Vec<Element>` - the call site (see `dioxus-rsx`'s `component.rs`)
+                // always produces a `Vec<Element>` for a component's children, and it's this
+                // `SuperInto` resolution (against whichever shape this field actually declares)
+                // that makes both declared shapes accept that exact same call-site syntax.
+                if name == "children" {
+                    builder_attr.auto_into = true;
+                    if !strip_option_auto {
+                        builder_attr.default = Some(
+                            if field.ty == parse_quote!(Vec<Element>)
+                                || field.ty == parse_quote!(::std::vec::Vec<Element>)
+                                || field.ty == parse_quote!(std::vec::Vec<Element>)
+                                || field.ty == parse_quote!(Vec<dioxus_core::Element>)
+                            {
+                                syn::parse(quote!(::std::vec::Vec::new()).into()).unwrap()
+                            } else {
+                                syn::parse(quote!(dioxus_core::VNode::empty()).into()).unwrap()
+                            },
+                        );
+                    }
                 }
 
                 // String fields automatically use impl Display

--- a/packages/core/src/portal.rs
+++ b/packages/core/src/portal.rs
@@ -93,11 +93,20 @@ impl<__children> PortalPropsBuilder<((), __children)> {
 
 #[allow(dead_code, non_camel_case_types, missing_docs)]
 impl<__target> PortalPropsBuilder<(__target, ())> {
+    /// Accepts `impl SuperInto<Element, __Marker>` rather than a bare `Element`, mirroring what
+    /// `#[derive(Props)]` now generates for every `children: Element` field - the `rsx!` call
+    /// site always compiles a component's children as a `Vec<Element>` and relies on `SuperInto`
+    /// (see `dioxus_core::properties::VecElementFromMarker`) to land it in whatever shape the
+    /// field actually declares. Without this, `Portal { ... }` would be the one component in the
+    /// entire framework a caller couldn't put ordinary children into.
     #[allow(clippy::type_complexity)]
-    pub fn children(self, children: Element) -> PortalPropsBuilder<(__target, (Element,))> {
+    pub fn children<__Marker>(
+        self,
+        children: impl crate::SuperInto<Element, __Marker>,
+    ) -> PortalPropsBuilder<(__target, (Element,))> {
         let (target, _) = self.fields;
         PortalPropsBuilder {
-            fields: (target, (children,)),
+            fields: (target, (children.super_into(),)),
             _phantom: self._phantom,
         }
     }
@@ -147,9 +156,9 @@ impl<RenderFn, ComponentMarker, __target>
     PortalComponentBuilder<RenderFn, ComponentMarker, (__target, ())>
 {
     #[allow(clippy::type_complexity)]
-    pub fn children(
+    pub fn children<__Marker>(
         self,
-        children: Element,
+        children: impl crate::SuperInto<Element, __Marker>,
     ) -> PortalComponentBuilder<RenderFn, ComponentMarker, (__target, (Element,))> {
         PortalComponentBuilder {
             render_fn: self.render_fn,

--- a/packages/core/src/properties.rs
+++ b/packages/core/src/properties.rs
@@ -356,6 +356,57 @@ where
     }
 }
 
+/// Marker used to merge a `Vec<Element>` - the top-level children an `rsx!` body produces when a
+/// component declares `children: Vec<Element>` instead of `children: Element` - back into a single
+/// [`Element`], for a callee that still declares `children: Element`. This is what makes the two
+/// declared shapes interchangeable at every call site: the macro always produces a `Vec<Element>`,
+/// and this impl (found through [`SuperFrom`]'s blanket bridge) is what a plain `Element` field's
+/// generated setter uses to accept it, with zero change to the calling code.
+#[doc(hidden)]
+pub struct VecElementFromMarker;
+
+/// Shared by both `Element` and `Option<Element>` targets below - `None` only for a genuinely
+/// empty list (an empty `Vec<Element>`, e.g. from an `if` branch with no `else`), never as a
+/// stand-in for a render error, same as `IntoDynNode for Element` already treats an `Err` as
+/// "nothing" rather than propagating it.
+fn merge_vnodes(input: Vec<Element>) -> Option<VNode> {
+    let mut nodes: Vec<VNode> = input.into_iter().map(IntoVNode::into_vnode).collect();
+    match nodes.len() {
+        0 => None,
+        // The overwhelmingly common case (a single child) skips the Fragment indirection below
+        // entirely, so it produces exactly the same VNode shape `children: Element` always has
+        // for one child.
+        1 => Some(nodes.pop().unwrap()),
+        // 2+ independently-built VNodes have no static Template in common (they may even come
+        // from different `for`/`if` branches), so they can only be combined at runtime, through
+        // the same dynamic-node-slot machinery a `for` loop's output already uses.
+        _ => {
+            use crate::view::{ViewExt, dynamic_node_builder};
+            Some(dynamic_node_builder::<_, ()>(DynamicNode::Fragment(nodes)).into_vnode())
+        }
+    }
+}
+
+impl SuperFrom<Vec<Element>, VecElementFromMarker> for Element {
+    fn super_from(input: Vec<Element>) -> Self {
+        // Matches the pre-existing `children: Element` default (`VNode::empty()`) exactly for an
+        // empty list - this is also what an empty `Vec<Element>` reduces to.
+        Ok(merge_vnodes(input).unwrap_or_default())
+    }
+}
+
+/// Marker used to merge a `Vec<Element>` into `Option<Element>`, for a callee whose `children`
+/// is itself optional (e.g. an optional label) - `None` for an empty list, same as that field's
+/// own pre-existing default.
+#[doc(hidden)]
+pub struct VecElementFromOptionMarker;
+
+impl SuperFrom<Vec<Element>, VecElementFromOptionMarker> for Option<Element> {
+    fn super_from(input: Vec<Element>) -> Self {
+        merge_vnodes(input).map(Ok)
+    }
+}
+
 /// Marker used to convert `&str` into `Option<String>` through [`SuperFrom`].
 #[doc(hidden)]
 pub struct OptionStringFromMarker;

--- a/packages/core/src/suspense/component.rs
+++ b/packages/core/src/suspense/component.rs
@@ -105,9 +105,9 @@ impl<RenderFn, ComponentMarker, __fallback>
 {
     #[allow(clippy::type_complexity)]
     #[doc(hidden)]
-    pub fn children(
+    pub fn children<__Marker>(
         self,
-        children: Element,
+        children: impl SuperInto<Element, __Marker>,
     ) -> SuspenseBoundaryComponentBuilder<RenderFn, ComponentMarker, (__fallback, (Element,))> {
         SuspenseBoundaryComponentBuilder {
             render_fn: self.render_fn,
@@ -175,11 +175,11 @@ impl<__children> SuspenseBoundaryPropsBuilder<((Callback<SuspenseContext, Elemen
 impl<__fallback> SuspenseBoundaryPropsBuilder<(__fallback, ())> {
     #[allow(clippy::type_complexity)]
     #[doc(hidden)]
-    pub fn children(
+    pub fn children<__Marker>(
         self,
-        children: Element,
+        children: impl SuperInto<Element, __Marker>,
     ) -> SuspenseBoundaryPropsBuilder<(__fallback, (Element,))> {
-        let children = (children,);
+        let children = (SuperInto::super_into(children),);
         let (fallback, _) = self.fields;
         SuspenseBoundaryPropsBuilder {
             owner: self.owner,

--- a/packages/core/tests/vec_children_experiment.rs
+++ b/packages/core/tests/vec_children_experiment.rs
@@ -1,0 +1,223 @@
+#![allow(non_snake_case)]
+
+//! Proves out `children: Vec<Element>` as an alternative to `children: Element`: the exact same
+//! call-site syntax (natural rsx composition, `for`/`if` included) should populate either shape,
+//! with `for`/`if` roots flattened to however many elements they actually produce.
+
+use dioxus::prelude::*;
+
+#[derive(Props, Clone, PartialEq)]
+struct WrapProps {
+    children: Element,
+}
+
+fn Wrap(props: WrapProps) -> Element {
+    rsx! {
+        div { id: "wrap", {props.children} }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct SplitProps {
+    children: Vec<Element>,
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct OptionalProps {
+    children: Option<Element>,
+}
+
+fn Optional(props: OptionalProps) -> Element {
+    let has_label = props.children.is_some();
+    rsx! {
+        div {
+            id: "optional",
+            "has-label": has_label,
+            if let Some(children) = props.children {
+                {children}
+            }
+        }
+    }
+}
+
+fn Split(props: SplitProps) -> Element {
+    rsx! {
+        div {
+            id: "split",
+            for child in props.children {
+                dd { {child} }
+            }
+        }
+    }
+}
+
+fn render(app: fn() -> Element) -> String {
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    let out = dioxus_ssr::render(&dom);
+    println!("{out}");
+    out
+}
+
+#[test]
+fn element_children_unchanged() {
+    fn app() -> Element {
+        rsx! {
+            Wrap {
+                "a"
+                "b"
+            }
+        }
+    }
+    let out = render(app);
+    assert!(out.contains('a'));
+    assert!(out.contains('b'));
+}
+
+#[test]
+fn vec_children_static_multiple() {
+    fn app() -> Element {
+        rsx! {
+            Split {
+                "one"
+                "two"
+                "three"
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 3);
+}
+
+#[test]
+fn vec_children_single() {
+    fn app() -> Element {
+        rsx! {
+            Split { "only" }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 1);
+}
+
+#[test]
+fn vec_children_for_loop_flattens() {
+    fn app() -> Element {
+        let items = vec!["x", "y", "z", "w"];
+        rsx! {
+            Split {
+                for item in items {
+                    "{item}"
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 4);
+}
+
+#[test]
+fn vec_children_mixed_literal_and_for_loop() {
+    fn app() -> Element {
+        let items = vec!["x", "y"];
+        rsx! {
+            Split {
+                "first"
+                for item in items {
+                    "{item}"
+                }
+                "last"
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 4);
+}
+
+#[test]
+fn vec_children_if_chain_true_branch() {
+    fn app() -> Element {
+        let show_extra = true;
+        rsx! {
+            Split {
+                "always"
+                if show_extra {
+                    "extra"
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 2);
+}
+
+#[test]
+fn vec_children_if_chain_false_branch_contributes_zero() {
+    fn app() -> Element {
+        let show_extra = false;
+        rsx! {
+            Split {
+                "always"
+                if show_extra {
+                    "extra"
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 1);
+}
+
+#[test]
+fn vec_children_nested_for_and_if() {
+    fn app() -> Element {
+        let groups = vec![vec!["a1", "a2"], vec!["b1"]];
+        rsx! {
+            Split {
+                for group in groups {
+                    for item in group {
+                        if item != "skip" {
+                            "{item}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 3);
+}
+
+#[test]
+fn vec_children_empty_default() {
+    fn app() -> Element {
+        rsx! {
+            Split {}
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 0);
+}
+
+#[test]
+fn option_element_children_with_content() {
+    fn app() -> Element {
+        rsx! {
+            Optional { "a label" }
+        }
+    }
+    let out = render(app);
+    assert!(out.contains("has-label=true"));
+    assert!(out.contains("a label"));
+}
+
+#[test]
+fn option_element_children_empty_is_none() {
+    fn app() -> Element {
+        rsx! {
+            Optional {}
+        }
+    }
+    let out = render(app);
+    assert!(out.contains("has-label=false"));
+}

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -239,14 +239,20 @@ impl Component {
 
         if !self.children.is_empty() {
             let children = &self.children;
+            // Always compiled as a `Vec<Element>` - one entry per top-level child, `for`/`if`
+            // flattened - rather than one merged `Element`. Whether the callee actually wants a
+            // `Vec<Element>` or a plain `Element` is resolved on the other side, through
+            // `SuperInto` (see `dioxus_core::properties::VecElementFromMarker`), not here: this
+            // call site has no visibility into the callee's declared field type.
+            let children = children.to_vec_tokens();
             // If the props don't accept children, attach the error to the first child
             if manual_props.is_some() {
                 tokens.append_all(
-                    quote_spanned! { children.first_root_span() => __manual_props.children = #children; },
+                    quote_spanned! { self.children.first_root_span() => __manual_props.children = dioxus_core::SuperInto::super_into(#children); },
                 )
             } else {
                 tokens.append_all(
-                    quote_spanned! { children.first_root_span() => .children( #children ) },
+                    quote_spanned! { self.children.first_root_span() => .children( #children ) },
                 )
             }
         }

--- a/packages/rsx/src/ifchain.rs
+++ b/packages/rsx/src/ifchain.rs
@@ -131,6 +131,61 @@ impl ToTokens for IfChain {
     }
 }
 
+impl IfChain {
+    /// Like [`ToTokens`], but produces a `Vec<Element>` per branch instead of merging each
+    /// branch's body into one nested [`Element`] - see [`TemplateBody::to_vec_tokens`].
+    pub(crate) fn to_vec_tokens(&self) -> TokenStream2 {
+        let mut body = TokenStream2::new();
+        let mut terminated = false;
+
+        let mut elif = Some(self);
+
+        while let Some(chain) = elif {
+            let IfChain {
+                if_token,
+                cond,
+                then_branch,
+                else_if_branch,
+                else_branch,
+                ..
+            } = chain;
+
+            let then_vec = then_branch.to_vec_tokens();
+            body.append_all(quote! {
+                #if_token #cond {
+                    #then_vec
+                }
+            });
+
+            if let Some(next) = else_if_branch {
+                body.append_all(quote! {
+                    else
+                });
+                elif = Some(next);
+            } else if let Some(else_branch) = else_branch {
+                let else_vec = else_branch.to_vec_tokens();
+                body.append_all(quote! {
+                    else {
+                        #else_vec
+                    }
+                });
+                terminated = true;
+                break;
+            } else {
+                elif = None;
+            }
+        }
+
+        if !terminated {
+            body.append_all(quote! {
+                else { ::std::vec::Vec::new() }
+            });
+        }
+
+        body
+    }
+}
+
 #[test]
 fn parses_if_chain() {
     let input = quote! {

--- a/packages/rsx/src/template_body.rs
+++ b/packages/rsx/src/template_body.rs
@@ -263,6 +263,59 @@ impl ToTokens for TemplateBody {
     }
 }
 
+impl TemplateBody {
+    /// Like [`ToTokens`], but produces a `Vec<Element>` - one entry per top-level "thing" this
+    /// body's `roots` contains - instead of one merged [`Element`]. A `for`/`if` root contributes
+    /// however many elements it actually produces at runtime (0, 1, or many), flattened into the
+    /// same list, rather than being merged into one nested dynamic node the way the single-
+    /// `Element` form (above) does.
+    ///
+    /// This is what lets a component declare `children: Vec<Element>` instead of `children:
+    /// Element` and get each of its caller's top-level children as an independent value, with no
+    /// change to how the caller writes them - see `dioxus-core-macro`'s handling of the
+    /// `children` field, and `dioxus_core::properties::VecElementFromMarker`, for the other half
+    /// of this: how the same call site still works for a component that keeps `children: Element`.
+    pub(crate) fn to_vec_tokens(&self) -> TokenStream2 {
+        let root_exprs = self.roots.iter().map(BodyNode::to_vec_tokens);
+        quote! {
+            {
+                let mut __children: ::std::vec::Vec<dioxus_core::Element> = ::std::vec::Vec::new();
+                #( __children.extend(#root_exprs); )*
+                __children
+            }
+        }
+    }
+}
+
+impl BodyNode {
+    /// See [`TemplateBody::to_vec_tokens`]. Produces an expression implementing `IntoIterator<Item
+    /// = Element>` (a `Vec<Element>`, or a lazy iterator for a `for` loop) so the caller can
+    /// `.extend(...)` it directly regardless of how many elements this one root turns out to
+    /// contribute.
+    fn to_vec_tokens(&self) -> TokenStream2 {
+        match self {
+            BodyNode::ForLoop(for_loop) => {
+                let ForLoop {
+                    pat, expr, body, ..
+                } = for_loop;
+                let inner = body.to_vec_tokens();
+                quote! {
+                    (#expr).into_iter().flat_map(move |#pat| #inner)
+                }
+            }
+            BodyNode::IfChain(if_chain) => if_chain.to_vec_tokens(),
+            // A plain node (element, component, text, raw `{expr}`, or a synthetic boundary)
+            // contributes exactly one `Element` - compile it as its own standalone single-root
+            // template, reusing the existing `ToTokens` impl above unchanged (and its fresh
+            // `TemplateBody::new` path/index bookkeeping) rather than re-deriving it here.
+            _ => {
+                let single = TemplateBody::new(vec![self.clone()]);
+                quote! { ::std::vec::Vec::from([ #single ]) }
+            }
+        }
+    }
+}
+
 pub(crate) struct ViewBuilderPieces {
     definitions: Vec<TokenStream2>,
     view: TokenStream2,


### PR DESCRIPTION
# `children: Vec<Element>` - iterable children without new syntax

**Disclaimer**: Idea from me, but implemented using Claude.

## The problem

[DioxusLabs/dioxus#1177 "Iterable Children"](https://github.com/DioxusLabs/dioxus/issues/1177)
is a three-year-old open issue: there's no good way for a component to get
its caller's children as independent, individually-usable values. A
`Breadcrumbs` component that wants to intersperse a divider between each
crumb, or (our own motivating case) a `DataListItem` that wants to let a
term have more than one description, both need this. `children: Element` -
the only option today - hands you one already-merged node; there's nothing
to iterate.

The issue's own opening example already shows the syntax people actually
want:

```rust
Breadcrumbs {
  divider: "/",
  Breadcrumb { name: "Level 1", link: "/" }
  Breadcrumb { name: "Level 2", link: "/level2" }
}
```

with `children: Vec<Element>` on the props struct - ordinary composition, no
special ceremony. That syntax has never actually worked. The maintainer's
own documented workaround, three years ago, was this instead:

```rust
Breadcrumbs {
    divider: "/",
    child_routes: vec![
        render! { Breadcrumb { name: "Level 1", link: "/" } },
        render! { Breadcrumb { name: "Level 2", link: "/level2" } },
    ]
}
```

- a differently-named field (not even `children`), explicit `vec![]`, every
entry manually wrapped in `render!`/`rsx!`. Called "less clean" by its own
author. Three follow-up PRs (#1621, #2722, #2946) all tried to close the gap
a different way - walking or visiting an already-compiled `VNode`/`Template`
at runtime, trying to recover "what did the caller write" from a
representation that's already erased that information. All three stalled
and were closed unmerged. Nobody, as far as we could find, tried closing the
gap between the aspirational syntax and the real workaround directly.

## The idea

Let a component declare `children: Vec<Element>` as a straight alternative
to `children: Element`, and make **the exact same call-site syntax** work
for either one:

```rust
DataListItem {
    label: "Phone",
    "555-1234"
    "555-5678"
}
```

works today whether `DataListItem::children` is `Element` (both lines merge
into one node, current behavior, unchanged) or `Vec<Element>` (each line
becomes its own entry). No new field, no `vec![]`, no per-entry `rsx!{}`,
and it composes with `for`/`if` exactly the way plain children already do:

```rust
DataListItem {
    label: "Phone",
    for phone in &phones {
        "{phone}"
    }
}
```

produces one `Element` per iteration, flattened into the list - not one
`Element` containing all of them.

## Why this is the right layer to fix it at

The three earlier attempts tried to reconstruct structure from an
already-compiled `VNode`. That's fighting the wrong layer: by the time
there's a `VNode` to inspect, "how many things did the caller write" is
already gone - collapsed into a compiled template with static roots and
dynamic-node slots, which has no general notion of "the top-level children"
to hand back out.

The fix instead happens where that information still exists: at macro
*parse* time. `dioxus-rsx`'s `TemplateBody` already stores a component's
children as `roots: Vec<BodyNode>` - the parser already knows exactly how
many top-level things were written, and what kind each one is, before any
of that gets compiled away. Producing a `Vec<Element>` from that list is
just a different (and simpler) codegen target than producing one merged
`Element` - it doesn't require walking anything after the fact.

The other half of the problem - the call site can't know what the *callee*
wants, because macros expand before type-checking - turns out to already
have a solution living in the same codebase. `#[props(into)]` fields are
generated with a builder setter of the form `impl SuperInto<FieldType,
Marker>`, and `SuperInto`/`SuperFrom` are ordinary traits resolved by
ordinary Rust type inference *after* macro expansion, against whatever type
the callee's own struct declares. That's exactly the mechanism needed here:
make the macro always produce one shape (`Vec<Element>`), and let the
callee's own generated setter - which really does know its field's type,
since `#[derive(Props)]` runs directly on that struct - pick the right
conversion.

## How it's implemented

**`dioxus-rsx` (`packages/rsx`)** - `component.rs`'s children codegen no
longer emits `TemplateBody`'s normal single-`Element` `ToTokens` output for
a component's children. It calls a new `TemplateBody::to_vec_tokens`
(`template_body.rs`) instead, which recurses over `roots`:

- A plain node (element, component, text, `{expr}`) becomes its own
  standalone single-root `TemplateBody` via `TemplateBody::new(vec![node])`
  - reusing the existing single-`Element` codegen completely unchanged, just
  invoked once per root instead of once for the whole list - and
  contributes exactly one `Element`.
- A `for` root recurses into its own body and `flat_map`s per iteration, so
  a loop's output is spliced in flat rather than nested as one entry.
- An `if`/`else` chain (`IfChain::to_vec_tokens`, `ifchain.rs`) unifies its
  branches directly to `Vec<Element>` - each branch recurses the same way -
  instead of merging through `IntoDynNode` the way the `Element` form does.
  A branch with no matching arm contributes an empty `Vec`, same as the
  existing `VNode::empty()` fallback does for the `Element` form.

**`dioxus-core-macro` (`packages/core-macro/src/props/mod.rs`)** - the
`children` field is now unconditionally treated as `auto_into` (the same
flag `#[props(into)]` sets), regardless of whether the struct author wrote
it - so `impl SuperInto<FieldType, Marker>` is what every `children` setter
accepts now, not just the ones that opted in. The field's generated default
also switched from the hardcoded `dioxus_core::VNode::empty()` to an empty
`Vec::new()` when the declared type is `Vec<Element>` (checked by comparing
`field.ty` against a few literal spellings, same technique this file
already uses to special-case bare `String` fields).

**`dioxus-core` (`packages/core/src/properties.rs`)** - two new `SuperFrom`
impls do the actual merging, for the two shapes a `children` field can
already legally have:

```rust
impl SuperFrom<Vec<Element>, VecElementFromMarker> for Element { .. }
impl SuperFrom<Vec<Element>, VecElementFromOptionMarker> for Option<Element> { .. }
```

Both go through a shared `merge_vnodes`: zero elements produces `VNode::
empty()`/`None` (identical to today's existing default), exactly one
element is returned directly with no wrapping at all (so the overwhelmingly
common single-child case produces the exact same `VNode` shape as
`children: Element` always has), and two or more are combined through
`DynamicNode::Fragment` - the same dynamic-node-slot machinery a `for`
loop's own output already goes through internally (`view::dynamic_node_
builder(..).into_vnode()`). Nothing here is a new rendering concept; it's
the existing multi-node machinery, just reached from a new place.

**Two hand-rolled `Properties` implementations** - `Portal`
(`packages/core/src/portal.rs`) and `SuspenseBoundary` (`packages/core/src/
suspense/component.rs`) - predate `#[derive(Props)]`'s current shape and
had exact-type `children(self, children: Element)` setters, hand-written to
mirror what the macro used to generate. A workspace-wide search confirmed
these are the *only* two hand-rolled `Properties` impls in the whole
codebase - both updated to `children<M>(self, children: impl SuperInto
<Element, M>)`, mirroring the pattern their own `fallback` setters already
used right next to them. Without this, `Portal { ... }` and
`SuspenseBoundary { ... }` would have been the two components in the entire
framework a caller could no longer put ordinary children into.

## Verification

- `packages/core/tests/vec_children.rs` (new): single child,
  multiple static children, a bare `for` loop, a `for` loop mixed with
  literal children, nested `for`-inside-`for`-inside-`if`, an empty body
  (default), and both `Element` and `Option<Element>` targets. 11/11.
- Full existing suites, unmodified: `dioxus-core` (every test file
  including `render_targets.rs`/`suspense.rs`, which exercise `Portal`/
  `SuspenseBoundary` directly - this is what caught both hand-rolled-builder
  gaps above), `dioxus-rsx`, `dioxus-core-macro`, `dioxus-html`, `dioxus-
  hooks`, `dioxus-ssr`, `dioxus`. All green. (One `dioxus` doctest -
  `LaunchBuilder::with_cfg` - fails with an unrelated missing-feature import
  error; confirmed pre-existing by reproducing it on unmodified `main`.)
- `dx` (the CLI) rebuilds cleanly from the rebased `fix/combined` - this
  change never touches `packages/cli`, so there was no reason to expect
  otherwise, but confirmed anyway.
- Real usage, not just tests: `libero`'s new `DataList`/`DataListItem`
  components (see below) build and serve in the actual `docs` app.

## Proof in a real component: `DataList`/`DataListItem`

```rust
base_props! {
    pub struct DataListItemProps {
        label: Element,
        children: Vec<Element>,
    }
}

#[component]
pub fn DataListItem(props: DataListItemProps) -> Element {
    rsx! {
        Box { component: "dt", class: props.class, sx: props.sx, states: props.states,
              attributes: props.attributes, {props.label} }
        for (index, value) in props.children.into_iter().enumerate() {
            Box { component: "dd", key: "{index}", {value} }
        }
    }
}
```

Every design considered before this feature existed had a real cost:

| Shape | Single-child call site | Multi-child call site | Cost |
|---|---|---|---|
| `DataListItem { label, children: Element }` | `DataListItem { label: .., "x" }` | not possible | can't express >1 description at all |
| + a sibling `DataListDescription` marker component | `DataListItem { label: .., DataListDescription { "x" } }` | `DataListItem { label: .., DataListDescription{"x"} DataListDescription{"y"} }` | a second public component to learn, purely to work around the framework gap |
| `children: Vec<Element>`, hand-built | `DataListItem { label: .., values: vec![rsx!{"x"}] }` | `values: vec![rsx!{"x"}, rsx!{"y"}]` | `vec![]`/`rsx!{}` ceremony on *every* call, including the common single-value case |
| this feature | `DataListItem { label: .., "x" }` | `DataListItem { label: .., "x" "y" }` | none - same syntax as `children: Element` always had |

Only the last one keeps the single-value call site exactly as terse as
`children: Element`'s always was, while still making the multi-value case
fully expressible - including through an ordinary `for` loop, which is what
`DataList`'s own "Horizontal" docs example uses to show a `Phone` entry with
two numbers.

## Known rough edges

- **Hot-reload template indices for the synthetic per-root templates**:
  `TemplateBody::new` (used for each plain root's standalone template) gets
  fresh path/index bookkeeping rather than participating in the whole-
  `CallBody`'s normal index-assignment pass. Regular (non-hot-reload)
  compilation and rendering are unaffected - verified above - but hot-
  reloading a single child inside a `Vec<Element>`-typed children list
  hasn't been separately stress-tested and may not swap cleanly. Same
  category of caveat as everything else in this fork building against
  `main`'s alpha.
- **Bare literal values for `Element`-typed *named* (non-`children`) props**
  still need explicit `rsx! { .. }` wrapping - `label: "Phone"` doesn't
  compile for a `label: Element` field the way `children` content does;
  `label: rsx! { "Phone" }` does. This is unrelated to this feature (it's
  true today for any `Element`-typed named prop) and out of scope here, but
  it's the one visible rough edge in `DataList`'s own docs page.
- This is a fork experiment, not an upstream PR - not stress-tested against
  hydration, SSR streaming, or the desktop/native renderers beyond what
  `dioxus-ssr`'s existing test suite already covers.
