### PR TITLE
feat(cli): add independent [bundle.rpm] settings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,8 +198,8 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libayatana-appindicator3-dev libxdo-dev libglib2.0-dev patchelf desktop-file-utils librsvg2-dev
-          version: 1.0
+          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libayatana-appindicator3-dev libxdo-dev libglib2.0-dev patchelf desktop-file-utils librsvg2-dev rpm cpio
+          version: 1.1
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ needs.rust.outputs.rust_stable }}
@@ -213,13 +213,11 @@ jobs:
         working-directory: ./examples/01-app-demos/hotdog
         run: cargo run --manifest-path ../../../Cargo.toml -p dioxus-cli -- bundle --platform desktop --package-types appimage --package-types deb --package-types rpm
       - name: Verify Linux bundle outputs
-        run: |
-          find target -name '*.AppImage' -print
-          find target -name '*.deb' -print
-          find target -name '*.rpm' -print
-          test -n "$(find target -name '*.AppImage' -print -quit)"
-          test -n "$(find target -name '*.deb' -print -quit)"
-          test -n "$(find target -name '*.rpm' -print -quit)"
+        env:
+          DEB_DEPENDS: libwebkit2gtk-4.1-0
+          RPM_REQUIRES: webkit2gtk4.1
+          DESKTOP_TEMPLATE_TEST_ID: hotdog-desktop-template-test-id
+        run: bash .github/workflows/verify-linux-packages.sh
       - uses: actions/upload-artifact@v6
         if: failure()
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,7 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: libwebkit2gtk-4.1-dev libgtk-3-dev libasound2-dev libudev-dev libayatana-appindicator3-dev libxdo-dev libglib2.0-dev patchelf desktop-file-utils librsvg2-dev rpm cpio
-          version: 1.1
+          version: 1.0
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ needs.rust.outputs.rust_stable }}

