### PR TITLE
fix(autofmt): keep multi-line string literals verbatim

### DIFF
--- a/packages/autofmt/src/prettier_please.rs
+++ b/packages/autofmt/src/prettier_please.rs
@@ -17,6 +17,33 @@ impl Writer<'_> {
 const MARKER: &str = "𝕣𝕤𝕩";
 const MARKER_REPLACE: &str = "𝕣𝕤𝕩! {}";
 
+/// Zero-based indices of the lines in `src` that continue a multi-line string literal.
+///
+/// The leading whitespace on those lines belongs to the string's value, so they must not be
+/// re-indented: doing so changes the string, and since the next run reads the added whitespace
+/// back as source, the indentation grows every time the file is formatted.
+pub(crate) fn string_literal_continuation_lines(src: &str) -> std::collections::HashSet<usize> {
+    fn collect(tokens: proc_macro2::TokenStream, lines: &mut std::collections::HashSet<usize>) {
+        for token in tokens {
+            match token {
+                proc_macro2::TokenTree::Group(group) => collect(group.stream(), lines),
+                proc_macro2::TokenTree::Literal(literal) => {
+                    // `LineColumn` lines are one-based, so this range holds the zero-based
+                    // indices of every line after the literal's first one.
+                    lines.extend(literal.span().start().line..literal.span().end().line);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut lines = std::collections::HashSet::new();
+    if let Ok(tokens) = src.parse::<proc_macro2::TokenStream>() {
+        collect(tokens, &mut lines);
+    }
+    lines
+}
+
 pub fn unparse_expr(expr: &Expr, src: &str, cfg: &IndentOptions) -> String {
     struct ReplaceMacros<'a> {
         src: &'a str,
@@ -57,12 +84,15 @@ pub fn unparse_expr(expr: &Expr, src: &str, cfg: &IndentOptions) -> String {
 
                 // Push out the indent level of the formatted block if it's multiline
                 if multiline || formatted.contains('\n') {
+                    let string_lines = string_literal_continuation_lines(&formatted);
                     formatted = formatted
                         .lines()
-                        .map(|line| {
+                        .enumerate()
+                        .map(|(index, line)| {
                             // Don't add indentation to blank lines (avoid trailing whitespace)
-                            if line.is_empty() {
-                                String::new()
+                            // or to lines inside a string literal (the whitespace is its value)
+                            if line.is_empty() || string_lines.contains(&index) {
+                                line.to_string()
                             } else {
                                 format!("{}{line}", self.cfg.indent_str())
                             }
@@ -114,11 +144,13 @@ pub fn unparse_expr(expr: &Expr, src: &str, cfg: &IndentOptions) -> String {
             }
         }
 
+        let string_lines = string_literal_continuation_lines(&fmted);
         let mut lines = fmted.lines().enumerate().peekable();
 
-        while let Some((_idx, fmt_line)) = lines.next() {
-            // Push the indentation (but not for blank lines - avoid trailing whitespace)
-            if is_multiline && !fmt_line.is_empty() {
+        while let Some((idx, fmt_line)) = lines.next() {
+            // Push the indentation (but not for blank lines - avoid trailing whitespace - or
+            // for lines inside a string literal, whose whitespace is part of its value)
+            if is_multiline && !fmt_line.is_empty() && !string_lines.contains(&idx) {
                 out_fmt.push_str(&cfg.indent_str().repeat(whitespace));
             }
 
@@ -195,13 +227,22 @@ pub fn unparse_pat(pat: &syn::Pat) -> String {
 
 // Split off the fn main and then cut the tabs off the front
 fn unwrapped(raw: String) -> String {
-    let mut o = raw
+    let body = raw
         .strip_prefix("fn main() {\n")
         .unwrap()
         .strip_suffix("}\n")
-        .unwrap()
+        .unwrap();
+    let string_lines = string_literal_continuation_lines(body);
+    let mut o = body
         .lines()
-        .map(|line| line.strip_prefix("    ").unwrap_or_default()) // todo: set this to tab level
+        .enumerate()
+        .map(|(index, line)| {
+            if string_lines.contains(&index) {
+                line
+            } else {
+                line.strip_prefix("    ").unwrap_or_default() // todo: set this to tab level
+            }
+        })
         .collect::<Vec<_>>()
         .join("\n");
 

--- a/packages/autofmt/src/writer.rs
+++ b/packages/autofmt/src/writer.rs
@@ -236,16 +236,21 @@ impl<'a> Writer<'a> {
     /// An expression within a for or if block that might need to be spread out across several lines
     fn write_inline_expr(&mut self, expr: &Expr) -> std::fmt::Result {
         let unparsed = self.unparse_expr(expr);
-        let mut lines = unparsed.lines();
-        let first_line = lines.next().ok_or(std::fmt::Error)?;
+        let string_lines = crate::prettier_please::string_literal_continuation_lines(&unparsed);
+        let mut lines = unparsed.lines().enumerate();
+        let (_, first_line) = lines.next().ok_or(std::fmt::Error)?;
 
         write!(self.out, "{first_line}")?;
 
         let mut was_multiline = false;
 
-        for line in lines {
+        for (index, line) in lines {
             was_multiline = true;
-            self.out.tabbed_line()?;
+            if string_lines.contains(&index) {
+                self.out.new_line()?;
+            } else {
+                self.out.tabbed_line()?;
+            }
             write!(self.out, "{line}")?;
         }
 
@@ -1175,8 +1180,9 @@ impl<'a> Writer<'a> {
     }
 
     fn write_mulitiline_tokens(&mut self, out: String) -> Result {
-        let mut lines = out.split('\n').peekable();
-        let first = lines.next().unwrap();
+        let string_lines = crate::prettier_please::string_literal_continuation_lines(&out);
+        let mut lines = out.split('\n').enumerate().peekable();
+        let (_, first) = lines.next().unwrap();
 
         // a one-liner for whatever reason
         // Does not need a new line
@@ -1185,8 +1191,9 @@ impl<'a> Writer<'a> {
         } else {
             writeln!(self.out, "{first}")?;
 
-            while let Some(line) = lines.next() {
-                if !line.trim().is_empty() {
+            while let Some((index, line)) = lines.next() {
+                // A line inside a multi-line string literal is part of the string's value
+                if !line.trim().is_empty() && !string_lines.contains(&index) {
                     self.out.tab()?;
                 }
 
@@ -1204,14 +1211,19 @@ impl<'a> Writer<'a> {
 
     fn write_spread_attribute(&mut self, attr: &Expr) -> Result {
         let formatted = self.unparse_expr(attr);
+        let string_lines = crate::prettier_please::string_literal_continuation_lines(&formatted);
 
-        let mut lines = formatted.lines();
+        let mut lines = formatted.lines().enumerate();
 
-        let first_line = lines.next().unwrap();
+        let (_, first_line) = lines.next().unwrap();
 
         write!(self.out, "..{first_line}")?;
-        for line in lines {
-            self.out.indented_tabbed_line()?;
+        for (index, line) in lines {
+            if string_lines.contains(&index) {
+                self.out.new_line()?;
+            } else {
+                self.out.indented_tabbed_line()?;
+            }
             write!(self.out, "{line}")?;
         }
 

--- a/packages/autofmt/tests/samples.rs
+++ b/packages/autofmt/tests/samples.rs
@@ -77,7 +77,34 @@ twoway![
     long_if_else_attr,
     empty_component_body,
     empty_braces_oneliner,
+    multiline_string_literals,
 ];
+
+#[test]
+fn multiline_strings_in_conditions_and_spreads_are_idempotent() {
+    let src = r#"rsx! {
+    div {
+        if label == "first
+            second" {
+            "string in an if condition"
+        }
+        button {
+            ..attributes_from("first
+                second"),
+            "string in a spread attribute"
+        }
+    }
+}"#;
+    // The first pass may still move these into their usual layout; it must settle after that.
+    let once =
+        dioxus_autofmt::apply_formats(src, dioxus_autofmt::fmt_file(src, Default::default()));
+    let twice =
+        dioxus_autofmt::apply_formats(&once, dioxus_autofmt::fmt_file(&once, Default::default()));
+    let thrice =
+        dioxus_autofmt::apply_formats(&twice, dioxus_autofmt::fmt_file(&twice, Default::default()));
+    pretty_assertions::assert_eq!(&once, &twice, "pass 1 vs pass 2");
+    pretty_assertions::assert_eq!(&twice, &thrice, "pass 2 vs pass 3");
+}
 
 fn assert_idempotent(src: &str) {
     let src = src.replace("\r", "");

--- a/packages/autofmt/tests/samples/multiline_string_literals.rsx
+++ b/packages/autofmt/tests/samples/multiline_string_literals.rsx
@@ -1,0 +1,48 @@
+rsx! {
+    div {
+        button {
+            onclick: move |_| {
+                spawn(async move {
+                    match Ok::<(), ()>(()) {
+                        Ok(()) => {
+                            let script = format!(
+                                r#"
+                                requestAnimationFrame(() => {{
+                                    console.log("restore");
+                                }});
+                                "#,
+                            );
+                            let _ = script;
+                        }
+                        Err(_) => {}
+                    }
+                });
+            },
+            "raw string in a nested closure"
+        }
+        button {
+            onclick: move |_| {
+                let indented = "first
+                    second";
+                let flush_left = "first
+second";
+                let _ = (indented, flush_left);
+            },
+            "plain strings"
+        }
+        {
+            let inner = rsx! {
+                button {
+                    onclick: move |_| {
+                        let script = r#"
+                            console.log("nested");
+                        "#;
+                        let _ = script;
+                    },
+                    "raw string in a nested rsx block"
+                }
+            };
+            inner
+        }
+    }
+}


### PR DESCRIPTION
Fixes #5804.

`dx fmt` re-indents every line of an expression it prints, including the lines inside a multi-line string literal. That leading whitespace is part of the string, so the value changes, and the next run reads the added whitespace back as source and adds more on top. That's the unbounded growth in the issue. It isn't specific to raw strings in closures: a plain `"..."` string and a raw string inside a nested `rsx!` grow the same way.

There's a worse case on the same path. `unwrapped()` strips four spaces from each line of the prettyplease output and falls back to `unwrap_or_default()` when a line doesn't have them, so a continuation line indented by less than four spaces is replaced with an empty line. A flush-left `"first\nsecond"` loses `second"`, and formatting the result again panics because the file no longer parses.

This adds `string_literal_continuation_lines`, which tokenizes the text being re-indented (the crate already enables proc-macro2 span locations) and returns the lines that continue a multi-line literal. Each place that adds or strips per-line indentation skips those lines:

- `unwrapped`
- the nested `rsx!` indent and replacement in `unparse_expr`
- `write_mulitiline_tokens`
- `write_inline_expr` (`if` / `for` headers)
- `write_spread_attribute`

Tests:

- `multiline_string_literals` sample: the issue's raw string in a nested closure, an indented and a flush-left plain string, and a raw string inside a nested `rsx!`.
- `multiline_strings_in_conditions_and_spreads_are_idempotent`: the `if` condition and spread attribute paths, checked for idempotency only, since their layout isn't what this changes.

Both fail on main and pass here. `cargo test -p dioxus-autofmt`, `cargo fmt --check` and `cargo clippy -p dioxus-autofmt --all-targets --all-features -- -D warnings` are clean.
