### PR TITLE
CI: make Playwright install deterministic and cache browser downloads

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -354,14 +354,18 @@ jobs:
           cache-provider: "warpbuild"
           workspaces: ${{ env.DIOXUS_WORKSPACE }}
           # save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~\AppData\Local\ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('packages/playwright-tests/package-lock.json') }}
       - name: Playwright
         working-directory: ${{ env.DIOXUS_WORKSPACE }}/packages/playwright-tests
         env:
           CARGO_INCREMENTAL: 1
         run: |
           npm ci
-          npm install -D @playwright/test
-          npx playwright install
+          npx playwright install chromium
           npx playwright test
       # - name: Clean Windows artifacts before cache save
       #   if: always()
@@ -415,6 +419,11 @@ jobs:
           cache-workspace-crates: "true"
           cache-provider: "warpbuild"
           # save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.os == 'Linux' && '~/.cache/ms-playwright' || '~/Library/Caches/ms-playwright' }}
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('packages/playwright-tests/package-lock.json') }}
       - name: Wipe dx cache
         if: runner.os == 'Linux'
         run: |
@@ -426,8 +435,7 @@ jobs:
           CARGO_INCREMENTAL: 1
         run: |
           npm ci
-          npm install -D @playwright/test
-          npx playwright install
+          npx playwright install chromium
           npx playwright test
       - uses: actions/upload-artifact@v6
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -359,14 +359,17 @@ jobs:
         with:
           path: ~\AppData\Local\ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('packages/playwright-tests/package-lock.json') }}
+      - name: Install npm dependencies
+        working-directory: ${{ env.DIOXUS_WORKSPACE }}/packages/playwright-tests
+        run: npm ci
+      - name: Install Playwright browsers
+        working-directory: ${{ env.DIOXUS_WORKSPACE }}/packages/playwright-tests
+        run: npx playwright install chromium
       - name: Playwright
         working-directory: ${{ env.DIOXUS_WORKSPACE }}/packages/playwright-tests
         env:
           CARGO_INCREMENTAL: 1
-        run: |
-          npm ci
-          npx playwright install chromium
-          npx playwright test
+        run: npx playwright test
       # - name: Clean Windows artifacts before cache save
       #   if: always()
       #   shell: pwsh
@@ -428,15 +431,18 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           rm -rf ./target/dx
+      - name: Install npm dependencies
+        working-directory: ./packages/playwright-tests
+        run: npm ci
+      - name: Install Playwright browsers
+        working-directory: ./packages/playwright-tests
+        run: npx playwright install chromium
       - name: Playwright
         working-directory: ./packages/playwright-tests
         env:
           # The hot patch test requires incremental compilation
           CARGO_INCREMENTAL: 1
-        run: |
-          npm ci
-          npx playwright install chromium
-          npx playwright test
+        run: npx playwright test
       - uses: actions/upload-artifact@v6
         if: failure()
         with:

--- a/packages/playwright-tests/package-lock.json
+++ b/packages/playwright-tests/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.56.1"
+        "@playwright/test": "1.56.1"
       }
     },
     "node_modules/@playwright/test": {

--- a/packages/playwright-tests/package.json
+++ b/packages/playwright-tests/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.56.1"
+    "@playwright/test": "1.56.1"
   }
 }


### PR DESCRIPTION
## Summary

Removes a source of nondeterminism from the two Playwright CI jobs ("Playwright | Windows" and "Playwright | <matrix>") and caches the browser downloads.

- Both jobs ran `npm ci` followed by `npm install -D @playwright/test`, which re-resolved `@playwright/test` to the newest version matching the `^1.56.1` range — silently overriding the lockfile, so every CI run could get a different Playwright runner + browser build. The stray `npm install` line is removed so `npm ci` + the lockfile fully determine the version, and `@playwright/test` is pinned exactly (`"1.56.1"`, no caret) in `packages/playwright-tests/package.json` (lockfile regenerated) so upgrades are explicit.
- Only Chromium is used (see `projects` in `playwright.config.js`), so `npx playwright install` becomes `npx playwright install chromium` (no `--with-deps`; the Linux job already installs system deps via `cache-apt-pkgs-action`).
- Adds an `actions/cache@v5` step for the Playwright browser directory in both jobs, keyed on `runner.os` + `hashFiles('packages/playwright-tests/package-lock.json')`:
  - Windows: `~\AppData\Local\ms-playwright`
  - Linux/macOS (matrix job): `~/.cache/ms-playwright` / `~/Library/Caches/ms-playwright`

  On cache hit, `npx playwright install chromium` no-ops (it skips already-downloaded browsers).

Verified locally: `npm ci && npx playwright install chromium` resolves 1.56.1 matching the lockfile. actionlint reports no new findings on the workflow (only preexisting warnings about custom warp runner labels and a `Swatinem/rust-cache` input).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/266de4d3e2bd42208aed86ad92cce74d
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/266de4d3e2bd42208aed86ad92cce74d?variant=devin-insiders
Requested by: @nicoburns