### PR TITLE
Skip stable fragment edge scans when no children need placement

### DIFF
--- a/packages/cli/src/serve/output.rs
+++ b/packages/cli/src/serve/output.rs
@@ -139,7 +139,7 @@ impl Output {
     /// Enable raw mode, but don't let it block forever.
     ///
     /// This lets us check if writing to tty is going to block forever and then recover, allowing
-    /// interopability with programs like `bg`.
+    /// interoperability with programs like `bg`.
     fn enable_raw_mode() -> Result<()> {
         #[cfg(unix)]
         {

--- a/packages/core/src/diff/iterator.rs
+++ b/packages/core/src/diff/iterator.rs
@@ -403,47 +403,52 @@ impl DiffState<'_, '_, '_, '_> {
             }
         }
 
-        let stable_edges = StableFragmentEdges::new(new, &new_mounts, &anchorable, self.dom);
-        for range in plan.placement_runs(&stable_edges.live_stable) {
-            let context = self.context();
-            let runtime = self.dom.runtime.clone();
-            let dom = &mut *self.dom;
-            let mut replaced_nodes = Vec::new();
-            if let Some(to) = self.to.as_deref_mut() {
-                let site = stable_edges
-                    .next_first(range.end)
-                    .map(InsertionSite::before)
-                    .or_else(|| {
-                        stable_edges
-                            .prev_last(range.start)
-                            .map(InsertionSite::after)
-                    })
-                    .or(fallback_site)
-                    .expect("visible fragment placement requires a fallback insertion site");
-                site.create_and_place_with_result(to, runtime, |to| {
-                    let mut state = DiffState::new_with_context(dom, Some(to), context);
-                    let nodes = state.create_or_diff_placed_range(
+        // `placement_runs` only opens a run on a `!stable` child, so when every child is
+        // stable there is nothing to place and the stable edges are never read. Skip the
+        // two per-child element scans `StableFragmentEdges::new` would otherwise perform.
+        if plan.stable.iter().any(|stable| !stable) {
+            let stable_edges = StableFragmentEdges::new(new, &new_mounts, &anchorable, self.dom);
+            for range in plan.placement_runs(&stable_edges.live_stable) {
+                let context = self.context();
+                let runtime = self.dom.runtime.clone();
+                let dom = &mut *self.dom;
+                let mut replaced_nodes = Vec::new();
+                if let Some(to) = self.to.as_deref_mut() {
+                    let site = stable_edges
+                        .next_first(range.end)
+                        .map(InsertionSite::before)
+                        .or_else(|| {
+                            stable_edges
+                                .prev_last(range.start)
+                                .map(InsertionSite::after)
+                        })
+                        .or(fallback_site)
+                        .expect("visible fragment placement requires a fallback insertion site");
+                    site.create_and_place_with_result(to, runtime, |to| {
+                        let mut state = DiffState::new_with_context(dom, Some(to), context);
+                        let nodes = state.create_or_diff_placed_range(
+                            &inputs,
+                            &plan,
+                            range.clone(),
+                            &mut new_mounts,
+                            &mut replaced_nodes,
+                        );
+                        (nodes, nodes)
+                    });
+                } else {
+                    let mut state = DiffState::new_with_context(dom, None, context);
+                    state.create_or_diff_placed_range(
                         &inputs,
                         &plan,
                         range.clone(),
                         &mut new_mounts,
                         &mut replaced_nodes,
                     );
-                    (nodes, nodes)
-                });
-            } else {
-                let mut state = DiffState::new_with_context(dom, None, context);
-                state.create_or_diff_placed_range(
-                    &inputs,
-                    &plan,
-                    range.clone(),
-                    &mut new_mounts,
-                    &mut replaced_nodes,
-                );
-            }
+                }
 
-            for (node, mount) in replaced_nodes.into_iter().rev() {
-                node.remove_node(mount, self.dom, self.to.as_deref_mut());
+                for (node, mount) in replaced_nodes.into_iter().rev() {
+                    node.remove_node(mount, self.dom, self.to.as_deref_mut());
+                }
             }
         }
 

--- a/packages/hooks/src/use_future.rs
+++ b/packages/hooks/src/use_future.rs
@@ -95,7 +95,7 @@ pub enum UseFutureState {
     /// The future has been forcefully stopped
     Stopped,
 
-    /// The future has been paused, tempoarily
+    /// The future has been paused, temporarily
     Paused,
 
     /// The future has completed

--- a/packages/hooks/src/use_resource.rs
+++ b/packages/hooks/src/use_resource.rs
@@ -156,7 +156,7 @@ pub enum UseResourceState {
     /// The resource's future has been forcefully stopped
     Stopped,
 
-    /// The resource's future has been paused, tempoarily
+    /// The resource's future has been paused, temporarily
     Paused,
 
     /// The resource's future has completed


### PR DESCRIPTION
## Summary

Fixes #5801 — a perf regression from #5554 where `execute_fragment_plan` builds `StableFragmentEdges` unconditionally, walking every fragment child twice (`find_first_element` + `find_last_element`) on every diff. In the steady-state re-render of an unchanged list, every child is stable, `placement_runs` returns no runs, and all `2n` tree walks are discarded.

The fix guards the edge construction and the placement loop behind:

```rust
if plan.stable.iter().any(|stable| !stable) {
    let stable_edges = StableFragmentEdges::new(new, &new_mounts, &anchorable, self.dom);
    for range in plan.placement_runs(&stable_edges.live_stable) { ... }
}
```

This is behavior-preserving by construction: `placement_runs` only opens a run on a `!stable` child, so all-stable input yields no runs regardless of `live_stable`, and the placement loop body holds the only reads of the edges. The skipped scans are side-effect free (`&VirtualDom`). When any child is unstable, the guard short-circuits and the existing path runs unchanged.

Per the issue's benchmarks this cuts steady-state re-render cost by ~55% for plain-element fragments and ~23-32% for component fragments (component children pay more per scan since `find_first_element` descends into the scope).

Verified with `cargo test -p dioxus-core` (all green, including the mutation-asserting `diff_*`, `render_targets`, `many_roots`, `kitchen_sink` suites), `cargo clippy -p dioxus-core --all-targets`, and `cargo fmt --check`.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d364931212bf4c2a80d8139b337a5ef7
Open in Devin Desktop: https://dioxus.staging.devinenterprise.com/desktop/session/d364931212bf4c2a80d8139b337a5ef7?variant=devin-insiders
Requested by: @ealmloff