### PR TITLE
`children: Vec<Element>` - iterable children without new syntax

### DIFF
--- a/packages/core-macro/src/props/mod.rs
+++ b/packages/core-macro/src/props/mod.rs
@@ -172,7 +172,10 @@ mod util {
 }
 
 mod field_info {
-    use crate::props::{looks_like_store_type, looks_like_write_type, type_from_inside_option};
+    use crate::props::{
+        looks_like_store_type, looks_like_write_type, type_from_inside_option,
+        type_is_vec_of_elements,
+    };
     use proc_macro2::TokenStream;
     use quote::{format_ident, quote};
     use syn::spanned::Spanned;
@@ -204,10 +207,24 @@ mod field_info {
                 let strip_option_auto = builder_attr.strip_option
                     || !builder_attr.ignore_option && type_from_inside_option(&field.ty).is_some();
 
-                // children field is automatically defaulted to an empty VNode unless it is marked as optional (in which case it defaults to None)
-                if name == "children" && !strip_option_auto {
-                    builder_attr.default =
-                        Some(syn::parse(quote!(dioxus_core::VNode::empty()).into()).unwrap());
+                if name == "children" {
+                    // The call site always builds a `Vec<Element>` (see `dioxus-rsx`'s
+                    // `component.rs`), so the setter takes `impl SuperInto<_>` like
+                    // `#[props(into)]` does - that's what lets the field declare either
+                    // `Element` or `Vec<Element>` and still accept the same call-site syntax.
+                    builder_attr.auto_into = true;
+
+                    // children is automatically defaulted to an empty VNode - or an empty Vec,
+                    // for a `children: Vec<Element>` field - unless it is marked as optional (in
+                    // which case it defaults to None)
+                    if !strip_option_auto {
+                        let default = if type_is_vec_of_elements(&field.ty) {
+                            quote!(::std::vec::Vec::new())
+                        } else {
+                            quote!(dioxus_core::VNode::empty())
+                        };
+                        builder_attr.default = Some(syn::parse(default.into()).unwrap());
+                    }
                 }
 
                 // String fields automatically use impl Display
@@ -495,6 +512,31 @@ mod field_info {
             }
         }
     }
+}
+
+/// Whether this is a `Vec<Element>`, however `Vec` and `Element` are spelled or pathed
+fn type_is_vec_of_elements(ty: &Type) -> bool {
+    let Type::Path(type_path) = ty else {
+        return false;
+    };
+
+    let Some(seg) = type_path.path.segments.last() else {
+        return false;
+    };
+
+    if seg.ident != "Vec" {
+        return false;
+    }
+
+    let Some(Type::Path(inner)) = extract_inner_type_from_segment(seg) else {
+        return false;
+    };
+
+    inner
+        .path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "Element")
 }
 
 fn type_from_inside_option(ty: &Type) -> Option<&Type> {

--- a/packages/core/src/portal.rs
+++ b/packages/core/src/portal.rs
@@ -93,11 +93,19 @@ impl<__children> PortalPropsBuilder<((), __children)> {
 
 #[allow(dead_code, non_camel_case_types, missing_docs)]
 impl<__target> PortalPropsBuilder<(__target, ())> {
+    /// Takes `impl SuperInto<Element, _>` rather than a bare `Element`, mirroring what
+    /// `#[derive(Props)]` now generates for every `children: Element` field - the call site
+    /// compiles children to a `Vec<Element>` (see
+    /// [`crate::properties::VecElementFromMarker`]), so a bare `Element` here wouldn't accept
+    /// them.
     #[allow(clippy::type_complexity)]
-    pub fn children(self, children: Element) -> PortalPropsBuilder<(__target, (Element,))> {
+    pub fn children<__Marker>(
+        self,
+        children: impl crate::SuperInto<Element, __Marker>,
+    ) -> PortalPropsBuilder<(__target, (Element,))> {
         let (target, _) = self.fields;
         PortalPropsBuilder {
-            fields: (target, (children,)),
+            fields: (target, (children.super_into(),)),
             _phantom: self._phantom,
         }
     }
@@ -147,9 +155,9 @@ impl<RenderFn, ComponentMarker, __target>
     PortalComponentBuilder<RenderFn, ComponentMarker, (__target, ())>
 {
     #[allow(clippy::type_complexity)]
-    pub fn children(
+    pub fn children<__Marker>(
         self,
-        children: Element,
+        children: impl crate::SuperInto<Element, __Marker>,
     ) -> PortalComponentBuilder<RenderFn, ComponentMarker, (__target, (Element,))> {
         PortalComponentBuilder {
             render_fn: self.render_fn,

--- a/packages/core/src/properties.rs
+++ b/packages/core/src/properties.rs
@@ -356,6 +356,48 @@ where
     }
 }
 
+/// Marker used to merge the `Vec<Element>` an `rsx!` body compiles its children to back into a
+/// single [`Element`], for a component that declares `children: Element`. Together with the
+/// `Vec<Element>` shape passing straight through, this is what makes both declarations accept the
+/// exact same call-site syntax.
+#[doc(hidden)]
+pub struct VecElementFromMarker;
+
+/// `None` only for a genuinely empty list, never for a render error - `IntoDynNode for Element`
+/// already treats an `Err` as "nothing" rather than propagating it
+fn merge_vnodes(input: Vec<Element>) -> Option<VNode> {
+    let mut nodes: Vec<VNode> = input.into_iter().map(IntoVNode::into_vnode).collect();
+    match nodes.len() {
+        0 => None,
+        // One child, the common case, keeps exactly the VNode shape `children: Element` has
+        1 => Some(nodes.pop().unwrap()),
+        // 2+ separately built VNodes share no static Template, so they can only be combined at
+        // runtime, through the same dynamic-node slot a `for` loop's output already uses
+        _ => {
+            use crate::view::{ViewExt, dynamic_node_builder};
+            Some(dynamic_node_builder::<_, ()>(DynamicNode::Fragment(nodes)).into_vnode())
+        }
+    }
+}
+
+impl SuperFrom<Vec<Element>, VecElementFromMarker> for Element {
+    fn super_from(input: Vec<Element>) -> Self {
+        // An empty list lands on `VNode::empty()`, the `children: Element` default
+        Ok(merge_vnodes(input).unwrap_or_default())
+    }
+}
+
+/// Marker used to merge a `Vec<Element>` into `Option<Element>`, for a component whose `children`
+/// is itself optional - `None` for an empty list, same as that field's own default.
+#[doc(hidden)]
+pub struct VecElementFromOptionMarker;
+
+impl SuperFrom<Vec<Element>, VecElementFromOptionMarker> for Option<Element> {
+    fn super_from(input: Vec<Element>) -> Self {
+        merge_vnodes(input).map(Ok)
+    }
+}
+
 /// Marker used to convert `&str` into `Option<String>` through [`SuperFrom`].
 #[doc(hidden)]
 pub struct OptionStringFromMarker;

--- a/packages/core/src/suspense/component.rs
+++ b/packages/core/src/suspense/component.rs
@@ -105,9 +105,9 @@ impl<RenderFn, ComponentMarker, __fallback>
 {
     #[allow(clippy::type_complexity)]
     #[doc(hidden)]
-    pub fn children(
+    pub fn children<__Marker>(
         self,
-        children: Element,
+        children: impl SuperInto<Element, __Marker>,
     ) -> SuspenseBoundaryComponentBuilder<RenderFn, ComponentMarker, (__fallback, (Element,))> {
         SuspenseBoundaryComponentBuilder {
             render_fn: self.render_fn,
@@ -175,11 +175,11 @@ impl<__children> SuspenseBoundaryPropsBuilder<((Callback<SuspenseContext, Elemen
 impl<__fallback> SuspenseBoundaryPropsBuilder<(__fallback, ())> {
     #[allow(clippy::type_complexity)]
     #[doc(hidden)]
-    pub fn children(
+    pub fn children<__Marker>(
         self,
-        children: Element,
+        children: impl SuperInto<Element, __Marker>,
     ) -> SuspenseBoundaryPropsBuilder<(__fallback, (Element,))> {
-        let children = (children,);
+        let children = (SuperInto::super_into(children),);
         let (fallback, _) = self.fields;
         SuspenseBoundaryPropsBuilder {
             owner: self.owner,

--- a/packages/core/tests/vec_children.rs
+++ b/packages/core/tests/vec_children.rs
@@ -1,0 +1,253 @@
+#![allow(non_snake_case)]
+
+//! Proves out `children: Vec<Element>` as an alternative to `children: Element`: the exact same
+//! call-site syntax (natural rsx composition, `for`/`if` included) should populate either shape,
+//! with `for`/`if` roots flattened to however many elements they actually produce.
+
+use dioxus::prelude::*;
+
+#[derive(Props, Clone, PartialEq)]
+struct WrapProps {
+    children: Element,
+}
+
+fn Wrap(props: WrapProps) -> Element {
+    rsx! {
+        div { id: "wrap", {props.children} }
+    }
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct SplitProps {
+    children: Vec<Element>,
+}
+
+#[derive(Props, Clone, PartialEq)]
+struct OptionalProps {
+    children: Option<Element>,
+}
+
+/// The `Vec<Element>` detection has to be structural - a fully pathed spelling declares the very
+/// same field, and defaulting it to a `VNode` instead of a `Vec` wouldn't compile
+#[derive(Props, Clone, PartialEq)]
+struct PathedProps {
+    children: std::vec::Vec<dioxus::prelude::Element>,
+}
+
+fn Pathed(props: PathedProps) -> Element {
+    let count = props.children.len();
+    rsx! {
+        div { id: "pathed", "count": count }
+    }
+}
+
+fn Optional(props: OptionalProps) -> Element {
+    let has_label = props.children.is_some();
+    rsx! {
+        div {
+            id: "optional",
+            "has-label": has_label,
+            if let Some(children) = props.children {
+                {children}
+            }
+        }
+    }
+}
+
+fn Split(props: SplitProps) -> Element {
+    rsx! {
+        div {
+            id: "split",
+            for child in props.children {
+                dd { {child} }
+            }
+        }
+    }
+}
+
+fn render(app: fn() -> Element) -> String {
+    let mut dom = VirtualDom::new(app);
+    dom.rebuild(&mut dioxus_core::NoOpMutations);
+    let out = dioxus_ssr::render(&dom);
+    println!("{out}");
+    out
+}
+
+#[test]
+fn element_children_unchanged() {
+    fn app() -> Element {
+        rsx! {
+            Wrap {
+                "a"
+                "b"
+            }
+        }
+    }
+    let out = render(app);
+    assert!(out.contains('a'));
+    assert!(out.contains('b'));
+}
+
+#[test]
+fn vec_children_static_multiple() {
+    fn app() -> Element {
+        rsx! {
+            Split {
+                "one"
+                "two"
+                "three"
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 3);
+}
+
+#[test]
+fn vec_children_single() {
+    fn app() -> Element {
+        rsx! {
+            Split { "only" }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 1);
+}
+
+#[test]
+fn vec_children_for_loop_flattens() {
+    fn app() -> Element {
+        let items = vec!["x", "y", "z", "w"];
+        rsx! {
+            Split {
+                for item in items {
+                    "{item}"
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 4);
+}
+
+#[test]
+fn vec_children_mixed_literal_and_for_loop() {
+    fn app() -> Element {
+        let items = vec!["x", "y"];
+        rsx! {
+            Split {
+                "first"
+                for item in items {
+                    "{item}"
+                }
+                "last"
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 4);
+}
+
+#[test]
+fn vec_children_if_chain_true_branch() {
+    fn app() -> Element {
+        let show_extra = true;
+        rsx! {
+            Split {
+                "always"
+                if show_extra {
+                    "extra"
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 2);
+}
+
+#[test]
+fn vec_children_if_chain_false_branch_contributes_zero() {
+    fn app() -> Element {
+        let show_extra = false;
+        rsx! {
+            Split {
+                "always"
+                if show_extra {
+                    "extra"
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 1);
+}
+
+#[test]
+fn vec_children_nested_for_and_if() {
+    fn app() -> Element {
+        let groups = vec![vec!["a1", "a2"], vec!["b1"]];
+        rsx! {
+            Split {
+                for group in groups {
+                    for item in group {
+                        if item != "skip" {
+                            "{item}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 3);
+}
+
+#[test]
+fn vec_children_empty_default() {
+    fn app() -> Element {
+        rsx! {
+            Split {}
+        }
+    }
+    let out = render(app);
+    assert_eq!(out.matches("<dd").count(), 0);
+}
+
+#[test]
+fn vec_children_pathed_type_still_defaults_to_empty_vec() {
+    fn app() -> Element {
+        rsx! {
+            Pathed {}
+            Pathed {
+                span {}
+                span {}
+            }
+        }
+    }
+    let out = render(app);
+    assert!(out.contains("count=0"));
+    assert!(out.contains("count=2"));
+}
+
+#[test]
+fn option_element_children_with_content() {
+    fn app() -> Element {
+        rsx! {
+            Optional { "a label" }
+        }
+    }
+    let out = render(app);
+    assert!(out.contains("has-label=true"));
+    assert!(out.contains("a label"));
+}
+
+#[test]
+fn option_element_children_empty_is_none() {
+    fn app() -> Element {
+        rsx! {
+            Optional {}
+        }
+    }
+    let out = render(app);
+    assert!(out.contains("has-label=false"));
+}

--- a/packages/rsx/src/component.rs
+++ b/packages/rsx/src/component.rs
@@ -238,15 +238,18 @@ impl Component {
         ));
 
         if !self.children.is_empty() {
-            let children = &self.children;
+            // Always a `Vec<Element>`, one entry per top-level child. This call site can't see
+            // the callee's declared field type, so which shape it actually wants is resolved on
+            // the other side, through `SuperInto`.
+            let children = self.children.to_vec_tokens();
             // If the props don't accept children, attach the error to the first child
             if manual_props.is_some() {
                 tokens.append_all(
-                    quote_spanned! { children.first_root_span() => __manual_props.children = #children; },
+                    quote_spanned! { self.children.first_root_span() => __manual_props.children = dioxus_core::SuperInto::super_into(#children); },
                 )
             } else {
                 tokens.append_all(
-                    quote_spanned! { children.first_root_span() => .children( #children ) },
+                    quote_spanned! { self.children.first_root_span() => .children( #children ) },
                 )
             }
         }

--- a/packages/rsx/src/ifchain.rs
+++ b/packages/rsx/src/ifchain.rs
@@ -131,6 +131,61 @@ impl ToTokens for IfChain {
     }
 }
 
+impl IfChain {
+    /// Like [`ToTokens`], but produces a `Vec<Element>` per branch instead of merging each
+    /// branch's body into one nested [`Element`] - see [`TemplateBody::to_vec_tokens`].
+    pub(crate) fn to_vec_tokens(&self) -> TokenStream2 {
+        let mut body = TokenStream2::new();
+        let mut terminated = false;
+
+        let mut elif = Some(self);
+
+        while let Some(chain) = elif {
+            let IfChain {
+                if_token,
+                cond,
+                then_branch,
+                else_if_branch,
+                else_branch,
+                ..
+            } = chain;
+
+            let then_vec = then_branch.to_vec_tokens();
+            body.append_all(quote! {
+                #if_token #cond {
+                    #then_vec
+                }
+            });
+
+            if let Some(next) = else_if_branch {
+                body.append_all(quote! {
+                    else
+                });
+                elif = Some(next);
+            } else if let Some(else_branch) = else_branch {
+                let else_vec = else_branch.to_vec_tokens();
+                body.append_all(quote! {
+                    else {
+                        #else_vec
+                    }
+                });
+                terminated = true;
+                break;
+            } else {
+                elif = None;
+            }
+        }
+
+        if !terminated {
+            body.append_all(quote! {
+                else { ::std::vec::Vec::new() }
+            });
+        }
+
+        body
+    }
+}
+
 #[test]
 fn parses_if_chain() {
     let input = quote! {

--- a/packages/rsx/src/template_body.rs
+++ b/packages/rsx/src/template_body.rs
@@ -263,6 +263,51 @@ impl ToTokens for TemplateBody {
     }
 }
 
+impl TemplateBody {
+    /// Like [`ToTokens`], but produces a `Vec<Element>` - one entry per top-level root, with
+    /// `for`/`if` roots flattened into however many elements they produce at runtime - instead of
+    /// one merged [`Element`].
+    ///
+    /// This is what a component declaring `children: Vec<Element>` receives. A component keeping
+    /// `children: Element` gets the same list merged back, via
+    /// `dioxus_core::properties::VecElementFromMarker`.
+    pub(crate) fn to_vec_tokens(&self) -> TokenStream2 {
+        let root_exprs = self.roots.iter().map(BodyNode::to_vec_tokens);
+        quote! {
+            {
+                let mut __children: ::std::vec::Vec<dioxus_core::Element> = ::std::vec::Vec::new();
+                #( __children.extend(#root_exprs); )*
+                __children
+            }
+        }
+    }
+}
+
+impl BodyNode {
+    /// See [`TemplateBody::to_vec_tokens`]. Produces an `IntoIterator<Item = Element>` expression
+    /// so the caller can `.extend(...)` it however many elements this root contributes.
+    fn to_vec_tokens(&self) -> TokenStream2 {
+        match self {
+            BodyNode::ForLoop(for_loop) => {
+                let ForLoop {
+                    pat, expr, body, ..
+                } = for_loop;
+                let inner = body.to_vec_tokens();
+                quote! {
+                    (#expr).into_iter().flat_map(move |#pat| #inner)
+                }
+            }
+            BodyNode::IfChain(if_chain) => if_chain.to_vec_tokens(),
+            // Everything else contributes exactly one `Element`: compile it as its own single-root
+            // template, reusing the `ToTokens` impl above rather than re-deriving its bookkeeping
+            _ => {
+                let single = TemplateBody::new(vec![self.clone()]);
+                quote! { ::std::vec::Vec::from([ #single ]) }
+            }
+        }
+    }
+}
+
 pub(crate) struct ViewBuilderPieces {
     definitions: Vec<TokenStream2>,
     view: TokenStream2,


### PR DESCRIPTION
# `children: Vec<Element>` - iterable children without new syntax

**Disclaimer**: Idea from me, but implemented using Claude.

## The problem

[#1177 "Iterable Children"](https://github.com/DioxusLabs/dioxus/issues/1177) is a
three-year-old open issue: there's no good way for a component to get its caller's
children as independent, individually usable values. A `Breadcrumbs` component
that wants a divider between each crumb, or (our motivating case) a
`DataListItem` that wants a term to have more than one description, both need
this. `children: Element` - the only option today - hands you one already-merged
node; there's nothing to iterate.

The issue's own opening example shows the syntax people actually want:

```rust
Breadcrumbs {
  divider: "/",
  Breadcrumb { name: "Level 1", link: "/" }
  Breadcrumb { name: "Level 2", link: "/level2" }
}
```

with `children: Vec<Element>` on the props struct. That has never worked. The
documented workaround, three years ago, was a differently named field (not even
`children`), an explicit `vec![]`, and every entry manually wrapped in
`render!`/`rsx!` - called "less clean" by its own author. Three follow-up PRs
(#1621, #2722, #2946) each tried to close the gap by walking or visiting an
already-compiled `VNode`/`Template` at runtime, recovering "what did the caller
write" from a representation that has already erased it. All three stalled and
closed unmerged.

## The idea

Let a component declare `children: Vec<Element>` as a straight alternative to
`children: Element`, and make **the exact same call-site syntax** work for either:

```rust
DataListItem {
    label: "Phone",
    "555-1234"
    "555-5678"
}
```

works whether `DataListItem::children` is `Element` (both lines merge into one
node - current behavior, unchanged) or `Vec<Element>` (each line becomes its own
entry). No new field, no `vec![]`, no per-entry `rsx!{}`. It composes with
`for`/`if` the way plain children already do - a `for` produces one `Element` per
iteration, flattened into the list, not one `Element` containing all of them.

## Why this layer

The earlier attempts tried to reconstruct structure from an already-compiled
`VNode`. By then, "how many things did the caller write" is gone - collapsed into
a template with static roots and dynamic-node slots that has no general notion of
"the top-level children" to hand back.

This fixes it where the information still exists: at macro *parse* time.
`dioxus-rsx`'s `TemplateBody` already stores a component's children as `roots:
Vec<BodyNode>`. Producing a `Vec<Element>` from that list is just a different, and
simpler, codegen target than producing one merged `Element`.

The other half - the call site can't know what the *callee* wants, because macros
expand before type-checking - already has a solution in this codebase.
`#[props(into)]` fields generate a setter of the form `impl SuperInto<FieldType,
Marker>`, and `SuperInto`/`SuperFrom` are ordinary traits resolved by inference
*after* macro expansion, against whatever type the callee declares. So: make the
macro always produce one shape (`Vec<Element>`), and let the callee's own
generated setter pick the conversion.

## How it's implemented

**`dioxus-rsx`** - `component.rs`'s children codegen calls a new
`TemplateBody::to_vec_tokens` (`template_body.rs`) instead of the normal
single-`Element` `ToTokens` output. It recurses over `roots`:

- A plain node (element, component, text, `{expr}`) becomes its own standalone
  single-root `TemplateBody` via `TemplateBody::new(vec![node])` - reusing the
  existing single-`Element` codegen unchanged, just invoked once per root - and
  contributes exactly one `Element`.
- A `for` root recurses into its body and `flat_map`s per iteration, so a loop's
  output is spliced in flat rather than nested as one entry.
- An `if`/`else` chain (`IfChain::to_vec_tokens`, `ifchain.rs`) unifies its
  branches directly to `Vec<Element>` instead of merging through `IntoDynNode`. A
  branch with no matching arm contributes an empty `Vec`, same as the existing
  `VNode::empty()` fallback does for the `Element` form.

**`dioxus-core-macro` (`packages/core-macro/src/props/mod.rs`)** - the `children`
field is now unconditionally `auto_into` (the flag `#[props(into)]` sets), so
`impl SuperInto<FieldType, Marker>` is what every `children` setter accepts, not
just the ones that opted in. Its generated default switches from
`dioxus_core::VNode::empty()` to `Vec::new()` when the declared type is
`Vec<Element>`. That check is **structural** - last path segment `Vec`, whose
single generic argument's last path segment is `Element` - written in the same
shape as the `type_from_inside_option` helper next to it. The neighbouring
bare-`String` special case does compare `field.ty` against literal spellings, but
the failure modes differ: a missed `String` just means no `impl Display` sugar,
whereas a missed `Vec<Element>` gives the field a `VNode` default and fails to
compile with a confusing error at the component's own definition.
`std::vec::Vec<dioxus::prelude::Element>` has to work, and it does.

**`dioxus-core` (`packages/core/src/properties.rs`)** - two new `SuperFrom` impls
do the merging, for the two shapes a `children` field can already legally have:

```rust
impl SuperFrom<Vec<Element>, VecElementFromMarker> for Element { .. }
impl SuperFrom<Vec<Element>, VecElementFromOptionMarker> for Option<Element> { .. }
```

Both go through a shared `merge_vnodes`: zero elements produces
`VNode::empty()`/`None` (identical to today's default), exactly one element is
returned directly with no wrapping (so the overwhelmingly common single-child case
produces the exact same `VNode` shape `children: Element` always has), and two or
more are combined through `DynamicNode::Fragment` - the same dynamic-node-slot
machinery a `for` loop's output already goes through
(`view::dynamic_node_builder(..).into_vnode()`). Nothing here is a new rendering
concept; it's the existing multi-node machinery reached from a new place.

**Two hand-rolled `Properties` impls** - `Portal` (`packages/core/src/portal.rs`)
and `SuspenseBoundary` (`packages/core/src/suspense/component.rs`) - predate
`#[derive(Props)]`'s current shape and had exact-type `children(self, children:
Element)` setters. A workspace-wide search confirmed these are the *only* two
hand-rolled `Properties` impls in the codebase; both are updated to `children<M>
(self, children: impl SuperInto<Element, M>)`, mirroring the pattern their own
`fallback` setters already use right next to them. Without this, `Portal { .. }`
and `SuspenseBoundary { .. }` would be the two components in the framework a
caller could no longer put ordinary children into.

## Verification

- `packages/core/tests/vec_children.rs` (new, **12/12**): single child, multiple
  static children, a bare `for` loop, a `for` loop mixed with literal children,
  nested `for`-inside-`for`-inside-`if`, an empty body (default), a fully pathed
  `std::vec::Vec<dioxus::prelude::Element>` declaration - which fails to *compile*
  if the type check above ever regresses to spelling comparison - and both
  `Element` and `Option<Element>` targets.
- Full existing suites, unmodified: `dioxus-core` (every test file, including
  `render_targets.rs`/`suspense.rs`, which exercise `Portal`/`SuspenseBoundary`
  directly - that's what caught both hand-rolled-builder gaps above),
  `dioxus-rsx`, `dioxus-core-macro`, `dioxus-html`, `dioxus-hooks`, `dioxus-ssr`,
  `dioxus`. All green. (One `dioxus` doctest, `LaunchBuilder::with_cfg`, fails
  with an unrelated missing-feature import error; confirmed pre-existing by
  reproducing it on unmodified `main`.)
- `dx` rebuilds cleanly - this change never touches `packages/cli`, but confirmed
  anyway.
- Real usage, not just tests: a downstream component library's
  `DataList`/`DataListItem` (below) build and serve in an actual app.

## Proof in a real component: `DataList`/`DataListItem`

```rust
base_props! {
    pub struct DataListItemProps {
        label: Element,
        children: Vec<Element>,
    }
}

#[component]
pub fn DataListItem(props: DataListItemProps) -> Element {
    rsx! {
        Box { component: "dt", class: props.class, sx: props.sx, states: props.states,
              attributes: props.attributes, {props.label} }
        for (index, value) in props.children.into_iter().enumerate() {
            Box { component: "dd", key: "{index}", {value} }
        }
    }
}
```

Every design considered before this feature existed had a real cost:

| Shape | Single-child call site | Multi-child call site | Cost |
|---|---|---|---|
| `children: Element` | `DataListItem { label: .., "x" }` | not possible | can't express >1 description at all |
| + a sibling `DataListDescription` marker component | `DataListItem { label: .., DataListDescription { "x" } }` | `DataListItem { label: .., DataListDescription{"x"} DataListDescription{"y"} }` | a second public component to learn, purely to work around the gap |
| `children: Vec<Element>`, hand-built | `DataListItem { label: .., values: vec![rsx!{"x"}] }` | `values: vec![rsx!{"x"}, rsx!{"y"}]` | `vec![]`/`rsx!{}` ceremony on *every* call, including the common single-value case |
| this feature | `DataListItem { label: .., "x" }` | `DataListItem { label: .., "x" "y" }` | none - same syntax as `children: Element` always had |

Only the last keeps the single-value call site as terse as `children: Element`'s
always was while making the multi-value case fully expressible - including through
an ordinary `for` loop.

## Known rough edges

- **Hot-reload template indices for the synthetic per-root templates**:
  `TemplateBody::new`, used for each plain root's standalone template, gets fresh
  path/index bookkeeping rather than participating in the whole `CallBody`'s
  normal index-assignment pass. Regular compilation and rendering are unaffected
  (verified above), but hot-reloading a single child inside a
  `Vec<Element>`-typed children list hasn't been separately stress-tested and may
  not swap cleanly.
- **Bare literal values for `Element`-typed *named* (non-`children`) props** still
  need explicit `rsx! { .. }` wrapping - `label: "Phone"` doesn't compile for a
  `label: Element` field the way `children` content does; `label: rsx! { "Phone" }`
  does. Unrelated to this feature (true today for any `Element`-typed named prop)
  and out of scope here.
- Not stress-tested against hydration, SSR streaming, or the desktop/native
  renderers beyond what `dioxus-ssr`'s existing test suite already covers.