--- a/.github/workflows/verify-linux-packages.sh
+++ b/.github/workflows/verify-linux-packages.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Inspect Linux bundle artifacts produced by `dx bundle`.
+#
+# Each packager's dependency field must equal its config list (RPM also has
+# rpmlib(...) markers from the format). Isolation follows: extra names from
+# the other format fail the equality check, shared names are allowed.
+set -euo pipefail
+
+target_dir=${TARGET_DIR:-target}
+deb_depends=${DEB_DEPENDS:-libwebkit2gtk-4.1-0}
+rpm_requires=${RPM_REQUIRES:-webkit2gtk4.1}
+desktop_template_test_id=${DESKTOP_TEMPLATE_TEST_ID:-linux-desktop-template-test-id}
+
+assert_equal_deps() {
+  local label=$1 configured=$2 packaged=$3
+  if [[ "$configured" != "$packaged" ]]; then
+    echo "${label} mismatch" >&2
+    echo "configured: ${configured}" >&2
+    echo "packaged: ${packaged}" >&2
+    exit 1
+  fi
+}
+
+mapfile -t appimages < <(find "$target_dir" -name '*.AppImage' -print)
+mapfile -t debs < <(find "$target_dir" -name '*.deb' -print)
+mapfile -t rpms < <(find "$target_dir" -name '*.rpm' -print)
+
+printf '%s\n' "${appimages[@]+"${appimages[@]}"}" "${debs[@]+"${debs[@]}"}" "${rpms[@]+"${rpms[@]}"}"
+
+if (( ${#appimages[@]} != 1 || ${#debs[@]} != 1 || ${#rpms[@]} != 1 )); then
+  echo "expected one AppImage, one .deb, and one .rpm under ${target_dir}" >&2
+  exit 1
+fi
+
+deb=${debs[0]}
+rpm_pkg=${rpms[0]}
+
+packaged_deb_depends=$(dpkg-deb -f "$deb" Depends)
+echo "Depends: ${packaged_deb_depends}"
+assert_equal_deps "deb Depends" "$deb_depends" "$packaged_deb_depends"
+
+packaged_rpm_requires=$(rpm -qp --requires "$rpm_pkg")
+echo "$packaged_rpm_requires"
+assert_equal_deps "rpm Requires" "$rpm_requires" \
+  "$(printf '%s\n' "$packaged_rpm_requires" | awk '!/^rpmlib\(/')"
+
+staging=$(mktemp -d)
+trap 'rm -rf "$staging"' EXIT
+mkdir -p "$staging/deb" "$staging/rpm"
+dpkg-deb -x "$deb" "$staging/deb"
+rpm2cpio "$rpm_pkg" | (cd "$staging/rpm" && cpio -idm --quiet --no-absolute-filenames)
+grep -F -q "$desktop_template_test_id" "$staging/deb"/usr/share/applications/*.desktop
+grep -F -q "$desktop_template_test_id" "$staging/rpm"/usr/share/applications/*.desktop

--- a/.github/workflows/verify-linux-packages.sh
+++ b/.github/workflows/verify-linux-packages.sh
@@ -3,7 +3,8 @@
 #
 # Each packager's dependency field must equal its config list (RPM also has
 # rpmlib(...) markers from the format). Isolation follows: extra names from
-# the other format fail the equality check, shared names are allowed.
+# the other format fail the equality check, shared names are allowed. The
+# custom [linux] desktop_template id must appear in .deb, .rpm, and AppImage.
 set -euo pipefail
 
 target_dir=${TARGET_DIR:-target}
@@ -32,6 +33,7 @@ if (( ${#appimages[@]} != 1 || ${#debs[@]} != 1 || ${#rpms[@]} != 1 )); then
   exit 1
 fi
 
+appimage=$(readlink -f "${appimages[0]}")
 deb=${debs[0]}
 rpm_pkg=${rpms[0]}
 
@@ -46,8 +48,12 @@ assert_equal_deps "rpm Requires" "$rpm_requires" \
 
 staging=$(mktemp -d)
 trap 'rm -rf "$staging"' EXIT
-mkdir -p "$staging/deb" "$staging/rpm"
+mkdir -p "$staging/deb" "$staging/rpm" "$staging/appimage"
+
 dpkg-deb -x "$deb" "$staging/deb"
 rpm2cpio "$rpm_pkg" | (cd "$staging/rpm" && cpio -idm --quiet --no-absolute-filenames)
+( cd "$staging/appimage" && "$appimage" --appimage-extract )
+
 grep -F -q "$desktop_template_test_id" "$staging/deb"/usr/share/applications/*.desktop
 grep -F -q "$desktop_template_test_id" "$staging/rpm"/usr/share/applications/*.desktop
+grep -F -q "$desktop_template_test_id" "$staging/appimage"/squashfs-root/usr/share/applications/*.desktop

--- a/examples/01-app-demos/hotdog/Dioxus.toml
+++ b/examples/01-app-demos/hotdog/Dioxus.toml
@@ -6,3 +6,13 @@ name = "hot_dog"
 [bundle]
 identifier = "com.dioxuslabs"
 publisher = "Dioxus Labs"
+
+# Shared by .deb, .rpm, and AppImage. Format-specific packaging stays under [bundle.*].
+[linux]
+desktop_template = "hotdog.desktop"
+
+[bundle.deb]
+depends = ["libwebkit2gtk-4.1-0"]
+
+[bundle.rpm]
+requires = ["webkit2gtk4.1"]

--- a/examples/01-app-demos/hotdog/hotdog.desktop
+++ b/examples/01-app-demos/hotdog/hotdog.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Categories={{categories}}
+{{#if comment}}
+Comment={{comment}}
+{{/if}}
+Exec={{exec}}
+Icon={{icon}}
+Name={{name}}
+Terminal=false
+Type=Application
+# Test-only id; CI greps packaged .desktop files for this value.
+X-Desktop-Template-Test-Id=hotdog-desktop-template-test-id

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -30,7 +30,7 @@
     },
     "linux": {
       "description": "Linux-specific configuration.",
-      "$ref": "#/$defs/LinuxConfig"
+      "$ref": "#/$defs/LinuxSettings"
     },
     "macos": {
       "description": "macOS-specific configuration.",
@@ -848,13 +848,6 @@
             "type": "string"
           }
         },
-        "desktop_template": {
-          "description": "Path to a custom desktop file Handlebars template.\n\nOverrides `[linux] desktop_template`. Available variables: `categories`,\n`comment` (optional), `exec`, `icon` and `name`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "files": {
           "description": "List of custom files to add to the deb package.\nMaps the path on the debian package to the path of the file to include (relative to the current working directory).",
           "type": "object",
@@ -1258,127 +1251,6 @@
         "identifier"
       ]
     },
-    "LinuxConfig": {
-      "description": "Linux-specific configuration.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"  # Override bundle.identifier for Linux\ncategories = [\"Utility\"]\n\ndesktop_template = \"linux.desktop\"\n\n# Debian package settings (previously in [bundle.deb])\n[linux.deb]\ndepends = [\"libwebkit2gtk-4.0-37\"]\nsection = \"utils\"\n```",
-      "type": "object",
-      "properties": {
-        "categories": {
-          "description": "Desktop entry categories.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "category": {
-          "description": "App category.\nOverrides `bundle.category` for Linux builds.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "copyright": {
-          "description": "Copyright notice.\nOverrides `bundle.copyright` for Linux builds.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "dbus_access": {
-          "description": "D-Bus interfaces to access.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "deb": {
-          "description": "Debian-specific package settings.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LinuxDebSettings"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "desktop_template": {
-          "description": "Custom `.desktop` file Handlebars template used by `.deb`, `.rpm`, and AppImage.\n\n`[bundle.deb] desktop_template` overrides this. RPM and AppImage use this value.\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "flatpak_permissions": {
-          "description": "Flatpak sandbox permissions.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "icon": {
-          "description": "Icons for the app.\nOverrides `bundle.icon` for Linux builds.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "identifier": {
-          "description": "The app's identifier (e.g., \"com.example.myapp\").\nOverrides `bundle.identifier` for Linux builds.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "keywords": {
-          "description": "Desktop entry keywords.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "long_description": {
-          "description": "Long description.\nOverrides `bundle.long_description` for Linux builds.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "mime_types": {
-          "description": "MIME types the app can handle.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "publisher": {
-          "description": "The app's publisher.\nOverrides `bundle.publisher` for Linux builds.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "resources": {
-          "description": "Additional resources to bundle.\nOverrides `bundle.resources` for Linux builds.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "short_description": {
-          "description": "Short description.\nOverrides `bundle.short_description` for Linux builds.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
     "LinuxDebSettings": {
       "description": "Debian package settings.",
       "type": "object",
@@ -1409,13 +1281,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "desktop_template": {
-          "description": "Path to custom desktop template.",
-          "type": [
-            "string",
-            "null"
-          ]
         },
         "files": {
           "description": "Additional files to include. Maps package path to source path.",
@@ -1491,6 +1356,127 @@
         },
         "section": {
           "description": "Debian section (e.g., \"utils\", \"web\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "LinuxSettings": {
+      "description": "Linux-specific settings.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"  # Override bundle.identifier for Linux\ncategories = [\"Utility\"]\n\ndesktop_template = \"linux.desktop\"\n\n# Debian package settings (previously in [bundle.deb])\n[linux.deb]\ndepends = [\"libwebkit2gtk-4.0-37\"]\nsection = \"utils\"\n```",
+      "type": "object",
+      "properties": {
+        "categories": {
+          "description": "Desktop entry categories.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "category": {
+          "description": "App category.\nOverrides `bundle.category` for Linux builds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "copyright": {
+          "description": "Copyright notice.\nOverrides `bundle.copyright` for Linux builds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dbus_access": {
+          "description": "D-Bus interfaces to access.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deb": {
+          "description": "Debian-specific package settings.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinuxDebSettings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "desktop_template": {
+          "description": "Custom `.desktop` file Handlebars template used by `.deb`, `.rpm`, and AppImage.\n\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "flatpak_permissions": {
+          "description": "Flatpak sandbox permissions.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "icon": {
+          "description": "Icons for the app.\nOverrides `bundle.icon` for Linux builds.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "identifier": {
+          "description": "The app's identifier (e.g., \"com.example.myapp\").\nOverrides `bundle.identifier` for Linux builds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "keywords": {
+          "description": "Desktop entry keywords.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "long_description": {
+          "description": "Long description.\nOverrides `bundle.long_description` for Linux builds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mime_types": {
+          "description": "MIME types the app can handle.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "publisher": {
+          "description": "The app's publisher.\nOverrides `bundle.publisher` for Linux builds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "resources": {
+          "description": "Additional resources to bundle.\nOverrides `bundle.resources` for Linux builds.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "short_description": {
+          "description": "Short description.\nOverrides `bundle.short_description` for Linux builds.",
           "type": [
             "string",
             "null"

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -640,7 +640,7 @@
         "deb": {
           "anyOf": [
             {
-              "$ref": "#/$defs/DebianSettings"
+              "$ref": "#/$defs/DebSettings"
             },
             {
               "type": "null"
@@ -818,7 +818,7 @@
         "args"
       ]
     },
-    "DebianSettings": {
+    "DebSettings": {
       "type": "object",
       "properties": {
         "changelog": {

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -1252,7 +1252,7 @@
       ]
     },
     "LinuxConfig": {
-      "description": "Linux-specific configuration.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"\ncategories = [\"Utility\"]\ndesktop_template = \"linux.desktop\"\n\n[bundle.deb]\ndepends = [\"libwebkit2gtk-4.1-0\"]\n\n[bundle.rpm]\ndepends = [\"webkit2gtk4.1\"]\n```",
+      "description": "Linux-specific configuration.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"\ncategories = [\"Utility\"]\ndesktop_template = \"linux.desktop\"\n\n[bundle.deb]\ndepends = [\"libwebkit2gtk-4.1-0\"]\n\n[bundle.rpm]\nrequires = [\"webkit2gtk4.1\"]\n```",
       "type": "object",
       "properties": {
         "categories": {
@@ -2110,16 +2110,6 @@
     "RpmSettings": {
       "type": "object",
       "properties": {
-        "depends": {
-          "description": "RPM package dependencies (`Requires`).",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
         "files": {
           "description": "Extra files to add to the RPM payload.\nMaps the path in the package to the source path (relative to the crate directory).",
           "type": "object",
@@ -2154,6 +2144,16 @@
             "string",
             "null"
           ]
+        },
+        "requires": {
+          "description": "RPM package `Requires`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -30,7 +30,7 @@
     },
     "linux": {
       "description": "Linux-specific configuration.",
-      "$ref": "#/$defs/LinuxSettings"
+      "$ref": "#/$defs/LinuxConfig"
     },
     "macos": {
       "description": "macOS-specific configuration.",
@@ -1251,120 +1251,8 @@
         "identifier"
       ]
     },
-    "LinuxDebSettings": {
-      "description": "Debian package settings.",
-      "type": "object",
-      "properties": {
-        "changelog": {
-          "description": "Path to changelog file.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "conflicts": {
-          "description": "Package conflicts.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "depends": {
-          "description": "Package dependencies.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "files": {
-          "description": "Additional files to include. Maps package path to source path.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "post_install_script": {
-          "description": "Post-install script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "post_remove_script": {
-          "description": "Post-remove script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "pre_install_script": {
-          "description": "Pre-install script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "pre_remove_script": {
-          "description": "Pre-remove script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "priority": {
-          "description": "Package priority (\"required\", \"important\", \"standard\", \"optional\", \"extra\").",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "provides": {
-          "description": "Packages this provides.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "recommends": {
-          "description": "Recommended packages.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "replaces": {
-          "description": "Packages this replaces.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "section": {
-          "description": "Debian section (e.g., \"utils\", \"web\").",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
-    "LinuxSettings": {
-      "description": "Linux-specific settings.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"\ncategories = [\"Utility\"]\ndesktop_template = \"linux.desktop\"\n\n[bundle.deb]\ndepends = [\"libwebkit2gtk-4.1-0\"]\n\n[bundle.rpm]\ndepends = [\"webkit2gtk4.1\"]\n```",
+    "LinuxConfig": {
+      "description": "Linux-specific configuration.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"\ncategories = [\"Utility\"]\ndesktop_template = \"linux.desktop\"\n\n[bundle.deb]\ndepends = [\"libwebkit2gtk-4.1-0\"]\n\n[bundle.rpm]\ndepends = [\"webkit2gtk4.1\"]\n```",
       "type": "object",
       "properties": {
         "categories": {
@@ -1477,6 +1365,118 @@
         },
         "short_description": {
           "description": "Short description.\nOverrides `bundle.short_description` for Linux builds.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "LinuxDebSettings": {
+      "description": "Debian package settings.",
+      "type": "object",
+      "properties": {
+        "changelog": {
+          "description": "Path to changelog file.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "conflicts": {
+          "description": "Package conflicts.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "depends": {
+          "description": "Package dependencies.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "description": "Additional files to include. Maps package path to source path.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "post_install_script": {
+          "description": "Post-install script path.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "post_remove_script": {
+          "description": "Post-remove script path.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pre_install_script": {
+          "description": "Pre-install script path.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pre_remove_script": {
+          "description": "Pre-remove script path.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Package priority (\"required\", \"important\", \"standard\", \"optional\", \"extra\").",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "provides": {
+          "description": "Packages this provides.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommends": {
+          "description": "Recommended packages.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "replaces": {
+          "description": "Packages this replaces.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "section": {
+          "description": "Debian section (e.g., \"utils\", \"web\").",
           "type": [
             "string",
             "null"

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -714,6 +714,16 @@
             "type": "string"
           }
         },
+        "rpm": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RpmSettings"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "short_description": {
           "type": [
             "string",
@@ -839,7 +849,7 @@
           }
         },
         "desktop_template": {
-          "description": "Path to a custom desktop file Handlebars template.\n\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.",
+          "description": "Path to a custom desktop file Handlebars template.\n\nOverrides `[linux] desktop_template`. Available variables: `categories`,\n`comment` (optional), `exec`, `icon` and `name`.",
           "type": [
             "string",
             "null"
@@ -1249,7 +1259,7 @@
       ]
     },
     "LinuxConfig": {
-      "description": "Linux-specific configuration.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"  # Override bundle.identifier for Linux\ncategories = [\"Utility\"]\n\n# Debian package settings (previously in [bundle.deb])\n[linux.deb]\ndepends = [\"libwebkit2gtk-4.0-37\"]\nsection = \"utils\"\n```",
+      "description": "Linux-specific configuration.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"  # Override bundle.identifier for Linux\ncategories = [\"Utility\"]\n\ndesktop_template = \"linux.desktop\"\n\n# Debian package settings (previously in [bundle.deb])\n[linux.deb]\ndepends = [\"libwebkit2gtk-4.0-37\"]\nsection = \"utils\"\n```",
       "type": "object",
       "properties": {
         "categories": {
@@ -1289,6 +1299,13 @@
             {
               "type": "null"
             }
+          ]
+        },
+        "desktop_template": {
+          "description": "Custom `.desktop` file Handlebars template used by `.deb`, `.rpm`, and AppImage.\n\n`[bundle.deb] desktop_template` overrides this. RPM and AppImage use this value.\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.",
+          "type": [
+            "string",
+            "null"
           ]
         },
         "flatpak_permissions": {
@@ -2226,6 +2243,56 @@
       "required": [
         "description"
       ]
+    },
+    "RpmSettings": {
+      "type": "object",
+      "properties": {
+        "depends": {
+          "description": "RPM package dependencies (`Requires`).",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "files": {
+          "description": "Extra files to add to the RPM payload.\nMaps the path in the package to the source path (relative to the crate directory).",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "post_install_script": {
+          "description": "Script run after the package is installed (`%post`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "post_remove_script": {
+          "description": "Script run after the package is removed (`%postun`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pre_install_script": {
+          "description": "Script run before the package is installed (`%pre`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pre_remove_script": {
+          "description": "Script run before the package is removed (`%preun`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
     },
     "SimplePermission": {
       "description": "Simple permission with just a description.",

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -2110,10 +2110,30 @@
     "RpmSettings": {
       "type": "object",
       "properties": {
+        "conflicts": {
+          "description": "RPM package `Conflicts`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "files": {
           "description": "Extra files to add to the RPM payload.\nMaps the path in the package to the source path (relative to the crate directory).",
           "type": "object",
           "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "obsoletes": {
+          "description": "RPM package `Obsoletes`. Closest equivalent of Debian `Replaces`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
           }
         },
@@ -2144,6 +2164,26 @@
             "string",
             "null"
           ]
+        },
+        "provides": {
+          "description": "RPM package `Provides`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommends": {
+          "description": "RPM package `Recommends`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         },
         "requires": {
           "description": "RPM package `Requires`.",

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -1283,17 +1283,6 @@
             "type": "string"
           }
         },
-        "deb": {
-          "description": "Debian-specific package settings.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LinuxDebSettings"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
         "desktop_template": {
           "description": "Custom `.desktop` file Handlebars template used by `.deb`, `.rpm`, and AppImage.\n\nAvailable variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.",
           "type": [
@@ -1365,118 +1354,6 @@
         },
         "short_description": {
           "description": "Short description.\nOverrides `bundle.short_description` for Linux builds.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
-    },
-    "LinuxDebSettings": {
-      "description": "Debian package settings.",
-      "type": "object",
-      "properties": {
-        "changelog": {
-          "description": "Path to changelog file.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "conflicts": {
-          "description": "Package conflicts.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "depends": {
-          "description": "Package dependencies.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "files": {
-          "description": "Additional files to include. Maps package path to source path.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "post_install_script": {
-          "description": "Post-install script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "post_remove_script": {
-          "description": "Post-remove script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "pre_install_script": {
-          "description": "Pre-install script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "pre_remove_script": {
-          "description": "Pre-remove script path.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "priority": {
-          "description": "Package priority (\"required\", \"important\", \"standard\", \"optional\", \"extra\").",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "provides": {
-          "description": "Packages this provides.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "recommends": {
-          "description": "Recommended packages.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "replaces": {
-          "description": "Packages this replaces.",
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
-            "type": "string"
-          }
-        },
-        "section": {
-          "description": "Debian section (e.g., \"utils\", \"web\").",
           "type": [
             "string",
             "null"

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -1364,7 +1364,7 @@
       }
     },
     "LinuxSettings": {
-      "description": "Linux-specific settings.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"  # Override bundle.identifier for Linux\ncategories = [\"Utility\"]\n\ndesktop_template = \"linux.desktop\"\n\n# Debian package settings (previously in [bundle.deb])\n[linux.deb]\ndepends = [\"libwebkit2gtk-4.0-37\"]\nsection = \"utils\"\n```",
+      "description": "Linux-specific settings.\n\nExample:\n```toml\n[linux]\nidentifier = \"com.example.myapp.linux\"\ncategories = [\"Utility\"]\ndesktop_template = \"linux.desktop\"\n\n[bundle.deb]\ndepends = [\"libwebkit2gtk-4.1-0\"]\n\n[bundle.rpm]\ndepends = [\"webkit2gtk4.1\"]\n```",
       "type": "object",
       "properties": {
         "categories": {

--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -222,7 +222,7 @@ impl BundleContext<'_> {
     /// 6. Copy configured sidecar binaries into `/usr/bin` so RPM payloads match the
     ///    other Linux formats.
     /// 7. Add custom files and maintainer scripts from `[bundle.rpm]`.
-    /// 8. Attach `Requires` from `[bundle.rpm] depends`.
+    /// 8. Attach `Requires` from `[bundle.rpm] requires`.
     /// 9. Serialize the final package to disk and remove the temporary staging area.
     ///
     /// The resulting artifact is written to `project_out_directory()/bundle/rpm`.
@@ -416,9 +416,9 @@ impl BundleContext<'_> {
             builder = builder.post_uninstall_script(content);
         }
 
-        if let Some(deps) = &rpm_settings.depends {
-            for dep in deps {
-                builder = builder.requires(rpm::Dependency::any(dep));
+        if let Some(requires) = &rpm_settings.requires {
+            for require in requires {
+                builder = builder.requires(rpm::Dependency::any(require));
             }
         }
 

--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -222,7 +222,7 @@ impl BundleContext<'_> {
     /// 6. Copy configured sidecar binaries into `/usr/bin` so RPM payloads match the
     ///    other Linux formats.
     /// 7. Reuse Debian-style custom files and maintainer scripts where applicable.
-    /// 8. Attach runtime dependency declarations from the Debian settings.
+    /// 8. Attach `Requires` from `[bundle.rpm] depends`.
     /// 9. Serialize the final package to disk and remove the temporary staging area.
     ///
     /// The resulting artifact is written to `project_out_directory()/bundle/rpm`.
@@ -417,7 +417,7 @@ impl BundleContext<'_> {
             builder = builder.post_uninstall_script(content);
         }
 
-        if let Some(deps) = &deb_settings.depends {
+        if let Some(deps) = &self.rpm().depends {
             for dep in deps {
                 builder = builder.requires(rpm::Dependency::any(dep));
             }

--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -57,8 +57,7 @@ impl BundleContext<'_> {
         }
         fs::create_dir_all(&appdir)?;
 
-        let desktop_template = self.linux_desktop_template(None);
-        self.generate_linux_common_data(&appdir, desktop_template.as_deref())?;
+        self.generate_linux_common_data(&appdir)?;
         self.create_linux_appdir_symlinks(&appdir, &name)?;
 
         let linuxdeploy = self
@@ -165,10 +164,7 @@ impl BundleContext<'_> {
         }
         fs::create_dir_all(&data_dir)?;
 
-        let deb_settings = self.deb();
-        let desktop_template =
-            self.linux_desktop_template(deb_settings.desktop_template.as_deref());
-        self.generate_linux_common_data(&data_dir, desktop_template.as_deref())?;
+        self.generate_linux_common_data(&data_dir)?;
         self.add_linux_deb_data(&data_dir)?;
 
         let installed_size = dir_size_kb(&data_dir)?;
@@ -259,8 +255,7 @@ impl BundleContext<'_> {
             .context("Failed to add binary to RPM")?;
 
         let rpm_settings = self.rpm();
-        let desktop_content =
-            self.generate_linux_desktop_file(self.linux_desktop_template(None).as_deref())?;
+        let desktop_content = self.generate_linux_desktop_file()?;
         let desktop_dest = format!("/usr/share/applications/{name}.desktop");
 
         let temp_dir = output_dir.join("_rpm_temp");
@@ -484,11 +479,7 @@ impl BundleContext<'_> {
     }
 
     /// Generate the Linux payload shared across bundle formats.
-    fn generate_linux_common_data(
-        &self,
-        data_dir: &Path,
-        desktop_template: Option<&Path>,
-    ) -> Result<()> {
+    fn generate_linux_common_data(&self, data_dir: &Path) -> Result<()> {
         let bin_name = self.main_binary_name();
         let resource_dir_name = self.linux_resource_dir_name();
 
@@ -507,7 +498,7 @@ impl BundleContext<'_> {
         let desktop_dir = data_dir.join("usr/share/applications");
         fs::create_dir_all(&desktop_dir)?;
 
-        let desktop_content = self.generate_linux_desktop_file(desktop_template)?;
+        let desktop_content = self.generate_linux_desktop_file()?;
         let desktop_path = desktop_dir.join(format!("{bin_name}.desktop"));
         fs::write(&desktop_path, &desktop_content)?;
 
@@ -573,11 +564,11 @@ impl BundleContext<'_> {
     }
 
     /// Generate the contents of a .desktop file for the given bundle context.
-    fn generate_linux_desktop_file(&self, desktop_template: Option<&Path>) -> Result<String> {
+    fn generate_linux_desktop_file(&self) -> Result<String> {
         let mut handlebars = Handlebars::new();
         handlebars.set_strict_mode(false);
 
-        let template = match desktop_template {
+        let template = match self.linux().desktop_template.as_deref() {
             // Path to template
             Some(path) => fs::read_to_string(path)
                 .with_context(|| format!("Failed to read desktop template: {}", path.display()))?,

--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -57,7 +57,8 @@ impl BundleContext<'_> {
         }
         fs::create_dir_all(&appdir)?;
 
-        self.generate_linux_common_data(&appdir)?;
+        let desktop_template = self.linux_desktop_template(None);
+        self.generate_linux_common_data(&appdir, desktop_template.as_deref())?;
         self.create_linux_appdir_symlinks(&appdir, &name)?;
 
         let linuxdeploy = self
@@ -164,7 +165,10 @@ impl BundleContext<'_> {
         }
         fs::create_dir_all(&data_dir)?;
 
-        self.generate_linux_common_data(&data_dir)?;
+        let deb_settings = self.deb();
+        let desktop_template =
+            self.linux_desktop_template(deb_settings.desktop_template.as_deref());
+        self.generate_linux_common_data(&data_dir, desktop_template.as_deref())?;
         self.add_linux_deb_data(&data_dir)?;
 
         let installed_size = dir_size_kb(&data_dir)?;
@@ -221,7 +225,7 @@ impl BundleContext<'_> {
     ///    under `/usr/lib/<product-name>/...`.
     /// 6. Copy configured sidecar binaries into `/usr/bin` so RPM payloads match the
     ///    other Linux formats.
-    /// 7. Reuse Debian-style custom files and maintainer scripts where applicable.
+    /// 7. Add custom files and maintainer scripts from `[bundle.rpm]`.
     /// 8. Attach `Requires` from `[bundle.rpm] depends`.
     /// 9. Serialize the final package to disk and remove the temporary staging area.
     ///
@@ -254,9 +258,9 @@ impl BundleContext<'_> {
             )
             .context("Failed to add binary to RPM")?;
 
-        let deb_settings = self.deb();
+        let rpm_settings = self.rpm();
         let desktop_content =
-            self.generate_linux_desktop_file(deb_settings.desktop_template.as_deref())?;
+            self.generate_linux_desktop_file(self.linux_desktop_template(None).as_deref())?;
         let desktop_dest = format!("/usr/share/applications/{name}.desktop");
 
         let temp_dir = output_dir.join("_rpm_temp");
@@ -369,7 +373,7 @@ impl BundleContext<'_> {
         }
 
         let crate_dir = self.crate_dir();
-        for (dest_path, src_path) in &deb_settings.files {
+        for (dest_path, src_path) in &rpm_settings.files {
             let src = if src_path.is_absolute() {
                 src_path.clone()
             } else {
@@ -388,28 +392,28 @@ impl BundleContext<'_> {
             }
         }
 
-        if let Some(script_path) = &deb_settings.pre_install_script {
+        if let Some(script_path) = &rpm_settings.pre_install_script {
             let path = resolve_path(&crate_dir, script_path);
             let content = fs::read_to_string(&path).with_context(|| {
                 format!("Failed to read pre-install script: {}", path.display())
             })?;
             builder = builder.pre_install_script(content);
         }
-        if let Some(script_path) = &deb_settings.post_install_script {
+        if let Some(script_path) = &rpm_settings.post_install_script {
             let path = resolve_path(&crate_dir, script_path);
             let content = fs::read_to_string(&path).with_context(|| {
                 format!("Failed to read post-install script: {}", path.display())
             })?;
             builder = builder.post_install_script(content);
         }
-        if let Some(script_path) = &deb_settings.pre_remove_script {
+        if let Some(script_path) = &rpm_settings.pre_remove_script {
             let path = resolve_path(&crate_dir, script_path);
             let content = fs::read_to_string(&path).with_context(|| {
                 format!("Failed to read pre-uninstall script: {}", path.display())
             })?;
             builder = builder.pre_uninstall_script(content);
         }
-        if let Some(script_path) = &deb_settings.post_remove_script {
+        if let Some(script_path) = &rpm_settings.post_remove_script {
             let path = resolve_path(&crate_dir, script_path);
             let content = fs::read_to_string(&path).with_context(|| {
                 format!("Failed to read post-uninstall script: {}", path.display())
@@ -417,7 +421,7 @@ impl BundleContext<'_> {
             builder = builder.post_uninstall_script(content);
         }
 
-        if let Some(deps) = &self.rpm().depends {
+        if let Some(deps) = &rpm_settings.depends {
             for dep in deps {
                 builder = builder.requires(rpm::Dependency::any(dep));
             }
@@ -480,7 +484,11 @@ impl BundleContext<'_> {
     }
 
     /// Generate the Linux payload shared across bundle formats.
-    fn generate_linux_common_data(&self, data_dir: &Path) -> Result<()> {
+    fn generate_linux_common_data(
+        &self,
+        data_dir: &Path,
+        desktop_template: Option<&Path>,
+    ) -> Result<()> {
         let bin_name = self.main_binary_name();
         let resource_dir_name = self.linux_resource_dir_name();
 
@@ -499,9 +507,7 @@ impl BundleContext<'_> {
         let desktop_dir = data_dir.join("usr/share/applications");
         fs::create_dir_all(&desktop_dir)?;
 
-        let deb_settings = self.deb();
-        let desktop_content =
-            self.generate_linux_desktop_file(deb_settings.desktop_template.as_deref())?;
+        let desktop_content = self.generate_linux_desktop_file(desktop_template)?;
         let desktop_path = desktop_dir.join(format!("{bin_name}.desktop"));
         fs::write(&desktop_path, &desktop_content)?;
 

--- a/packages/cli/src/bundler/linux.rs
+++ b/packages/cli/src/bundler/linux.rs
@@ -222,7 +222,8 @@ impl BundleContext<'_> {
     /// 6. Copy configured sidecar binaries into `/usr/bin` so RPM payloads match the
     ///    other Linux formats.
     /// 7. Add custom files and maintainer scripts from `[bundle.rpm]`.
-    /// 8. Attach `Requires` from `[bundle.rpm] requires`.
+    /// 8. Attach `Requires`, `Recommends`, `Provides`, `Conflicts`, and `Obsoletes`
+    ///    from `[bundle.rpm]`.
     /// 9. Serialize the final package to disk and remove the temporary staging area.
     ///
     /// The resulting artifact is written to `project_out_directory()/bundle/rpm`.
@@ -419,6 +420,26 @@ impl BundleContext<'_> {
         if let Some(requires) = &rpm_settings.requires {
             for require in requires {
                 builder = builder.requires(rpm::Dependency::any(require));
+            }
+        }
+        if let Some(recommends) = &rpm_settings.recommends {
+            for recommend in recommends {
+                builder = builder.recommends(rpm::Dependency::any(recommend));
+            }
+        }
+        if let Some(provides) = &rpm_settings.provides {
+            for provide in provides {
+                builder = builder.provides(rpm::Dependency::any(provide));
+            }
+        }
+        if let Some(conflicts) = &rpm_settings.conflicts {
+            for conflict in conflicts {
+                builder = builder.conflicts(rpm::Dependency::any(conflict));
+            }
+        }
+        if let Some(obsoletes) = &rpm_settings.obsoletes {
+            for obsolete in obsoletes {
+                builder = builder.obsoletes(rpm::Dependency::any(obsolete));
             }
         }
 

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -6,7 +6,7 @@ mod updater;
 mod windows;
 
 use crate::PackageType;
-use crate::{BuildRequest, DebianSettings, MacOsSettings, WindowsSettings};
+use crate::{BuildRequest, DebianSettings, MacOsSettings, RpmSettings, WindowsSettings};
 use anyhow::Context;
 use anyhow::Result;
 use std::collections::HashMap;
@@ -418,6 +418,11 @@ impl<'a> BundleContext<'a> {
     /// Debian settings from config.
     pub(crate) fn deb(&self) -> DebianSettings {
         self.build.config.bundle.deb.clone().unwrap_or_default()
+    }
+
+    /// RPM settings from config.
+    pub(crate) fn rpm(&self) -> RpmSettings {
+        self.build.config.bundle.rpm.clone().unwrap_or_default()
     }
 
     /// macOS settings from config.

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -6,9 +6,7 @@ mod updater;
 mod windows;
 
 use crate::PackageType;
-use crate::{
-    BuildRequest, DebianSettings, LinuxConfig, MacOsSettings, RpmSettings, WindowsSettings,
-};
+use crate::{BuildRequest, DebSettings, LinuxConfig, MacOsSettings, RpmSettings, WindowsSettings};
 use anyhow::Context;
 use anyhow::Result;
 use std::collections::HashMap;
@@ -417,8 +415,8 @@ impl<'a> BundleContext<'a> {
         self.build.crate_dir()
     }
 
-    /// Debian settings from config.
-    pub(crate) fn deb(&self) -> DebianSettings {
+    /// Deb settings from config.
+    pub(crate) fn deb(&self) -> DebSettings {
         self.build.config.bundle.deb.clone().unwrap_or_default()
     }
 

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -425,6 +425,15 @@ impl<'a> BundleContext<'a> {
         self.build.config.bundle.rpm.clone().unwrap_or_default()
     }
 
+    /// Desktop template: `[bundle.deb] desktop_template` override, else `[linux] desktop_template`.
+    pub(crate) fn linux_desktop_template(&self, format_override: Option<&Path>) -> Option<PathBuf> {
+        resolve_linux_desktop_template(
+            format_override,
+            self.build.config.linux.desktop_template.as_deref(),
+        )
+        .map(Path::to_path_buf)
+    }
+
     /// macOS settings from config.
     pub(crate) fn macos(&self) -> MacOsSettings {
         self.build.config.bundle.macos.clone().unwrap_or_default()
@@ -433,6 +442,38 @@ impl<'a> BundleContext<'a> {
     /// Windows settings from config.
     pub(crate) fn windows(&self) -> WindowsSettings {
         self.build.config.bundle.windows.clone().unwrap_or_default()
+    }
+}
+
+fn resolve_linux_desktop_template<'a>(
+    format_override: Option<&'a Path>,
+    linux: Option<&'a Path>,
+) -> Option<&'a Path> {
+    format_override.or(linux)
+}
+
+#[cfg(test)]
+mod linux_desktop_template_tests {
+    use super::resolve_linux_desktop_template;
+    use std::path::Path;
+
+    #[test]
+    fn format_override_wins_over_linux() {
+        let format = Path::new("deb.desktop");
+        let linux = Path::new("linux.desktop");
+        assert_eq!(
+            resolve_linux_desktop_template(Some(format), Some(linux)),
+            Some(format)
+        );
+    }
+
+    #[test]
+    fn linux_is_used_when_format_is_unset() {
+        let linux = Path::new("linux.desktop");
+        assert_eq!(
+            resolve_linux_desktop_template(None, Some(linux)),
+            Some(linux)
+        );
     }
 }
 

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -7,7 +7,7 @@ mod windows;
 
 use crate::PackageType;
 use crate::{
-    BuildRequest, DebianSettings, LinuxSettings, MacOsSettings, RpmSettings, WindowsSettings,
+    BuildRequest, DebianSettings, LinuxConfig, MacOsSettings, RpmSettings, WindowsSettings,
 };
 use anyhow::Context;
 use anyhow::Result;
@@ -428,7 +428,7 @@ impl<'a> BundleContext<'a> {
     }
 
     /// Linux settings from config.
-    pub(crate) fn linux(&self) -> &LinuxSettings {
+    pub(crate) fn linux(&self) -> &LinuxConfig {
         &self.build.config.linux
     }
 

--- a/packages/cli/src/bundler/mod.rs
+++ b/packages/cli/src/bundler/mod.rs
@@ -6,7 +6,9 @@ mod updater;
 mod windows;
 
 use crate::PackageType;
-use crate::{BuildRequest, DebianSettings, MacOsSettings, RpmSettings, WindowsSettings};
+use crate::{
+    BuildRequest, DebianSettings, LinuxSettings, MacOsSettings, RpmSettings, WindowsSettings,
+};
 use anyhow::Context;
 use anyhow::Result;
 use std::collections::HashMap;
@@ -425,13 +427,9 @@ impl<'a> BundleContext<'a> {
         self.build.config.bundle.rpm.clone().unwrap_or_default()
     }
 
-    /// Desktop template: `[bundle.deb] desktop_template` override, else `[linux] desktop_template`.
-    pub(crate) fn linux_desktop_template(&self, format_override: Option<&Path>) -> Option<PathBuf> {
-        resolve_linux_desktop_template(
-            format_override,
-            self.build.config.linux.desktop_template.as_deref(),
-        )
-        .map(Path::to_path_buf)
+    /// Linux settings from config.
+    pub(crate) fn linux(&self) -> &LinuxSettings {
+        &self.build.config.linux
     }
 
     /// macOS settings from config.
@@ -442,38 +440,6 @@ impl<'a> BundleContext<'a> {
     /// Windows settings from config.
     pub(crate) fn windows(&self) -> WindowsSettings {
         self.build.config.bundle.windows.clone().unwrap_or_default()
-    }
-}
-
-fn resolve_linux_desktop_template<'a>(
-    format_override: Option<&'a Path>,
-    linux: Option<&'a Path>,
-) -> Option<&'a Path> {
-    format_override.or(linux)
-}
-
-#[cfg(test)]
-mod linux_desktop_template_tests {
-    use super::resolve_linux_desktop_template;
-    use std::path::Path;
-
-    #[test]
-    fn format_override_wins_over_linux() {
-        let format = Path::new("deb.desktop");
-        let linux = Path::new("linux.desktop");
-        assert_eq!(
-            resolve_linux_desktop_template(Some(format), Some(linux)),
-            Some(format)
-        );
-    }
-
-    #[test]
-    fn linux_is_used_when_format_is_unset() {
-        let linux = Path::new("linux.desktop");
-        assert_eq!(
-            resolve_linux_desktop_template(None, Some(linux)),
-            Some(linux)
-        );
     }
 }
 

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -24,7 +24,7 @@ pub(crate) struct BundleConfig {
     #[serde(default)]
     pub(crate) external_bin: Option<Vec<String>>,
     #[serde(default)]
-    pub(crate) deb: Option<DebianSettings>,
+    pub(crate) deb: Option<DebSettings>,
     #[serde(default)]
     pub(crate) rpm: Option<RpmSettings>,
     #[serde(default)]
@@ -44,7 +44,7 @@ pub(crate) struct BundleConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
-pub(crate) struct DebianSettings {
+pub(crate) struct DebSettings {
     // OS-specific settings:
     /// the list of debian dependencies.
     #[serde(default)]

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -26,6 +26,8 @@ pub(crate) struct BundleConfig {
     #[serde(default)]
     pub(crate) deb: Option<DebianSettings>,
     #[serde(default)]
+    pub(crate) rpm: Option<RpmSettings>,
+    #[serde(default)]
     pub(crate) macos: Option<MacOsSettings>,
     #[serde(default)]
     pub(crate) windows: Option<WindowsSettings>,
@@ -95,6 +97,13 @@ pub(crate) struct DebianSettings {
     /// <https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html>
     #[serde(default)]
     pub post_remove_script: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
+pub(crate) struct RpmSettings {
+    /// RPM package dependencies (`Requires`).
+    #[serde(default)]
+    pub depends: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -67,7 +67,8 @@ pub(crate) struct DebianSettings {
     pub files: HashMap<PathBuf, PathBuf>,
     /// Path to a custom desktop file Handlebars template.
     ///
-    /// Available variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.
+    /// Overrides `[linux] desktop_template`. Available variables: `categories`,
+    /// `comment` (optional), `exec`, `icon` and `name`.
     #[serde(default)]
     pub desktop_template: Option<PathBuf>,
     /// Define the section in Debian Control file. See : <https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections>
@@ -104,6 +105,22 @@ pub(crate) struct RpmSettings {
     /// RPM package dependencies (`Requires`).
     #[serde(default)]
     pub depends: Option<Vec<String>>,
+    /// Extra files to add to the RPM payload.
+    /// Maps the path in the package to the source path (relative to the crate directory).
+    #[serde(default)]
+    pub files: HashMap<PathBuf, PathBuf>,
+    /// Script run before the package is installed (`%pre`).
+    #[serde(default)]
+    pub pre_install_script: Option<PathBuf>,
+    /// Script run after the package is installed (`%post`).
+    #[serde(default)]
+    pub post_install_script: Option<PathBuf>,
+    /// Script run before the package is removed (`%preun`).
+    #[serde(default)]
+    pub pre_remove_script: Option<PathBuf>,
+    /// Script run after the package is removed (`%postun`).
+    #[serde(default)]
+    pub post_remove_script: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -96,9 +96,9 @@ pub(crate) struct DebSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
 pub(crate) struct RpmSettings {
-    /// RPM package dependencies (`Requires`).
+    /// RPM package `Requires`.
     #[serde(default)]
-    pub depends: Option<Vec<String>>,
+    pub requires: Option<Vec<String>>,
     /// Extra files to add to the RPM payload.
     /// Maps the path in the package to the source path (relative to the crate directory).
     #[serde(default)]

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -65,12 +65,6 @@ pub(crate) struct DebianSettings {
     /// Maps the path on the debian package to the path of the file to include (relative to the current working directory).
     #[serde(default)]
     pub files: HashMap<PathBuf, PathBuf>,
-    /// Path to a custom desktop file Handlebars template.
-    ///
-    /// Overrides `[linux] desktop_template`. Available variables: `categories`,
-    /// `comment` (optional), `exec`, `icon` and `name`.
-    #[serde(default)]
-    pub desktop_template: Option<PathBuf>,
     /// Define the section in Debian Control file. See : <https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections>
     #[serde(default)]
     pub section: Option<String>,

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -99,6 +99,18 @@ pub(crate) struct RpmSettings {
     /// RPM package `Requires`.
     #[serde(default)]
     pub requires: Option<Vec<String>>,
+    /// RPM package `Recommends`.
+    #[serde(default)]
+    pub recommends: Option<Vec<String>>,
+    /// RPM package `Provides`.
+    #[serde(default)]
+    pub provides: Option<Vec<String>>,
+    /// RPM package `Conflicts`.
+    #[serde(default)]
+    pub conflicts: Option<Vec<String>>,
+    /// RPM package `Obsoletes`. Closest equivalent of Debian `Replaces`.
+    #[serde(default)]
+    pub obsoletes: Option<Vec<String>>,
     /// Extra files to add to the RPM payload.
     /// Maps the path in the package to the source path (relative to the crate directory).
     #[serde(default)]

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -182,6 +182,20 @@ mod tests {
     }
 
     #[test]
+    fn bundle_rpm_depends_parses() {
+        let source = r#"
+            [bundle.rpm]
+            depends = ["libxdo"]
+        "#;
+
+        let config: DioxusConfig = toml::from_str(source).expect("parse config");
+        assert_eq!(
+            config.bundle.rpm.unwrap().depends.unwrap(),
+            vec!["libxdo".to_string()]
+        );
+    }
+
+    #[test]
     fn static_dir_can_be_disabled() {
         let source = r#"
             [application]

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -182,16 +182,33 @@ mod tests {
     }
 
     #[test]
-    fn bundle_rpm_depends_parses() {
+    fn linux_desktop_template_parses() {
         let source = r#"
-            [bundle.rpm]
-            depends = ["libxdo"]
+            [linux]
+            desktop_template = "linux.desktop"
         "#;
 
         let config: DioxusConfig = toml::from_str(source).expect("parse config");
         assert_eq!(
-            config.bundle.rpm.unwrap().depends.unwrap(),
-            vec!["libxdo".to_string()]
+            config.linux.desktop_template.as_deref(),
+            Some(std::path::Path::new("linux.desktop"))
+        );
+    }
+
+    #[test]
+    fn bundle_rpm_settings_parse() {
+        let source = r#"
+            [bundle.rpm]
+            depends = ["libxdo"]
+            pre_install_script = "rpm-pre.sh"
+        "#;
+
+        let config: DioxusConfig = toml::from_str(source).expect("parse config");
+        let rpm = config.bundle.rpm.unwrap();
+        assert_eq!(rpm.depends.unwrap(), vec!["libxdo".to_string()]);
+        assert_eq!(
+            rpm.pre_install_script.as_deref(),
+            Some(std::path::Path::new("rpm-pre.sh"))
         );
     }
 

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -200,12 +200,23 @@ mod tests {
         let source = r#"
             [bundle.rpm]
             requires = ["libxdo"]
+            recommends = ["shared-mime-info"]
+            provides = ["hotdog"]
+            conflicts = ["hotdog-nightly"]
+            obsoletes = ["hotdog-legacy"]
             pre_install_script = "rpm-pre.sh"
         "#;
 
         let config: DioxusConfig = toml::from_str(source).expect("parse config");
         let rpm = config.bundle.rpm.unwrap();
         assert_eq!(rpm.requires.unwrap(), vec!["libxdo".to_string()]);
+        assert_eq!(
+            rpm.recommends.unwrap(),
+            vec!["shared-mime-info".to_string()]
+        );
+        assert_eq!(rpm.provides.unwrap(), vec!["hotdog".to_string()]);
+        assert_eq!(rpm.conflicts.unwrap(), vec!["hotdog-nightly".to_string()]);
+        assert_eq!(rpm.obsoletes.unwrap(), vec!["hotdog-legacy".to_string()]);
         assert_eq!(
             rpm.pre_install_script.as_deref(),
             Some(std::path::Path::new("rpm-pre.sh"))

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -54,7 +54,7 @@ pub(crate) struct DioxusConfig {
 
     /// Linux-specific configuration.
     #[serde(default)]
-    pub(crate) linux: LinuxSettings,
+    pub(crate) linux: LinuxConfig,
 }
 
 /// Platform identifier for bundle resolution.
@@ -149,7 +149,7 @@ impl Default for DioxusConfig {
             android: AndroidConfig::default(),
             macos: MacosConfig::default(),
             windows: WindowsConfig::default(),
-            linux: LinuxSettings::default(),
+            linux: LinuxConfig::default(),
         }
     }
 }

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -54,7 +54,7 @@ pub(crate) struct DioxusConfig {
 
     /// Linux-specific configuration.
     #[serde(default)]
-    pub(crate) linux: LinuxConfig,
+    pub(crate) linux: LinuxSettings,
 }
 
 /// Platform identifier for bundle resolution.
@@ -149,7 +149,7 @@ impl Default for DioxusConfig {
             android: AndroidConfig::default(),
             macos: MacosConfig::default(),
             windows: WindowsConfig::default(),
-            linux: LinuxConfig::default(),
+            linux: LinuxSettings::default(),
         }
     }
 }

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -199,13 +199,13 @@ mod tests {
     fn bundle_rpm_settings_parse() {
         let source = r#"
             [bundle.rpm]
-            depends = ["libxdo"]
+            requires = ["libxdo"]
             pre_install_script = "rpm-pre.sh"
         "#;
 
         let config: DioxusConfig = toml::from_str(source).expect("parse config");
         let rpm = config.bundle.rpm.unwrap();
-        assert_eq!(rpm.depends.unwrap(), vec!["libxdo".to_string()]);
+        assert_eq!(rpm.requires.unwrap(), vec!["libxdo".to_string()]);
         assert_eq!(
             rpm.pre_install_script.as_deref(),
             Some(std::path::Path::new("rpm-pre.sh"))

--- a/packages/cli/src/config/manifest.rs
+++ b/packages/cli/src/config/manifest.rs
@@ -1301,6 +1301,8 @@ pub struct WindowsSignCommand {
 /// identifier = "com.example.myapp.linux"  # Override bundle.identifier for Linux
 /// categories = ["Utility"]
 ///
+/// desktop_template = "linux.desktop"
+///
 /// # Debian package settings (previously in [bundle.deb])
 /// [linux.deb]
 /// depends = ["libwebkit2gtk-4.0-37"]
@@ -1348,6 +1350,13 @@ pub struct LinuxConfig {
     /// Overrides `bundle.long_description` for Linux builds.
     #[serde(default)]
     pub long_description: Option<String>,
+
+    /// Custom `.desktop` file Handlebars template used by `.deb`, `.rpm`, and AppImage.
+    ///
+    /// `[bundle.deb] desktop_template` overrides this. RPM and AppImage use this value.
+    /// Available variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.
+    #[serde(default)]
+    pub desktop_template: Option<PathBuf>,
 
     // === Debian package settings (previously in bundle.deb) ===
     /// Debian-specific package settings.

--- a/packages/cli/src/config/manifest.rs
+++ b/packages/cli/src/config/manifest.rs
@@ -1306,7 +1306,7 @@ pub struct WindowsSignCommand {
 /// depends = ["libwebkit2gtk-4.1-0"]
 ///
 /// [bundle.rpm]
-/// depends = ["webkit2gtk4.1"]
+/// requires = ["webkit2gtk4.1"]
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
 pub struct LinuxConfig {

--- a/packages/cli/src/config/manifest.rs
+++ b/packages/cli/src/config/manifest.rs
@@ -1357,11 +1357,6 @@ pub struct LinuxConfig {
     #[serde(default)]
     pub desktop_template: Option<PathBuf>,
 
-    // === Debian package settings (previously in bundle.deb) ===
-    /// Debian-specific package settings.
-    #[serde(default)]
-    pub deb: Option<LinuxDebSettings>,
-
     // === Linux-specific settings ===
     /// Flatpak sandbox permissions.
     #[serde(default)]
@@ -1382,62 +1377,6 @@ pub struct LinuxConfig {
     /// MIME types the app can handle.
     #[serde(default)]
     pub mime_types: Vec<String>,
-}
-
-/// Debian package settings.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
-pub struct LinuxDebSettings {
-    /// Package dependencies.
-    #[serde(default)]
-    pub depends: Option<Vec<String>>,
-
-    /// Recommended packages.
-    #[serde(default)]
-    pub recommends: Option<Vec<String>>,
-
-    /// Packages this provides.
-    #[serde(default)]
-    pub provides: Option<Vec<String>>,
-
-    /// Package conflicts.
-    #[serde(default)]
-    pub conflicts: Option<Vec<String>>,
-
-    /// Packages this replaces.
-    #[serde(default)]
-    pub replaces: Option<Vec<String>>,
-
-    /// Additional files to include. Maps package path to source path.
-    #[serde(default)]
-    pub files: HashMap<PathBuf, PathBuf>,
-
-    /// Debian section (e.g., "utils", "web").
-    #[serde(default)]
-    pub section: Option<String>,
-
-    /// Package priority ("required", "important", "standard", "optional", "extra").
-    #[serde(default)]
-    pub priority: Option<String>,
-
-    /// Path to changelog file.
-    #[serde(default)]
-    pub changelog: Option<PathBuf>,
-
-    /// Pre-install script path.
-    #[serde(default)]
-    pub pre_install_script: Option<PathBuf>,
-
-    /// Post-install script path.
-    #[serde(default)]
-    pub post_install_script: Option<PathBuf>,
-
-    /// Pre-remove script path.
-    #[serde(default)]
-    pub pre_remove_script: Option<PathBuf>,
-
-    /// Post-remove script path.
-    #[serde(default)]
-    pub post_remove_script: Option<PathBuf>,
 }
 
 // ============================================================================

--- a/packages/cli/src/config/manifest.rs
+++ b/packages/cli/src/config/manifest.rs
@@ -1298,15 +1298,15 @@ pub struct WindowsSignCommand {
 /// Example:
 /// ```toml
 /// [linux]
-/// identifier = "com.example.myapp.linux"  # Override bundle.identifier for Linux
+/// identifier = "com.example.myapp.linux"
 /// categories = ["Utility"]
-///
 /// desktop_template = "linux.desktop"
 ///
-/// # Debian package settings (previously in [bundle.deb])
-/// [linux.deb]
-/// depends = ["libwebkit2gtk-4.0-37"]
-/// section = "utils"
+/// [bundle.deb]
+/// depends = ["libwebkit2gtk-4.1-0"]
+///
+/// [bundle.rpm]
+/// depends = ["webkit2gtk4.1"]
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
 pub struct LinuxSettings {

--- a/packages/cli/src/config/manifest.rs
+++ b/packages/cli/src/config/manifest.rs
@@ -1293,7 +1293,7 @@ pub struct WindowsSignCommand {
 // Linux Configuration
 // ============================================================================
 
-/// Linux-specific configuration.
+/// Linux-specific settings.
 ///
 /// Example:
 /// ```toml
@@ -1309,7 +1309,7 @@ pub struct WindowsSignCommand {
 /// section = "utils"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
-pub struct LinuxConfig {
+pub struct LinuxSettings {
     // === Bundle settings (override [bundle] section) ===
     /// The app's identifier (e.g., "com.example.myapp").
     /// Overrides `bundle.identifier` for Linux builds.
@@ -1353,7 +1353,6 @@ pub struct LinuxConfig {
 
     /// Custom `.desktop` file Handlebars template used by `.deb`, `.rpm`, and AppImage.
     ///
-    /// `[bundle.deb] desktop_template` overrides this. RPM and AppImage use this value.
     /// Available variables: `categories`, `comment` (optional), `exec`, `icon` and `name`.
     #[serde(default)]
     pub desktop_template: Option<PathBuf>,
@@ -1411,10 +1410,6 @@ pub struct LinuxDebSettings {
     /// Additional files to include. Maps package path to source path.
     #[serde(default)]
     pub files: HashMap<PathBuf, PathBuf>,
-
-    /// Path to custom desktop template.
-    #[serde(default)]
-    pub desktop_template: Option<PathBuf>,
 
     /// Debian section (e.g., "utils", "web").
     #[serde(default)]
@@ -1776,7 +1771,7 @@ mod tests {
         assert!(json.contains("AndroidConfig"));
         assert!(json.contains("MacosConfig"));
         assert!(json.contains("WindowsConfig"));
-        assert!(json.contains("LinuxConfig"));
+        assert!(json.contains("LinuxSettings"));
 
         // Verify some specific properties exist
         assert!(json.contains("location"));

--- a/packages/cli/src/config/manifest.rs
+++ b/packages/cli/src/config/manifest.rs
@@ -1293,7 +1293,7 @@ pub struct WindowsSignCommand {
 // Linux Configuration
 // ============================================================================
 
-/// Linux-specific settings.
+/// Linux-specific configuration.
 ///
 /// Example:
 /// ```toml
@@ -1309,7 +1309,7 @@ pub struct WindowsSignCommand {
 /// depends = ["webkit2gtk4.1"]
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
-pub struct LinuxSettings {
+pub struct LinuxConfig {
     // === Bundle settings (override [bundle] section) ===
     /// The app's identifier (e.g., "com.example.myapp").
     /// Overrides `bundle.identifier` for Linux builds.
@@ -1771,7 +1771,7 @@ mod tests {
         assert!(json.contains("AndroidConfig"));
         assert!(json.contains("MacosConfig"));
         assert!(json.contains("WindowsConfig"));
-        assert!(json.contains("LinuxSettings"));
+        assert!(json.contains("LinuxConfig"));
 
         // Verify some specific properties exist
         assert!(json.contains("location"));


### PR DESCRIPTION
RPM bundling no longer reads Debian packaging settings. `[bundle.rpm]` is a first-class packager config next to `[bundle.deb]`, with RPM-native relation names. Shared Linux payload (the `.desktop` template) lives on `[linux]`.

Debian and Fedora package names are not interchangeable (e.g. `libwebkit2gtk-4.1-0` vs `webkit2gtk4.1`), so one `depends` list cannot produce a correct `.deb` and `.rpm`. Previously `bundle_linux_rpm` copied `[bundle.deb] depends` into RPM `Requires`.

## Config

```toml
[linux]
desktop_template = "linux.desktop"

[bundle.deb]
depends = ["libwebkit2gtk-4.1-0"]

[bundle.rpm]
requires = ["webkit2gtk4.1"]
recommends = ["shared-mime-info"]
provides = ["myapp"]
conflicts = ["myapp-nightly"]
obsoletes = ["myapp-legacy"]
```

`[bundle.rpm]` also keeps files and maintainer scripts (`pre_install_script`, `post_install_script`, `pre_remove_script`, `post_remove_script`).

Relation mapping:

| Deb | RPM |
|---|---|
| `depends` | `requires` |
| `recommends` | `recommends` |
| `provides` | `provides` |
| `conflicts` | `conflicts` |
| `replaces` | `obsoletes` |

`suggests` / `enhances` / `supplements` are not added here. No default WebKit/GTK runtime deps are injected; that can be a follow-up gated on webview vs native.

## Breaking changes

Hard cut, no compatibility shims.

- **RPM `Requires` only from `[bundle.rpm] requires`.** Unset means no user `Requires` (plus `rpmlib(...)` format markers). There is no fallback to `[bundle.deb] depends`.
- **RPM files and scripts only from `[bundle.rpm]`.** The RPM bundler no longer reads Debian `files` or maintainer scripts.
- **`.desktop` template only from `[linux] desktop_template`.** Used by `.deb`, `.rpm`, and AppImage. Format-level `desktop_template` on `[bundle.deb]` is gone.
- **`[linux.deb]` is removed.** It was unused (bundler never read it). Packaging stays under `[bundle.deb]` / `[bundle.rpm]`, matching `[bundle.macos]` / `[bundle.windows]`.
- **`DebianSettings` renamed to `DebSettings`** (the `.deb` packager, not the Debian distro). TOML key remains `[bundle.deb]`.

## Test plan

- [x] `bundle_rpm_settings_parse` covers `requires` / `recommends` / `provides` / `conflicts` / `obsoletes`
- [x] Linux smoke (`bundle-linux-smoke`) builds hotdog as AppImage, `.deb`, and `.rpm`
- [x] Smoke inspects `dpkg-deb -f Depends` and `rpm -qp --requires` (minus `rpmlib`)
- [x] Smoke extracts `.deb`, `.rpm`, and AppImage (`--appimage-extract`) and greps the custom `[linux]` desktop-template test id