### PR TITLE
Improve diagnostics for overlong asset paths

### DIFF
--- a/packages/cli/src/build/assets.rs
+++ b/packages/cli/src/build/assets.rs
@@ -606,7 +606,7 @@ pub(crate) async fn extract_symbols_from_file(path: impl AsRef<Path>) -> Result<
     // Add the hash to each asset in parallel
     assets
         .par_iter_mut()
-        .for_each(crate::opt::add_hash_to_asset);
+        .try_for_each(crate::opt::add_hash_to_asset)?;
 
     // Write back only assets to the binary file (permissions are not modified)
     for entry in write_entries {

--- a/packages/cli/src/build/request.rs
+++ b/packages/cli/src/build/request.rs
@@ -209,7 +209,6 @@ use depinfo::RustcDepInfo;
 use dioxus_cli_config::PRODUCT_NAME_ENV;
 use dioxus_cli_config::{APP_TITLE_ENV, ASSET_ROOT_ENV};
 use krates::{NodeId, cm::TargetKind};
-use manganis::BundledAsset;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use serde::Deserialize;
 use std::{borrow::Cow, collections::VecDeque, ffi::OsString};
@@ -1461,13 +1460,13 @@ impl BuildRequest {
                     let from = entry.path().to_path_buf();
                     let relative_path = from.strip_prefix(&dir).unwrap();
                     let to = format!("../{}", relative_path.display());
-                    manifest.insert_asset(BundledAsset::new(
+                    manifest.insert_asset(crate::opt::try_create_bundled_asset(
                         from.to_string_lossy().as_ref(),
                         to.as_str(),
                         manganis_core::AssetOptions::builder()
                             .with_hash_suffix(false)
                             .into_asset_options(),
-                    ));
+                    )?);
                 }
             }
         }

--- a/packages/cli/src/opt/hash.rs
+++ b/packages/cli/src/opt/hash.rs
@@ -10,6 +10,7 @@ use crate::opt::{
     css::hash_scss,
     file::{ResolvedAssetType, resolve_asset_options},
     js::hash_js,
+    try_create_bundled_asset,
 };
 use manganis::{AssetOptions, BundledAsset};
 
@@ -126,7 +127,7 @@ pub(crate) fn hash_file_contents(source: &Path, hasher: &mut impl Hasher) -> any
 }
 
 /// Add a hash to the asset, or log an error if it fails
