### PR TITLE
Use linker-provided WASM hotpatch allocation layouts

### DIFF
--- a/packages/cli/src/build/patch.rs
+++ b/packages/cli/src/build/patch.rs
@@ -15,7 +15,7 @@ use std::{
     path::PathBuf,
     sync::{Arc, RwLock},
 };
-use subsecond_types::{AddressMap, JumpTable};
+use subsecond_types::{AddressMap, JumpTable, WasmPatchLayout};
 use target_lexicon::{Architecture, OperatingSystem, PointerWidth, Triple};
 use thiserror::Error;
 use walrus::{
@@ -442,6 +442,7 @@ pub fn create_windows_jump_table(patch: &Path, cache: &HotpatchModuleCache) -> R
         new_base_address,
         aslr_reference,
         ifunc_count: 0,
+        wasm_layout: None,
     })
 }
 
@@ -508,6 +509,7 @@ pub fn create_native_jump_table(
         new_base_address,
         aslr_reference,
         ifunc_count: 0,
+        wasm_layout: None,
     })
 }
 
@@ -815,13 +817,14 @@ pub fn create_wasm_jump_table(patch: &Path, cache: &HotpatchModuleCache) -> Resu
 
     // Update the wasm module on the filesystem to use the newly lifted version
     let lib = patch.to_path_buf();
+    let wasm_layout = wasm_patch_layout(&new, &new_bytes)?;
 
     // And now assemble the jump table by mapping the old ifunc table to the new one, by name
     //
     // The ifunc_count will be passed to the dynamic loader so it can allocate the right amount of space
     // in the indirect function table when loading the patch.
     let name_to_ifunc_new = collect_func_ifuncs(&new);
-    let ifunc_count = name_to_ifunc_new.len() as u64;
+    let ifunc_count = u64::from(wasm_layout.table_size);
     let mut map = AddressMap::default();
     for (name, idx) in name_to_ifunc_new.iter() {
         // Find the corresponding ifunc in the old module by name
@@ -838,7 +841,89 @@ pub fn create_wasm_jump_table(patch: &Path, cache: &HotpatchModuleCache) -> Resu
         ifunc_count,
         aslr_reference: 0,
         new_base_address: 0,
+        wasm_layout: Some(wasm_layout),
     })
