### PR TITLE
fix(router): skip the query `?` when the query serializes empty

### DIFF
--- a/packages/router-macro/src/query.rs
+++ b/packages/router-macro/src/query.rs
@@ -39,10 +39,17 @@ impl QuerySegment {
             QuerySegment::Single(segment) => segment.write(),
             QuerySegment::Segments(segments) => {
                 let mut tokens = TokenStream2::new();
-                tokens.extend(quote! { write!(f, "?")?; });
-                for (i, segment) in segments.iter().enumerate() {
-                    tokens.extend(segment.write(i == segments.len() - 1));
+                // Buffer the pairs so the `?` (and each joining `&`) is only
+                // written when something actually follows it.
+                tokens.extend(quote! { let mut __query_string = String::new(); });
+                for segment in segments {
+                    tokens.extend(segment.write());
                 }
+                tokens.extend(quote! {
+                    if !__query_string.is_empty() {
+                        write!(f, "?{}", __query_string)?;
+                    }
+                });
                 tokens
             }
         }
@@ -129,7 +136,9 @@ impl FullQuerySegment {
         quote! {
             {
                 let as_string = #ident.to_string();
-                write!(f, "?{}", dioxus_router::exports::percent_encoding::utf8_percent_encode(&as_string, dioxus_router::exports::QUERY_ASCII_SET))?;
+                if !as_string.is_empty() {
+                    write!(f, "?{}", dioxus_router::exports::percent_encoding::utf8_percent_encode(&as_string, dioxus_router::exports::QUERY_ASCII_SET))?;
+                }
             }
         }
     }
@@ -156,18 +165,17 @@ impl QueryArgument {
         }
     }
 
-    pub fn write(&self, trailing: bool) -> TokenStream2 {
+    pub fn write(&self) -> TokenStream2 {
         let ident = &self.ident;
-        let write_ampersand = if !trailing {
-            quote! { if !as_string.is_empty() { write!(f, "&")?; } }
-        } else {
-            quote! {}
-        };
         quote! {
             {
                 let as_string = dioxus_router::routable::DisplayQueryArgument::new(stringify!(#ident), #ident).to_string();
-                write!(f, "{}", dioxus_router::exports::percent_encoding::utf8_percent_encode(&as_string, dioxus_router::exports::QUERY_ASCII_SET))?;
-                #write_ampersand
+                if !as_string.is_empty() {
+                    if !__query_string.is_empty() {
+                        __query_string.push('&');
+                    }
+                    __query_string.push_str(&dioxus_router::exports::percent_encoding::utf8_percent_encode(&as_string, dioxus_router::exports::QUERY_ASCII_SET).to_string());
+                }
             }
         }
     }

--- a/packages/router/tests/parsing.rs
+++ b/packages/router/tests/parsing.rs
@@ -221,3 +221,80 @@ fn child_route_preserves_query_and_hash() {
     assert_eq!(reserved.to_string(), "/search?query=a%23b&word_count=1");
     assert_eq!(Route::from_str(&reserved.to_string()).unwrap(), reserved);
 }
+
+#[test]
+fn empty_query_serializes_without_question_mark() {
+    #[derive(Debug, Clone, PartialEq, Default)]
+    struct SearchParams {
+        search: Option<String>,
+    }
+
+    impl From<&str> for SearchParams {
+        fn from(query: &str) -> Self {
+            let search = query
+                .split('&')
+                .filter_map(|segment| segment.split_once('='))
+                .find(|(key, _)| *key == "search")
+                .map(|(_, value)| value.to_string())
+                .filter(|value| !value.is_empty());
+            Self { search }
+        }
+    }
+
+    impl Display for SearchParams {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match &self.search {
+                Some(search) => write!(f, "search={}", search),
+                None => Ok(()),
+            }
+        }
+    }
+
+    #[component]
+    fn Spread(params: SearchParams) -> Element {
+        unimplemented!()
+    }
+
+    #[component]
+    fn Optional(query: Option<u64>) -> Element {
+        unimplemented!()
+    }
+
+    #[derive(Debug, Clone, PartialEq, Routable)]
+    enum Route {
+        #[route("/spread?:..params")]
+        Spread { params: SearchParams },
+        #[route("/optional?:query")]
+        Optional { query: Option<u64> },
+    }
+
+    // A spread query whose Display renders empty leaves no `?` behind.
+    let spread_empty = Route::Spread {
+        params: SearchParams::default(),
+    };
+    assert_eq!(spread_empty.to_string(), "/spread");
+    assert_eq!(Route::from_str("/spread").unwrap(), spread_empty);
+
+    let spread_filled = Route::Spread {
+        params: SearchParams {
+            search: Some("zone".to_string()),
+        },
+    };
+    assert_eq!(spread_filled.to_string(), "/spread?search=zone");
+    assert_eq!(
+        Route::from_str(&spread_filled.to_string()).unwrap(),
+        spread_filled
+    );
+
+    // A named query whose only argument is None leaves no `?` behind either.
+    let optional_none = Route::Optional { query: None };
+    assert_eq!(optional_none.to_string(), "/optional");
+    assert_eq!(Route::from_str("/optional").unwrap(), optional_none);
+
+    let optional_some = Route::Optional { query: Some(5) };
+    assert_eq!(optional_some.to_string(), "/optional?query=5");
+    assert_eq!(
+        Route::from_str(&optional_some.to_string()).unwrap(),
+        optional_some
+    );
+}


### PR DESCRIPTION
Fixes #5792.

Routes with a query segment wrote the `?` unconditionally, so a spread segment (`?:..params`) whose Display renders empty serialized as `/translations?`, and a named segment with only None options as `/reset?`.

This buffers the named pairs and writes the `?` only when something follows it. As far as I can tell that also fixes a related edge where a trailing `&` was left behind when a later pair elided (`?a=1&` for `(Some(1), None)`), since each pair wrote its own separator without knowing what came after. The spread form now checks the rendered string before writing.

Added a regression test covering both forms, round-tripping through FromStr. The existing router tests pass unchanged.
