### PR TITLE
feat(cli): add MSI install scope and default it to per-user

### DIFF
--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -3286,7 +3286,7 @@
           }
         },
         "install_scope": {
-          "description": "MSI install scope. Defaults to `PerUser` (`%LOCALAPPDATA%\\Programs`, no\nelevation). `PerMachine` installs under `ProgramFiles` and requires\nelevation.",
+          "description": "MSI install scope. Defaults to `PerUser` (`%LOCALAPPDATA%\\Programs`, no\nelevation). `PerMachine` installs under `ProgramFiles` and requires\nelevation.\n\nThis value must stay the same across updates because Windows Installer\ncannot perform a major upgrade across per-user and per-machine scopes.",
           "$ref": "#/$defs/WixInstallScope"
         },
         "language": {

--- a/packages/cli/schema.json
+++ b/packages/cli/schema.json
@@ -3226,6 +3226,14 @@
         }
       }
     },
+    "WixInstallScope": {
+      "description": "MSI `InstallScope`. Defaults to `PerUser`.",
+      "type": "string",
+      "enum": [
+        "PerMachine",
+        "PerUser"
+      ]
+    },
     "WixSettings": {
       "type": "object",
       "properties": {
@@ -3276,6 +3284,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "install_scope": {
+          "description": "MSI install scope. Defaults to `PerUser` (`%LOCALAPPDATA%\\Programs`, no\nelevation). `PerMachine` installs under `ProgramFiles` and requires\nelevation.",
+          "$ref": "#/$defs/WixInstallScope"
         },
         "language": {
           "type": "array",

--- a/packages/cli/src/bundler/windows.rs
+++ b/packages/cli/src/bundler/windows.rs
@@ -1,5 +1,5 @@
 use crate::bundler::BundleContext;
-use crate::{NSISInstallerMode, WebviewInstallMode, WindowsSettings};
+use crate::{NSISInstallerMode, WebviewInstallMode, WindowsSettings, WixInstallScope};
 use anyhow::{Context, Result, bail};
 use handlebars::Handlebars;
 use serde_json::Value as JsonValue;
@@ -107,6 +107,17 @@ impl BundleContext<'_> {
         data.insert(
             "wix_program_files_folder".to_string(),
             serde_json::Value::String(wix_program_files_folder.to_string()),
+        );
+        data.insert(
+            "install_scope".to_string(),
+            serde_json::Value::String(wix_settings.install_scope.as_wix_attr().to_string()),
+        );
+        data.insert(
+            "install_scope_per_user".to_string(),
+            serde_json::Value::Bool(matches!(
+                wix_settings.install_scope,
+                WixInstallScope::PerUser
+            )),
         );
         data.insert(
             "main_binary_name".to_string(),
@@ -983,7 +994,10 @@ const WIX_TEMPLATE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
             Description="{{short_description}}"
             {{/if}}
             Manufacturer="{{publisher}}"
-            InstallScope="perMachine"
+            InstallScope="{{install_scope}}"
+            {{#if install_scope_per_user}}
+            InstallPrivileges="limited"
+            {{/if}}
             Languages="1033"
             Compressed="yes"
             SummaryCodepage="1252" />
@@ -1027,8 +1041,13 @@ const WIX_TEMPLATE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
 
         <Directory Id="TARGETDIR" Name="SourceDir">
+            {{#if install_scope_per_user}}
+            <Directory Id="LocalAppDataFolder">
+                <Directory Id="LocalAppDataPrograms" Name="Programs">
+            {{else}}
             <Directory Id="{{wix_program_files_folder}}">
-                <Directory Id="INSTALLDIR" Name="{{product_name}}">
+            {{/if}}
+                    <Directory Id="INSTALLDIR" Name="{{product_name}}">
                     <Component Id="MainExecutable" Guid="*">
                         <File
                             Id="MainExe"
@@ -1037,8 +1056,13 @@ const WIX_TEMPLATE: &str = r#"<?xml version="1.0" encoding="utf-8"?>
                             KeyPath="yes" />
                     </Component>
 {{{install_tree}}}
+                    </Directory>
+            {{#if install_scope_per_user}}
                 </Directory>
             </Directory>
+            {{else}}
+            </Directory>
+            {{/if}}
 
             <Directory Id="ProgramMenuFolder">
                 <Directory Id="ProgramMenuSubfolder" Name="{{product_name}}">
@@ -1272,7 +1296,27 @@ mod tests {
 
     #[test]
     fn wix_template_uses_arch_specific_program_files_folder() {
-        let data: BTreeMap<String, serde_json::Value> = serde_json::from_value(json!({
+        let rendered = render_template(
+            WIX_TEMPLATE,
+            &wix_template_data("perMachine", false, "ProgramFiles64Folder"),
+        )
+        .unwrap();
+
+        assert!(rendered.contains("InstallScope=\"perMachine\""));
+        assert!(!rendered.contains("InstallPrivileges=\"limited\""));
+        assert!(rendered.contains("<Directory Id=\"ProgramFiles64Folder\">"));
+        assert!(!rendered.contains("<Directory Id=\"ProgramFilesFolder\">"));
+        assert!(!rendered.contains("<Directory Id=\"LocalAppDataFolder\">"));
+        // Verify \{{ substitution works: registry key should contain actual values
+        assert!(rendered.contains("Software\\Dioxus Labs\\Hotdog"));
+    }
+
+    fn wix_template_data(
+        install_scope: &str,
+        per_user: bool,
+        program_files: &str,
+    ) -> BTreeMap<String, serde_json::Value> {
+        serde_json::from_value(json!({
             "product_name": "Hotdog",
             "upgrade_code": "00000000-0000-0000-0000-000000000000",
             "version": "0.1.0",
@@ -1289,15 +1333,25 @@ mod tests {
             "feature_group_refs": [],
             "feature_refs": [],
             "merge_refs": [],
-            "wix_program_files_folder": "ProgramFiles64Folder"
+            "wix_program_files_folder": program_files,
+            "install_scope": install_scope,
+            "install_scope_per_user": per_user
         }))
+        .unwrap()
+    }
+
+    #[test]
+    fn wix_template_per_user_uses_local_app_data() {
+        let rendered = render_template(
+            WIX_TEMPLATE,
+            &wix_template_data("perUser", true, "ProgramFiles64Folder"),
+        )
         .unwrap();
 
-        let rendered = render_template(WIX_TEMPLATE, &data).unwrap();
-
-        assert!(rendered.contains("<Directory Id=\"ProgramFiles64Folder\">"));
-        assert!(!rendered.contains("<Directory Id=\"ProgramFilesFolder\">"));
-        // Verify \{{ substitution works: registry key should contain actual values
-        assert!(rendered.contains("Software\\Dioxus Labs\\Hotdog"));
+        assert!(rendered.contains("InstallScope=\"perUser\""));
+        assert!(rendered.contains("InstallPrivileges=\"limited\""));
+        assert!(rendered.contains("<Directory Id=\"LocalAppDataFolder\">"));
+        assert!(rendered.contains("<Directory Id=\"LocalAppDataPrograms\" Name=\"Programs\">"));
+        assert!(!rendered.contains("<Directory Id=\"ProgramFiles64Folder\">"));
     }
 }

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -147,6 +147,28 @@ pub(crate) struct WixSettings {
     #[serde(default)]
     #[schemars(with = "Option<String>")]
     pub upgrade_code: Option<uuid::Uuid>,
+    /// MSI install scope. Defaults to `PerUser` (`%LOCALAPPDATA%\Programs`, no
+    /// elevation). `PerMachine` installs under `ProgramFiles` and requires
+    /// elevation.
+    #[serde(default)]
+    pub(crate) install_scope: WixInstallScope,
+}
+
+/// MSI `InstallScope`. Defaults to `PerUser`.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub(crate) enum WixInstallScope {
+    PerMachine,
+    #[default]
+    PerUser,
+}
+
+impl WixInstallScope {
+    pub(crate) fn as_wix_attr(self) -> &'static str {
+        match self {
+            Self::PerMachine => "perMachine",
+            Self::PerUser => "perUser",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/packages/cli/src/config/bundle.rs
+++ b/packages/cli/src/config/bundle.rs
@@ -150,6 +150,9 @@ pub(crate) struct WixSettings {
     /// MSI install scope. Defaults to `PerUser` (`%LOCALAPPDATA%\Programs`, no
     /// elevation). `PerMachine` installs under `ProgramFiles` and requires
     /// elevation.
+    ///
+    /// This value must stay the same across updates because Windows Installer
+    /// cannot perform a major upgrade across per-user and per-machine scopes.
     #[serde(default)]
     pub(crate) install_scope: WixInstallScope,
 }

--- a/packages/cli/src/config/dioxus_config.rs
+++ b/packages/cli/src/config/dioxus_config.rs
@@ -182,6 +182,33 @@ mod tests {
     }
 
     #[test]
+    fn wix_install_scope_parses() {
+        let source = r#"
+            [bundle.windows.wix]
+            install_scope = "PerMachine"
+        "#;
+
+        let config: DioxusConfig = toml::from_str(source).expect("parse config");
+        assert_eq!(
+            config.bundle.windows.unwrap().wix.unwrap().install_scope,
+            super::WixInstallScope::PerMachine
+        );
+    }
+
+    #[test]
+    fn wix_install_scope_defaults_to_per_user() {
+        let source = r#"
+            [bundle.windows.wix]
+        "#;
+
+        let config: DioxusConfig = toml::from_str(source).expect("parse config");
+        assert_eq!(
+            config.bundle.windows.unwrap().wix.unwrap().install_scope,
+            super::WixInstallScope::PerUser
+        );
+    }
+
+    #[test]
     fn static_dir_can_be_disabled() {
         let source = r#"
             [application]


### PR DESCRIPTION
MSI installers from `dx bundle` now default to per-user: `%LOCALAPPDATA%\Programs\<product>`, `InstallScope="perUser"`, `InstallPrivileges="limited"`, no UAC. That matches the existing NSIS default (`CurrentUser`). Per-machine (`ProgramFiles`, elevated) is opt-in.

Previously the WiX template hardcoded `InstallScope="perMachine"` with no config.

## Config

```toml
[bundle.windows.wix]
install_scope = "PerUser"    # default if omitted
# install_scope = "PerMachine"
```

## Breaking changes

Stock `dx bundle --package-types msi` (no `install_scope`) installs per-user instead of per-machine.

## Test plan

- [x] Parse: omitted `[bundle.windows.wix]` → `PerUser`; `install_scope = "PerMachine"` → `PerMachine`
- [x] Template: per-user uses `LocalAppDataFolder\Programs` and `InstallPrivileges="limited"`; per-machine keeps `ProgramFiles*Folder`