### PR TITLE
Playwright: pre-build test apps before webServer startup

### DIFF
--- a/packages/playwright-tests/playwright.config.js
+++ b/packages/playwright-tests/playwright.config.js
@@ -61,6 +61,22 @@ const activeServers = specArgs.length > 0
     ? ALL_SERVERS.filter((s) => s.specs.some((spec) => spec.includes("windows")))
     : ALL_SERVERS.filter((s) => !s.specs.some((spec) => spec.includes("windows")));
 
+// Derive a build-only command from a server's run command so the app can be
+// compiled before Playwright starts the webServers. `dx run`/`cargo run` reuse
+// the artifacts as long as the build flags match, so startup becomes
+// launch-only instead of ~20 concurrent compiles racing at once.
+//
+// Hot-patch servers (`dx serve --hot-patch`) are excluded: their initial fat
+// build is not shared with a plain `dx build`.
+function preBuildCommand(s) {
+  if (s.command.includes("--hot-patch")) return null;
+  if (s.command.startsWith("cargo run")) return s.command.replace("cargo run", "cargo build");
+  return s.command
+    .replace(`${dx} run`, `${dx} build`)
+    .replace(/ --addr \S+/, "")
+    .replace(/ --port \S+/, "");
+}
+
 // Run any setup functions (e.g. copying source to temp dirs for hot-patch tests)
 // Only happens on initialize
 //
@@ -76,6 +92,19 @@ if (!process.env._DX_BUILT) {
     env: { ...process.env, CARGO_TERM_PROGRESS_WHEN: "never" },
     stdio: "inherit",
   });
+
+  // Pre-build every active test app sequentially (cargo parallelizes
+  // internally) so the webServer commands only need to launch.
+  for (const s of activeServers) {
+    const command = preBuildCommand(s);
+    if (!command) continue;
+    console.log(`Pre-building ${s.cwd ?? s.specs[0]}: ${command}`);
+    execSync(command, {
+      cwd: s.cwd ? path.join(__dirname, s.cwd) : __dirname,
+      env: { ...process.env, CARGO_TERM_PROGRESS_WHEN: "never", ...s.env },
+      stdio: "inherit",
+    });
+  }
 
   process.env._DX_BUILT = "1";
 }
@@ -96,7 +125,9 @@ module.exports = defineConfig({
     command: s.command,
     port: s.port,
     cwd: s.cwd ? path.join(__dirname, s.cwd) : __dirname,
-    timeout: 50 * 60 * 1000,
+    // Pre-built servers only need to relaunch; hot-patch servers still do
+    // their full fat build at startup.
+    timeout: (preBuildCommand(s) ? 10 : 50) * 60 * 1000,
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## Summary

Playwright previously started ~20 `dx run`/`cargo run` webServers concurrently, each doing a full build at startup — ~20 cargo invocations racing over CPU and the target-dir lock, a major source of CI slowness and flaky server-startup failures.

This extends the existing `_DX_BUILT` one-time init block in `playwright.config.js`: after building `dx`, it now pre-builds every **active** test app **sequentially** (cargo parallelizes internally), so webServer startup is launch-only. The build command is derived from each server's run command:

```js
preBuildCommand(s):
  command includes "--hot-patch"  -> null (skip: fat build isn't shared with plain `dx build`)
  "cargo run ..."                 -> "cargo build ..."          // liveview
  "dx run <flags>"                -> "dx build <flags>" minus serve-only `--addr`/`--port`
```

Keeping the remaining flags (`--web`, `--release`, `--ssg`, `--bin`, `--wasm-split`, `--profile`, `--force-sequential`) identical means the subsequent `dx run` hits the same cargo fingerprint and reuses all artifacts. Non-hot-patch `dx run`/`dx serve` builds use `BuildMode::Base`, same as `dx build`.

webServer timeout drops from 50 min to 10 min for pre-built servers; hot-patch servers (which still do their full fat build at startup) keep 50 min.

Local workflow is unchanged: `activeServers` already filters to the specs passed on the CLI, so a single-spec run only pre-builds that one app.

## Verification

On Linux, ran `npx playwright test web.spec.js web-routing.spec.js --reporter=line` from a clean target state:
- Pre-build phase compiled both apps sequentially (`Pre-building web: ... dx build --force-sequential --web`, then web-routing).
- webServer startup did **no** crate compilation — logs show only `Bundling app` / `Running WASM bindgen` / `Build completed successfully in 2.08s, launching app!`.
- All 19 tests passed (7.0s).

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/1ad909911b2445319691f40122f4f2e9
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/1ad909911b2445319691f40122f4f2e9?variant=devin-insiders
Requested by: @nicoburns