### PR TITLE
perf(core): reduce allocation in keyed-list diffing

### DIFF
--- a/packages/core/benches/keyed_diff.rs
+++ b/packages/core/benches/keyed_diff.rs
@@ -57,6 +57,7 @@ fn keyed_diff(c: &mut Criterion) {
     // ~490 stable rows on each side untouched.
     bench(&mut group, "reverse 20 mid-list", &initial, reverse_window);
     bench(&mut group, "shuffle 20 mid-list", &initial, shuffle_window);
+    bench(&mut group, "replace 100 mid-list", &initial, replace_middle);
 
     // No shared keys: the create-all + remove-all path.
     bench(&mut group, "replace all", &initial, replace_all);
@@ -147,6 +148,11 @@ fn shuffle_window(v: &mut Vec<u64>) {
     let mid = v.len() / 2;
     let mut rng = SmallRng::seed_from_u64(0xD10C);
     v[mid - 10..mid + 10].shuffle(&mut rng);
+}
+
+fn replace_middle(v: &mut Vec<u64>) {
+    let start = (v.len() - CHUNK as usize) / 2;
+    v.splice(start..start + CHUNK as usize, FRESH..FRESH + CHUNK);
 }
 
 // --- harness -----------------------------------------------------------------

--- a/packages/core/src/diff/iterator.rs
+++ b/packages/core/src/diff/iterator.rs
@@ -278,71 +278,80 @@ impl DiffState<'_, '_, '_, '_> {
         let new_suffix_start = new.len() - suffix;
 
         let mut plan = FragmentPlacementPlan::new(new.len());
-        let mut old_is_shared = vec![false; old.len()];
 
         for idx in 0..prefix {
             plan.reuse(idx, idx, &old[idx], &new[idx]);
-            old_is_shared[idx] = true;
         }
 
         for offset in 0..suffix {
             let old_idx = old_suffix_start + offset;
             let new_idx = new_suffix_start + offset;
             plan.reuse(new_idx, old_idx, &old[old_idx], &new[new_idx]);
-            old_is_shared[old_idx] = true;
         }
 
-        if prefix < old_suffix_start && prefix < new_suffix_start {
-            let old_key_to_old_index = old[prefix..old_suffix_start]
-                .iter()
-                .enumerate()
-                .map(|(i, o)| (o.key().unwrap(), prefix + i))
-                .collect::<FxHashMap<_, _>>();
-
-            let mut shared_middle_indices = Vec::new();
-            let mut shared_old_indices = Vec::new();
-            let new_index_to_old_index = new[prefix..new_suffix_start]
-                .iter()
-                .enumerate()
-                .map(|(middle_new_idx, node)| {
-                    let key = node.key().unwrap();
-                    if let Some(&index) = old_key_to_old_index.get(key) {
-                        if !old_is_shared[index] {
-                            old_is_shared[index] = true;
-                            shared_middle_indices.push(middle_new_idx);
-                            shared_old_indices.push(index);
-                        }
-                        Some(index)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<Box<[_]>>();
-
-            let mut in_lis = vec![false; new_index_to_old_index.len()];
-            if !shared_old_indices.is_empty() {
-                let mut lis_sequence = Vec::with_capacity(shared_old_indices.len());
-                let mut allocation = vec![0; shared_old_indices.len() * 2];
-                let (predecessors, starts) = allocation.split_at_mut(shared_old_indices.len());
-
-                longest_increasing_subsequence::lis_with(
-                    &shared_old_indices,
-                    &mut lis_sequence,
-                    |a, b| a < b,
-                    predecessors,
-                    starts,
+        if prefix == old_suffix_start || prefix == new_suffix_start {
+            self.execute_fragment_plan(
+                FragmentInputs {
+                    old,
+                    old_mounts,
+                    new,
+                    parent,
+                    new_children,
+                    new_offset: 0,
+                },
+                plan,
+                fallback_site,
+            );
+            if prefix < old_suffix_start {
+                self.dom.remove_nodes(
+                    self.to.as_deref_mut(),
+                    &old[prefix..old_suffix_start],
+                    &old_mounts[prefix..old_suffix_start],
                 );
-
-                for idx in lis_sequence {
-                    in_lis[shared_middle_indices[idx]] = true;
-                }
             }
+            return;
+        }
 
-            for (middle_new_idx, old_index) in new_index_to_old_index.iter().copied().enumerate() {
-                let Some(old_index) = old_index else { continue };
-                let new_idx = prefix + middle_new_idx;
-                plan.reuse(new_idx, old_index, &old[old_index], &new[new_idx]);
-                plan.stable[new_idx] = plan.stable[new_idx] && in_lis[middle_new_idx];
+        let mut old_is_shared = vec![false; old.len()];
+        old_is_shared[..prefix].fill(true);
+        old_is_shared[old_suffix_start..].fill(true);
+
+        let old_key_to_old_index = old[prefix..old_suffix_start]
+            .iter()
+            .enumerate()
+            .map(|(i, o)| (o.key().unwrap(), prefix + i))
+            .collect::<FxHashMap<_, _>>();
+
+        let mut shared = Vec::new();
+        for (middle_new_idx, node) in new[prefix..new_suffix_start].iter().enumerate() {
+            let Some(&old_index) = old_key_to_old_index.get(node.key().unwrap()) else {
+                continue;
+            };
+            if old_is_shared[old_index] {
+                continue;
+            }
+            old_is_shared[old_index] = true;
+            let new_idx = prefix + middle_new_idx;
+            plan.new_to_old[new_idx] = Some(old_index);
+            shared.push((new_idx, old_index));
+        }
+
+        if !shared.is_empty() {
+            let mut lis_sequence = Vec::with_capacity(shared.len());
+            let mut allocation = vec![0; shared.len() * 2];
+            let (predecessors, starts) = allocation.split_at_mut(shared.len());
+
+            longest_increasing_subsequence::lis_with(
+                &shared,
+                &mut lis_sequence,
+                |a, b| a.1 < b.1,
+                predecessors,
+                starts,
+            );
+
+            for idx in lis_sequence {
+                let (new_idx, old_idx) = shared[idx];
+                plan.stable[new_idx] = old[old_idx].template() == new[new_idx].template();
             }
         }
 

--- a/packages/core/tests/diff_keyed_list.rs
+++ b/packages/core/tests/diff_keyed_list.rs
@@ -310,6 +310,31 @@ fn no_common_keys() {
 }
 
 #[test]
+fn replace_keyed_middle_preserves_edges() {
+    fn app() -> Element {
+        let order: &[_] = match generation() % 2 {
+            0 => &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            1 => &[0, 1, 2, 10, 11, 12, 6, 7, 8, 9],
+            _ => unreachable!(),
+        };
+
+        rsx!({
+            order.iter().map(|i| {
+                rsx! {
+                    div { key: "{i}", id: "{i}" }
+                }
+            })
+        })
+    }
+
+    let (mut dom, mut oracle, _) = rebuild(app, &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let (summary, _) = rerender(&mut dom, &mut oracle, &[0, 1, 2, 10, 11, 12, 6, 7, 8, 9]);
+    assert_eq!(summary.loads, 3);
+    assert_eq!(summary.removes, 3);
+    assert_eq!(summary.replaces, 0);
+}
+
+#[test]
 fn perfect_reverse() {
     fn app() -> Element {
         let order: &[_] = match generation() % 2 {


### PR DESCRIPTION
## Summary

Evan's markerless-anchor refactor in package core's fragment diffing (PR #5554) introduced a fresh `FxHashMap` plus several scratch vectors on every keyed-child diff. This change adds fast paths and reduces allocation overhead while keeping the new semantics intact.

### What changed

- **`packages/core/src/diff/iterator.rs`** — `diff_keyed_children` now peels shared prefixes and suffixes first:
  - Append, prepend, truncation, in-place updates, and localized replacements at the edge skip the `FxHashMap` / LIS pass entirely.
  - The reordering path builds the key map only for the middle section, reuses a single `shared` scratch `Vec`, and allocates one `Vec<bool>` for old-entry sharing instead of multiple vectors.
  - `FragmentPlacementPlan` now tracks `new_to_old` and per-index `stable`, and stable entries are computed from the LIS on `(new_idx, old_idx)` pairs.

- **`packages/core/benches/keyed_diff.rs`** — added a `replace 100 mid-list` case to exercise localized keyed replacement that still shares a long prefix and suffix.

- **`packages/core/tests/diff_keyed_list.rs`** — added `replace_keyed_middle_preserves_edges`, a regression test that verifies the middle replacement creates the expected number of loads and removals without unnecessary replacements.

`packages/core/src/diff/node.rs` was left untouched after measuring that a `FxHashMap` change there regressed the microbenchmarks.

### Validation

- `cargo clippy` passes for `packages/core`.
- `cargo test -p dioxus-core --test diff_keyed_list` passes.
- The `keyed_diff` Criterion benchmark shows consistent improvements across the `reverse`, `shuffle`, and new `replace 100 mid-list` cases.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/1a4c9f6f09ae4d2db9325672352b60c8
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/1a4c9f6f09ae4d2db9325672352b60c8?variant=devin-insiders
Requested by: @jkelleyrtp