### PR TITLE
Fix stale sibling edge-scan panic during fragment/placement diffing

### DIFF
--- a/packages/core/src/diff/iterator.rs
+++ b/packages/core/src/diff/iterator.rs
@@ -92,8 +92,8 @@ impl StableFragmentEdges {
             let Some(mount) = new_mounts[idx] else {
                 continue;
             };
-            first_edges[idx] = new[idx].find_first_element(mount, dom);
-            last_edges[idx] = new[idx].find_last_element(mount, dom);
+            first_edges[idx] = new[idx].find_first_element_committed(mount, dom);
+            last_edges[idx] = new[idx].find_last_element_committed(mount, dom);
             live_stable[idx] = first_edges[idx].is_some() || last_edges[idx].is_some();
         }
 

--- a/packages/core/src/diff/node.rs
+++ b/packages/core/src/diff/node.rs
@@ -304,9 +304,21 @@ impl VNode {
         self.find_element_in_roots(
             mount,
             dom,
-            dom.current_render_target_id(),
+            EdgeScan::live(dom.current_render_target_id()),
             ElementEdge::First,
         )
+    }
+
+    /// Like [`Self::find_first_element`], but reads the committed component mount view instead of
+    /// trusting every live mount - for sibling scans during placement, where a neighboring
+    /// component may be mid-diff and its live mount state transiently incoherent (see
+    /// [`EdgeScan`]).
+    pub(crate) fn find_first_element_committed(
+        &self,
+        mount: MountId,
+        dom: &VirtualDom,
+    ) -> Option<ElementId> {
+        self.find_element_in_roots(mount, dom, EdgeScan::placement(dom), ElementEdge::First)
     }
 
     fn find_static_anchor_in_target(
@@ -323,32 +335,31 @@ impl VNode {
             .map(MountedElementId::element_id)
     }
 
-    pub(crate) fn find_last_element(&self, mount: MountId, dom: &VirtualDom) -> Option<ElementId> {
-        self.find_element_in_roots(
-            mount,
-            dom,
-            dom.current_render_target_id(),
-            ElementEdge::Last,
-        )
+    /// See [`Self::find_first_element_committed`]. There is no live counterpart to this - every
+    /// last-edge lookup is a sibling scan.
+    pub(crate) fn find_last_element_committed(
+        &self,
+        mount: MountId,
+        dom: &VirtualDom,
+    ) -> Option<ElementId> {
+        self.find_element_in_roots(mount, dom, EdgeScan::placement(dom), ElementEdge::Last)
     }
 
     pub(super) fn find_element_in_roots(
         &self,
         mount: MountId,
         dom: &VirtualDom,
-        target_id: crate::RenderTargetId,
+        scan: EdgeScan,
         edge: ElementEdge,
     ) -> Option<ElementId> {
         match edge {
             ElementEdge::First => self
                 .children()
-                .find_map(|child| self.root_child_edge_element(child, mount, target_id, dom, edge)),
+                .find_map(|child| self.root_child_edge_element(child, mount, scan, dom, edge)),
             ElementEdge::Last => {
                 let mut found = None;
                 for child in self.children() {
-                    if let Some(id) =
-                        self.root_child_edge_element(child, mount, target_id, dom, edge)
-                    {
+                    if let Some(id) = self.root_child_edge_element(child, mount, scan, dom, edge) {
                         found = Some(id);
                     }
                 }
@@ -361,24 +372,24 @@ impl VNode {
         &self,
         child: VNodeChild<'_>,
         mount: MountId,
-        target_id: crate::RenderTargetId,
+        scan: EdgeScan,
         dom: &VirtualDom,
         edge: ElementEdge,
     ) -> Option<ElementId> {
         match child {
             VNodeChild::Dynamic(anchor) => {
-                self.dynamic_anchor_edge_element(anchor, mount, dom, target_id, edge)
+                self.dynamic_anchor_edge_element(anchor, mount, dom, scan, edge)
             }
             VNodeChild::Element(element) => self.find_static_anchor_in_target(
                 element.anchor_index().expect("root element"),
                 mount,
-                target_id,
+                scan.target_id,
                 dom,
             ),
             VNodeChild::Text(text) => self.find_static_anchor_in_target(
                 text.anchor_index().expect("root text"),
                 mount,
-                target_id,
+                scan.target_id,
                 dom,
             ),
         }
@@ -389,10 +400,9 @@ impl VNode {
         anchor: DynamicAnchor<'_>,
         mount: MountId,
         dom: &VirtualDom,
-        target_id: crate::RenderTargetId,
+        scan: EdgeScan,
         edge: ElementEdge,
     ) -> Option<ElementId> {
-        let scan = EdgeScan::live(target_id);
         match edge {
             ElementEdge::First => anchor.nodes().find_map(|slot| {
                 self.dynamic_node_edge_element(mount, slot.index(), dom, scan, edge)
@@ -627,21 +637,23 @@ impl VNode {
                 .try_with_mounted_fragment_children(mount, idx, nodes.len(), |child_mounts| {
                     edge.find_map(nodes.len(), |i| {
                         let child_mount = child_mounts[i];
-                        nodes[i].find_element_in_roots(child_mount, dom, target_id, edge)
+                        nodes[i].find_element_in_roots(child_mount, dom, scan, edge)
                     })
                 })
                 .flatten(),
             Component(_) => {
                 // Placement scans read the committed mount view, which is stable while a sibling
-                // component is mid-diff; the live edge walk reads the scope's current render output.
+                // component is mid-diff; the live edge walk reads the scope's current render
+                // output. Recursing with the whole `scan` keeps that choice in force however
+                // deeply fragments and components nest below this one.
                 if committed_component_view {
                     let root_mount = dom.mounted_dynamic_component_root_mount(mount, idx)?;
                     let view = dom.current_mounted_view(root_mount)?;
-                    view.find_element_in_roots(root_mount, dom, target_id, edge)
+                    view.find_element_in_roots(root_mount, dom, scan, edge)
                 } else {
                     let scope_id = dom.unchecked_mounted_dynamic_component_scope(mount, idx);
                     let root = live_component_root(dom, scope_id)?;
-                    root.find_element_in_roots(root.mount(), dom, target_id, edge)
+                    root.find_element_in_roots(root.mount(), dom, scan, edge)
                 }
             }
         }

--- a/packages/core/src/diff/placement.rs
+++ b/packages/core/src/diff/placement.rs
@@ -237,7 +237,7 @@ impl<'dom, 'ctx> PlacementResolver<'dom, 'ctx> {
                 .filter(|(_, m)| **m != mount)
                 .find_map(|(child, &m)| {
                     child
-                        .find_first_element(m, self.dom)
+                        .find_first_element_committed(m, self.dom)
                         .map(InsertionSite::before)
                 })
         };
@@ -251,7 +251,7 @@ impl<'dom, 'ctx> PlacementResolver<'dom, 'ctx> {
                 .filter(|(_, m)| **m != mount)
                 .find_map(|(child, &m)| {
                     child
-                        .find_last_element(m, self.dom)
+                        .find_last_element_committed(m, self.dom)
                         .map(InsertionSite::after)
                 })
         };

--- a/packages/core/src/mount.rs
+++ b/packages/core/src/mount.rs
@@ -229,8 +229,16 @@ impl Mount {
         self.anchor_count as usize
     }
 
+    /// Bounds-checked, because an edge scan (see [`crate::diff::node::EdgeScan`]) can reach a
+    /// sibling mount mid-diff, before it has that many dynamic slots. Every reader of this treats
+    /// the result as optional anyway, and an empty slot is indistinguishable from a mount that
+    /// renders nothing. The write paths below stay unchecked - a bad index there is a real
+    /// invariant violation.
     fn dynamic_slot(&self, idx: usize) -> PackedMountedSlot {
-        self.slots[self.dynamic_offset() + idx]
+        self.slots
+            .get(self.dynamic_offset() + idx)
+            .copied()
+            .unwrap_or(PackedMountedSlot::empty())
     }
 
     fn dynamic_slot_mut(&mut self, idx: usize) -> &mut PackedMountedSlot {


### PR DESCRIPTION
**Disclaimer**: Found in my own app; root-caused and patched using Claude.

## Environment

- Dioxus `0.8.0-alpha.1`, upstream `main` at `24f6a829d`
- `rustc 1.99.0-nightly (1a98b1e13 2026-08-07)`, Arch Linux, x86_64
- `dioxus-web`, `dx serve --platform web`, with and without `--hot-patch`

## Problem

Clicking a button that conditionally renders a new component - a plain `if open()
{ SomeComponent { .. } }` toggle, or a component that portals its real content
elsewhere via a hook that writes a signal during its own render - panics
`dioxus-core` itself:

```
panicked at packages/core/src/mount.rs:233:9:
index out of bounds: the len is 0 but the index is 0
```

Reliable, not intermittent: every fresh page load, every first click, same
location. Nothing in the code path is web-specific; it's a plain in-memory diffing
bug reachable on any renderer. Bisection ruled out any application-side
regression - the bug was latent in `dioxus-core` the whole time, and app changes
only shifted *when* a build first hit the right concurrent-diff shape.

**On reproducing it:** several rounds of attempts failed to isolate this into a
portable example. A bare `if open() { .. }` toggle with siblings on both sides
doesn't do it; neither does the same shape with the new item writing to a signal
the sibling reads; neither does a byte-identical copy of the reproducing page
dropped onto a different route of the *same* app, while the original route still
panics on the same build. It depends on the exact scope/mount-id sequencing of the
whole running application - which two scopes end up dirty together, and in what
order the work queue drains them - not on any locally reproducible component
shape. The root cause below was confirmed by instrumenting the failing path
directly (tracing exactly which mount and index panic, and why), not by a
black-box repro.

## Root cause

`EdgeScan` (`packages/core/src/diff/node.rs`) already exists for this exact
hazard. Its own doc comment lays out the design: `find_first`/`find_last` walk the
*live* render output and trust every mount, while placement *sibling* scans should
read the *committed* component mount view, because the sibling being scanned can
itself be mid-diff with transiently incoherent live state. Three gaps meant that
distinction wasn't actually honored:

1. **Two real sibling-scan call sites went through the "live" path.**
   `PlacementResolver::resolve_fragment_child_site`'s `following`/`previous`
   closures (`diff/placement.rs`) and `StableFragmentEdges::new`'s keyed-reorder
   edge computation (`diff/iterator.rs`) both called the plain
   `find_first_element`/`find_last_element`, which build `EdgeScan::live`
   internally. A third sibling scan in the same file,
   `adjacent_dynamic_sibling_{before,after}_in_vnode`, already used
   `EdgeScan::placement` - the pattern existed, it just wasn't applied to every
   caller that needed it.

2. **The scan mode reset on every level of recursion.** Even starting in committed
   mode, `dynamic_anchor_edge_element` took a bare `target_id` and rebuilt
   `EdgeScan::live(target_id)` fresh each call, so descending into one nested
   `Fragment` silently reverted to trusting live, possibly-mid-diff state for
   everything beneath it. `dynamic_node_edge_element`'s `Fragment` and `Component`
   arms had the same problem one level further in.

3. **The committed path had no bounds check.** `mounted_dynamic_component_scope`
   bottoms out in `Mount::dynamic_slot`, which indexed unconditionally:
   `self.slots[self.dynamic_offset() + idx]`. A concurrently-mid-diff sibling's
   mount table can legitimately not have that many dynamic slots yet - a mount
   about to render nothing and a mount whose slots aren't populated for this pass
   look identical (zero slots) from outside. `current_mounted_view` re-reads the
   mount's *node*, but nothing re-validated that `idx` was in range for that
   mount's *slots* array.

## Patch

`packages/core/src/{mount.rs,diff/node.rs,diff/placement.rs,diff/iterator.rs}`.

**1. Give sibling scans a way to ask for the committed view, and use it at both
call sites that needed it:**

```diff
+    /// Like [`Self::find_first_element`], but reads the committed component mount view instead of
+    /// trusting every live mount - for sibling scans during placement, where a neighboring
+    /// component may be mid-diff and its live mount state transiently incoherent (see
+    /// [`EdgeScan`]).
+    pub(crate) fn find_first_element_committed(
+        &self,
+        mount: MountId,
+        dom: &VirtualDom,
+    ) -> Option<ElementId> {
+        self.find_element_in_roots(mount, dom, EdgeScan::placement(dom), ElementEdge::First)
+    }
```

...and a `_last_` counterpart, which **replaces `find_last_element` outright**:
every last-edge lookup in the tree is a sibling scan, so once these two call sites
moved there was no caller left for the live variant, and it is deleted rather than
left to warn. `find_first_element` keeps its own callers and stays - those read a
scope's *own*, not-yet-replaced content right before mutating it, not a sibling's,
so `EdgeScan::live` is correct there. Then in `diff/placement.rs`:

```diff
-                    child.find_first_element(m, self.dom).map(InsertionSite::before)
+                    child.find_first_element_committed(m, self.dom).map(InsertionSite::before)
```

...and the equivalent one-line swap in `diff/iterator.rs`.

**2. Thread the whole `EdgeScan` through recursion instead of a bare `target_id`:**

```diff
     pub(super) fn find_element_in_roots(
         &self,
         mount: MountId,
         dom: &VirtualDom,
-        target_id: crate::RenderTargetId,
+        scan: EdgeScan,
         edge: ElementEdge,
     ) -> Option<ElementId> {
```

...propagated through `root_child_edge_element` and `dynamic_anchor_edge_element`
(which no longer rebuilds `EdgeScan::live` internally), and into
`dynamic_node_edge_element`'s `Fragment`/`Component` arms, each of which now
passes the same `scan` into its own recursive call.

**3. Bounds-check the leaf read:**

```diff
+    /// Bounds-checked, because an edge scan (see [`crate::diff::node::EdgeScan`]) can reach a
+    /// sibling mount mid-diff, before it has that many dynamic slots. Every reader of this treats
+    /// the result as optional anyway, and an empty slot is indistinguishable from a mount that
+    /// renders nothing. The write paths below stay unchecked - a bad index there is a real
+    /// invariant violation.
     fn dynamic_slot(&self, idx: usize) -> PackedMountedSlot {
-        self.slots[self.dynamic_offset() + idx]
+        self.slots
+            .get(self.dynamic_offset() + idx)
+            .copied()
+            .unwrap_or(PackedMountedSlot::empty())
     }
```

`PackedMountedSlot::empty()` is already this module's established "nothing mounted
here" value - exactly what a genuinely empty component's slot produces for
`.component_scope()`/`.text()`. This introduces no new sentinel, just extends the
existing "not found" case to cover "this mount doesn't have that many slots at
all". All four readers that go through `dynamic_slot`
(`mounted_dynamic_node_slot_snapshot`, `mounted_dynamic_text_node`,
`try_with_mounted_fragment_children`, `mounted_dynamic_component_scope`) already
return `Option` or are otherwise fallible-shaped, so none has to invent a meaning
for the fallback. The write paths (`dynamic_slot_mut`, `anchor_slot_mut`) and the
anchor read (`anchor_slot`) are untouched, since an out-of-range index there is a
real, load-bearing invariant violation worth panicking on.

**A caveat on part 3, stated plainly:** it was derived by reading the code path,
not by re-measuring the panic with parts 1 and 2 already applied. Because the
trigger is scheduling-dependent and never reduced to a portable repro, there's no
cheap experiment separating "still load-bearing" from "now redundant
belt-and-braces". I kept it deliberately - being wrong in that direction costs a
hard panic in a renderer-agnostic diffing path, while being wrong the other way
costs one bounds check on four already-fallible reads. Happy to drop it if you'd
rather the invariant stay loud.

## Why this fixes it

(1) and (2) together mean a placement scan now actually reaches the committed,
stable view of every mount it touches at every level of nesting, matching what
`EdgeScan`'s own design already intended. (3) is the safety net for whatever's
left: briefly-behind bookkeeping becomes a graceful "nothing here yet" rather than
a panic, since a placement scan's job is to find *a* reasonable insertion anchor,
not to assert every sibling is perfectly synchronized at the instant it's read.

## Verification

- The original app's two reproducing pages, driven end to end with Puppeteer (a
  real click, not just a page load) against a rebuilt `dx`: panicked every time
  before the fix (3/3 runs each), zero panics after (3/3 runs each). The portaled
  component's open/close round trip was checked functionally too, not just "didn't
  crash".
- `cargo test -p dioxus-core` fully green, and the crate builds without warnings.
- The official `wasm-split.spec.js` and `web-patch.spec.js` Playwright suites
  (`packages/playwright-tests/`) both still pass unchanged - this touches shared
  diffing code they exercise end to end, and neither regressed.
