### PR TITLE
fix(router): preserve reserved query values

### DIFF
--- a/packages/router-macro/src/query.rs
+++ b/packages/router-macro/src/query.rs
@@ -25,7 +25,21 @@ impl QuerySegment {
             QuerySegment::Single(segment) => segment.parse(),
             QuerySegment::Segments(segments) => {
                 let mut tokens = TokenStream2::new();
-                tokens.extend(quote! { let split_query: std::collections::HashMap<&str, &str> = query.split('&').filter_map(|s| s.split_once('=')).collect(); });
+                tokens.extend(quote! {
+                    let split_query: std::collections::HashMap<_, _> = raw_query
+                        .split('&')
+                        .filter_map(|segment| {
+                            let (key, value) = segment.split_once('=')?;
+                            let key = dioxus_router::exports::percent_encoding::percent_decode_str(key)
+                                .decode_utf8()
+                                .unwrap_or(key.into());
+                            let value = dioxus_router::exports::percent_encoding::percent_decode_str(value)
+                                .decode_utf8()
+                                .unwrap_or(value.into());
+                            Some((key, value))
+                        })
+                        .collect();
+                });
                 for segment in segments {
                     tokens.extend(segment.parse());
                 }
@@ -149,7 +163,7 @@ impl QueryArgument {
             let #ident = match split_query.get(stringify!(#ident)) {
                 Some(query_argument) => {
                     use dioxus_router::routable::FromQueryArgument;
-                    <#ty>::from_query_argument(query_argument).unwrap_or_default()
+                    <#ty>::from_query_argument(query_argument.as_ref()).unwrap_or_default()
                 },
                 None => <#ty as Default>::default(),
             };
@@ -166,7 +180,7 @@ impl QueryArgument {
         quote! {
             {
                 let as_string = dioxus_router::routable::DisplayQueryArgument::new(stringify!(#ident), #ident).to_string();
-                write!(f, "{}", dioxus_router::exports::percent_encoding::utf8_percent_encode(&as_string, dioxus_router::exports::QUERY_ASCII_SET))?;
+                write!(f, "{}", dioxus_router::exports::percent_encoding::utf8_percent_encode(&as_string, dioxus_router::exports::QUERY_ARGUMENT_ASCII_SET))?;
                 #write_ampersand
             }
         }

--- a/packages/router/src/lib.rs
+++ b/packages/router/src/lib.rs
@@ -109,6 +109,9 @@ pub(crate) mod query_sets {
         .add(b'<')
         .add(b'>');
 
+    /// The ASCII set that must be escaped in segmented query arguments.
+    pub const QUERY_ARGUMENT_ASCII_SET: &AsciiSet = &QUERY_ASCII_SET.add(b'%').add(b'&');
+
     /// The ASCII set that must be escaped in path segments.
     pub const PATH_ASCII_SET: &AsciiSet = &QUERY_ASCII_SET
         .add(b'?')

--- a/packages/router/tests/parsing.rs
+++ b/packages/router/tests/parsing.rs
@@ -221,3 +221,38 @@ fn child_route_preserves_query_and_hash() {
     assert_eq!(reserved.to_string(), "/search?query=a%23b&word_count=1");
     assert_eq!(Route::from_str(&reserved.to_string()).unwrap(), reserved);
 }
+
+#[test]
+fn segmented_query_values_round_trip_reserved_characters() {
+    #[derive(Routable, Clone, PartialEq, Debug)]
+    enum Route {
+        #[route("/search?:query&:sort")]
+        Search { query: String, sort: String },
+    }
+
+    #[component]
+    fn Search(query: String, sort: String) -> Element {
+        unimplemented!()
+    }
+
+    for (query, encoded) in [
+        ("one & two", "/search?query=one%20%26%20two&sort=name"),
+        ("%26", "/search?query=%2526&sort=name"),
+        ("a=b", "/search?query=a=b&sort=name"),
+    ] {
+        let route = Route::Search {
+            query: query.to_string(),
+            sort: "name".to_string(),
+        };
+        assert_eq!(route.to_string(), encoded);
+        assert_eq!(Route::from_str(encoded).unwrap(), route);
+    }
+
+    assert_eq!(
+        Route::from_str("/search?query=one%20%26%20two&sort=name").unwrap(),
+        Route::Search {
+            query: "one & two".to_string(),
+            sort: "name".to_string(),
+        }
+    );
+}


### PR DESCRIPTION
## Summary
- split segmented query strings before decoding each key and value
- escape `%` and `&` inside query arguments so reserved values round-trip correctly
- add regression coverage for encoded ampersands, literal percent escapes, and equals signs

## Testing
- [x] `cargo test -p dioxus-router --test parsing`
- [x] `cargo clippy -p dioxus-router -p dioxus-router-macro --tests --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`

Closes #5751
