### PR TITLE
docs: remove commented-out expired video links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ With one command, `dx serve` and your app is running. Edit your markup, styles, 
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/DioxusLabs/screenshots/refs/heads/main/blitz/hotreload-video.webp">
-  <!-- <video src="https://private-user-images.githubusercontent.com/10237910/386919031-6da371d5-3340-46da-84ff-628216851ba6.mov" width="500"></video> -->
-  <!-- <video src="https://private-user-images.githubusercontent.com/10237910/386919031-6da371d5-3340-46da-84ff-628216851ba6.mov" width="500"></video> -->
 </div>
 
 ## Build Beautiful Apps


### PR DESCRIPTION
Removes two commented-out `<video>` lines whose URLs are permanently dead: `private-user-images.githubusercontent.com` attachment URLs are short-lived signed links (require a `jwt` token) and 404 forever once expired — unrecoverable by design. Both lines are already inside HTML comments, and the live line directly above serves the same hot-reload demo, so there is zero rendered-output change — this is pure cleanup of dead references.
