### PR TITLE
fix(cli): map SemVer prereleases to legal native package versions

### DIFF
--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -228,7 +228,7 @@ impl BundleContext<'_> {
     /// The resulting artifact is written to `project_out_directory()/bundle/rpm`.
     pub(crate) async fn bundle_linux_rpm(&self) -> Result<Vec<PathBuf>> {
         let name = self.main_binary_name().to_string();
-        let version = self.version_string();
+        let version = rpm_version(&self.version_string());
         let arch = self.binary_arch().rpm_arch();
         let license = self.license().unwrap_or("Unknown").to_string();
         let description = self.short_description();
@@ -1149,5 +1149,52 @@ fn resolve_path(crate_dir: &Path, path: &Path) -> PathBuf {
         path.to_path_buf()
     } else {
         crate_dir.join(path)
+    }
+}
+
+/// Convert a SemVer version string into an RPM-compatible version.
+fn rpm_version(version: &str) -> String {
+    let (core, build) = match version.split_once('+') {
+        Some((core, build)) => (core, Some(build)),
+        None => (version, None),
+    };
+    let core = match core.split_once('-') {
+        Some((release, prerelease)) => {
+            format!("{release}~{}", prerelease.replace('-', "_"))
+        }
+        None => core.to_string(),
+    };
+
+    match build {
+        Some(build) => format!("{core}+{}", build.replace('-', "_")),
+        None => core,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rpm_version;
+
+    #[test]
+    fn rpm_version_preserves_release_versions() {
+        assert_eq!(rpm_version("1.2.3"), "1.2.3");
+    }
+
+    #[test]
+    fn rpm_version_maps_prerelease_separator_for_rpm_ordering() {
+        assert_eq!(rpm_version("1.2.3-rc.1"), "1.2.3~rc.1");
+    }
+
+    #[test]
+    fn rpm_version_sanitizes_hyphens_inside_identifiers() {
+        assert_eq!(
+            rpm_version("1.2.3-alpha-1+build-5"),
+            "1.2.3~alpha_1+build_5"
+        );
+    }
+
+    #[test]
+    fn rpm_version_preserves_build_metadata() {
+        assert_eq!(rpm_version("1.2.3+build.5"), "1.2.3+build.5");
     }
 }

--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -1,6 +1,6 @@
 use crate::{
     PackageType,
-    bundler::{AppCategory, BundleContext},
+    bundler::{AppCategory, BundleContext, version},
 };
 use anyhow::{Context, Result, bail};
 use handlebars::Handlebars;
@@ -148,7 +148,7 @@ impl BundleContext<'_> {
     pub(crate) async fn bundle_linux_deb(&self) -> Result<Vec<PathBuf>> {
         let arch = self.binary_arch().deb_arch();
         let package_name = self.deb_package_name();
-        let version = self.version_string();
+        let version = version::deb(self.package_version());
 
         let output_dir = self.project_out_directory().join("deb");
         fs::create_dir_all(&output_dir)?;
@@ -228,7 +228,7 @@ impl BundleContext<'_> {
     /// The resulting artifact is written to `project_out_directory()/bundle/rpm`.
     pub(crate) async fn bundle_linux_rpm(&self) -> Result<Vec<PathBuf>> {
         let name = self.main_binary_name().to_string();
-        let version = rpm_version(&self.version_string());
+        let version = version::rpm(self.package_version());
         let arch = self.binary_arch().rpm_arch();
         let license = self.license().unwrap_or("Unknown").to_string();
         let description = self.short_description();
@@ -1149,52 +1149,5 @@ fn resolve_path(crate_dir: &Path, path: &Path) -> PathBuf {
         path.to_path_buf()
     } else {
         crate_dir.join(path)
-    }
-}
-
-/// Convert a SemVer version string into an RPM-compatible version.
-fn rpm_version(version: &str) -> String {
-    let (core, build) = match version.split_once('+') {
-        Some((core, build)) => (core, Some(build)),
-        None => (version, None),
-    };
-    let core = match core.split_once('-') {
-        Some((release, prerelease)) => {
-            format!("{release}~{}", prerelease.replace('-', "_"))
-        }
-        None => core.to_string(),
-    };
-
-    match build {
-        Some(build) => format!("{core}+{}", build.replace('-', "_")),
-        None => core,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::rpm_version;
-
-    #[test]
-    fn rpm_version_preserves_release_versions() {
-        assert_eq!(rpm_version("1.2.3"), "1.2.3");
-    }
-
-    #[test]
-    fn rpm_version_maps_prerelease_separator_for_rpm_ordering() {
-        assert_eq!(rpm_version("1.2.3-rc.1"), "1.2.3~rc.1");
-    }
-
-    #[test]
-    fn rpm_version_sanitizes_hyphens_inside_identifiers() {
-        assert_eq!(
-            rpm_version("1.2.3-alpha-1+build-5"),
-            "1.2.3~alpha_1+build_5"
-        );
-    }
-
-    #[test]
-    fn rpm_version_preserves_build_metadata() {
-        assert_eq!(rpm_version("1.2.3+build.5"), "1.2.3+build.5");
     }
 }

--- a/packages/cli/src/bundler/macos.rs
+++ b/packages/cli/src/bundler/macos.rs
@@ -1,4 +1,4 @@
-use crate::bundler::{AppCategory, Bundle, BundleContext, copy_dir_recursive};
+use crate::bundler::{AppCategory, Bundle, BundleContext, copy_dir_recursive, version};
 use crate::{MacOsSettings, PackageType};
 use anyhow::{Context, Result, bail};
 use image::{DynamicImage, ImageReader};
@@ -481,7 +481,7 @@ impl BundleContext<'_> {
             plist::Value::String("APPL".into()),
         );
 
-        let version = self.version_string();
+        let version = version::macos(self.package_version());
         let bundle_version = macos_settings.bundle_version.as_deref().unwrap_or(&version);
 
         dict.insert(

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -3,12 +3,14 @@ mod linux;
 mod macos;
 mod tools;
 mod updater;
+mod version;
 mod windows;
 
 use crate::PackageType;
 use crate::{BuildRequest, DebianSettings, MacOsSettings, WindowsSettings};
 use anyhow::Context;
 use anyhow::Result;
+use krates::semver::Version;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tools::ResolvedTools;
@@ -233,9 +235,14 @@ impl<'a> BundleContext<'a> {
         self.build.config.bundle.publisher.as_deref()
     }
 
-    /// The version string from Cargo.toml.
+    /// Parsed version from Cargo.toml.
+    pub(crate) fn package_version(&self) -> &Version {
+        &self.build.package().version
+    }
+
+    /// String version from Cargo.toml.
     pub(crate) fn version_string(&self) -> String {
-        self.build.package().version.to_string()
+        self.package_version().to_string()
     }
 
     /// The short description.

--- a/packages/cli/src/bundler/version.rs
+++ b/packages/cli/src/bundler/version.rs
@@ -15,6 +15,13 @@ fn linux(version: &Version) -> String {
     projected
 }
 
+fn validate_component(value: u64, max: u64) -> Result<()> {
+    if value > max {
+        bail!("Version component {value} exceeds maximum value of {max}");
+    }
+    Ok(())
+}
+
 /// Convert a SemVer version into an RPM-compatible version.
 pub(crate) fn rpm(version: &Version) -> String {
     linux(version)
@@ -27,9 +34,9 @@ pub(crate) fn deb(version: &Version) -> String {
 
 /// Convert a SemVer version into a WiX-compatible product version.
 pub(crate) fn wix(version: &Version) -> Result<String> {
-    wix_validate_component(version.major, 0)?;
-    wix_validate_component(version.minor, 1)?;
-    wix_validate_component(version.patch, 2)?;
+    validate_component(version.major, u8::MAX.into())?;
+    validate_component(version.minor, u8::MAX.into())?;
+    validate_component(version.patch, u16::MAX.into())?;
     Ok(core(version))
 }
 
@@ -49,7 +56,12 @@ pub(crate) fn wix_from_string(version: &str) -> Result<String> {
         let value: u64 = part
             .parse()
             .with_context(|| format!("Invalid version component: '{part}'"))?;
-        wix_validate_component(value, index)?;
+        let max = if index < 2 {
+            u8::MAX.into()
+        } else {
+            u16::MAX.into()
+        };
+        validate_component(value, max)?;
     }
 
     if parts.len() == 2 {
@@ -59,23 +71,14 @@ pub(crate) fn wix_from_string(version: &str) -> Result<String> {
     }
 }
 
-fn wix_validate_component(value: u64, index: usize) -> Result<()> {
-    match index {
-        0 | 1 if value > 255 => {
-            bail!("Version component {value} exceeds maximum value of 255")
-        }
-        2 | 3 if value > 65535 => {
-            bail!("Version component {value} exceeds maximum value of 65535")
-        }
-        _ => Ok(()),
-    }
-}
-
 /// Convert a SemVer version into an NSIS-compatible product version.
 ///
 /// The NSIS template appends `.0` to form `VIProductVersion`.
-pub(crate) fn nsis(version: &Version) -> String {
-    core(version)
+pub(crate) fn nsis(version: &Version) -> Result<String> {
+    validate_component(version.major, u16::MAX.into())?;
+    validate_component(version.minor, u16::MAX.into())?;
+    validate_component(version.patch, u16::MAX.into())?;
+    Ok(core(version))
 }
 
 /// Convert a SemVer version into a macOS bundle version (`CFBundleShortVersionString`).
@@ -108,8 +111,9 @@ mod tests {
     #[test]
     fn macos_and_nsis_use_the_numeric_core() {
         assert_eq!(macos(&version("1.2.3-rc.1+build.5")), "1.2.3");
-        assert_eq!(nsis(&version("1.2.3-rc.1+build.5")), "1.2.3");
-        assert_eq!(nsis(&version("256.2.3")), "256.2.3");
+        assert_eq!(nsis(&version("1.2.3-rc.1+build.5")).unwrap(), "1.2.3");
+        assert_eq!(nsis(&version("256.2.3")).unwrap(), "256.2.3");
+        assert!(nsis(&version("65536.0.0")).is_err());
     }
 
     #[test]

--- a/packages/cli/src/bundler/version.rs
+++ b/packages/cli/src/bundler/version.rs
@@ -1,0 +1,134 @@
+use anyhow::{Context, Result, bail};
+use krates::semver::Version;
+
+fn core(version: &Version) -> String {
+    format!("{}.{}.{}", version.major, version.minor, version.patch)
+}
+
+/// Shared RPM/Debian projection: `~` for prereleases, hyphens folded, build metadata dropped.
+fn linux(version: &Version) -> String {
+    let mut projected = core(version);
+    if !version.pre.is_empty() {
+        projected.push('~');
+        projected.push_str(&version.pre.as_str().replace('-', "."));
+    }
+    projected
+}
+
+/// Convert a SemVer version into an RPM-compatible version.
+pub(crate) fn rpm(version: &Version) -> String {
+    linux(version)
+}
+
+/// Convert a SemVer version into a Debian-compatible version.
+pub(crate) fn deb(version: &Version) -> String {
+    linux(version)
+}
+
+/// Convert a SemVer version into a WiX-compatible product version.
+pub(crate) fn wix(version: &Version) -> Result<String> {
+    wix_validate_component(version.major, 0)?;
+    wix_validate_component(version.minor, 1)?;
+    wix_validate_component(version.patch, 2)?;
+    Ok(core(version))
+}
+
+/// Validate and normalize an explicitly configured WiX product version.
+pub(crate) fn wix_from_string(version: &str) -> Result<String> {
+    let version = version.split(['-', '+']).next().unwrap_or(version);
+    let parts: Vec<&str> = version.split('.').collect();
+
+    if parts.len() < 2 || parts.len() > 4 {
+        bail!(
+            "Invalid version for MSI: '{}'. Expected format: major.minor.patch[.build]",
+            version
+        );
+    }
+
+    for (index, part) in parts.iter().enumerate() {
+        let value: u64 = part
+            .parse()
+            .with_context(|| format!("Invalid version component: '{part}'"))?;
+        wix_validate_component(value, index)?;
+    }
+
+    if parts.len() == 2 {
+        Ok(format!("{}.{}.0", parts[0], parts[1]))
+    } else {
+        Ok(parts.join("."))
+    }
+}
+
+fn wix_validate_component(value: u64, index: usize) -> Result<()> {
+    match index {
+        0 | 1 if value > 255 => {
+            bail!("Version component {value} exceeds maximum value of 255")
+        }
+        2 | 3 if value > 65535 => {
+            bail!("Version component {value} exceeds maximum value of 65535")
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Convert a SemVer version into an NSIS-compatible product version.
+///
+/// The NSIS template appends `.0` to form `VIProductVersion`.
+pub(crate) fn nsis(version: &Version) -> String {
+    core(version)
+}
+
+/// Convert a SemVer version into a macOS bundle version (`CFBundleShortVersionString`).
+pub(crate) fn macos(version: &Version) -> String {
+    core(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{deb, macos, nsis, rpm, wix, wix_from_string};
+    use krates::semver::Version;
+
+    fn version(value: &str) -> Version {
+        Version::parse(value).unwrap()
+    }
+
+    #[test]
+    fn linux_formats_share_a_projection() {
+        assert_eq!(rpm(&version("1.2.3")), "1.2.3");
+        assert_eq!(rpm(&version("1.2.3-rc.1")), "1.2.3~rc.1");
+        assert_eq!(rpm(&version("1.2.3-alpha-1+build-5")), "1.2.3~alpha.1");
+        assert_eq!(rpm(&version("1.2.3+build.5")), "1.2.3");
+        assert_eq!(deb(&version("1.2.3-rc.1")), rpm(&version("1.2.3-rc.1")));
+        assert_eq!(
+            deb(&version("1.2.3-alpha-1+build-5")),
+            rpm(&version("1.2.3-alpha-1+build-5"))
+        );
+    }
+
+    #[test]
+    fn macos_and_nsis_use_the_numeric_core() {
+        assert_eq!(macos(&version("1.2.3-rc.1+build.5")), "1.2.3");
+        assert_eq!(nsis(&version("1.2.3-rc.1+build.5")), "1.2.3");
+        assert_eq!(nsis(&version("256.2.3")), "256.2.3");
+    }
+
+    #[test]
+    fn wix_projects_semver_versions() {
+        assert_eq!(wix(&version("1.2.3")).unwrap(), "1.2.3");
+        assert_eq!(wix(&version("1.2.3-rc.1+build.5")).unwrap(), "1.2.3");
+        assert!(wix(&version("256.2.3")).is_err());
+        assert!(wix(&version("1.256.3")).is_err());
+        assert!(wix(&version("1.2.65536")).is_err());
+    }
+
+    #[test]
+    fn wix_from_string_preserves_explicit_version_compatibility() {
+        assert_eq!(wix_from_string("1.2").unwrap(), "1.2.0");
+        assert_eq!(wix_from_string("1.2.3.4").unwrap(), "1.2.3.4");
+        assert_eq!(wix_from_string("1.2.3-rc.1").unwrap(), "1.2.3");
+        assert_eq!(wix_from_string("1.2.3+build.5").unwrap(), "1.2.3");
+        assert!(wix_from_string("1").is_err());
+        assert!(wix_from_string("1.2.3.4.5").is_err());
+        assert!(wix_from_string("1.2.invalid").is_err());
+    }
+}

--- a/packages/cli/src/bundler/version.rs
+++ b/packages/cli/src/bundler/version.rs
@@ -35,7 +35,7 @@ pub(crate) fn wix(version: &Version) -> Result<String> {
 
 /// Validate and normalize an explicitly configured WiX product version.
 pub(crate) fn wix_from_string(version: &str) -> Result<String> {
-    let version = version.split(['-', '+']).next().unwrap_or(version);
+    let version = version.split('-').next().unwrap_or(version);
     let parts: Vec<&str> = version.split('.').collect();
 
     if parts.len() < 2 || parts.len() > 4 {
@@ -126,7 +126,7 @@ mod tests {
         assert_eq!(wix_from_string("1.2").unwrap(), "1.2.0");
         assert_eq!(wix_from_string("1.2.3.4").unwrap(), "1.2.3.4");
         assert_eq!(wix_from_string("1.2.3-rc.1").unwrap(), "1.2.3");
-        assert_eq!(wix_from_string("1.2.3+build.5").unwrap(), "1.2.3");
+        assert!(wix_from_string("1.2.3+build.5").is_err());
         assert!(wix_from_string("1").is_err());
         assert!(wix_from_string("1.2.3.4.5").is_err());
         assert!(wix_from_string("1.2.invalid").is_err());

--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -391,7 +391,7 @@ impl BundleContext<'_> {
 
         let product_name = self.product_name();
         let version = self.version_string();
-        let product_version = version::nsis(self.package_version());
+        let product_version = version::nsis(self.package_version())?;
         let installer_name = format!("{product_name}_{version}_{arch_str}-setup.exe");
         let output_path = output_dir.join(&installer_name);
 

--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -390,7 +390,8 @@ impl BundleContext<'_> {
         let arch_str = arch.windows_arch();
 
         let product_name = self.product_name();
-        let version = version::nsis(self.package_version());
+        let version = self.version_string();
+        let product_version = version::nsis(self.package_version());
         let installer_name = format!("{product_name}_{version}_{arch_str}-setup.exe");
         let output_path = output_dir.join(&installer_name);
 
@@ -428,6 +429,10 @@ impl BundleContext<'_> {
             JsonValue::String(product_name.clone()),
         );
         data.insert("version".to_string(), JsonValue::String(version.clone()));
+        data.insert(
+            "product_version".to_string(),
+            JsonValue::String(product_version),
+        );
         data.insert(
             "output_path".to_string(),
             JsonValue::String(output_path.to_string_lossy().replace('/', "\\")),
@@ -1096,7 +1101,7 @@ RequestExecutionLevel user
 {{/if}}
 
 ; Version information
-VIProductVersion "{{version}}.0"
+VIProductVersion "{{product_version}}.0"
 VIAddVersionKey "ProductName" "{{product_name}}"
 VIAddVersionKey "FileVersion" "{{version}}"
 VIAddVersionKey "ProductVersion" "{{version}}"

--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -1,4 +1,4 @@
-use crate::bundler::BundleContext;
+use crate::bundler::{BundleContext, version};
 use crate::{NSISInstallerMode, WebviewInstallMode, WindowsSettings};
 use anyhow::{Context, Result, bail};
 use handlebars::Handlebars;
@@ -54,12 +54,10 @@ impl BundleContext<'_> {
         let wix_program_files_folder = arch.wix_program_files_folder();
 
         let product_name = self.product_name();
-        let version = wix_version(
-            &wix_settings
-                .version
-                .clone()
-                .unwrap_or_else(|| self.version_string()),
-        )?;
+        let version = match wix_settings.version.as_deref() {
+            Some(version) => version::wix_from_string(version)?,
+            None => version::wix(self.package_version())?,
+        };
 
         let msi_name = format!("{product_name}_{version}_{arch_str}.msi");
         let output_path = output_dir.join(&msi_name);
@@ -392,7 +390,7 @@ impl BundleContext<'_> {
         let arch_str = arch.windows_arch();
 
         let product_name = self.product_name();
-        let version = self.version_string();
+        let version = version::nsis(self.package_version());
         let installer_name = format!("{product_name}_{version}_{arch_str}-setup.exe");
         let output_path = output_dir.join(&installer_name);
 
@@ -926,42 +924,6 @@ fn render_template(template: &str, data: &BTreeMap<String, JsonValue>) -> Result
         .render("template", data)
         .context("Failed to render template")?;
     Ok(rendered.replace(BACKSLASH_PLACEHOLDER, "\\"))
-}
-
-/// Convert a semver version string to a WiX-compatible version.
-fn wix_version(version: &str) -> Result<String> {
-    let version = version.split('-').next().unwrap_or(version);
-    let parts: Vec<&str> = version.split('.').collect();
-
-    if parts.len() < 2 || parts.len() > 4 {
-        bail!(
-            "Invalid version for MSI: '{}'. Expected format: major.minor.patch[.build]",
-            version
-        );
-    }
-
-    for (i, part) in parts.iter().enumerate() {
-        let num: u64 = part
-            .parse()
-            .with_context(|| format!("Invalid version component: '{part}'"))?;
-        match i {
-            0 | 1 if num > 255 => {
-                bail!("Version component {part} exceeds maximum value of 255");
-            }
-            2 | 3 if num > 65535 => {
-                bail!("Version component {part} exceeds maximum value of 65535");
-            }
-            _ => {}
-        }
-    }
-
-    let version_str = if parts.len() == 2 {
-        format!("{}.{}.0", parts[0], parts[1])
-    } else {
-        parts.join(".")
-    };
-
-    Ok(version_str)
 }
 
 /// The embedded WiX template.


### PR DESCRIPTION
Dioxus passes the Cargo package version directly to `rpm::PackageBuilder`. The `rpm` crate validates the RPM `Version` field during `build()` and rejects SemVer prereleases that contain `-`, such as `1.2.3-rc.1`.

This projects Cargo `semver::Version` per format instead of using the raw string:

- **RPM / Debian:** `1.2.3-rc.1` → `1.2.3~rc.1` (`-` is illegal in RPM `Version`, and in Debian without a revision; `~` sorts before the final release). Build metadata is dropped so it cannot invert upgrades.
- **WiX:** numeric `major.minor.patch` with MSI limits (`u8` / `u8` / `u16`). Explicit `[bundle.windows.wix] version` stays `major.minor.patch[.build]`.
- **NSIS:** `VIProductVersion` is numeric (`u16` components); installer names and version-key strings keep the raw Cargo version so prereleases stay distinct.
- **macOS:** `CFBundleShortVersionString` / default `CFBundleVersion` use the numeric core.

Format-specific exports (`rpm` / `deb` / `wix` / `nsis` / `macos`) share private helpers. AppImage and other unconstrained artifact names are unchanged.