+}
+
+fn wasm_patch_layout(module: &Module, bytes: &[u8]) -> Result<WasmPatchLayout> {
+    use wasmparser::{Dylink0SectionReader, Dylink0Subsection};
+    let mut metadata = None;
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let Payload::CustomSection(section) = payload?
+            && section.name() == "dylink.0"
+        {
+            for subsection in
+                Dylink0SectionReader::new(BinaryReader::new(section.data(), section.data_offset()))
+            {
+                if let Dylink0Subsection::MemInfo(info) = subsection? {
+                    if metadata.is_some() {
+                        return Err(PatchError::InvalidModule(
+                            "Duplicate WASM memory metadata".into(),
+                        ));
+                    }
+                    metadata = Some(WasmPatchLayout {
+                        memory_size: info.memory_size,
+                        memory_alignment: info.memory_alignment,
+                        table_size: info.table_size,
+                        table_alignment: info.table_alignment,
+                    });
+                }
+            }
+        }
+    }
+    if metadata.is_none()
+        && (module.data.iter().next().is_some() || module.memories.iter().next().is_some())
+    {
+        return Err(PatchError::InvalidModule(
+            "Missing dylink.0 memory layout; rebuild required".into(),
+        ));
+    }
+    let mut layout = metadata.unwrap_or_default();
+    let is_base = |global, name| {
+        module.imports.iter().any(|i| {
+            i.module == "env"
+                && i.name == name
+                && matches!(i.kind, ImportKind::Global(id) if id == global)
+        })
+    };
+    for element in module.elements.iter() {
+        let ElementKind::Active { table, offset } = element.kind else {
+            continue;
+        };
+        let is_shared_table = module.imports.iter().any(|i| {
+            i.module == "env"
+                && i.name == "__indirect_function_table"
+                && matches!(i.kind, ImportKind::Table(id) if id == table)
+        });
+        if !is_shared_table || !matches!(offset, ConstExpr::Global(g) if is_base(g, "__table_base"))
+        {
+            return Err(PatchError::InvalidModule(
+                "Patch element segment is not relative to __table_base".into(),
+            ));
+        }
+        let count = match &element.items {
+            ElementItems::Functions(items) => items.len(),
+            ElementItems::Expressions(_, items) => items.len(),
+        };
+        layout.table_size = layout
+            .table_size
+            .max(u32::try_from(count).context("WASM table size overflows")?);
+    }
+    for data in module.data.iter() {
+        if let DataKind::Active { offset, .. } = data.kind {
+            if !matches!(offset, ConstExpr::Global(g) if is_base(g, "__memory_base"))
+                || data.value.len() as u64 > u64::from(layout.memory_size)
+            {
+                return Err(PatchError::InvalidModule(
+                    "Patch data segment exceeds its relocatable memory layout".into(),
+                ));
+            }
+        }
+    }
+    layout
+        .reservation()
+        .context("WASM patch allocation overflows")?;
+    Ok(layout)
 }
 
 fn convert_func_to_ifunc_call(

--- a/packages/cli/tests/unit/patch.rs
+++ b/packages/cli/tests/unit/patch.rs
@@ -326,6 +326,31 @@ fn malformed_wasm_metadata_is_not_silently_ignored() {
 }
 
 #[test]
+fn wasm_layout_preserves_bss_and_alignment() {
+    let mut module = Module::default();
+    module.customs.add(walrus::RawCustomSection {
+        name: "dylink.0".into(),
+        data: vec![1, 6, 0x84, 0x80, 0x40, 20, 7, 2],
+    });
+    let bytes = module.emit_wasm();
+    let layout = wasm_patch_layout(&module, &bytes).unwrap();
+    assert_eq!(layout.memory_size, 1048580);
+    assert_eq!(layout.memory_alignment, 20);
+    assert_eq!(layout.table_size, 7);
+    assert_eq!(layout.table_alignment, 2);
+    let (pages, _) = layout.reservation().unwrap();
+    assert!(pages >= 17);
+}
+
+#[test]
+fn wasm_memory_requires_linker_layout() {
+    let mut module = Module::default();
+    module.add_import_memory("env", "memory", false, false, 0, None, None);
+    let bytes = module.emit_wasm();
+    assert!(wasm_patch_layout(&module, &bytes).is_err());
+}
+
+#[test]
 fn wasm_patch_without_elements_is_rewritable() {
     let dir = tempdir().unwrap();
     let mut module = Module::default();
@@ -392,4 +417,42 @@ fn native_stubs_preserve_absolute_symbols_and_unix_import_prefixes() {
         st_other: 0,
     };
     assert!(create_undefined_symbol_stub(&cache, &[path], &triple, 0x10000).is_err());
+}
+
+#[test]
+fn wasm_table_size_counts_duplicate_and_unnamed_slots() {
+    let dir = tempdir().unwrap();
+    let mut module = Module::default();
+    let (table, _) = module.add_import_table(
+        "env",
+        "__indirect_function_table",
+        false,
+        0,
+        None,
+        walrus::RefType::Funcref,
+    );
+    let (base, _) =
+        module.add_import_global("env", "__table_base", walrus::ValType::I32, false, false);
+    let mut builder = FunctionBuilder::new(&mut module.types, &[], &[]);
+    builder.name("duplicate".to_string());
+    let function = builder.finish(vec![], &mut module.funcs);
+    let unnamed =
+        FunctionBuilder::new(&mut module.types, &[], &[]).finish(vec![], &mut module.funcs);
+    module.elements.add(
+        ElementKind::Active {
+            table,
+            offset: ConstExpr::Global(base),
+        },
+        ElementItems::Functions(vec![function, function, unnamed]),
+    );
+    let path = dir.path().join("patch.wasm");
+    std::fs::write(&path, module.emit_wasm()).unwrap();
+    let mut old = Module::default();
+    let cache = HotpatchModuleCache {
+        old_bytes: old.emit_wasm(),
+        old_wasm: old,
+        ..Default::default()
+    };
+    let patch = create_wasm_jump_table(&path, &cache).unwrap();
+    assert_eq!(patch.ifunc_count, 3);
 }

--- a/packages/subsecond/subsecond-types/src/lib.rs
+++ b/packages/subsecond/subsecond-types/src/lib.rs
@@ -44,6 +44,110 @@ pub struct JumpTable {
     /// The amount of ifuncs this will register. This is used by WASM to know how much space to allocate
     /// for the ifuncs in the ifunc table
     pub ifunc_count: u64,
+
+    #[serde(default)]
+    pub wasm_layout: Option<WasmPatchLayout>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WasmPatchLayout {
+    pub memory_size: u32,
+    pub memory_alignment: u32,
+    pub table_size: u32,
+    pub table_alignment: u32,
+}
+
+impl WasmPatchLayout {
+    pub const PAGE_SIZE: u64 = 65536;
+
+    pub fn reservation(&self) -> Option<(u32, u32)> {
+        let memory_alignment = 1u64.checked_shl(self.memory_alignment)?;
+        let table_alignment = 1u32.checked_shl(self.table_alignment)?;
+        if self.memory_alignment > 31 {
+            return None;
+        }
+        let pages = 1
+            + u64::from(self.memory_size).div_ceil(Self::PAGE_SIZE)
+            + memory_alignment.saturating_sub(Self::PAGE_SIZE) / Self::PAGE_SIZE;
+        if pages > 65536 {
+            return None;
+        }
+        Some((
+            pages as u32,
+            self.table_size.checked_add(table_alignment - 1)?,
+        ))
+    }
+
+    pub fn memory_base(&self, previous_pages: u32) -> Option<u32> {
+        let address = (u64::from(previous_pages) + 1).checked_mul(Self::PAGE_SIZE)?;
+        let alignment = 1u64.checked_shl(self.memory_alignment)?;
+        u32::try_from(address.checked_add(alignment - 1)? & !(alignment - 1)).ok()
+    }
+
+    pub fn table_base(&self, previous_slots: u32) -> Option<u32> {
+        let alignment = 1u32.checked_shl(self.table_alignment)?;
+        Some(previous_slots.checked_add(alignment - 1)? & !(alignment - 1))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wasm_reservations_cover_bss_and_alignment() {
+        for memory_alignment in [0, 4, 16, 20] {
+            for table_alignment in [0, 2, 5] {
+                let layout = WasmPatchLayout {
+                    memory_size: 1048580,
+                    memory_alignment,
+                    table_size: 7,
+                    table_alignment,
+                };
+                let (pages, slots) = layout.reservation().unwrap();
+                for previous in [0, 1, 3, 16, 123] {
+                    let base = u64::from(layout.memory_base(previous).unwrap());
+                    assert_eq!(base % (1u64 << memory_alignment), 0);
+                    assert!(
+                        base + u64::from(layout.memory_size)
+                            <= u64::from(previous + pages) * WasmPatchLayout::PAGE_SIZE
+                    );
+                    let base = layout.table_base(previous).unwrap();
+                    assert_eq!(base % (1u32 << table_alignment), 0);
+                    assert!(base + layout.table_size <= previous + slots);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn wasm_reservations_reject_overflow() {
+        assert!(
+            WasmPatchLayout {
+                memory_alignment: 32,
+                ..Default::default()
+            }
+            .reservation()
+            .is_none()
+        );
+        assert!(
+            WasmPatchLayout {
+                table_alignment: 32,
+                ..Default::default()
+            }
+            .reservation()
+            .is_none()
+        );
+        assert!(
+            WasmPatchLayout {
+                memory_size: u32::MAX,
+                ..Default::default()
+            }
+            .reservation()
+            .is_none()
+        );
+        assert!(WasmPatchLayout::default().memory_base(65535).is_none());
+    }
 }
 
 /// An address to address hashmap that does not hash addresses since addresses are by definition unique.

--- a/packages/subsecond/subsecond/src/lib.rs
+++ b/packages/subsecond/subsecond/src/lib.rs
@@ -569,6 +569,16 @@ pub unsafe fn apply_patch(mut table: JumpTable) -> Result<(), PatchError> {
 
     // On wasm, we need to download the module, compile it, and then run it.
     #[cfg(target_arch = "wasm32")]
+    let layout = table.wasm_layout.ok_or_else(|| {
+        PatchError::InvalidJumpTable(
+            "Missing WASM memory layout; rebuild with the current CLI".into(),
+        )
+    })?;
+    #[cfg(target_arch = "wasm32")]
+    let (patch_pages, patch_slots) = layout
+        .reservation()
+        .ok_or_else(|| PatchError::InvalidJumpTable("WASM allocation overflows".into()))?;
+    #[cfg(target_arch = "wasm32")]
     let generation = PATCH_GENERATION
         .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         .wrapping_add(1);
@@ -648,21 +658,29 @@ pub unsafe fn apply_patch(mut table: JumpTable) -> Result<(), PatchError> {
             return;
         }
 
-        const PAGE_SIZE: u32 = 64 * 1024;
-        let patch_pages = (dl_bytes.byte_length() as f64 / PAGE_SIZE as f64).ceil() as u32 + 1;
-
         // Use grow's return value (the prior page count) to derive
         // memory_base. Atomic w.r.t. concurrent grows, unlike reading
         // memory.buffer().byteLength().
         let prev_pages = memory.grow(patch_pages);
-        let memory_base = (prev_pages + 1) * PAGE_SIZE;
+        let memory_base = layout
+            .memory_base(prev_pages)
+            .expect("WASM memory base overflows");
 
-        // grow returns the prior table length, which is __table_base.
-        let table_base = funcs.grow(table.ifunc_count as u32).unwrap();
+        // grow returns the prior table length, from which we align __table_base.
+        let table_base = layout
+            .table_base(funcs.grow(patch_slots).unwrap())
+            .expect("WASM table base overflows");
 
         // Rebase the jump table entries onto the patch's table slot range.
         for v in table.map.values_mut() {
-            *v += table_base as u64;
+            assert!(
+                *v < u64::from(layout.table_size),
+                "Patch function exceeds its table allocation"
+            );
+            *v = u64::from(table_base)
+                .checked_add(*v)
+                .filter(|v| *v <= u64::from(u32::MAX))
+                .expect("WASM function address overflows");
         }
 
         // Build the env import object: copy every host export through and
@@ -1012,6 +1030,7 @@ mod tests {
                 aslr_reference: 0,
                 new_base_address: 0,
                 ifunc_count: 0,
+                wasm_layout: None,
             })
         };
         std::thread::spawn(|| {


### PR DESCRIPTION
## Stack

Depends on #5808 (`fix/hotpatch-binary-correctness`). This PR contains only the WASM allocation/layout changes split out of that PR, so the public `JumpTable` change can be reviewed, redesigned, or deferred separately. Merge the parent first.

## Why

The serialized size of a WASM patch is not its linear-memory requirement: the reproduced 695-byte patch needs 1,048,580 bytes of data/BSS. Similarly, the number of named functions is not the number of element-table slots when entries are duplicated or unnamed.

The loader needs the linker's memory/table sizes and alignment requirements before instantiation. This implementation transports them in `JumpTable` rather than guessing from the downloaded file.

## Changes

- Add `WasmPatchLayout` and optional, serde-defaulted `JumpTable::wasm_layout` metadata.
- Read `dylink.0` memory/table size and alignment requirements in the CLI, account for all active element slots, and validate relocatable segment placement.
- Reserve and align the required linear-memory and table ranges, with overflow and function-range checks.
- Move the allocation, missing-metadata, duplicate/unnamed-slot, and alignment regression tests into this follow-up.

The native TLS/symbol fixes, publication synchronization, and independent WASM initialization/order hardening remain in #5808. Applying both PRs reproduces the previously tested combined tree exactly; this split does not introduce a new implementation.

## API and compatibility

This is intentionally a public-type and wire-format change:
- Rust `JumpTable` literals gain a `wasm_layout` field (`None` for native patches).
- Existing serialized tables can deserialize because the field defaults to `None`.
- The updated WASM loader rejects missing layout metadata rather than falling back to an unsafe allocation guess. Use the updated CLI and runtime together.

#5808 itself no longer changes `JumpTable` or `subsecond-types` and can be merged without accepting this extension. Deferring this PR also defers the WASM BSS/table allocation fixes.

#### Test plan
- [x] Compare the restored working tree with `c4cfa77eb`: identical combined implementation.
- [x] `cargo test -p dioxus-cli --bin dx --locked` — 173 tests pass.
- [x] `cargo test -p subsecond-types -p subsecond --lib --locked` — 3 tests pass.
- [x] `cargo check -p subsecond --target wasm32-unknown-unknown --locked`.
- [x] Formatting and diff checks.
- [x] Previously verified the identical implementation with isolated Node WebAssembly fixtures for large BSS and duplicate table slots; both execute successfully.
- [ ] Cross-platform CI and full browser/application hotpatch validation.

Generated with [Devin](https://devin.ai)