-pub(crate) fn add_hash_to_asset(asset: &mut BundledAsset) {
+pub(crate) fn add_hash_to_asset(asset: &mut BundledAsset) -> anyhow::Result<()> {
     let source = asset.absolute_source_path();
     match AssetHash::hash_file_contents(asset.options(), source) {
         Ok(hash) => {
@@ -136,7 +137,7 @@ pub(crate) fn add_hash_to_asset(asset: &mut BundledAsset) {
             let source_path = PathBuf::from(source);
             let Some(file_name) = source_path.file_name() else {
                 tracing::error!("Failed to get file name from path: {source}");
-                return;
+                return Ok(());
             };
 
             // The output extension path is the extension set by the options
@@ -173,10 +174,12 @@ pub(crate) fn add_hash_to_asset(asset: &mut BundledAsset) {
 
             let bundled_path = bundled_path.to_string_lossy().to_string();
 
-            *asset = BundledAsset::new(source, &bundled_path, options);
+            *asset = try_create_bundled_asset(source, &bundled_path, options)?;
         }
         Err(err) => {
             tracing::error!("Failed to hash asset {source}: {err}");
         }
     }
+
+    Ok(())
 }

--- a/packages/cli/src/opt/mod.rs
+++ b/packages/cli/src/opt/mod.rs
@@ -54,8 +54,8 @@ impl AppManifest {
         ))?;
 
         let mut bundled_asset =
-            manganis::macro_helpers::create_bundled_asset(output_path_str, options);
-        add_hash_to_asset(&mut bundled_asset);
+            try_create_bundled_asset(output_path_str, BundledAsset::PLACEHOLDER_HASH, options)?;
+        add_hash_to_asset(&mut bundled_asset)?;
 
         self.assets
             .entry(asset_path.to_path_buf())
@@ -101,5 +101,84 @@ impl AppManifest {
             .values()
             .flat_map(|assets| assets.iter())
             .filter(move |asset| seen.insert(asset.bundled_path()))
+    }
+}
+
+pub(crate) fn try_create_bundled_asset(
+    absolute_source_path: &str,
+    bundled_path: &str,
+    options: manganis::AssetOptions,
+) -> anyhow::Result<BundledAsset> {
+    validate_asset_path("source", absolute_source_path, None)?;
+    validate_asset_path("bundled", bundled_path, Some(absolute_source_path))?;
+    Ok(BundledAsset::new(
+        absolute_source_path,
+        bundled_path,
+        options,
+    ))
+}
+
+fn validate_asset_path(kind: &str, path: &str, source_path: Option<&str>) -> anyhow::Result<()> {
+    let actual = path.len();
+    let maximum = BundledAsset::MAX_PATH_LEN;
+    if actual <= maximum {
+        return Ok(());
+    }
+
+    let excess = actual - maximum;
+    let unit = if excess == 1 { "byte" } else { "bytes" };
+    let source = source_path
+        .map(|source_path| format!(" for source {source_path:?}"))
+        .unwrap_or_default();
+    anyhow::bail!(
+        "Asset {kind} path {path:?}{source} is {actual} bytes long, exceeding the {maximum}-byte limit by {excess} {unit}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> manganis::AssetOptions {
+        manganis::AssetOptions::builder().into_asset_options()
+    }
+
+    #[test]
+    fn accepts_asset_paths_at_maximum_length() {
+        let path = "a".repeat(BundledAsset::MAX_PATH_LEN);
+        let asset = try_create_bundled_asset(&path, &path, options()).unwrap();
+        assert_eq!(asset.absolute_source_path(), path);
+        assert_eq!(asset.bundled_path(), path);
+    }
+
+    #[test]
+    fn rejects_overlong_source_path() {
+        let maximum = BundledAsset::MAX_PATH_LEN;
+        let actual = maximum + 1;
+        let path = "a".repeat(actual);
+        let error = try_create_bundled_asset(&path, "asset", options()).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Asset source path {path:?} is {actual} bytes long, exceeding the {maximum}-byte limit by 1 byte"
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_overlong_bundled_path() {
+        let maximum = BundledAsset::MAX_PATH_LEN;
+        let actual = maximum + 17;
+        let path = "a".repeat(actual);
+        let source = "source-file";
+        let error = try_create_bundled_asset(source, &path, options()).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Asset bundled path {path:?} for source {source:?} is {actual} bytes long, exceeding the {maximum}-byte limit by 17 bytes"
+            )
+        );
     }
 }

--- a/packages/const-serialize/src/str.rs
+++ b/packages/const-serialize/src/str.rs
@@ -62,9 +62,27 @@ unsafe impl SerializeConst for ConstStr {
 }
 
 impl ConstStr {
-    /// Create a new constant string
+    /// The maximum number of bytes a [`ConstStr`] can store.
+    pub const MAX_LEN: usize = MAX_STR_SIZE;
+
+    /// Create a new constant string.
+    ///
+    /// Values longer than [`ConstStr::MAX_LEN`] bytes cannot be stored.
+    ///
+    /// ```compile_fail
+    /// use const_serialize::ConstStr;
+    ///
+    /// const TOO_LONG: &str = unsafe {
+    ///     std::str::from_utf8_unchecked(&[b'a'; ConstStr::MAX_LEN + 1])
+    /// };
+    /// const _: ConstStr = ConstStr::new(TOO_LONG);
+    /// ```
     pub const fn new(s: &str) -> Self {
         let str_bytes = s.as_bytes();
+        assert!(
+            str_bytes.len() <= Self::MAX_LEN,
+            "ConstStr capacity exceeded"
+        );
         let mut bytes = [MaybeUninit::uninit(); MAX_STR_SIZE];
         let mut i = 0;
         while i < str_bytes.len() {
@@ -122,7 +140,7 @@ impl ConstStr {
     pub const fn push_str(self, str: &str) -> Self {
         let Self { mut bytes, len } = self;
         assert!(
-            str.len() + len as usize <= MAX_STR_SIZE,
+            str.len() + len as usize <= Self::MAX_LEN,
             "String is too long"
         );
         let str_bytes = str.as_bytes();

--- a/packages/const-serialize/tests/str.rs
+++ b/packages/const-serialize/tests/str.rs
@@ -38,3 +38,15 @@ fn test_serialize_str_too_little_data() {
     let buf = buf.as_ref();
     assert_eq!(deserialize_const!(ConstStr, buf), None);
 }
+
+#[test]
+fn const_str_accepts_its_maximum_length() {
+    let value = "a".repeat(ConstStr::MAX_LEN);
+    assert_eq!(ConstStr::new(&value).as_str(), value);
+}
+
+#[test]
+#[should_panic(expected = "ConstStr capacity exceeded")]
+fn const_str_rejects_values_over_its_maximum_length() {
+    ConstStr::new(&"a".repeat(ConstStr::MAX_LEN + 1));
+}

--- a/packages/manganis/manganis-core/src/asset.rs
+++ b/packages/manganis/manganis-core/src/asset.rs
@@ -56,6 +56,9 @@ impl BundledAsset {
     pub const PLACEHOLDER_HASH: &str = "This should be replaced by dx as part of the build process. If you see this error, make sure you are using a matching version of dx and dioxus and you are not stripping symbols from your binary.";
 
     #[doc(hidden)]
+    pub const MAX_PATH_LEN: usize = ConstStr::MAX_LEN;
+
+    #[doc(hidden)]
     /// This should only be called from the macro
     /// Create a new asset
     pub const fn new(

--- a/packages/manganis/manganis-macro/src/asset.rs
+++ b/packages/manganis/manganis-macro/src/asset.rs
@@ -76,6 +76,9 @@ impl ToTokens for AssetParser {
 impl AssetParser {
     pub(crate) fn expand_asset_tokens(&self, asset: &Path) -> proc_macro2::TokenStream {
         let asset_string = asset.to_string_lossy();
+        if let Some(error) = asset_path_length_error(&asset_string) {
+            return syn::Error::new(self.path_expr.span(), error).into_compile_error();
+        }
         let mut asset_str = proc_macro2::Literal::string(&asset_string);
         asset_str.set_span(self.path_expr.span());
 
@@ -142,5 +145,51 @@ impl AssetParser {
     fn error_tokens(&self, err: &AssetParseError) -> proc_macro2::TokenStream {
         let err = err.to_string();
         quote! { compile_error!(#err) }
+    }
+}
+
+fn asset_path_length_error(asset_path: &str) -> Option<String> {
+    let actual = asset_path.len();
+    let maximum = manganis_core::BundledAsset::MAX_PATH_LEN;
+    if actual <= maximum {
+        return None;
+    }
+
+    let excess = actual - maximum;
+    let unit = if excess == 1 { "byte" } else { "bytes" };
+    Some(format!(
+        "Asset path is {actual} bytes long, exceeding the {maximum}-byte limit by {excess} {unit}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_path_at_maximum_length_is_valid() {
+        let path = "a".repeat(manganis_core::BundledAsset::MAX_PATH_LEN);
+        assert_eq!(asset_path_length_error(&path), None);
+    }
+
+    #[test]
+    fn asset_path_over_maximum_length_has_actionable_error() {
+        let maximum = manganis_core::BundledAsset::MAX_PATH_LEN;
+        let actual = maximum + 1;
+        let path = "a".repeat(actual);
+        let expected = format!(
+            "Asset path is {actual} bytes long, exceeding the {maximum}-byte limit by 1 byte"
+        );
+
+        assert_eq!(asset_path_length_error(&path), Some(expected.clone()));
+
+        let parser = AssetParser {
+            path_expr: quote::quote!("/assets/asset.txt"),
+            asset: Ok(path.clone().into()),
+            options: TokenStream2::new(),
+        };
+        let expanded = parser.expand_asset_tokens(Path::new(&path)).to_string();
+        assert!(expanded.contains("compile_error"));
+        assert!(expanded.contains(&expected));
     }
 }


### PR DESCRIPTION
## Summary

- guard `ConstStr` capacity before writing into its fixed-size buffer
- report an actionable compile-time error when a resolved asset path exceeds the 256-byte limit
- validate CLI-created source and bundled paths, including hash-generated and public-directory assets
- propagate path-length errors before modifying the output binary
- include the offending path and original source in runtime diagnostics
- add boundary, overflow, diagnostic, and compile-fail coverage

## Testing

- `cargo test --offline -p const-serialize -p manganis-core -p manganis-macro`
- `cargo test --offline -p manganis`
- `cargo test --offline -p dioxus-cli opt::tests::`
- `cargo clippy --offline -p const-serialize -p manganis-core -p manganis-macro --tests --no-deps -- -D warnings`
- `cargo fmt --package const-serialize --package manganis-core --package manganis-macro --package dioxus-cli -- --check`
- `git diff HEAD^ --check`

Fixes #5777